### PR TITLE
fix(website): route Nester for Web button based on runtime hostname

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -1,11 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  env: {
-    NEXT_PUBLIC_DAPP_URL:
-      process.env.NEXT_PUBLIC_DAPP_URL ??
-      (process.env.NETLIFY ? "https://nesterdapp.netlify.app" : "http://localhost:3001"),
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/apps/website/src/components/navbar.tsx
+++ b/apps/website/src/components/navbar.tsx
@@ -18,8 +18,21 @@ const navLinks = [
     { name: "Docs", href: "/docs", newTab: true },
 ]
 
+const PROD_DAPP_URL = "https://nesterdapp.netlify.app"
+const LOCAL_DAPP_URL = "http://localhost:3001"
+
+function useDappUrl() {
+    const [url, setUrl] = React.useState(PROD_DAPP_URL)
+    React.useEffect(() => {
+        const host = window.location.hostname
+        setUrl(host === "localhost" || host === "127.0.0.1" ? LOCAL_DAPP_URL : PROD_DAPP_URL)
+    }, [])
+    return url
+}
+
 export function Navbar() {
     const [isScrolled, setIsScrolled] = React.useState(false)
+    const dappUrl = useDappUrl()
 
     React.useEffect(() => {
         const handleScroll = () => {
@@ -55,7 +68,7 @@ export function Navbar() {
                             </Link>
                         ))}
                     </div>
-                    <Link href={process.env.NEXT_PUBLIC_DAPP_URL ?? "http://localhost:3001"} target="_blank">
+                    <Link href={dappUrl} target="_blank">
                         <Button
                             className="bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full px-6 font-medium text-sm transition-all shadow-none"
                         >
@@ -87,7 +100,7 @@ export function Navbar() {
                                 ))}
                             </div>
                             <div className="mt-auto mb-8">
-                                <Link href={process.env.NEXT_PUBLIC_DAPP_URL ?? "http://localhost:3001"} target="_blank" className="w-full">
+                                <Link href={dappUrl} target="_blank" className="w-full">
                                     <Button className="w-full bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full">
                                         Nester for Web
                                     </Button>


### PR DESCRIPTION
Previously the button URL was baked at build time via next.config.ts env block, which was unreliable — local dev was sometimes routing to the Netlify dapp. Now the navbar reads window.location.hostname on mount: localhost → http://localhost:3001, everything else → the production Netlify dapp.