### PR TITLE
test: unit and integration tests for issues #40 #41 #42 #23

### DIFF
--- a/apps/api/internal/api/response.go
+++ b/apps/api/internal/api/response.go
@@ -1,0 +1,59 @@
+// Package api provides shared HTTP response helpers used by all handlers.
+//
+// Every API response follows a standard envelope:
+//
+//	Success: {"success":true,"data":{...}}
+//	Error:   {"success":false,"error":{"code":400,"message":"..."}}
+//
+// Using these helpers ensures consistency across all endpoints and makes
+// client-side parsing predictable.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// envelope is the top-level wrapper for every API response.
+// Data intentionally has no omitempty: a nil payload must still produce
+// "data":null rather than omitting the field entirely.
+type envelope struct {
+	Success bool      `json:"success"`
+	Data    any       `json:"data"`
+	Error   *apiError `json:"error,omitempty"`
+}
+
+// apiError carries the HTTP status code and a human-readable message.
+type apiError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// JSON writes a success envelope with the given status code and data payload.
+// If data is nil, the response body will be {"success":true,"data":null}.
+func JSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	resp := envelope{Success: true, Data: data}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		// Encoding already started — we cannot change the status code.
+		// Write a minimal fallback so the body is not empty.
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":500,"message":"encoding error"}}`))
+	}
+}
+
+// Error writes an error envelope with the given status code and message.
+// The message should be safe to expose to clients (no stack traces or
+// internal details).
+func Error(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	resp := envelope{
+		Success: false,
+		Error:   &apiError{Code: status, Message: message},
+	}
+	// If encoding fails here we cannot do much — headers are already sent.
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/apps/api/internal/api/response_test.go
+++ b/apps/api/internal/api/response_test.go
@@ -1,0 +1,261 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/api"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type envelope struct {
+	Success bool             `json:"success"`
+	Data    json.RawMessage  `json:"data"`
+	Error   *envelopeError   `json:"error"`
+}
+
+type envelopeError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func decodeEnvelope(t *testing.T, body string) envelope {
+	t.Helper()
+	var env envelope
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("response body is not valid JSON: %v\nbody: %q", err, body)
+	}
+	return env
+}
+
+// ---------------------------------------------------------------------------
+// JSON — success envelope
+// ---------------------------------------------------------------------------
+
+func TestJSON_WritesSuccessEnvelopeWithData(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.JSON(rec, http.StatusOK, map[string]string{"id": "vault-1"})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	env := decodeEnvelope(t, rec.Body.String())
+	if !env.Success {
+		t.Errorf("expected success=true, got false")
+	}
+	if env.Error != nil {
+		t.Errorf("expected no error field in success response, got %+v", env.Error)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("data field is not valid JSON: %v", err)
+	}
+	if data["id"] != "vault-1" {
+		t.Errorf("expected data.id=vault-1, got %q", data["id"])
+	}
+}
+
+func TestJSON_NilDataProducesNullDataField(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.JSON(rec, http.StatusOK, nil)
+
+	body := rec.Body.String()
+	if strings.TrimSpace(body) == "" {
+		t.Fatal("expected non-empty body for nil data, got empty")
+	}
+
+	// Confirm we get valid JSON back (not an empty body).
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("expected valid JSON for nil data, got %q: %v", body, err)
+	}
+	if !json.Valid(raw["data"]) && string(raw["data"]) != "null" {
+		t.Errorf("expected data=null for nil payload, got %q", raw["data"])
+	}
+}
+
+func TestJSON_StatusCodeIsWrittenCorrectly(t *testing.T) {
+	cases := []int{
+		http.StatusCreated,
+		http.StatusAccepted,
+		http.StatusNoContent,
+	}
+	for _, status := range cases {
+		rec := httptest.NewRecorder()
+		api.JSON(rec, status, map[string]string{"ok": "yes"})
+		if rec.Code != status {
+			t.Errorf("JSON(status=%d): got status %d", status, rec.Code)
+		}
+	}
+}
+
+func TestJSON_LargePayloadDoesNotTruncate(t *testing.T) {
+	large := make([]string, 10_000)
+	for i := range large {
+		large[i] = "value"
+	}
+	rec := httptest.NewRecorder()
+	api.JSON(rec, http.StatusOK, large)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("large payload produced invalid JSON: %v", err)
+	}
+
+	var decoded []string
+	if err := json.Unmarshal(raw["data"], &decoded); err != nil {
+		t.Fatalf("could not decode large data array: %v", err)
+	}
+	if len(decoded) != 10_000 {
+		t.Errorf("expected 10000 items, got %d", len(decoded))
+	}
+}
+
+func TestJSON_NonSerialisableDataReturnsInternalError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	// Channels are not JSON-serialisable.
+	api.JSON(rec, http.StatusOK, make(chan int))
+
+	// The handler must not panic.  Because headers are flushed before encoding
+	// errors surface, the status may already be 200 — what matters is that
+	// the body is not empty and no panic occurred.
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body even for non-serialisable data")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error — error envelope
+// ---------------------------------------------------------------------------
+
+func TestError_WritesBadRequestEnvelope(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.Error(rec, http.StatusBadRequest, "invalid user_id")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	env := decodeEnvelope(t, rec.Body.String())
+	if env.Success {
+		t.Errorf("expected success=false in error response")
+	}
+	if env.Error == nil {
+		t.Fatal("expected error field in error response, got nil")
+	}
+	if env.Error.Code != http.StatusBadRequest {
+		t.Errorf("expected error.code=400, got %d", env.Error.Code)
+	}
+	if env.Error.Message != "invalid user_id" {
+		t.Errorf("expected error.message=%q, got %q", "invalid user_id", env.Error.Message)
+	}
+}
+
+func TestError_StandardCodesMapToCorrectHTTPStatus(t *testing.T) {
+	cases := []struct {
+		status  int
+		message string
+	}{
+		{http.StatusBadRequest, "bad request"},
+		{http.StatusUnauthorized, "unauthorized"},
+		{http.StatusForbidden, "forbidden"},
+		{http.StatusNotFound, "not found"},
+		{http.StatusUnprocessableEntity, "validation failed"},
+		{http.StatusInternalServerError, "internal server error"},
+	}
+
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		api.Error(rec, tc.status, tc.message)
+
+		if rec.Code != tc.status {
+			t.Errorf("Error(status=%d): got HTTP status %d", tc.status, rec.Code)
+		}
+
+		env := decodeEnvelope(t, rec.Body.String())
+		if env.Error == nil {
+			t.Errorf("Error(status=%d): expected error envelope, got nil", tc.status)
+			continue
+		}
+		if env.Error.Code != tc.status {
+			t.Errorf("Error(status=%d): error.code=%d", tc.status, env.Error.Code)
+		}
+	}
+}
+
+func TestError_MessageDoesNotLeakStackTrace(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.Error(rec, http.StatusInternalServerError, "internal server error")
+
+	body := rec.Body.String()
+	forbidden := []string{
+		"goroutine",
+		"runtime/debug",
+		"stack trace",
+		".go:",
+	}
+	for _, fragment := range forbidden {
+		if strings.Contains(strings.ToLower(body), strings.ToLower(fragment)) {
+			t.Errorf("error response must not leak internal details; found %q in body %q", fragment, body)
+		}
+	}
+}
+
+func TestError_ResponseIsNotRawHTML(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.Error(rec, http.StatusNotFound, "not found")
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<html") || strings.Contains(body, "<!DOCTYPE") {
+		t.Errorf("error response must not be raw HTML, got %q", body)
+	}
+	// Must be parseable JSON.
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Errorf("error response is not valid JSON: %v\nbody: %q", err, body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Envelope shape invariants
+// ---------------------------------------------------------------------------
+
+func TestJSON_SuccessEnvelopeHasNoErrorField(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.JSON(rec, http.StatusOK, "payload")
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if errField, exists := raw["error"]; exists && string(errField) != "null" {
+		t.Errorf("success envelope must not include a non-null error field, got %q", errField)
+	}
+}
+
+func TestError_ErrorEnvelopeHasNoDataField(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.Error(rec, http.StatusBadRequest, "bad")
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if dataField, exists := raw["data"]; exists && string(dataField) != "null" {
+		t.Errorf("error envelope must not include a non-null data field, got %q", dataField)
+	}
+}

--- a/apps/api/internal/middleware/recover.go
+++ b/apps/api/internal/middleware/recover.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+)
+
+// RecoverPanic catches any panic that escapes a handler, logs the stack trace,
+// and writes a 500 JSON error response so the server process keeps running.
+func RecoverPanic(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					stack := string(debug.Stack())
+					// RecoverPanic sits outermost — the Logging middleware may not
+					// have injected a logger into the context yet.  Use the base
+					// logger and enrich with the request ID if it exists.
+					log := logger
+					if rid := logpkg.RequestIDFromContext(r.Context()); rid != "" {
+						log = logger.With("request_id", rid)
+					}
+					log.Error(
+						"panic recovered",
+						"panic", rec,
+						"stack", stack,
+					)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(
+						`{"success":false,"error":{"code":500,"message":"internal server error"}}`,
+					))
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -1,0 +1,82 @@
+// Package server wires together the HTTP mux, middleware chain, and graceful
+// shutdown logic so that each piece can be tested independently.
+package server
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+)
+
+const defaultMaxBodyBytes int64 = 1 << 20 // 1 MiB
+
+// HealthChecker is a function that returns nil when the service is healthy.
+// Callers may supply a database ping, a no-op, or a stub for tests.
+type HealthChecker func(ctx context.Context) error
+
+// New assembles the full HTTP handler: panic recovery → request-size limit →
+// structured logging → mux.  Routes are registered via the returned *Mux.
+//
+// The returned http.Handler is ready to pass to http.Server.
+func New(logger *slog.Logger, checker HealthChecker) (http.Handler, *http.ServeMux) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", healthHandler(checker))
+	mux.HandleFunc("GET /healthz", healthHandler(checker))
+
+	// Build the middleware stack (outermost first):
+	// RecoverPanic → LimitRequestBody → Logging → mux
+	handler := middleware.RecoverPanic(logger)(
+		middleware.LimitRequestBody(defaultMaxBodyBytes)(
+			middleware.Logging(logger)(mux),
+		),
+	)
+	return handler, mux
+}
+
+// RunWithGracefulShutdown starts srv and blocks until ctx is cancelled, then
+// shuts down with the given timeout.  It returns any server or shutdown error.
+func RunWithGracefulShutdown(ctx context.Context, srv *http.Server, timeout time.Duration) error {
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	select {
+	case err := <-serverErr:
+		return err
+	case <-ctx.Done():
+	}
+
+	shutCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutCtx); err != nil {
+		return err
+	}
+	return <-serverErr
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+func healthHandler(checker HealthChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if checker != nil {
+			if err := checker(r.Context()); err != nil {
+				http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}
+}

--- a/apps/api/internal/server/server_test.go
+++ b/apps/api/internal/server/server_test.go
@@ -1,0 +1,358 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/server"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func noopChecker(_ context.Context) error { return nil }
+
+// newTestServer returns a running httptest.Server backed by the full
+// middleware stack.  Callers must defer Close().
+func newTestServer(t *testing.T, extra func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	handler, mux := server.New(silentLogger(), noopChecker)
+	if extra != nil {
+		extra(mux)
+	}
+	return httptest.NewServer(handler)
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+func TestHealthCheck_Returns200WithStatusOK(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	for _, path := range []string{"/health", "/healthz"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s error = %v", path, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET %s: expected 200, got %d", path, resp.StatusCode)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("GET %s: response is not valid JSON: %v", path, err)
+		}
+		if body["status"] != "ok" {
+			t.Errorf("GET %s: expected {\"status\":\"ok\"}, got %v", path, body)
+		}
+	}
+}
+
+func TestHealthCheck_Returns503WhenCheckerFails(t *testing.T) {
+	checker := func(_ context.Context) error { return errors.New("db down") }
+	handler, _ := server.New(silentLogger(), checker)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+func TestUnregisteredRoute_Returns404(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET unknown route error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown route, got %d", resp.StatusCode)
+	}
+}
+
+func TestWrongMethodOnRegisteredRoute_Returns405(t *testing.T) {
+	srv := newTestServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /api/v1/items", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+	})
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/items", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST to GET-only route error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for wrong method, got %d", resp.StatusCode)
+	}
+}
+
+func TestRegisteredRoute_RespondsCorrectly(t *testing.T) {
+	srv := newTestServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /api/v1/ping", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ping":"pong"}`))
+		})
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/ping")
+	if err != nil {
+		t.Fatalf("GET /api/v1/ping error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware — request ID
+// ---------------------------------------------------------------------------
+
+func TestMiddleware_RequestIDIsPropagatedThroughContext(t *testing.T) {
+	var capturedBuf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&capturedBuf, nil))
+
+	handler, mux := server.New(log, noopChecker)
+	mux.HandleFunc("GET /api/v1/echo", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	http.Get(srv.URL + "/api/v1/echo") //nolint:errcheck
+
+	if !strings.Contains(capturedBuf.String(), "request_id") {
+		t.Errorf("expected request_id in log output, got %q", capturedBuf.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware — panic recovery
+// ---------------------------------------------------------------------------
+
+func TestPanicInHandler_Returns500NotCrash(t *testing.T) {
+	srv := newTestServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /api/v1/boom", func(_ http.ResponseWriter, _ *http.Request) {
+			panic("deliberate test panic")
+		})
+	})
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/boom")
+	if err != nil {
+		t.Fatalf("GET /boom unexpectedly closed connection: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 on panic, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var envelope map[string]any
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Errorf("panic response is not valid JSON: %v\nbody: %q", err, body)
+	}
+	if envelope["success"] != false {
+		t.Errorf("expected success=false in panic response, got %v", envelope["success"])
+	}
+}
+
+func TestPanicInHandler_StackTraceIsLogged(t *testing.T) {
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	handler, mux := server.New(log, noopChecker)
+	mux.HandleFunc("GET /api/v1/panic", func(_ http.ResponseWriter, _ *http.Request) {
+		panic("stack trace test")
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	http.Get(srv.URL + "/api/v1/panic") //nolint:errcheck
+
+	if !strings.Contains(logBuf.String(), "stack") {
+		t.Errorf("expected stack trace in log output after panic, got %q", logBuf.String())
+	}
+}
+
+func TestPanicDoesNotCrashSubsequentRequests(t *testing.T) {
+	srv := newTestServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /api/v1/boom", func(_ http.ResponseWriter, _ *http.Request) {
+			panic("test panic")
+		})
+		mux.HandleFunc("GET /api/v1/ok", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+	})
+	defer srv.Close()
+
+	// First request panics.
+	http.Get(srv.URL + "/api/v1/boom") //nolint:errcheck
+
+	// Server must still handle subsequent requests normally.
+	resp, err := http.Get(srv.URL + "/api/v1/ok")
+	if err != nil {
+		t.Fatalf("server crashed after panic, subsequent request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 on subsequent request after panic, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+
+func TestGracefulShutdown_InFlightRequestCompletes(t *testing.T) {
+	// Use a real listener on a random port so we can control the server lifecycle.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen error = %v", err)
+	}
+
+	requestStarted := make(chan struct{})
+	requestCanFinish := make(chan struct{})
+
+	handler, mux := server.New(silentLogger(), noopChecker)
+	mux.HandleFunc("GET /api/v1/slow", func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted) // signal: request is inside the handler
+		<-requestCanFinish    // wait until test unblocks us
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(ln) //nolint:errcheck
+
+	addr := fmt.Sprintf("http://%s/api/v1/slow", ln.Addr())
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		resp, _ := http.Get(addr)
+		respCh <- resp
+	}()
+
+	// Wait until the slow handler is executing.
+	select {
+	case <-requestStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for slow request to start")
+	}
+
+	// Begin graceful shutdown — the in-flight request must still complete.
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- srv.Shutdown(shutCtx)
+	}()
+
+	// Allow the slow handler to finish now.
+	close(requestCanFinish)
+
+	// The in-flight request should return 200.
+	select {
+	case resp := <-respCh:
+		if resp == nil {
+			t.Fatal("expected a response from the slow handler, got nil")
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 from slow handler, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "done" {
+			t.Errorf("expected body %q, got %q", "done", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for slow request to complete during shutdown")
+	}
+
+	// Shutdown itself should return nil (clean exit).
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Errorf("Shutdown() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server shutdown to complete")
+	}
+}
+
+func TestGracefulShutdown_NewConnectionsRejectedAfterShutdown(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen error = %v", err)
+	}
+
+	handler, _ := server.New(silentLogger(), noopChecker)
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(ln) //nolint:errcheck
+
+	addr := fmt.Sprintf("http://%s/health", ln.Addr())
+
+	// Confirm the server is up before shutting it down.
+	preResp, err := http.Get(addr)
+	if err != nil {
+		t.Fatalf("pre-shutdown request failed: %v", err)
+	}
+	preResp.Body.Close()
+
+	// Shut down cleanly.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	// Any new connection after shutdown should fail.
+	client := &http.Client{Timeout: 2 * time.Second}
+	_, postErr := client.Get(addr)
+	if postErr == nil {
+		t.Error("expected an error for new connection after shutdown, got nil")
+	}
+}

--- a/apps/api/pkg/logger/logger_test.go
+++ b/apps/api/pkg/logger/logger_test.go
@@ -1,0 +1,331 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// newHandler
+// ---------------------------------------------------------------------------
+
+func TestNewHandler_JSONProducesValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	handler, err := newHandler("json", &buf, &slog.HandlerOptions{})
+	if err != nil {
+		t.Fatalf("newHandler(json) error = %v", err)
+	}
+
+	slog.New(handler).Info("hello", "key", "value")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", buf.String(), err)
+	}
+	if entry["msg"] != "hello" {
+		t.Errorf("expected msg=hello, got %v", entry["msg"])
+	}
+	if entry["key"] != "value" {
+		t.Errorf("expected key=value, got %v", entry["key"])
+	}
+}
+
+func TestNewHandler_TextProducesNonJSONOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler, err := newHandler("text", &buf, &slog.HandlerOptions{})
+	if err != nil {
+		t.Fatalf("newHandler(text) error = %v", err)
+	}
+
+	slog.New(handler).Info("hello", "foo", "bar")
+
+	output := buf.String()
+	// Text format should not be parseable as a JSON object.
+	var entry map[string]any
+	if json.Unmarshal([]byte(strings.TrimSpace(output)), &entry) == nil {
+		t.Errorf("expected non-JSON text output, but got valid JSON: %q", output)
+	}
+	if !strings.Contains(output, "hello") {
+		t.Errorf("expected output to contain the log message, got %q", output)
+	}
+}
+
+func TestNewHandler_CaseInsensitiveFormat(t *testing.T) {
+	var buf bytes.Buffer
+	for _, format := range []string{"JSON", "Json", "TEXT", "Text"} {
+		_, err := newHandler(format, &buf, &slog.HandlerOptions{})
+		if err != nil {
+			t.Errorf("newHandler(%q) expected no error, got %v", format, err)
+		}
+	}
+}
+
+func TestNewHandler_UnsupportedFormatReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	_, err := newHandler("logfmt", &buf, &slog.HandlerOptions{})
+	if err == nil {
+		t.Fatal("expected error for unsupported format, got nil")
+	}
+	if !strings.Contains(err.Error(), "logfmt") {
+		t.Errorf("expected error message to mention the bad format, got %q", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseLevel
+// ---------------------------------------------------------------------------
+
+func TestParseLevel_AllValidLevels(t *testing.T) {
+	cases := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"WARN", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"ERROR", slog.LevelError},
+	}
+
+	for _, tc := range cases {
+		got, err := parseLevel(tc.input)
+		if err != nil {
+			t.Errorf("parseLevel(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseLevel(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseLevel_UnsupportedLevelReturnsError(t *testing.T) {
+	_, err := parseLevel("verbose")
+	if err == nil {
+		t.Fatal("expected error for unsupported level, got nil")
+	}
+	if !strings.Contains(err.Error(), "verbose") {
+		t.Errorf("expected error to mention the bad value, got %q", err.Error())
+	}
+}
+
+func TestParseLevel_DefaultsToInfoOnError(t *testing.T) {
+	got, err := parseLevel("bad")
+	if err == nil {
+		t.Fatal("expected error for bad level, got nil")
+	}
+	// parseLevel documents that it returns slog.LevelInfo on an unrecognised value.
+	if got != slog.LevelInfo {
+		t.Errorf("parseLevel(bad) default level = %v, want %v", got, slog.LevelInfo)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Log level filtering
+// ---------------------------------------------------------------------------
+
+func TestLogLevel_DebugLevelEmitsDebugMessages(t *testing.T) {
+	var buf bytes.Buffer
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	handler, _ := newHandler("json", &buf, opts)
+	slog.New(handler).Debug("debug message")
+
+	if !strings.Contains(buf.String(), "debug message") {
+		t.Errorf("expected DEBUG message to appear in output, got %q", buf.String())
+	}
+}
+
+func TestLogLevel_InfoLevelSuppressesDebugMessages(t *testing.T) {
+	var buf bytes.Buffer
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	handler, _ := newHandler("json", &buf, opts)
+	slog.New(handler).Debug("should not appear")
+
+	if strings.Contains(buf.String(), "should not appear") {
+		t.Errorf("expected DEBUG message to be suppressed at INFO level, got %q", buf.String())
+	}
+}
+
+func TestLogLevel_ErrorLevelSuppressesInfoAndWarn(t *testing.T) {
+	var buf bytes.Buffer
+	opts := &slog.HandlerOptions{Level: slog.LevelError}
+	handler, _ := newHandler("json", &buf, opts)
+	log := slog.New(handler)
+	log.Info("info message")
+	log.Warn("warn message")
+	log.Error("error message")
+
+	output := buf.String()
+	if strings.Contains(output, "info message") {
+		t.Errorf("INFO should be suppressed at ERROR level, got %q", output)
+	}
+	if strings.Contains(output, "warn message") {
+		t.Errorf("WARN should be suppressed at ERROR level, got %q", output)
+	}
+	if !strings.Contains(output, "error message") {
+		t.Errorf("ERROR message should appear at ERROR level, got %q", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithLogger / FromContext
+// ---------------------------------------------------------------------------
+
+func TestWithLoggerAndFromContext_RoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	handler, _ := newHandler("json", &buf, nil)
+	original := slog.New(handler)
+
+	ctx := WithLogger(context.Background(), original)
+	retrieved := FromContext(ctx)
+
+	retrieved.Info("from context")
+	if !strings.Contains(buf.String(), "from context") {
+		t.Errorf("expected log from retrieved logger to appear in buffer, got %q", buf.String())
+	}
+}
+
+func TestFromContext_ReturnsSlogDefaultWhenNoLoggerInContext(t *testing.T) {
+	retrieved := FromContext(context.Background())
+	if retrieved == nil {
+		t.Fatal("FromContext(empty context) returned nil, want non-nil default logger")
+	}
+	// The default logger should still be callable without panicking.
+	retrieved.Info("safe default call")
+}
+
+func TestFromContext_NilContextValueDoesNotPanic(t *testing.T) {
+	// Store a nil pointer via a typed nil.
+	key := loggerContextKey
+	ctx := context.WithValue(context.Background(), key, (*slog.Logger)(nil))
+
+	// FromContext must fall back to slog.Default() gracefully.
+	got := FromContext(ctx)
+	if got == nil {
+		t.Fatal("FromContext with nil logger in context returned nil, want slog.Default()")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithRequestID / RequestIDFromContext
+// ---------------------------------------------------------------------------
+
+func TestWithRequestIDAndRequestIDFromContext_RoundTrip(t *testing.T) {
+	ctx := WithRequestID(context.Background(), "req-abc-123")
+	got := RequestIDFromContext(ctx)
+	if got != "req-abc-123" {
+		t.Errorf("RequestIDFromContext = %q, want %q", got, "req-abc-123")
+	}
+}
+
+func TestRequestIDFromContext_EmptyStringWhenMissing(t *testing.T) {
+	got := RequestIDFromContext(context.Background())
+	if got != "" {
+		t.Errorf("RequestIDFromContext(empty context) = %q, want empty string", got)
+	}
+}
+
+func TestWithRequestID_OverwritesPreviousID(t *testing.T) {
+	ctx := WithRequestID(context.Background(), "first")
+	ctx = WithRequestID(ctx, "second")
+	got := RequestIDFromContext(ctx)
+	if got != "second" {
+		t.Errorf("expected overwritten request ID %q, got %q", "second", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive field filtering
+// ---------------------------------------------------------------------------
+
+func TestLogger_AuthorizationHeaderIsNotLogged(t *testing.T) {
+	var buf bytes.Buffer
+	handler, _ := newHandler("json", &buf, nil)
+	log := slog.New(handler)
+
+	// Simulate what a handler might log — only safe fields should appear.
+	// The logger itself does not strip fields; callers must not log sensitive data.
+	// This test documents and enforces the contract: nothing in the logger package
+	// should ever log Authorization or password fields automatically.
+	log.Info("request received", "method", "POST", "path", "/api/v1/vaults")
+
+	output := buf.String()
+	if strings.Contains(strings.ToLower(output), "authorization") {
+		t.Errorf("logger must not emit Authorization fields automatically, got %q", output)
+	}
+	if strings.Contains(strings.ToLower(output), "password") {
+		t.Errorf("logger must not emit password fields automatically, got %q", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// logger.With — attaches key-value pairs to subsequent entries
+// ---------------------------------------------------------------------------
+
+func TestLoggerWith_AttachesFieldsToSubsequentEntries(t *testing.T) {
+	var buf bytes.Buffer
+	handler, _ := newHandler("json", &buf, nil)
+	log := slog.New(handler).With("service", "nester-api", "env", "test")
+
+	log.Info("boot")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("expected valid JSON, got %q", buf.String())
+	}
+	if entry["service"] != "nester-api" {
+		t.Errorf("expected service=nester-api, got %v", entry["service"])
+	}
+	if entry["env"] != "test" {
+		t.Errorf("expected env=test, got %v", entry["env"])
+	}
+}
+
+func TestLoggerWith_DoesNotMutateParentLogger(t *testing.T) {
+	var parentBuf, childBuf bytes.Buffer
+
+	parentHandler, _ := newHandler("json", &parentBuf, nil)
+	parent := slog.New(parentHandler)
+
+	childHandler, _ := newHandler("json", &childBuf, nil)
+	child := slog.New(childHandler).With("child_key", "child_value")
+
+	parent.Info("parent message")
+	child.Info("child message")
+
+	parentOutput := parentBuf.String()
+	if strings.Contains(parentOutput, "child_key") {
+		t.Errorf("parent logger should not contain child_key, got %q", parentOutput)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON structured fields
+// ---------------------------------------------------------------------------
+
+func TestJSONOutput_ContainsExpectedLevelAndTimestampFields(t *testing.T) {
+	var buf bytes.Buffer
+	handler, _ := newHandler("json", &buf, nil)
+	slog.New(handler).Warn("check fields")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("expected valid JSON, got %q", buf.String())
+	}
+	if _, ok := entry["time"]; !ok {
+		t.Errorf("expected 'time' field in JSON output, got %v", entry)
+	}
+	if entry["level"] != "WARN" {
+		t.Errorf("expected level=WARN, got %v", entry["level"])
+	}
+	if entry["msg"] != "check fields" {
+		t.Errorf("expected msg='check fields', got %v", entry["msg"])
+	}
+}

--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -666,11 +666,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nester-integration-tests"
+version = "0.1.0"
+dependencies = [
+ "allocation-strategy-contract",
+ "nester-access-control",
+ "nester-common",
+ "nester-test-utils",
+ "soroban-sdk",
+ "vault-contract",
+ "vault-token-contract",
+ "yield-registry-contract",
+]
+
+[[package]]
 name = "nester-test-utils"
 version = "0.1.0"
 dependencies = [
+ "allocation-strategy-contract",
  "nester-common",
  "soroban-sdk",
+ "vault-contract",
+ "vault-token-contract",
+ "yield-registry-contract",
 ]
 
 [[package]]

--- a/packages/contracts/Cargo.toml
+++ b/packages/contracts/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "contracts/*",
   "libs/common",
   "libs/test_utils",
+  "tests/integration",
 ]
 
 [workspace.dependencies]

--- a/packages/contracts/Makefile
+++ b/packages/contracts/Makefile
@@ -1,14 +1,15 @@
-.PHONY: build test fmt clippy clean help deploy-testnet
+.PHONY: build test integration-test fmt clippy clean help deploy-testnet
 
 help:
 	@echo "Nester Soroban Workspace Commands"
 	@echo "=================================="
-	@echo "make build           - Build all contracts to WASM"
-	@echo "make test            - Run all tests"
-	@echo "make fmt             - Format code with cargo fmt"
-	@echo "make clippy          - Run clippy linter (must pass clean)"
-	@echo "make clean           - Remove build artifacts"
-	@echo "make deploy-testnet  - Deploy contracts to Stellar testnet"
+	@echo "make build            - Build all contracts to WASM"
+	@echo "make test             - Run all unit tests"
+	@echo "make integration-test - Run multi-contract integration tests only"
+	@echo "make fmt              - Format code with cargo fmt"
+	@echo "make clippy           - Run clippy linter (must pass clean)"
+	@echo "make clean            - Remove build artifacts"
+	@echo "make deploy-testnet   - Deploy contracts to Stellar testnet"
 
 build:
 	@echo "Building all Soroban contracts to WASM..."
@@ -25,6 +26,11 @@ test:
 	@echo "Running all tests..."
 	@cargo test --lib
 	@echo "✓ All tests passed"
+
+integration-test:
+	@echo "Running multi-contract integration tests..."
+	@cargo test -p nester-integration-tests --lib
+	@echo "✓ Integration tests passed"
 
 fmt:
 	@echo "Formatting code..."

--- a/packages/contracts/TESTING.md
+++ b/packages/contracts/TESTING.md
@@ -1,0 +1,109 @@
+# Nester Smart-Contract Testing Guide
+
+This document describes the test strategy for the Nester Soroban contract
+workspace.
+
+---
+
+## Test types
+
+| Type | Location | Command |
+|------|----------|---------|
+| Unit tests | `contracts/*/src/` and `contracts/*/src/test.rs` | `make test` |
+| Integration tests | `tests/integration/src/integration/mod.rs` | `make integration-test` |
+
+---
+
+## Running tests
+
+```bash
+# All unit tests
+make test
+
+# Multi-contract integration tests only
+make integration-test
+
+# Everything (unit + integration)
+cargo test --lib
+```
+
+---
+
+## Unit tests
+
+Each contract has its own inline `#[cfg(test)]` block or a companion
+`test.rs` module. Unit tests deploy only the contract under test and verify
+its behaviour in isolation using Soroban's in-process test environment
+(`soroban_sdk::Env::default()`).
+
+### Contracts with unit tests
+
+| Contract | Test file |
+|----------|-----------|
+| `vault` | `contracts/vault/src/lib.rs` (inline) |
+| `vault_token` | `contracts/vault_token/src/test.rs` |
+| `yield_registry` | `contracts/yield_registry/src/test.rs` |
+| `allocation_strategy` | `contracts/allocation_strategy/src/test.rs` |
+| `access_control` | `contracts/access_control/src/test.rs` |
+
+---
+
+## Integration tests
+
+Multi-contract tests live in the `nester-integration-tests` crate
+(`tests/integration/`). They use the `NesterHarness` helper from
+`libs/test_utils` to deploy all contracts in a single environment with correct
+cross-references.
+
+### `NesterHarness`
+
+`NesterHarness::setup()` deploys all five contracts and initialises them in
+dependency order:
+
+1. `VaultContract` — AccessControl bootstrapped with a shared admin.
+2. `VaultTokenContract` — vault address stored as sole minter/burner.
+3. `YieldRegistryContract` — AccessControl bootstrapped with the same admin.
+4. `AllocationStrategyContract` — registry address stored so `set_weights` can
+   validate sources via cross-contract calls.
+
+Client handles are available via `h.vault()`, `h.token()`, `h.registry()`,
+and `h.strategy()`.
+
+### Integration scenarios
+
+| Scenario | Test function | What it validates |
+|----------|---------------|-------------------|
+| 1 | `all_contracts_initialise_cleanly` | All five contracts deploy and initialise without error |
+| 2 | `strategy_set_weights_validates_sources_via_registry` | `set_weights` performs a live cross-contract call to the registry to confirm each source is active |
+| 3 | `strategy_rejects_weights_for_unregistered_source` | Cross-contract validation rejects unknown source IDs |
+| 4 | `strategy_rejects_weights_for_paused_source` | Cross-contract validation rejects paused (inactive) sources |
+| 5 | `calculate_allocation_distributes_total_proportionally` | Allocation math distributes a total correctly across sources after cross-contract weight validation |
+| 6 | `calculate_allocation_assigns_remainder_to_highest_weight_source` | Rounding remainder is fully assigned (no funds lost) |
+| 7 | `admin_can_grant_operator_who_can_set_weights` | Admin grants Operator role; operator can call `set_weights` |
+| 8 | `non_operator_cannot_set_weights` | Unauthorised address is rejected by `set_weights` |
+| 9 | `deposit_is_rejected_when_vault_is_paused` | `deposit()` panics when vault is paused |
+| 10 | `withdraw_is_rejected_when_vault_is_paused` | `withdraw()` panics when vault is paused |
+| 11 | `vault_accepts_deposit_after_unpause` | Unpause restores deposit functionality |
+| 12 | `non_admin_cannot_pause_vault` | Non-admin address is rejected by `pause()` |
+| 13 | `two_users_receive_proportional_yield_on_withdrawal` | Two users share yield proportionally via VaultToken share math |
+| 14 | `late_depositor_does_not_capture_prior_yield` | A user who deposits after yield accrues does not retroactively earn that yield |
+
+---
+
+## Test utilities (`libs/test_utils`)
+
+| Module | Purpose |
+|--------|---------|
+| `env` | `setup_test_env()` — creates a default `Env` |
+| `assertions` | `assert_error`, `assert_ok`, `assert_eq_balance` helpers |
+| `harness` | `NesterHarness` — full-protocol deployment harness for integration tests |
+
+---
+
+## Adding new integration scenarios
+
+1. Open `tests/integration/src/integration/mod.rs`.
+2. Add a `#[test]` function that calls `NesterHarness::setup()`.
+3. Use `h.vault()`, `h.token()`, `h.registry()`, `h.strategy()` to interact
+   with contracts.
+4. Run `make integration-test` to verify.

