### PR TITLE
fix(dapp): fall back to mock soroban flow when vault contract IDs unset

### DIFF
--- a/apps/dapp/frontend/app/savings/page.tsx
+++ b/apps/dapp/frontend/app/savings/page.tsx
@@ -23,11 +23,7 @@ import { usePortfolio } from "@/components/portfolio-provider";
 import { cn } from "@/lib/utils";
 import { PositionCards } from "@/components/position-cards";
 import {
-    buildDepositTransaction,
-    signTransaction,
-    submitTransaction,
-    VAULT_CONTRACT_ID,
-    VAULT_XLM_CONTRACT_ID,
+    executeVaultDeposit,
     UserRejectedError,
     TransactionFailedError,
     TransactionTimeoutError,
@@ -519,22 +515,13 @@ function DepositModal({
                                     if (!vault || !canSubmit || !address) return;
                                     setErrorMsg("");
                                     try {
-                                        const contractId = selectedAsset === "XLM"
-                                            ? (VAULT_XLM_CONTRACT_ID || `mock_${vault.id}_xlm`)
-                                            : (VAULT_CONTRACT_ID || `mock_${vault.id}`);
-
                                         setTxState("building");
-                                        const { xdr } = await buildDepositTransaction({
+                                        const receipt = await executeVaultDeposit({
                                             walletAddress: address,
-                                            contractId,
+                                            vaultId: vault.id,
+                                            asset: selectedAsset,
                                             amount: parsedAmount,
                                         });
-
-                                        setTxState("signing");
-                                        const signedXdr = await signTransaction(xdr);
-
-                                        setTxState("submitting");
-                                        const receipt = await submitTransaction(signedXdr);
 
                                         setTxHash(receipt.txHash);
                                         setTxState("success");

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -18,11 +18,7 @@ import { useWallet } from "@/components/wallet-provider";
 import { cn } from "@/lib/utils";
 import { type Vault as VaultDefinition, type MarketStrategy } from "@/lib/mock-vaults";
 import {
-  buildDepositTransaction,
-  signTransaction,
-  submitTransaction,
-  VAULT_CONTRACT_ID,
-  VAULT_XLM_CONTRACT_ID,
+  executeVaultDeposit,
   UserRejectedError,
   TransactionFailedError,
   TransactionTimeoutError,
@@ -231,25 +227,13 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
     setErrorMsg("");
 
     try {
-      // Step 1 — Build
       setState("building");
-      const vaultContractId = selectedAsset === "XLM"
-        ? (VAULT_XLM_CONTRACT_ID || `mock_${vault.id}_xlm`)
-        : (VAULT_CONTRACT_ID || `mock_${vault.id}`);
-
-      const { xdr } = await buildDepositTransaction({
+      const txReceipt = await executeVaultDeposit({
         walletAddress: address,
-        contractId: vaultContractId,
+        vaultId: vault.id,
+        asset: selectedAsset,
         amount,
       });
-
-      // Step 2 — Sign
-      setState("signing");
-      const signedXdr = await signTransaction(xdr);
-
-      // Step 3 — Submit
-      setState("submitting");
-      const txReceipt = await submitTransaction(signedXdr);
 
       // Record in portfolio state
       recordDeposit({

--- a/apps/dapp/frontend/components/vault/withdrawModal.tsx
+++ b/apps/dapp/frontend/components/vault/withdrawModal.tsx
@@ -20,11 +20,7 @@ import {
 import { useWallet } from "@/components/wallet-provider";
 import { cn } from "@/lib/utils";
 import {
-  buildWithdrawTransaction,
-  signTransaction,
-  submitTransaction,
-  VAULT_CONTRACT_ID,
-  VAULT_XLM_CONTRACT_ID,
+  executeVaultWithdraw,
   UserRejectedError,
   TransactionFailedError,
   TransactionTimeoutError,
@@ -188,25 +184,13 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
     setErrorMsg("");
 
     try {
-      // Step 1 — Build
       setState("building");
-      const isXlm = position.asset?.toUpperCase() === "XLM";
-      const contractId = isXlm
-        ? (VAULT_XLM_CONTRACT_ID || `mock_${position.vaultId}_xlm`)
-        : (VAULT_CONTRACT_ID || `mock_${position.vaultId}`);
-      const { xdr } = await buildWithdrawTransaction({
+      const txReceipt = await executeVaultWithdraw({
         walletAddress: address,
-        contractId,
+        vaultId: position.vaultId,
+        asset: position.asset?.toUpperCase() === "XLM" ? "XLM" : "USDC",
         shares: quote.sharesBurned,
       });
-
-      // Step 2 — Sign
-      setState("signing");
-      const signedXdr = await signTransaction(xdr);
-
-      // Step 3 — Submit
-      setState("submitting");
-      const txReceipt = await submitTransaction(signedXdr);
 
       const result = recordWithdrawal({
         positionId: position.id,

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -296,6 +296,69 @@ export async function submitTransaction(
   throw new TransactionTimeoutError();
 }
 
+// ── High-level vault flows (auto-fallback to mock) ───────────────────────────
+
+function isRealContractId(id: string): boolean {
+  return /^C[A-Z0-9]{55}$/.test(id);
+}
+
+function resolveVaultContractId(asset: "USDC" | "XLM"): string {
+  return asset === "XLM" ? VAULT_XLM_CONTRACT_ID : VAULT_CONTRACT_ID;
+}
+
+async function runMockFlow(
+  walletAddress: string,
+  memo: string
+): Promise<TransactionReceipt> {
+  const { buildMockTransactionXdr, signWithWalletOrMock, simulateSubmission } =
+    await import("@/lib/mock-soroban");
+  const network = getCurrentNetwork();
+  const xdr = await buildMockTransactionXdr(
+    walletAddress,
+    memo,
+    network.networkPassphrase
+  );
+  await signWithWalletOrMock(xdr, network.networkPassphrase);
+  const submission = await simulateSubmission(network.explorerUrl);
+  return { txHash: submission.txHash, explorerUrl: submission.explorerUrl, ledger: 0 };
+}
+
+export async function executeVaultDeposit(params: {
+  walletAddress: string;
+  vaultId: string;
+  asset: "USDC" | "XLM";
+  amount: number;
+}): Promise<TransactionReceipt> {
+  const { walletAddress, vaultId, asset, amount } = params;
+  const contractId = resolveVaultContractId(asset);
+
+  if (!isRealContractId(contractId)) {
+    return runMockFlow(walletAddress, `deposit:${vaultId}:${amount.toFixed(2)}`);
+  }
+
+  const { xdr } = await buildDepositTransaction({ walletAddress, contractId, amount });
+  const signedXdr = await signTransaction(xdr);
+  return submitTransaction(signedXdr);
+}
+
+export async function executeVaultWithdraw(params: {
+  walletAddress: string;
+  vaultId: string;
+  asset: "USDC" | "XLM";
+  shares: number;
+}): Promise<TransactionReceipt> {
+  const { walletAddress, vaultId, asset, shares } = params;
+  const contractId = resolveVaultContractId(asset);
+
+  if (!isRealContractId(contractId)) {
+    return runMockFlow(walletAddress, `withdraw:${vaultId}:${shares.toFixed(2)}`);
+  }
+
+  const { xdr } = await buildWithdrawTransaction({ walletAddress, contractId, shares });
+  const signedXdr = await signTransaction(xdr);
+  return submitTransaction(signedXdr);
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
Deposits/withdrawals from savings, markets, and stocks pages were crashing with 'Invalid contract ID: mock_<id>' because the modals passed a fake string into new Contract() when NEXT_PUBLIC_VAULT_* env vars weren't configured.

Introduces executeVaultDeposit/executeVaultWithdraw helpers that detect a real Soroban contract ID (C... 56 chars) and otherwise route through the existing mock-soroban flow. The modals now call these helpers instead of constructing contract IDs inline.