### PR TITLE
revert(dev): remove netlify.toml so per-site dashboard configs apply

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  base    = "apps/dapp/frontend"
-  command = "npm run build"
-  publish = ".next"
-
-[build.environment]
-  NODE_VERSION = "22"


### PR DESCRIPTION
The netlify.toml at repo root was re-introduced via merge from main and forces base=apps/dapp/frontend for any Netlify site building from dev, which broke the website deployment. Dev intentionally relies on per-project dashboard settings (see 0e19e7f).