### PR TITLE
fix: rename reserved 'module' variable in WalletProvider to avoid Next.js build errors

### DIFF
--- a/apps/dapp/frontend/components/wallet-provider.tsx
+++ b/apps/dapp/frontend/components/wallet-provider.tsx
@@ -122,9 +122,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                         try {
                             StellarWalletsKit.setWallet(savedWalletId);
                             // Use the module directly to request the address
-                            const module = StellarWalletsKit.selectedModule;
+                            const walletModule = StellarWalletsKit.selectedModule;
                             const { address: addr } =
-                                await module.getAddress();
+                                await walletModule.getAddress();
                             if (addr) {
                                 // Update the kit's internal state
                                 const { activeAddress } = await import(
@@ -175,8 +175,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 StellarWalletsKit.setWallet(walletId);
 
                 // Call the module directly to request the address from the wallet extension
-                const module = StellarWalletsKit.selectedModule;
-                const { address: addr } = await module.getAddress();
+                const walletModule = StellarWalletsKit.selectedModule;
+                const { address: addr } = await walletModule.getAddress();
 
                 if (addr) {
                     // Update the kit's internal state signal


### PR DESCRIPTION
### Extracted Build Fix
This PR extracts a build-breaking fix for the `WalletProvider` component. Next.js and ESLint produce errors if a variable named `module` is used implicitly in certain scopes (like within dynamic module loading for the wallet kit).

This specific fix was originally bundled with the Transaction History PR (#75) but has been moved to this standalone PR to keep project history clean.