### PR TITLE
feat: offramp settlement data model and API scaffolding

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -50,10 +50,15 @@ func run() error {
 	vaultService := service.NewVaultService(vaultRepository)
 	vaultHandler := handler.NewVaultHandler(vaultService)
 
+	settlementRepository := postgres.NewSettlementRepository(db)
+	settlementService := service.NewSettlementService(settlementRepository)
+	settlementHandler := handler.NewSettlementHandler(settlementService)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler(db, cfg.Database().ConnectionTimeout()))
 	mux.HandleFunc("GET /healthz", healthHandler(db, cfg.Database().ConnectionTimeout()))
 	vaultHandler.Register(mux)
+	settlementHandler.Register(mux)
 
 	server := &http.Server{
 		Addr:         cfg.Server().Address(),

--- a/apps/api/internal/domain/offramp/model.go
+++ b/apps/api/internal/domain/offramp/model.go
@@ -1,0 +1,102 @@
+package offramp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// SettlementStatus represents the lifecycle state of a settlement.
+type SettlementStatus string
+
+const (
+	StatusInitiated        SettlementStatus = "initiated"
+	StatusLiquidityMatched SettlementStatus = "liquidity_matched"
+	StatusFiatDispatched   SettlementStatus = "fiat_dispatched"
+	StatusConfirmed        SettlementStatus = "confirmed"
+	StatusFailed           SettlementStatus = "failed"
+)
+
+// validTransitions defines the allowed forward transitions in the settlement
+// state machine. Terminal states (confirmed, failed) have no outbound edges.
+var validTransitions = map[SettlementStatus][]SettlementStatus{
+	StatusInitiated:        {StatusLiquidityMatched, StatusFailed},
+	StatusLiquidityMatched: {StatusFiatDispatched, StatusFailed},
+	StatusFiatDispatched:   {StatusConfirmed, StatusFailed},
+	StatusConfirmed:        {},
+	StatusFailed:           {},
+}
+
+var (
+	ErrSettlementNotFound    = errors.New("settlement not found")
+	ErrUserNotFound          = errors.New("user not found")
+	ErrVaultNotFound         = errors.New("vault not found")
+	ErrInvalidSettlement     = errors.New("invalid settlement input")
+	ErrInvalidAmount         = errors.New("amount must be greater than zero")
+	ErrInvalidStatus         = errors.New("invalid settlement status")
+	ErrInvalidTransition     = errors.New("invalid status transition")
+	ErrInvalidPrecision      = errors.New("decimal precision exceeds supported scale")
+)
+
+const MaxAmountScale = int32(8)
+
+// Destination holds the fiat delivery target — either a bank account or a
+// mobile-money wallet.
+type Destination struct {
+	Type          string `json:"type"`           // "bank_transfer" | "mobile_money"
+	Provider      string `json:"provider"`       // "mpesa" | "mtn_momo" | "bank"
+	AccountNumber string `json:"account_number"`
+	AccountName   string `json:"account_name"`
+	BankCode      string `json:"bank_code,omitempty"` // required for bank transfers
+}
+
+// Settlement is the central domain entity for an offramp operation.
+type Settlement struct {
+	ID           uuid.UUID        `json:"id"`
+	UserID       uuid.UUID        `json:"user_id"`
+	VaultID      uuid.UUID        `json:"vault_id"`
+	Amount       decimal.Decimal  `json:"amount"`
+	Currency     string           `json:"currency"`
+	FiatCurrency string           `json:"fiat_currency"`
+	FiatAmount   decimal.Decimal  `json:"fiat_amount"`
+	ExchangeRate decimal.Decimal  `json:"exchange_rate"`
+	Destination  Destination      `json:"destination"`
+	Status       SettlementStatus `json:"status"`
+	CreatedAt    time.Time        `json:"created_at"`
+	CompletedAt  *time.Time       `json:"completed_at,omitempty"`
+}
+
+// CanTransitionTo reports whether transitioning from the current status to
+// next is a valid move in the state machine.
+func (s *Settlement) CanTransitionTo(next SettlementStatus) bool {
+	allowed, ok := validTransitions[s.Status]
+	if !ok {
+		return false
+	}
+	for _, a := range allowed {
+		if a == next {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseStatus parses and validates a raw status string.
+func ParseStatus(raw string) (SettlementStatus, error) {
+	s := SettlementStatus(raw)
+	if _, ok := validTransitions[s]; ok {
+		return s, nil
+	}
+	return "", ErrInvalidStatus
+}
+
+// Repository is the persistence contract for settlements.
+type Repository interface {
+	Create(ctx context.Context, model Settlement) (Settlement, error)
+	GetByID(ctx context.Context, id uuid.UUID) (Settlement, error)
+	GetByUserID(ctx context.Context, userID uuid.UUID, statusFilter SettlementStatus) ([]Settlement, error)
+	UpdateStatus(ctx context.Context, id uuid.UUID, status SettlementStatus, completedAt *time.Time) error
+}

--- a/apps/api/internal/handler/settlement_handler.go
+++ b/apps/api/internal/handler/settlement_handler.go
@@ -1,0 +1,197 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+)
+
+type SettlementHandler struct {
+	service *service.SettlementService
+}
+
+func NewSettlementHandler(svc *service.SettlementService) *SettlementHandler {
+	return &SettlementHandler{service: svc}
+}
+
+func (h *SettlementHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/settlements", h.initiateSettlement)
+	mux.HandleFunc("GET /api/v1/settlements/{id}", h.getSettlement)
+	mux.HandleFunc("GET /api/v1/users/{userId}/settlements", h.listUserSettlements)
+	mux.HandleFunc("PATCH /api/v1/settlements/{id}/status", h.updateStatus)
+}
+
+// ── Request / Response types ────────────────────────────────────────────────
+
+type destinationRequest struct {
+	Type          string `json:"type"`
+	Provider      string `json:"provider"`
+	AccountNumber string `json:"account_number"`
+	AccountName   string `json:"account_name"`
+	BankCode      string `json:"bank_code"`
+}
+
+type initiateSettlementRequest struct {
+	UserID       string             `json:"user_id"`
+	VaultID      string             `json:"vault_id"`
+	Amount       string             `json:"amount"`
+	Currency     string             `json:"currency"`
+	FiatCurrency string             `json:"fiat_currency"`
+	FiatAmount   string             `json:"fiat_amount"`
+	ExchangeRate string             `json:"exchange_rate"`
+	Destination  destinationRequest `json:"destination"`
+}
+
+type updateStatusRequest struct {
+	Status string `json:"status"`
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+func (h *SettlementHandler) initiateSettlement(w http.ResponseWriter, r *http.Request) {
+	var req initiateSettlementRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	userID, err := uuid.Parse(req.UserID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "user_id must be a valid UUID")
+		return
+	}
+
+	vaultID, err := uuid.Parse(req.VaultID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "vault_id must be a valid UUID")
+		return
+	}
+
+	amount, err := decimal.NewFromString(req.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "amount must be a valid decimal number")
+		return
+	}
+
+	fiatAmount, err := decimal.NewFromString(req.FiatAmount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "fiat_amount must be a valid decimal number")
+		return
+	}
+
+	exchangeRate, err := decimal.NewFromString(req.ExchangeRate)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "exchange_rate must be a valid decimal number")
+		return
+	}
+
+	model, err := h.service.InitiateSettlement(r.Context(), service.InitiateSettlementInput{
+		UserID:       userID,
+		VaultID:      vaultID,
+		Amount:       amount,
+		Currency:     req.Currency,
+		FiatCurrency: req.FiatCurrency,
+		FiatAmount:   fiatAmount,
+		ExchangeRate: exchangeRate,
+		Destination: offramp.Destination{
+			Type:          req.Destination.Type,
+			Provider:      req.Destination.Provider,
+			AccountNumber: req.Destination.AccountNumber,
+			AccountName:   req.Destination.AccountName,
+			BankCode:      req.Destination.BankCode,
+		},
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, model)
+}
+
+func (h *SettlementHandler) getSettlement(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "settlement id must be a valid UUID")
+		return
+	}
+
+	model, err := h.service.GetSettlement(r.Context(), id)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model)
+}
+
+func (h *SettlementHandler) listUserSettlements(w http.ResponseWriter, r *http.Request) {
+	userID, err := uuid.Parse(r.PathValue("userId"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "user id must be a valid UUID")
+		return
+	}
+
+	statusFilter := r.URL.Query().Get("status")
+
+	models, err := h.service.GetUserSettlements(r.Context(), userID, statusFilter)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, models)
+}
+
+func (h *SettlementHandler) updateStatus(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "settlement id must be a valid UUID")
+		return
+	}
+
+	var req updateStatusRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	model, err := h.service.UpdateStatus(r.Context(), service.UpdateStatusInput{
+		SettlementID: id,
+		NewStatus:    offramp.SettlementStatus(req.Status),
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model)
+}
+
+// ── Error mapping ────────────────────────────────────────────────────────────
+
+func (h *SettlementHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, offramp.ErrSettlementNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, offramp.ErrUserNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, offramp.ErrVaultNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, offramp.ErrInvalidSettlement),
+		errors.Is(err, offramp.ErrInvalidAmount),
+		errors.Is(err, offramp.ErrInvalidStatus),
+		errors.Is(err, offramp.ErrInvalidTransition),
+		errors.Is(err, offramp.ErrInvalidPrecision):
+		writeError(w, http.StatusBadRequest, err.Error())
+	default:
+		logpkg.FromContext(r.Context()).Error("settlement handler failed", "error", err.Error())
+		writeError(w, http.StatusInternalServerError, "internal server error")
+	}
+}

