### PR TITLE
Enhance settlement service tests and update integration migrations

### DIFF
--- a/apps/api/internal/domain/offramp/model_test.go
+++ b/apps/api/internal/domain/offramp/model_test.go
@@ -1,0 +1,92 @@
+package offramp
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseStatus_ValidStatuses(t *testing.T) {
+	for _, raw := range []string{
+		string(StatusInitiated),
+		string(StatusLiquidityMatched),
+		string(StatusFiatDispatched),
+		string(StatusConfirmed),
+		string(StatusFailed),
+	} {
+		t.Run(raw, func(t *testing.T) {
+			s, err := ParseStatus(raw)
+			if err != nil {
+				t.Fatalf("ParseStatus(%q) error = %v", raw, err)
+			}
+			if s != SettlementStatus(raw) {
+				t.Fatalf("got %q, want %q", s, raw)
+			}
+		})
+	}
+}
+
+func TestParseStatus_Invalid(t *testing.T) {
+	for _, raw := range []string{"", "pending", "settled", "refunded", "nonsense"} {
+		name := raw
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseStatus(raw)
+			if err != ErrInvalidStatus {
+				t.Fatalf("ParseStatus(%q) want ErrInvalidStatus, got %v", raw, err)
+			}
+		})
+	}
+}
+
+func TestSettlement_CanTransitionTo_AllValidEdges(t *testing.T) {
+	cases := []struct {
+		from SettlementStatus
+		to   SettlementStatus
+	}{
+		{StatusInitiated, StatusLiquidityMatched},
+		{StatusInitiated, StatusFailed},
+		{StatusLiquidityMatched, StatusFiatDispatched},
+		{StatusLiquidityMatched, StatusFailed},
+		{StatusFiatDispatched, StatusConfirmed},
+		{StatusFiatDispatched, StatusFailed},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s_to_%s", c.from, c.to), func(t *testing.T) {
+			s := Settlement{Status: c.from}
+			if !s.CanTransitionTo(c.to) {
+				t.Fatalf("expected valid transition %q -> %q", c.from, c.to)
+			}
+		})
+	}
+}
+
+func TestSettlement_CanTransitionTo_InvalidTransitionsRejected(t *testing.T) {
+	cases := []struct {
+		from SettlementStatus
+		to   SettlementStatus
+	}{
+		{StatusInitiated, StatusInitiated},
+		{StatusInitiated, StatusFiatDispatched},
+		{StatusInitiated, StatusConfirmed},
+		{StatusLiquidityMatched, StatusInitiated},
+		{StatusLiquidityMatched, StatusConfirmed},
+		{StatusFiatDispatched, StatusInitiated},
+		{StatusFiatDispatched, StatusLiquidityMatched},
+		{StatusConfirmed, StatusInitiated},
+		{StatusConfirmed, StatusFailed},
+		{StatusFailed, StatusInitiated},
+		{StatusFailed, StatusConfirmed},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s_to_%s", c.from, c.to), func(t *testing.T) {
+			s := Settlement{Status: c.from}
+			if s.CanTransitionTo(c.to) {
+				t.Fatalf("expected invalid transition %q -> %q", c.from, c.to)
+			}
+		})
+	}
+}

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -1,0 +1,300 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+type settlementStubRepo struct {
+	data map[uuid.UUID]*offramp.Settlement
+}
+
+func newSettlementStubRepo() *settlementStubRepo {
+	return &settlementStubRepo{data: make(map[uuid.UUID]*offramp.Settlement)}
+}
+
+func (r *settlementStubRepo) Create(_ context.Context, model offramp.Settlement) (offramp.Settlement, error) {
+	model.CreatedAt = time.Now().UTC()
+	cp := model
+	r.data[model.ID] = &cp
+	return cp, nil
+}
+
+func (r *settlementStubRepo) GetByID(_ context.Context, id uuid.UUID) (offramp.Settlement, error) {
+	s, ok := r.data[id]
+	if !ok {
+		return offramp.Settlement{}, offramp.ErrSettlementNotFound
+	}
+	return *s, nil
+}
+
+func (r *settlementStubRepo) GetByUserID(_ context.Context, userID uuid.UUID, filter offramp.SettlementStatus) ([]offramp.Settlement, error) {
+	var out []offramp.Settlement
+	for _, s := range r.data {
+		if s.UserID != userID {
+			continue
+		}
+		if filter != "" && s.Status != filter {
+			continue
+		}
+		out = append(out, *s)
+	}
+	return out, nil
+}
+
+func (r *settlementStubRepo) UpdateStatus(_ context.Context, id uuid.UUID, status offramp.SettlementStatus, completedAt *time.Time) error {
+	s, ok := r.data[id]
+	if !ok {
+		return offramp.ErrSettlementNotFound
+	}
+	s.Status = status
+	s.CompletedAt = completedAt
+	return nil
+}
+
+func validSettlementJSONBody(userID, vaultID uuid.UUID) string {
+	return `{
+		"user_id":"` + userID.String() + `",
+		"vault_id":"` + vaultID.String() + `",
+		"amount":"100.00",
+		"currency":"USDC",
+		"fiat_currency":"NGN",
+		"fiat_amount":"150000.00",
+		"exchange_rate":"1500.00",
+		"destination":{
+			"type":"bank_transfer",
+			"provider":"bank",
+			"account_number":"0123456789",
+			"account_name":"Test User",
+			"bank_code":"058"
+		}
+	}`
+}
+
+func TestSettlementHandler_PostCreates201(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	defer server.Close()
+
+	resp, err := http.Post(
+		server.URL+"/api/v1/settlements",
+		"application/json",
+		bytes.NewBufferString(validSettlementJSONBody(userID, vaultID)),
+	)
+	if err != nil {
+		t.Fatalf("POST settlements: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+	var body offramp.Settlement
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != offramp.StatusInitiated {
+		t.Fatalf("want initiated, got %s", body.Status)
+	}
+}
+
+func TestSettlementHandler_PostInvalidBody400(t *testing.T) {
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/api/v1/settlements", "application/json", bytes.NewBufferString(`{`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400 for invalid JSON, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettlementHandler_PostDomainValidation400(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// bank_transfer without bank_code
+	bad := `{
+		"user_id":"` + userID.String() + `",
+		"vault_id":"` + vaultID.String() + `",
+		"amount":"100.00",
+		"currency":"USDC",
+		"fiat_currency":"NGN",
+		"fiat_amount":"150000.00",
+		"exchange_rate":"1500.00",
+		"destination":{"type":"bank_transfer","provider":"bank","account_number":"1","account_name":"x","bank_code":""}
+	}`
+	resp, err := http.Post(server.URL+"/api/v1/settlements", "application/json", bytes.NewBufferString(bad))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400 for invalid settlement, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettlementHandler_Get200And404(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+	repo := newSettlementStubRepo()
+	svc := service.NewSettlementService(repo)
+	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
+		UserID:       userID,
+		VaultID:      vaultID,
+		Amount:       decimal.RequireFromString("10"),
+		Currency:     "USDC",
+		FiatCurrency: "NGN",
+		FiatAmount:   decimal.RequireFromString("100"),
+		ExchangeRate: decimal.RequireFromString("10"),
+		Destination: offramp.Destination{
+			Type:          "mobile_money",
+			Provider:      "mpesa",
+			AccountNumber: "0712345678",
+			AccountName:   "Jane",
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitiateSettlement: %v", err)
+	}
+
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/settlements/" + created.ID.String())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	resp404, err := http.Get(server.URL + "/api/v1/settlements/" + uuid.New().String())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp404.Body.Close()
+	if resp404.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp404.StatusCode)
+	}
+}
+
+func TestSettlementHandler_PatchStatus200(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
+		UserID:       userID,
+		VaultID:      vaultID,
+		Amount:       decimal.RequireFromString("10"),
+		Currency:     "USDC",
+		FiatCurrency: "NGN",
+		FiatAmount:   decimal.RequireFromString("100"),
+		ExchangeRate: decimal.RequireFromString("10"),
+		Destination: offramp.Destination{
+			Type:          "mobile_money",
+			Provider:      "mpesa",
+			AccountNumber: "0712345678",
+			AccountName:   "Jane",
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitiateSettlement: %v", err)
+	}
+
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"status":"liquidity_matched"}`)
+	req, err := http.NewRequest(http.MethodPatch, server.URL+"/api/v1/settlements/"+created.ID.String()+"/status", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var out offramp.Settlement
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Status != offramp.StatusLiquidityMatched {
+		t.Fatalf("want liquidity_matched, got %s", out.Status)
+	}
+}
+
+func TestSettlementHandler_ListUserSettlementsWithStatus(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	_, err := http.Post(server.URL+"/api/v1/settlements", "application/json", bytes.NewBufferString(validSettlementJSONBody(userID, vaultID)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+
+	resp, err := http.Get(server.URL + "/api/v1/users/" + userID.String() + "/settlements?status=initiated")
+	if err != nil {
+		t.Fatalf("GET list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var list []offramp.Settlement
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 settlement, got %d", len(list))
+	}
+}

--- a/apps/api/internal/repository/postgres/settlement_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/settlement_repository_integration_test.go
@@ -1,0 +1,147 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
+)
+
+func TestSettlementRepositoryIntegration_CreateGetUpdateAndFilter(t *testing.T) {
+	db := openIntegrationDB(t)
+	applyIntegrationMigrations(t, db)
+	resetIntegrationTables(t, db)
+
+	repo := NewSettlementRepository(db)
+	ctx := context.Background()
+	userID := seedIntegrationUser(t, db)
+	vaultID := seedIntegrationVault(t, db, userID)
+
+	dest := offramp.Destination{
+		Type:          "bank_transfer",
+		Provider:      "bank",
+		AccountNumber: "0123456789",
+		AccountName:   "Ada Lovelace",
+		BankCode:      "058",
+	}
+
+	model := offramp.Settlement{
+		ID:           uuid.New(),
+		UserID:       userID,
+		VaultID:      vaultID,
+		Amount:       decimal.RequireFromString("100.5"),
+		Currency:     "USDC",
+		FiatCurrency: "NGN",
+		FiatAmount:   decimal.RequireFromString("150000"),
+		ExchangeRate: decimal.RequireFromString("1492.5373"),
+		Destination:  dest,
+		Status:       offramp.StatusInitiated,
+	}
+
+	created, err := repo.Create(ctx, model)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.CreatedAt.IsZero() {
+		t.Fatal("expected created_at from DB")
+	}
+	if created.ID != model.ID {
+		t.Fatalf("ID mismatch")
+	}
+	if created.Destination.BankCode != "058" {
+		t.Fatalf("bank_code mismatch")
+	}
+
+	fetched, err := repo.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if !fetched.Amount.Equal(model.Amount) || fetched.FiatCurrency != "NGN" {
+		t.Fatalf("round-trip fields mismatch: %+v", fetched)
+	}
+
+	if err := repo.UpdateStatus(ctx, created.ID, offramp.StatusLiquidityMatched, nil); err != nil {
+		t.Fatalf("UpdateStatus(liquidity_matched) error = %v", err)
+	}
+	mid, _ := repo.GetByID(ctx, created.ID)
+	if mid.Status != offramp.StatusLiquidityMatched || mid.CompletedAt != nil {
+		t.Fatalf("expected liquidity_matched without completed_at, got %+v", mid)
+	}
+
+	completed := time.Now().UTC()
+	if err := repo.UpdateStatus(ctx, created.ID, offramp.StatusConfirmed, &completed); err != nil {
+		t.Fatalf("UpdateStatus(confirmed) error = %v", err)
+	}
+	done, _ := repo.GetByID(ctx, created.ID)
+	if done.Status != offramp.StatusConfirmed || done.CompletedAt == nil {
+		t.Fatalf("expected confirmed with completed_at, got %+v", done)
+	}
+	if done.CompletedAt.IsZero() {
+		t.Fatal("completed_at should be set for confirmed")
+	}
+
+	// second settlement same user, stays initiated
+	model2 := model
+	model2.ID = uuid.New()
+	if _, err := repo.Create(ctx, model2); err != nil {
+		t.Fatalf("Create second error = %v", err)
+	}
+
+	all, err := repo.GetByUserID(ctx, userID, "")
+	if err != nil || len(all) != 2 {
+		t.Fatalf("GetByUserID all: err=%v len=%d", err, len(all))
+	}
+	initiatedOnly, err := repo.GetByUserID(ctx, userID, offramp.StatusInitiated)
+	if err != nil || len(initiatedOnly) != 1 {
+		t.Fatalf("GetByUserID initiated: err=%v len=%d", err, len(initiatedOnly))
+	}
+	if initiatedOnly[0].ID != model2.ID {
+		t.Fatalf("wrong settlement in initiated filter")
+	}
+}
+
+func TestSettlementRepositoryIntegration_NotFound(t *testing.T) {
+	db := openIntegrationDB(t)
+	applyIntegrationMigrations(t, db)
+	resetIntegrationTables(t, db)
+
+	repo := NewSettlementRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.GetByID(ctx, uuid.New())
+	if !errors.Is(err, offramp.ErrSettlementNotFound) {
+		t.Fatalf("GetByID unknown: want ErrSettlementNotFound, got %v", err)
+	}
+
+	err = repo.UpdateStatus(ctx, uuid.New(), offramp.StatusFailed, nil)
+	if !errors.Is(err, offramp.ErrSettlementNotFound) {
+		t.Fatalf("UpdateStatus unknown id: want ErrSettlementNotFound, got %v", err)
+	}
+}
+
+func seedIntegrationVault(t *testing.T, db *sql.DB, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	vaultID := uuid.New()
+	_, err := db.ExecContext(
+		context.Background(),
+		`INSERT INTO vaults (id, user_id, contract_address, total_deposited, current_balance, currency, status)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		vaultID.String(),
+		userID.String(),
+		"CA-SETTLE-INT",
+		"0",
+		"0",
+		"USDC",
+		"active",
+	)
+	if err != nil {
+		t.Fatalf("seed vault: %v", err)
+	}
+	return vaultID
+}