--- a/packages/contracts/contracts/vault/Cargo.toml
+++ b/packages/contracts/contracts/vault/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]

--- a/packages/contracts/libs/test_utils/Cargo.toml
+++ b/packages/contracts/libs/test_utils/Cargo.toml
@@ -8,5 +8,9 @@ publish = false
 crate-type = ["rlib"]
 
 [dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
-nester-common = { path = "../common" }
+soroban-sdk        = { workspace = true, features = ["testutils"] }
+nester-common      = { path = "../common" }
+vault-contract     = { path = "../../contracts/vault" }
+vault-token-contract = { path = "../../contracts/vault_token" }
+yield-registry-contract = { path = "../../contracts/yield_registry" }
+allocation-strategy-contract = { path = "../../contracts/allocation_strategy" }

--- a/packages/contracts/libs/test_utils/src/harness.rs
+++ b/packages/contracts/libs/test_utils/src/harness.rs
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------------
+// Nester multi-contract test harness
+//
+// Deploys all five Nester contracts into a single Soroban test environment
+// and initialises them with the correct cross-references so integration tests
+// can exercise the full protocol without any off-chain scaffolding.
+//
+// Usage
+// -----
+// ```rust
+// let h = NesterHarness::setup();
+// let user = h.create_user();
+// h.registry().register_source(&h.admin, &symbol_short!("aave"), ...);
+// ```
+// ---------------------------------------------------------------------------
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use allocation_strategy_contract::{AllocationStrategyContract, AllocationStrategyContractClient};
+use vault_contract::{VaultContract, VaultContractClient};
+use vault_token::{VaultTokenContract, VaultTokenContractClient};
+use yield_registry::{YieldRegistryContract, YieldRegistryContractClient};
+
+/// Fully deployed Nester protocol in a single Soroban test environment.
+///
+/// Clients are created on demand via the `vault()`, `token()`, `registry()`,
+/// and `strategy()` methods so the struct can own the `Env` without running
+/// into self-referential lifetime issues.
+pub struct NesterHarness {
+    /// The shared in-process test environment.
+    pub env: Env,
+    /// The initial admin address — holds the Admin role on every contract.
+    pub admin: Address,
+
+    /// On-chain ID of the deployed Vault contract.
+    pub vault_id: Address,
+    /// On-chain ID of the deployed VaultToken contract.
+    pub token_id: Address,
+    /// On-chain ID of the deployed YieldRegistry contract.
+    pub registry_id: Address,
+    /// On-chain ID of the deployed AllocationStrategy contract.
+    pub strategy_id: Address,
+}
+
+impl NesterHarness {
+    /// Deploy and initialise all Nester contracts in a fresh test environment.
+    ///
+    /// Initialisation order:
+    /// 1. `VaultContract` — AccessControl bootstrapped with `admin`.
+    /// 2. `VaultTokenContract` — vault address stored as sole minter/burner.
+    /// 3. `YieldRegistryContract` — AccessControl bootstrapped with `admin`.
+    /// 4. `AllocationStrategyContract` — registry address stored for source
+    ///    validation; AccessControl bootstrapped with `admin`.
+    pub fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+
+        // Register contracts (allocates an on-chain address for each).
+        let vault_id    = env.register_contract(None, VaultContract);
+        let token_id    = env.register_contract(None, VaultTokenContract);
+        let registry_id = env.register_contract(None, YieldRegistryContract);
+        let strategy_id = env.register_contract(None, AllocationStrategyContract);
+
+        // Initialise in dependency order.
+        VaultContractClient::new(&env, &vault_id).initialize(&admin);
+
+        VaultTokenContractClient::new(&env, &token_id).initialize(
+            &vault_id,
+            &String::from_str(&env, "Nester USDC Vault"),
+            &String::from_str(&env, "nUSDC"),
+            &7u32,
+        );
+
+        YieldRegistryContractClient::new(&env, &registry_id).initialize(&admin);
+
+        // Strategy needs the registry address so it can validate sources via
+        // cross-contract calls in `set_weights`.
+        AllocationStrategyContractClient::new(&env, &strategy_id)
+            .initialize(&admin, &registry_id);
+
+        NesterHarness {
+            env,
+            admin,
+            vault_id,
+            token_id,
+            registry_id,
+            strategy_id,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Client accessors (short-lived borrows from &self)
+    // -----------------------------------------------------------------------
+
+    /// Return a fresh client handle for the Vault contract.
+    pub fn vault(&self) -> VaultContractClient<'_> {
+        VaultContractClient::new(&self.env, &self.vault_id)
+    }
+
+    /// Return a fresh client handle for the VaultToken contract.
+    pub fn token(&self) -> VaultTokenContractClient<'_> {
+        VaultTokenContractClient::new(&self.env, &self.token_id)
+    }
+
+    /// Return a fresh client handle for the YieldRegistry contract.
+    pub fn registry(&self) -> YieldRegistryContractClient<'_> {
+        YieldRegistryContractClient::new(&self.env, &self.registry_id)
+    }
+
+    /// Return a fresh client handle for the AllocationStrategy contract.
+    pub fn strategy(&self) -> AllocationStrategyContractClient<'_> {
+        AllocationStrategyContractClient::new(&self.env, &self.strategy_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /// Generate a fresh user address.
+    pub fn create_user(&self) -> Address {
+        Address::generate(&self.env)
+    }
+
+    /// Mint `amount` vault-share tokens to `user` by calling
+    /// `VaultToken::mint_for_deposit`.  Useful for seeding test balances
+    /// without going through the (stub) Vault deposit flow.
+    pub fn seed_token_balance(&self, user: &Address, amount: i128) {
+        self.token().mint_for_deposit(user, &amount);
+    }
+}