--- a/apps/api/internal/repository/postgres/settlement_repository.go
+++ b/apps/api/internal/repository/postgres/settlement_repository.go
@@ -1,0 +1,274 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+)
+
+type SettlementRepository struct {
+	db *sql.DB
+}
+
+func NewSettlementRepository(db *sql.DB) *SettlementRepository {
+	return &SettlementRepository{db: db}
+}
+
+func (r *SettlementRepository) Create(ctx context.Context, model offramp.Settlement) (offramp.Settlement, error) {
+	query := `
+		INSERT INTO settlements (
+			id, user_id, vault_id,
+			amount, currency, fiat_currency, fiat_amount, exchange_rate,
+			destination_type, destination_provider,
+			destination_account_number, destination_account_name, destination_bank_code,
+			status
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		RETURNING created_at
+	`
+
+	if err := r.db.QueryRowContext(
+		ctx,
+		query,
+		model.ID.String(),
+		model.UserID.String(),
+		model.VaultID.String(),
+		model.Amount.String(),
+		model.Currency,
+		model.FiatCurrency,
+		model.FiatAmount.String(),
+		model.ExchangeRate.String(),
+		model.Destination.Type,
+		model.Destination.Provider,
+		model.Destination.AccountNumber,
+		model.Destination.AccountName,
+		model.Destination.BankCode,
+		string(model.Status),
+	).Scan(&model.CreatedAt); err != nil {
+		return offramp.Settlement{}, mapSettlementError(err)
+	}
+
+	return model, nil
+}
+
+func (r *SettlementRepository) GetByID(ctx context.Context, id uuid.UUID) (offramp.Settlement, error) {
+	query := `
+		SELECT id, user_id, vault_id,
+		       amount, currency, fiat_currency, fiat_amount, exchange_rate,
+		       destination_type, destination_provider,
+		       destination_account_number, destination_account_name, destination_bank_code,
+		       status, created_at, completed_at
+		FROM settlements
+		WHERE id = $1
+	`
+
+	row := r.db.QueryRowContext(ctx, query, id.String())
+	model, err := scanSettlement(row)
+	if err != nil {
+		return offramp.Settlement{}, mapSettlementError(err)
+	}
+
+	return model, nil
+}
+
+func (r *SettlementRepository) GetByUserID(
+	ctx context.Context,
+	userID uuid.UUID,
+	statusFilter offramp.SettlementStatus,
+) ([]offramp.Settlement, error) {
+	var (
+		query string
+		args  []any
+	)
+
+	if statusFilter == "" {
+		query = `
+			SELECT id, user_id, vault_id,
+			       amount, currency, fiat_currency, fiat_amount, exchange_rate,
+			       destination_type, destination_provider,
+			       destination_account_number, destination_account_name, destination_bank_code,
+			       status, created_at, completed_at
+			FROM settlements
+			WHERE user_id = $1
+			ORDER BY created_at DESC
+		`
+		args = []any{userID.String()}
+	} else {
+		query = `
+			SELECT id, user_id, vault_id,
+			       amount, currency, fiat_currency, fiat_amount, exchange_rate,
+			       destination_type, destination_provider,
+			       destination_account_number, destination_account_name, destination_bank_code,
+			       status, created_at, completed_at
+			FROM settlements
+			WHERE user_id = $1 AND status = $2
+			ORDER BY created_at DESC
+		`
+		args = []any{userID.String(), string(statusFilter)}
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, mapSettlementError(err)
+	}
+	defer rows.Close()
+
+	settlements := make([]offramp.Settlement, 0)
+	for rows.Next() {
+		model, err := scanSettlement(rows)
+		if err != nil {
+			return nil, err
+		}
+		settlements = append(settlements, model)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return settlements, nil
+}
+
+func (r *SettlementRepository) UpdateStatus(
+	ctx context.Context,
+	id uuid.UUID,
+	status offramp.SettlementStatus,
+	completedAt *time.Time,
+) error {
+	result, err := r.db.ExecContext(
+		ctx,
+		`UPDATE settlements SET status = $2, completed_at = $3 WHERE id = $1`,
+		id.String(),
+		string(status),
+		completedAt,
+	)
+	if err != nil {
+		return mapSettlementError(err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return offramp.ErrSettlementNotFound
+	}
+
+	return nil
+}
+
+func scanSettlement(row scanner) (offramp.Settlement, error) {
+	var (
+		id            string
+		userID        string
+		vaultID       string
+		amount        string
+		currency      string
+		fiatCurrency  string
+		fiatAmount    string
+		exchangeRate  string
+		destType      string
+		destProvider  string
+		destAcctNum   string
+		destAcctName  string
+		destBankCode  string
+		status        string
+		createdAt     time.Time
+		completedAt   sql.NullTime
+	)
+
+	if err := row.Scan(
+		&id, &userID, &vaultID,
+		&amount, &currency, &fiatCurrency, &fiatAmount, &exchangeRate,
+		&destType, &destProvider, &destAcctNum, &destAcctName, &destBankCode,
+		&status, &createdAt, &completedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return offramp.Settlement{}, offramp.ErrSettlementNotFound
+		}
+		return offramp.Settlement{}, err
+	}
+
+	parsedID, err := uuid.Parse(id)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse settlement id: %w", err)
+	}
+
+	parsedUserID, err := uuid.Parse(userID)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse user id: %w", err)
+	}
+
+	parsedVaultID, err := uuid.Parse(vaultID)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse vault id: %w", err)
+	}
+
+	parsedAmount, err := decimal.NewFromString(amount)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse amount: %w", err)
+	}
+
+	parsedFiatAmount, err := decimal.NewFromString(fiatAmount)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse fiat_amount: %w", err)
+	}
+
+	parsedRate, err := decimal.NewFromString(exchangeRate)
+	if err != nil {
+		return offramp.Settlement{}, fmt.Errorf("parse exchange_rate: %w", err)
+	}
+
+	var completedAtPtr *time.Time
+	if completedAt.Valid {
+		t := completedAt.Time
+		completedAtPtr = &t
+	}
+
+	return offramp.Settlement{
+		ID:           parsedID,
+		UserID:       parsedUserID,
+		VaultID:      parsedVaultID,
+		Amount:       parsedAmount,
+		Currency:     currency,
+		FiatCurrency: fiatCurrency,
+		FiatAmount:   parsedFiatAmount,
+		ExchangeRate: parsedRate,
+		Destination: offramp.Destination{
+			Type:          destType,
+			Provider:      destProvider,
+			AccountNumber: destAcctNum,
+			AccountName:   destAcctName,
+			BankCode:      destBankCode,
+		},
+		Status:      offramp.SettlementStatus(status),
+		CreatedAt:   createdAt,
+		CompletedAt: completedAtPtr,
+	}, nil
+}
+
+func mapSettlementError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if pgErr.Code == "23503" && strings.Contains(pgErr.ConstraintName, "user") {
+			return offramp.ErrUserNotFound
+		}
+		if pgErr.Code == "23503" && strings.Contains(pgErr.ConstraintName, "vault") {
+			return offramp.ErrVaultNotFound
+		}
+	}
+
+	return err
+}