--- a/apps/api/internal/repository/postgres/vault_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_integration_test.go
@@ -225,6 +225,7 @@ func applyIntegrationMigrations(t *testing.T, db *sql.DB) {
 		"001_create_users_table.up.sql",
 		"004_create_vaults_table.up.sql",
 		"005_create_allocations_table.up.sql",
+		"006_create_settlements_table.up.sql",
 	} {
 		path := filepath.Join("..", "..", "..", "migrations", name)
 		contents, err := os.ReadFile(path)
@@ -240,7 +241,7 @@ func applyIntegrationMigrations(t *testing.T, db *sql.DB) {
 func resetIntegrationTables(t *testing.T, db *sql.DB) {
 	t.Helper()
 
-	if _, err := db.Exec(`TRUNCATE TABLE allocations, vaults, users RESTART IDENTITY CASCADE`); err != nil {
+	if _, err := db.Exec(`TRUNCATE TABLE settlements, allocations, vaults, users RESTART IDENTITY CASCADE`); err != nil {
 		t.Fatalf("TRUNCATE failed: %v", err)
 	}
 }

--- a/apps/api/internal/service/settlement_service_test.go
+++ b/apps/api/internal/service/settlement_service_test.go
@@ -147,6 +147,28 @@ func TestInitiateSettlement_ZeroAmountReturnsError(t *testing.T) {
 	}
 }
 
+func TestInitiateSettlement_EmptyCurrencyReturnsError(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+	in.Currency = "   "
+
+	_, err := svc.InitiateSettlement(context.Background(), in)
+	if !errors.Is(err, offramp.ErrInvalidSettlement) {
+		t.Errorf("expected ErrInvalidSettlement, got %v", err)
+	}
+}
+
+func TestInitiateSettlement_EmptyAccountNumberReturnsError(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	in := validInput()
+	in.Destination.AccountNumber = ""
+
+	_, err := svc.InitiateSettlement(context.Background(), in)
+	if !errors.Is(err, offramp.ErrInvalidSettlement) {
+		t.Errorf("expected ErrInvalidSettlement, got %v", err)
+	}
+}
+
 func TestInitiateSettlement_BankTransferRequiresBankCode(t *testing.T) {
 	svc := service.NewSettlementService(newStubRepo())
 	in := validInput()
@@ -288,6 +310,25 @@ func TestUpdateStatus_FullLifecycleToFailed(t *testing.T) {
 	}
 	if updated.CompletedAt == nil {
 		t.Error("failed settlement should have completed_at set")
+	}
+}
+
+func TestUpdateStatus_FailedAfterLiquidityMatched(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusLiquidityMatched})
+
+	updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		NewStatus:    offramp.StatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Status != offramp.StatusFailed {
+		t.Errorf("want failed, got %s", updated.Status)
 	}
 }
 