--- a/packages/contracts/libs/test_utils/src/lib.rs
+++ b/packages/contracts/libs/test_utils/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod assertions;
 pub mod env;
+pub mod harness;
 
 pub use assertions::*;
 pub use env::*;
+pub use harness::NesterHarness;
 
 #[cfg(test)]
 mod tests {

--- a/packages/contracts/tests/integration/Cargo.toml
+++ b/packages/contracts/tests/integration/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nester-integration-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# This crate contains only tests — no deployable artifact is produced.
+[lib]
+name = "nester_integration_tests"
+crate-type = ["rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk                  = { workspace = true, features = ["testutils"] }
+nester-test-utils            = { path = "../../libs/test_utils" }
+nester-common                = { path = "../../libs/common" }
+nester-access-control        = { path = "../../contracts/access_control" }
+vault-contract               = { path = "../../contracts/vault" }
+vault-token-contract         = { path = "../../contracts/vault_token" }
+yield-registry-contract      = { path = "../../contracts/yield_registry" }
+allocation-strategy-contract = { path = "../../contracts/allocation_strategy" }

--- a/packages/contracts/tests/integration/src/integration/mod.rs
+++ b/packages/contracts/tests/integration/src/integration/mod.rs
@@ -1,0 +1,361 @@
+// ---------------------------------------------------------------------------
+// Nester Protocol — Multi-Contract Integration Tests
+//
+// These tests exercise interactions that cross contract boundaries, validating
+// that the contracts function correctly as a coherent system rather than in
+// isolation.
+//
+// Run with:
+//   cargo test -p nester-integration-tests
+// or via the Makefile target:
+//   make integration-test
+// ---------------------------------------------------------------------------
+
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{symbol_short, vec, Vec};
+
+use allocation_strategy_contract::AllocationWeight;
+use nester_access_control::Role;
+use nester_test_utils::NesterHarness;
+use yield_registry::ProtocolType;
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Full protocol initialisation
+// ---------------------------------------------------------------------------
+
+/// All five contracts deploy and initialise without error, and cross-references
+/// are wired correctly.
+#[test]
+fn all_contracts_initialise_cleanly() {
+    let h = NesterHarness::setup();
+
+    // Vault: not paused after initialisation.
+    assert!(!h.vault().is_paused(), "vault should not be paused after init");
+
+    // Token: supply and assets start at zero.
+    assert_eq!(h.token().total_supply(), 0);
+    assert_eq!(h.token().total_assets(), 0);
+
+    // Registry: no sources registered yet.
+    let active = h.registry().get_active_sources();
+    assert_eq!(active.len(), 0, "registry should have no sources after init");
+
+    // Strategy: no weights set yet.
+    let weights = h.strategy().get_weights();
+    assert_eq!(weights.len(), 0, "strategy should have no weights after init");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Registry + Strategy cross-contract flow
+// ---------------------------------------------------------------------------
+
+/// Register sources in the registry, then set weights in the strategy.
+/// `set_weights` performs a cross-contract call to validate that each source
+/// is active — this is the primary registry ↔ strategy integration point.
+#[test]
+fn strategy_set_weights_validates_sources_via_registry() {
+    let h = NesterHarness::setup();
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+
+    h.registry().register_source(
+        &h.admin,
+        &aave,
+        &h.create_user(), // mock contract address
+        &ProtocolType::Lending,
+    );
+    h.registry().register_source(
+        &h.admin,
+        &blend,
+        &h.create_user(),
+        &ProtocolType::Lending,
+    );
+
+    // Both sources are active; set_weights should succeed.
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: aave.clone(), weight_bps: 6_000 },
+        AllocationWeight { source_id: blend.clone(), weight_bps: 4_000 },
+    ];
+    h.strategy().set_weights(&h.admin, &weights);
+
+    let stored = h.strategy().get_weights();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap().weight_bps, 6_000);
+    assert_eq!(stored.get(1).unwrap().weight_bps, 4_000);
+}
+
+/// Weights that reference an unknown source must be rejected by the strategy
+/// (the cross-contract validation fails).
+#[test]
+#[should_panic]
+fn strategy_rejects_weights_for_unregistered_source() {
+    let h = NesterHarness::setup();
+
+    let ghost = symbol_short!("ghost");
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: ghost, weight_bps: 10_000 },
+    ];
+    h.strategy().set_weights(&h.admin, &weights); // must panic
+}
+
+/// Weights that reference a paused (inactive) source must be rejected.
+#[test]
+#[should_panic]
+fn strategy_rejects_weights_for_paused_source() {
+    let h = NesterHarness::setup();
+    use yield_registry::SourceStatus;
+
+    let aave = symbol_short!("aave");
+    h.registry().register_source(
+        &h.admin,
+        &aave,
+        &h.create_user(),
+        &ProtocolType::Lending,
+    );
+    // Pause the source so it is no longer active.
+    h.registry().update_status(&h.admin, &aave, &SourceStatus::Paused);
+
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: aave, weight_bps: 10_000 },
+    ];
+    h.strategy().set_weights(&h.admin, &weights); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — Allocation calculation
+// ---------------------------------------------------------------------------
+
+/// After setting weights, `calculate_allocation` distributes a total across
+/// sources according to their weights in basis points.
+#[test]
+fn calculate_allocation_distributes_total_proportionally() {
+    let h = NesterHarness::setup();
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+
+    h.registry().register_source(&h.admin, &aave, &h.create_user(), &ProtocolType::Lending);
+    h.registry().register_source(&h.admin, &blend, &h.create_user(), &ProtocolType::Staking);
+
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: aave.clone(), weight_bps: 7_000 },
+        AllocationWeight { source_id: blend.clone(), weight_bps: 3_000 },
+    ];
+    h.strategy().set_weights(&h.admin, &weights);
+
+    let total = 100_000_i128;
+    let allocations = h.strategy().calculate_allocation(&total);
+
+    // Sum of all allocations must equal total (including rounding remainder).
+    let sum: i128 = allocations.iter().map(|(_, a)| a).sum();
+    assert_eq!(sum, total, "allocations must sum to total");
+
+    // aave gets 70%, blend gets 30%.
+    let aave_alloc = h.strategy().get_source_allocation(&aave);
+    let blend_alloc = h.strategy().get_source_allocation(&blend);
+
+    assert_eq!(aave_alloc + blend_alloc, total);
+    assert_eq!(blend_alloc, 30_000);
+    // Rounding remainder goes to the highest-weight source (aave).
+    assert_eq!(aave_alloc, 70_000);
+}
+
+/// Three sources — validates remainder assignment with uneven division.
+#[test]
+fn calculate_allocation_assigns_remainder_to_highest_weight_source() {
+    let h = NesterHarness::setup();
+
+    let a = symbol_short!("a");
+    let b = symbol_short!("b");
+    let c = symbol_short!("c");
+
+    for id in [&a, &b, &c] {
+        h.registry().register_source(&h.admin, id, &h.create_user(), &ProtocolType::Lending);
+    }
+
+    // 33.33% each — intentionally uneven for a total of 10.
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: a.clone(), weight_bps: 3_334 },
+        AllocationWeight { source_id: b.clone(), weight_bps: 3_333 },
+        AllocationWeight { source_id: c.clone(), weight_bps: 3_333 },
+    ];
+    h.strategy().set_weights(&h.admin, &weights);
+
+    let total = 10_i128;
+    let allocations = h.strategy().calculate_allocation(&total);
+    let sum: i128 = allocations.iter().map(|(_, a)| a).sum();
+    assert_eq!(sum, total, "remainder must be fully assigned");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — Access control flow
+// ---------------------------------------------------------------------------
+
+/// Admin grants the Operator role to a new address; that operator can then
+/// call `set_weights` on the strategy.
+#[test]
+fn admin_can_grant_operator_who_can_set_weights() {
+    let h = NesterHarness::setup();
+
+    let operator = h.create_user();
+    let aave = symbol_short!("aave");
+
+    h.registry().register_source(&h.admin, &aave, &h.create_user(), &ProtocolType::Lending);
+    h.strategy().grant_role(&h.admin, &operator, &Role::Operator);
+
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: aave, weight_bps: 10_000 },
+    ];
+    // Operator should be allowed to set weights.
+    h.strategy().set_weights(&operator, &weights);
+
+    assert_eq!(h.strategy().get_weights().len(), 1);
+}
+
+/// A non-authorised address must be rejected when attempting to set weights.
+#[test]
+#[should_panic]
+fn non_operator_cannot_set_weights() {
+    let h = NesterHarness::setup();
+
+    let outsider = h.create_user();
+    let aave = symbol_short!("aave");
+
+    h.registry().register_source(&h.admin, &aave, &h.create_user(), &ProtocolType::Lending);
+
+    let weights: Vec<AllocationWeight> = vec![
+        &h.env,
+        AllocationWeight { source_id: aave, weight_bps: 10_000 },
+    ];
+    h.strategy().set_weights(&outsider, &weights); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — Vault pause / unpause
+// ---------------------------------------------------------------------------
+
+/// When the vault is paused, `deposit` and `withdraw` must be rejected.
+/// When it is unpaused, they succeed again.
+#[test]
+#[should_panic]
+fn deposit_is_rejected_when_vault_is_paused() {
+    let h = NesterHarness::setup();
+    h.vault().pause(&h.admin);
+    assert!(h.vault().is_paused());
+    h.vault().deposit(); // must panic
+}
+
+#[test]
+#[should_panic]
+fn withdraw_is_rejected_when_vault_is_paused() {
+    let h = NesterHarness::setup();
+    h.vault().pause(&h.admin);
+    h.vault().withdraw(); // must panic
+}
+
+#[test]
+fn vault_accepts_deposit_after_unpause() {
+    let h = NesterHarness::setup();
+
+    h.vault().pause(&h.admin);
+    assert!(h.vault().is_paused());
+
+    h.vault().unpause(&h.admin);
+    assert!(!h.vault().is_paused());
+
+    // deposit() stub no-ops when not paused — it must not panic here.
+    h.vault().deposit();
+}
+
+#[test]
+fn non_admin_cannot_pause_vault() {
+    use soroban_sdk::testutils::Address as _;
+
+    // Use a fresh environment with no mocked auths so the role check fires.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let env2 = soroban_sdk::Env::default();
+        let admin2  = soroban_sdk::Address::generate(&env2);
+        let outsider = soroban_sdk::Address::generate(&env2);
+
+        // Bootstrap the vault (needs mock_all_auths for initialize).
+        env2.mock_all_auths();
+        let vault_id2 = env2.register_contract(None, vault_contract::VaultContract);
+        vault_contract::VaultContractClient::new(&env2, &vault_id2).initialize(&admin2);
+
+        // Strip all mocked auths so the role guard runs normally.
+        env2.set_auths(&[]);
+        vault_contract::VaultContractClient::new(&env2, &vault_id2).pause(&outsider);
+    }));
+
+    assert!(result.is_err(), "non-admin should not be able to pause the vault");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 6 — Multi-user VaultToken share accounting
+// ---------------------------------------------------------------------------
+
+/// Two users deposit, yield accrues, and both withdraw their correct
+/// proportional amounts.  This exercises the VaultToken contract via the
+/// harness's `seed_token_balance` helper and validates the share math across
+/// multiple actors.
+#[test]
+fn two_users_receive_proportional_yield_on_withdrawal() {
+    let h = NesterHarness::setup();
+
+    let alice = h.create_user();
+    let bob = h.create_user();
+
+    // Alice deposits 10_000, Bob deposits 10_000 — equal shares.
+    h.seed_token_balance(&alice, 10_000);
+    h.seed_token_balance(&bob, 10_000);
+
+    assert_eq!(h.token().total_supply(), 20_000);
+    assert_eq!(h.token().total_assets(), 20_000);
+
+    // Simulate 20% yield: total assets grow to 24_000.
+    h.token().set_total_assets(&24_000_i128);
+
+    // Each user redeems all their shares.
+    let alice_out = h.token().burn_for_withdrawal(&alice, &10_000_i128);
+    let bob_out   = h.token().burn_for_withdrawal(&bob,   &10_000_i128);
+
+    assert_eq!(alice_out, 12_000, "alice should receive 50% of 24_000");
+    assert_eq!(bob_out,   12_000, "bob should receive 50% of remaining assets");
+    assert_eq!(h.token().total_supply(), 0);
+    assert_eq!(h.token().total_assets(), 0);
+}
+
+/// A user who deposits after yield has accrued should not capture prior yield.
+#[test]
+fn late_depositor_does_not_capture_prior_yield() {
+    let h = NesterHarness::setup();
+
+    let alice = h.create_user();
+    let bob   = h.create_user();
+
+    h.seed_token_balance(&alice, 10_000);
+    // Yield: 10_000 → 12_000
+    h.token().set_total_assets(&12_000_i128);
+
+    // Bob deposits 12_000 at the post-yield exchange rate: gets 10_000 shares.
+    h.seed_token_balance(&bob, 12_000);
+
+    // total_supply=20_000, total_assets=24_000
+    assert_eq!(h.token().total_supply(), 20_000);
+
+    let alice_out = h.token().burn_for_withdrawal(&alice, &10_000_i128);
+    assert_eq!(alice_out, 12_000, "alice earned the yield");
+
+    let bob_out = h.token().burn_for_withdrawal(&bob, &10_000_i128);
+    assert_eq!(bob_out, 12_000, "bob receives exactly what he deposited");
+}

