### PR TITLE
feat: add contribute function with require_auth

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -863,6 +863,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rent-escrow-contract"
+version = "0.1.0"
+dependencies = [
+ "nester-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/packages/contracts/contracts/rent_escrow/Cargo.toml
+++ b/packages/contracts/contracts/rent_escrow/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rent-escrow-contract"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+nester-common = { path = "../../libs/common" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/contracts/rent_escrow/src/lib.rs
+++ b/packages/contracts/contracts/rent_escrow/src/lib.rs
@@ -1,0 +1,173 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, panic_with_error, symbol_short, token, Address, Env,
+    Symbol,
+};
+
+use nester_common::ContractError;
+
+const ESCROW: Symbol = symbol_short!("ESCROW");
+const CONTRIB: Symbol = symbol_short!("CONTRIB");
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Token,
+    Landlord,
+    RentTarget,
+    Contribution(Address),
+    TotalContributions,
+    Released,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_initialized(env: &Env) {
+    if !env.storage().instance().has(&DataKey::Token) {
+        panic_with_error!(env, ContractError::NotInitialized);
+    }
+}
+
+fn get_contribution(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Contribution(user.clone()))
+        .unwrap_or(0)
+}
+
+fn set_contribution(env: &Env, user: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Contribution(user.clone()), &amount);
+}
+
+fn get_total(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalContributions)
+        .unwrap_or(0)
+}
+
+fn set_total(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalContributions, &amount);
+}
+
+fn get_rent_target(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RentTarget)
+        .unwrap_or(0)
+}
+
+fn is_released(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Released)
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct RentEscrowContract;
+
+#[contractimpl]
+impl RentEscrowContract {
+    /// Initialize the rent escrow agreement.
+    pub fn initialize(env: Env, landlord: Address, token_address: Address, rent_target: i128) {
+        if env.storage().instance().has(&DataKey::Token) {
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+
+        landlord.require_auth();
+
+        if rent_target <= 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Token, &token_address);
+        env.storage()
+            .instance()
+            .set(&DataKey::Landlord, &landlord);
+        env.storage()
+            .instance()
+            .set(&DataKey::RentTarget, &rent_target);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalContributions, &0_i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::Released, &false);
+    }
+
+    /// Contribute tokens toward the rent target.
+    pub fn contribute(env: Env, from: Address, amount: i128) {
+        require_initialized(&env);
+        from.require_auth();
+
+        if is_released(&env) {
+            panic_with_error!(&env, ContractError::InvalidOperation);
+        }
+
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+
+        let token_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+        let contract_address = env.current_contract_address();
+
+        token::Client::new(&env, &token_address).transfer(&from, &contract_address, &amount);
+
+        let new_contribution = get_contribution(&env, &from) + amount;
+        set_contribution(&env, &from, new_contribution);
+
+        let new_total = get_total(&env) + amount;
+        set_total(&env, new_total);
+
+        env.events().publish((ESCROW, CONTRIB, from), amount);
+    }
+
+    // -----------------------------------------------------------------------
+    // View functions
+    // -----------------------------------------------------------------------
+
+    pub fn get_contribution(env: Env, user: Address) -> i128 {
+        require_initialized(&env);
+        get_contribution(&env, &user)
+    }
+
+    pub fn get_total_contributions(env: Env) -> i128 {
+        require_initialized(&env);
+        get_total(&env)
+    }
+
+    pub fn get_rent_target(env: Env) -> i128 {
+        require_initialized(&env);
+        get_rent_target(&env)
+    }
+
+    pub fn is_released(env: Env) -> bool {
+        require_initialized(&env);
+        is_released(&env)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/packages/contracts/contracts/rent_escrow/src/test.rs
+++ b/packages/contracts/contracts/rent_escrow/src/test.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    Address, Env,
+};
+
+fn setup(rent_target: i128) -> (Env, Address, Address, Address, RentEscrowContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let landlord = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+    let contract_id = env.register_contract(None, RentEscrowContract);
+    let client = RentEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&landlord, &token_address, &rent_target);
+
+    (env, landlord, token_address, contract_id, client)
+}
+
+fn mint_tokens(env: &Env, token_address: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token_address).mint(to, &amount);
+}
+
+#[test]
+fn test_initialize() {
+    let (_env, _landlord, _token, _contract_id, client) = setup(3_000);
+
+    assert_eq!(client.get_rent_target(), 3_000);
+    assert_eq!(client.get_total_contributions(), 0);
+    assert!(!client.is_released());
+}
+
+#[test]
+fn test_contribute() {
+    let (env, _landlord, token_address, contract_id, client) = setup(3_000);
+    let user = Address::generate(&env);
+
+    mint_tokens(&env, &token_address, &user, 5_000);
+    client.contribute(&user, &1_000);
+
+    assert_eq!(client.get_contribution(&user), 1_000);
+    assert_eq!(client.get_total_contributions(), 1_000);
+
+    let token = TokenClient::new(&env, &token_address);
+    assert_eq!(token.balance(&user), 4_000);
+    assert_eq!(token.balance(&contract_id), 1_000);
+}
+
+#[test]
+fn test_contribute_multiple_users() {
+    let (env, _landlord, token_address, _contract_id, client) = setup(3_000);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    mint_tokens(&env, &token_address, &user1, 5_000);
+    mint_tokens(&env, &token_address, &user2, 5_000);
+
+    client.contribute(&user1, &1_000);
+    client.contribute(&user2, &2_000);
+
+    assert_eq!(client.get_contribution(&user1), 1_000);
+    assert_eq!(client.get_contribution(&user2), 2_000);
+    assert_eq!(client.get_total_contributions(), 3_000);
+}
+
+#[test]
+fn test_contribute_zero_fails() {
+    let (env, _landlord, token_address, _contract_id, client) = setup(3_000);
+    let user = Address::generate(&env);
+    mint_tokens(&env, &token_address, &user, 5_000);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.contribute(&user, &0);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_contribute_negative_fails() {
+    let (env, _landlord, _token_address, _contract_id, client) = setup(3_000);
+    let user = Address::generate(&env);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.contribute(&user, &-100);
+    }));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- Created `rent-escrow` contract with `initialize` and `contribute` functions
- Enforced authorization using `require_auth()` on the `contribute` function
- Added per-user contribution tracking and total accumulation

## Test plan
- [x] `cargo test -p rent-escrow-contract` passes (5 tests)
- [ ] CI workflows pass

Closes #370