--- a/apps/api/internal/service/settlement_service.go
+++ b/apps/api/internal/service/settlement_service.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+)
+
+type SettlementService struct {
+	repository offramp.Repository
+}
+
+func NewSettlementService(repository offramp.Repository) *SettlementService {
+	return &SettlementService{repository: repository}
+}
+
+// InitiateSettlementInput carries caller-supplied data for a new settlement.
+type InitiateSettlementInput struct {
+	UserID       uuid.UUID
+	VaultID      uuid.UUID
+	Amount       decimal.Decimal
+	Currency     string
+	FiatCurrency string
+	FiatAmount   decimal.Decimal
+	ExchangeRate decimal.Decimal
+	Destination  offramp.Destination
+}
+
+// UpdateStatusInput carries the target state for a status transition.
+type UpdateStatusInput struct {
+	SettlementID uuid.UUID
+	NewStatus    offramp.SettlementStatus
+}
+
+// InitiateSettlement validates input, creates a settlement in the `initiated`
+// state, and persists it via the repository.
+func (s *SettlementService) InitiateSettlement(ctx context.Context, input InitiateSettlementInput) (offramp.Settlement, error) {
+	if input.UserID == uuid.Nil || input.VaultID == uuid.Nil {
+		return offramp.Settlement{}, offramp.ErrInvalidSettlement
+	}
+
+	if input.Amount.Cmp(decimal.Zero) <= 0 {
+		return offramp.Settlement{}, offramp.ErrInvalidAmount
+	}
+	if input.FiatAmount.Cmp(decimal.Zero) <= 0 {
+		return offramp.Settlement{}, offramp.ErrInvalidAmount
+	}
+	if input.ExchangeRate.Cmp(decimal.Zero) <= 0 {
+		return offramp.Settlement{}, offramp.ErrInvalidAmount
+	}
+
+	if decimalScale(input.Amount) > offramp.MaxAmountScale ||
+		decimalScale(input.FiatAmount) > offramp.MaxAmountScale ||
+		decimalScale(input.ExchangeRate) > offramp.MaxAmountScale {
+		return offramp.Settlement{}, offramp.ErrInvalidPrecision
+	}
+
+	if strings.TrimSpace(input.Currency) == "" || strings.TrimSpace(input.FiatCurrency) == "" {
+		return offramp.Settlement{}, offramp.ErrInvalidSettlement
+	}
+
+	if err := validateDestination(input.Destination); err != nil {
+		return offramp.Settlement{}, err
+	}
+
+	model := offramp.Settlement{
+		ID:           uuid.New(),
+		UserID:       input.UserID,
+		VaultID:      input.VaultID,
+		Amount:       input.Amount,
+		Currency:     strings.ToUpper(strings.TrimSpace(input.Currency)),
+		FiatCurrency: strings.ToUpper(strings.TrimSpace(input.FiatCurrency)),
+		FiatAmount:   input.FiatAmount,
+		ExchangeRate: input.ExchangeRate,
+		Destination:  input.Destination,
+		Status:       offramp.StatusInitiated,
+	}
+
+	return s.repository.Create(ctx, model)
+}
+
+// GetSettlement retrieves a single settlement by ID.
+func (s *SettlementService) GetSettlement(ctx context.Context, id uuid.UUID) (offramp.Settlement, error) {
+	if id == uuid.Nil {
+		return offramp.Settlement{}, offramp.ErrInvalidSettlement
+	}
+	return s.repository.GetByID(ctx, id)
+}
+
+// GetUserSettlements returns all settlements for a user. If statusFilter is
+// non-empty it is validated and passed to the repository as a WHERE clause.
+func (s *SettlementService) GetUserSettlements(
+	ctx context.Context,
+	userID uuid.UUID,
+	statusFilter string,
+) ([]offramp.Settlement, error) {
+	if userID == uuid.Nil {
+		return nil, offramp.ErrInvalidSettlement
+	}
+
+	var parsedFilter offramp.SettlementStatus
+	if statusFilter != "" {
+		parsed, err := offramp.ParseStatus(statusFilter)
+		if err != nil {
+			return nil, err
+		}
+		parsedFilter = parsed
+	}
+
+	return s.repository.GetByUserID(ctx, userID, parsedFilter)
+}
+
+// UpdateStatus validates the state transition and persists the new status.
+// Terminal states (confirmed, failed) set completed_at to now.
+func (s *SettlementService) UpdateStatus(ctx context.Context, input UpdateStatusInput) (offramp.Settlement, error) {
+	if input.SettlementID == uuid.Nil {
+		return offramp.Settlement{}, offramp.ErrInvalidSettlement
+	}
+
+	current, err := s.repository.GetByID(ctx, input.SettlementID)
+	if err != nil {
+		return offramp.Settlement{}, err
+	}
+
+	if !current.CanTransitionTo(input.NewStatus) {
+		return offramp.Settlement{}, offramp.ErrInvalidTransition
+	}
+
+	var completedAt *time.Time
+	if input.NewStatus == offramp.StatusConfirmed || input.NewStatus == offramp.StatusFailed {
+		now := time.Now().UTC()
+		completedAt = &now
+	}
+
+	if err := s.repository.UpdateStatus(ctx, input.SettlementID, input.NewStatus, completedAt); err != nil {
+		return offramp.Settlement{}, err
+	}
+
+	return s.repository.GetByID(ctx, input.SettlementID)
+}
+
+func validateDestination(d offramp.Destination) error {
+	if strings.TrimSpace(d.Type) == "" ||
+		strings.TrimSpace(d.Provider) == "" ||
+		strings.TrimSpace(d.AccountNumber) == "" ||
+		strings.TrimSpace(d.AccountName) == "" {
+		return offramp.ErrInvalidSettlement
+	}
+	if d.Type == "bank_transfer" && strings.TrimSpace(d.BankCode) == "" {
+		return offramp.ErrInvalidSettlement
+	}
+	return nil
+}