--- a/packages/contracts/tests/integration/src/lib.rs
+++ b/packages/contracts/tests/integration/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod integration;


### PR DESCRIPTION
## Summary

Resolves all four open testing issues in a single PR.

Closes #40
Closes #41
Closes #42
Closes #23

---

## Changes

### Go backend (`apps/api`)

#### #40 — Structured logging layer (`pkg/logger/logger_test.go`)
- `newHandler` format validation (json / text / unsupported returns error)
- `parseLevel` for all valid levels; error + `slog.LevelInfo` default on bad input
- Log-level filtering (DEBUG suppressed at INFO, WARN suppressed at ERROR, etc.)
- `WithLogger` / `FromContext` round-trip; graceful fallback to `slog.Default()` when no logger in context
- `WithRequestID` / `RequestIDFromContext` round-trip + overwrite behaviour
- Sensitive-field non-emission contract (Authorization / password must not be logged automatically)
- `slog.With` field propagation and parent-logger isolation
- **20 tests, all passing**

#### #42 — API response envelope (`internal/api/`)
- New `response.go`: exported `JSON()` and `Error()` helpers with the standard `{"success":bool,...}` envelope shape
- **Bug fixed**: `omitempty` on the `data` field was silently dropping nil payloads; removed so `nil` correctly renders as `"data":null`
- 11 tests covering success/error envelopes, all standard status codes, large payloads, non-serialisable data (no panic), stack-trace non-leakage, and raw-HTML guard
- **11 tests, all passing**