### PR DESCRIPTION
Closes #48

---

## Summary

This work adds automated test coverage for the offramp settlement flow as implemented in the Nester API: the domain state machine (`offramp` package), the settlement service layer, HTTP handlers, and the Postgres settlement repository. Tests follow the actual product model and routes (e.g. `initiated` → `liquidity_matched` → `fiat_dispatched` → `confirmed`, and `/api/v1/settlements` endpoints), not the alternate naming used in the original issue text.

## Changes

- **`internal/domain/offramp/model_test.go`** — Unit tests for `ParseStatus` (valid and invalid values) and `CanTransitionTo` over all allowed edges and a representative set of disallowed transitions.
- **`internal/service/settlement_service_test.go`** — Additional cases: empty currency, empty destination account number, and failure after `liquidity_matched` (alongside existing initiate/get/list/update tests).
- **`internal/handler/settlement_handler_test.go`** — Handler tests with an in-memory stub repository: `POST` create (201), invalid JSON and domain validation (400), `GET` by id (200/404), `PATCH` status (200), and user settlement list with `status` query.
- **`internal/repository/postgres/settlement_repository_integration_test.go`** — Integration tests for create/round-trip fields, `UpdateStatus` and `completed_at`, `GetByUserID` with status filter, and not-found behavior (skipped when `TEST_DATABASE_DSN` is unset).
- **`internal/repository/postgres/vault_repository_integration_test.go`** — Applies migration `006_create_settlements_table.up.sql` and extends `TRUNCATE` so settlement integration tests run against a consistent schema.

## Notes

- Run from `apps/api`: `go test ./...` or scope tests to `internal/domain/offramp`, `internal/service`, `internal/handler`, and `internal/repository/postgres`.
- The issue mentioned paths such as `./internal/offramp/...`, `/offramp/quote`, and a `refunded` state; those do not exist in the current codebase, so tests were written against the implemented contracts only.

I remain open to any corrections or feedback you may have.