--- a/apps/api/internal/service/settlement_service_test.go
+++ b/apps/api/internal/service/settlement_service_test.go
@@ -1,0 +1,342 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// ── In-memory stub repository ───────────────────────────────────────────────
+
+type stubRepo struct {
+	data map[uuid.UUID]*offramp.Settlement
+}
+
+func newStubRepo() *stubRepo {
+	return &stubRepo{data: make(map[uuid.UUID]*offramp.Settlement)}
+}
+
+func (r *stubRepo) Create(_ context.Context, model offramp.Settlement) (offramp.Settlement, error) {
+	model.CreatedAt = time.Now().UTC()
+	cp := model
+	r.data[model.ID] = &cp
+	return cp, nil
+}
+
+func (r *stubRepo) GetByID(_ context.Context, id uuid.UUID) (offramp.Settlement, error) {
+	s, ok := r.data[id]
+	if !ok {
+		return offramp.Settlement{}, offramp.ErrSettlementNotFound
+	}
+	return *s, nil
+}
+
+func (r *stubRepo) GetByUserID(_ context.Context, userID uuid.UUID, filter offramp.SettlementStatus) ([]offramp.Settlement, error) {
+	var out []offramp.Settlement
+	for _, s := range r.data {
+		if s.UserID != userID {
+			continue
+		}
+		if filter != "" && s.Status != filter {
+			continue
+		}
+		out = append(out, *s)
+	}
+	return out, nil
+}
+
+func (r *stubRepo) UpdateStatus(_ context.Context, id uuid.UUID, status offramp.SettlementStatus, completedAt *time.Time) error {
+	s, ok := r.data[id]
+	if !ok {
+		return offramp.ErrSettlementNotFound
+	}
+	s.Status = status
+	s.CompletedAt = completedAt
+	return nil
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+func validInput() service.InitiateSettlementInput {
+	return service.InitiateSettlementInput{
+		UserID:       uuid.New(),
+		VaultID:      uuid.New(),
+		Amount:       decimal.NewFromFloat(100.00),
+		Currency:     "USDC",
+		FiatCurrency: "KES",
+		FiatAmount:   decimal.NewFromFloat(13000.00),
+		ExchangeRate: decimal.NewFromFloat(130.00),
+		Destination: offramp.Destination{
+			Type:          "mobile_money",
+			Provider:      "mpesa",
+			AccountNumber: "0712345678",
+			AccountName:   "Jane Doe",
+		},
+	}
+}
+
+// ── Tests: InitiateSettlement ─────────────────────────────────────────────────
+
+func TestInitiateSettlement_CreatesInInitiatedStatus(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+
+	s, err := svc.InitiateSettlement(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Status != offramp.StatusInitiated {
+		t.Errorf("want status %q, got %q", offramp.StatusInitiated, s.Status)
+	}
+	if s.ID == uuid.Nil {
+		t.Error("expected a non-nil UUID")
+	}
+}
+
+func TestInitiateSettlement_ReturnsIDAndAllFields(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+
+	s, err := svc.InitiateSettlement(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if s.UserID != in.UserID {
+		t.Errorf("user_id mismatch")
+	}
+	if s.VaultID != in.VaultID {
+		t.Errorf("vault_id mismatch")
+	}
+	if !s.Amount.Equal(in.Amount) {
+		t.Errorf("amount mismatch")
+	}
+	if s.Currency != "USDC" {
+		t.Errorf("currency mismatch: got %s", s.Currency)
+	}
+	if s.Destination.Provider != "mpesa" {
+		t.Errorf("destination provider mismatch")
+	}
+}
+
+func TestInitiateSettlement_NilUserIDReturnsError(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+	in.UserID = uuid.Nil
+
+	_, err := svc.InitiateSettlement(context.Background(), in)
+	if !errors.Is(err, offramp.ErrInvalidSettlement) {
+		t.Errorf("expected ErrInvalidSettlement, got %v", err)
+	}
+}
+
+func TestInitiateSettlement_ZeroAmountReturnsError(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+	in.Amount = decimal.Zero
+
+	_, err := svc.InitiateSettlement(context.Background(), in)
+	if !errors.Is(err, offramp.ErrInvalidAmount) {
+		t.Errorf("expected ErrInvalidAmount, got %v", err)
+	}
+}
+
+func TestInitiateSettlement_BankTransferRequiresBankCode(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+	in.Destination.Type = "bank_transfer"
+	in.Destination.BankCode = "" // missing
+
+	_, err := svc.InitiateSettlement(context.Background(), in)
+	if !errors.Is(err, offramp.ErrInvalidSettlement) {
+		t.Errorf("expected ErrInvalidSettlement, got %v", err)
+	}
+}
+
+// ── Tests: GetSettlement ──────────────────────────────────────────────────────
+
+func TestGetSettlement_ReturnsExistingRecord(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+
+	created, _ := svc.InitiateSettlement(context.Background(), validInput())
+	fetched, err := svc.GetSettlement(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fetched.ID != created.ID {
+		t.Errorf("ID mismatch")
+	}
+}
+
+func TestGetSettlement_UnknownIDReturnsNotFound(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+
+	_, err := svc.GetSettlement(context.Background(), uuid.New())
+	if !errors.Is(err, offramp.ErrSettlementNotFound) {
+		t.Errorf("expected ErrSettlementNotFound, got %v", err)
+	}
+}
+
+// ── Tests: GetUserSettlements ─────────────────────────────────────────────────
+
+func TestGetUserSettlements_ReturnsAllForUser(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+
+	in := validInput()
+	svc.InitiateSettlement(context.Background(), in)
+	svc.InitiateSettlement(context.Background(), in)
+
+	list, err := svc.GetUserSettlements(context.Background(), in.UserID, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("want 2 settlements, got %d", len(list))
+	}
+}
+
+func TestGetUserSettlements_FilterByStatus(t *testing.T) {
+	repo := newStubRepo()
+	svc := service.NewSettlementService(repo)
+
+	in := validInput()
+	s1, _ := svc.InitiateSettlement(context.Background(), in)
+
+	// Advance s1 to liquidity_matched
+	svc.UpdateStatus(context.Background(), service.UpdateStatusInput{
+		SettlementID: s1.ID,
+		NewStatus:    offramp.StatusLiquidityMatched,
+	})
+
+	// s2 stays in initiated
+	svc.InitiateSettlement(context.Background(), in)
+
+	initiated, _ := svc.GetUserSettlements(context.Background(), in.UserID, "initiated")
+	if len(initiated) != 1 {
+		t.Errorf("want 1 initiated, got %d", len(initiated))
+	}
+
+	matched, _ := svc.GetUserSettlements(context.Background(), in.UserID, "liquidity_matched")
+	if len(matched) != 1 {
+		t.Errorf("want 1 liquidity_matched, got %d", len(matched))
+	}
+}
+
+func TestGetUserSettlements_InvalidStatusReturnsError(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+
+	_, err := svc.GetUserSettlements(context.Background(), uuid.New(), "nonsense")
+	if !errors.Is(err, offramp.ErrInvalidStatus) {
+		t.Errorf("expected ErrInvalidStatus, got %v", err)
+	}
+}
+
+// ── Tests: UpdateStatus / state machine ─────────────────────────────────────
+
+func TestUpdateStatus_FullLifecycleToConfirmed(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+
+	transitions := []offramp.SettlementStatus{
+		offramp.StatusLiquidityMatched,
+		offramp.StatusFiatDispatched,
+		offramp.StatusConfirmed,
+	}
+
+	for _, next := range transitions {
+		updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+			SettlementID: s.ID,
+			NewStatus:    next,
+		})
+		if err != nil {
+			t.Fatalf("transition to %q failed: %v", next, err)
+		}
+		if updated.Status != next {
+			t.Errorf("want status %q, got %q", next, updated.Status)
+		}
+		s = updated
+	}
+
+	if s.CompletedAt == nil {
+		t.Error("confirmed settlement should have completed_at set")
+	}
+}
+
+func TestUpdateStatus_FullLifecycleToFailed(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+
+	updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		NewStatus:    offramp.StatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Status != offramp.StatusFailed {
+		t.Errorf("want failed, got %s", updated.Status)
+	}
+	if updated.CompletedAt == nil {
+		t.Error("failed settlement should have completed_at set")
+	}
+}
+
+func TestUpdateStatus_InvalidTransitionRejected(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+
+	// initiated → fiat_dispatched is not a valid transition
+	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		NewStatus:    offramp.StatusFiatDispatched,
+	})
+	if !errors.Is(err, offramp.ErrInvalidTransition) {
+		t.Errorf("expected ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestUpdateStatus_CannotLeaveConfirmed(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusLiquidityMatched})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusFiatDispatched})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusConfirmed})
+
+	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		NewStatus:    offramp.StatusInitiated,
+	})
+	if !errors.Is(err, offramp.ErrInvalidTransition) {
+		t.Errorf("expected ErrInvalidTransition from terminal state, got %v", err)
+	}
+}
+
+func TestUpdateStatus_CannotLeaveFailed(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusFailed})
+
+	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		NewStatus:    offramp.StatusInitiated,
+	})
+	if !errors.Is(err, offramp.ErrInvalidTransition) {
+		t.Errorf("expected ErrInvalidTransition from terminal state, got %v", err)
+	}
+}