#### #41 — Server / router / graceful shutdown (`internal/middleware/`, `internal/server/`)
- New `recover.go`: `RecoverPanic` middleware catches any handler panic, logs the full stack trace to the base logger (not `slog.Default()`), and writes a `500` JSON error envelope — server keeps running
- New `server.go`: `New()` wires `RecoverPanic → LimitRequestBody → Logging → mux`; health check handler; `RunWithGracefulShutdown` helper
- 12 tests: `/health` and `/healthz` return `200 {"status":"ok"}`, health returns `503` when checker fails, `404` for unknown routes, `405` for wrong method, request-ID in log output, panic → `500` (no crash), stack trace logged, subsequent requests survive a panic, in-flight request completes before server exits, new connections rejected post-shutdown
- **12 tests, all passing**

### Smart contracts (`packages/contracts`)

#### #23 — Multi-contract integration test harness
- `contracts/vault/Cargo.toml`: added `rlib` to `crate-type` so the crate can be imported by the test crate
- `libs/test_utils/src/harness.rs`: `NesterHarness::setup()` deploys all 5 contracts in a single `Env`, initialises them in dependency order with correct cross-references, and exposes typed client accessors (`vault()`, `token()`, `registry()`, `strategy()`) plus `create_user()` and `seed_token_balance()` helpers
- `tests/integration/`: new workspace crate with 14 multi-contract scenarios (see below)
- `Makefile`: added `integration-test` target (`cargo test -p nester-integration-tests --lib`)
- `TESTING.md`: documents test types, run commands, harness usage, and all 14 scenarios with descriptions

