### PR TITLE
feat: add contract version query function

### DIFF
--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, panic_with_error, symbol_short, token, Address, Env,
-    IntoVal, Symbol,
+    IntoVal, String, Symbol,
 };
 
 use nester_access_control::{AccessControl, Role};
@@ -677,6 +677,11 @@ impl VaultContract {
 
     pub fn get_circuit_breaker_config(env: Env) -> CircuitBreakerConfig {
         env.storage().instance().get(&DataKey::CircuitBreakerConfig).expect("CB config missing")
+    }
+
+    /// Return the contract version string.
+    pub fn version(env: Env) -> String {
+        String::from_str(&env, "1.0.0")
     }
 }
 

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -6,7 +6,7 @@ use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token::{StellarAssetClient, TokenClient},
-    Address, Env,
+    Address, Env, String,
 };
 use nester_access_control::Role;
 
@@ -469,4 +469,10 @@ fn test_emergency_withdraw() {
     assert_eq!(returned, 1000);
     assert_eq!(client.get_shares(&user), 0);
     assert_eq!(client.get_total_deposits(), 0);
+}
+
+#[test]
+fn test_version() {
+    let (env, _admin, _token_address, _contract_id, client) = setup();
+    assert_eq!(client.version(), String::from_str(&env, "1.0.0"));
 }


### PR DESCRIPTION
## Summary
- Added `version()` function to the vault contract that returns `"1.0.0"`
- Enables external systems to identify the deployed contract version
- Includes unit test verifying the return value

Closes #161

## Test plan
- [x] `cargo test --lib -p vault-contract` — all 28 tests pass (27 existing + 1 new `test_version`)
- [x] No warnings during compilation