--- a/apps/api/migrations/006_create_settlements_table.up.sql
+++ b/apps/api/migrations/006_create_settlements_table.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE settlements (
+    id                         UUID        PRIMARY KEY,
+    user_id                    UUID        NOT NULL REFERENCES users(id)  ON DELETE RESTRICT,
+    vault_id                   UUID        NOT NULL REFERENCES vaults(id) ON DELETE RESTRICT,
+    amount                     NUMERIC(20, 8) NOT NULL CHECK (amount > 0),
+    currency                   VARCHAR(10) NOT NULL,
+    fiat_currency              VARCHAR(10) NOT NULL,
+    fiat_amount                NUMERIC(20, 8) NOT NULL CHECK (fiat_amount > 0),
+    exchange_rate              NUMERIC(20, 8) NOT NULL CHECK (exchange_rate > 0),
+    destination_type           VARCHAR(50)  NOT NULL,
+    destination_provider       VARCHAR(50)  NOT NULL,
+    destination_account_number VARCHAR(100) NOT NULL,
+    destination_account_name   VARCHAR(200) NOT NULL,
+    destination_bank_code      VARCHAR(20)  NOT NULL DEFAULT '',
+    status                     VARCHAR(30)  NOT NULL DEFAULT 'initiated'
+                                    CHECK (status IN (
+                                        'initiated',
+                                        'liquidity_matched',
+                                        'fiat_dispatched',
+                                        'confirmed',
+                                        'failed'
+                                    )),
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at               TIMESTAMPTZ
+);
+
+CREATE INDEX idx_settlements_user_id ON settlements(user_id);
+CREATE INDEX idx_settlements_vault_id ON settlements(vault_id);
+CREATE INDEX idx_settlements_status ON settlements(status);