**Integration scenarios (14 tests, all passing in ~0.6 s):**

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `all_contracts_initialise_cleanly` | All 5 contracts deploy and init without error |
| 2 | `strategy_set_weights_validates_sources_via_registry` | `set_weights` performs a live cross-contract call to validate sources |
| 3 | `strategy_rejects_weights_for_unregistered_source` | Cross-contract validation rejects unknown source IDs |
| 4 | `strategy_rejects_weights_for_paused_source` | Cross-contract validation rejects paused sources |
| 5 | `calculate_allocation_distributes_total_proportionally` | Allocation math after cross-contract weight validation |
| 6 | `calculate_allocation_assigns_remainder_to_highest_weight_source` | No funds lost on rounding |
| 7 | `admin_can_grant_operator_who_can_set_weights` | RBAC: granted operator can call set_weights |
| 8 | `non_operator_cannot_set_weights` | RBAC: unauthorised address is rejected |
| 9 | `deposit_is_rejected_when_vault_is_paused` | Vault pause blocks deposits |
| 10 | `withdraw_is_rejected_when_vault_is_paused` | Vault pause blocks withdrawals |
| 11 | `vault_accepts_deposit_after_unpause` | Unpause restores deposit functionality |
| 12 | `non_admin_cannot_pause_vault` | Non-admin cannot pause the vault |
| 13 | `two_users_receive_proportional_yield_on_withdrawal` | Share math across multiple users with yield |
| 14 | `late_depositor_does_not_capture_prior_yield` | Late depositor does not retroactively earn prior yield |

## Test plan

```bash
# Go — all four new packages
go test ./pkg/logger/... ./internal/api/... ./internal/server/... ./internal/middleware/...

# Rust — integration tests only
cd packages/contracts && make integration-test

# Rust — full suite including unit tests
cd packages/contracts && make test
```