### PR TITLE
fix: restore CI workflow execution for all monorepo packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ name: CI
 on:
   push:
     branches: [main, dev]
-    paths:
-      - 'packages/contracts/**'
-      - '.github/workflows/ci.yml'
-      - 'Makefile'
   pull_request:
     branches: [main, dev]
-    paths:
-      - 'packages/contracts/**'
-      - '.github/workflows/ci.yml'
-      - 'Makefile'
 
 jobs:
   website:


### PR DESCRIPTION
The workflow had a restrictive path filter that only allowed packages/contracts/** to trigger CI, preventing website, dapp, and intelligence jobs from running.

This fix removes the global paths filter to allow all jobs to execute based on their respective logic and triggers. All CI jobs will now run on push/PR to main/dev:
- Website (Next.js)
- Dapp Frontend (Next.js)
- Dapp Backend (Node.js)
- Intelligence (Node.js)
- Soroban Contracts (Rust/WASM)

Fixes workflow visibility on PRs #61, #62, #63.