### PR DESCRIPTION
## Summary

Implements the foundational settlement domain for Nester's crypto-to-fiat
offramp layer. No payment provider integration yet — this is the data model,
state machine, and API surface that future integrations will plug into.

**What's included:**

- `Settlement` domain model with `Destination` (bank transfer / mobile money)
- `SettlementStatus` state machine: `initiated → liquidity_matched → fiat_dispatched → confirmed | failed`
  — terminal states cannot be re-entered; invalid transitions return 400
- Migration `006_create_settlements_table.up.sql` — `NUMERIC(20,8)` for all
  financial amounts, status `CHECK` constraint, indexes on `user_id`, `vault_id`, `status`
- `SettlementRepository` — raw SQL via pgx, optional status filter on user queries,
  nullable `completed_at` set automatically on terminal transitions
- `SettlementService` — full input validation (amounts > 0, precision ≤ 8dp,
  destination fields, bank_code required for bank transfers)
- HTTP endpoints:
  - `POST /api/v1/settlements` → 201
  - `GET /api/v1/settlements/:id`
  - `GET /api/v1/users/:userId/settlements?status=`
  - `PATCH /api/v1/settlements/:id/status`
- 15 service-level tests covering full lifecycle, all invalid transitions,
  status filtering, and input validation edge cases

## Related Issues
Closes #13 