### PR TITLE
fix(website): resolve dapp URL at click time instead of render time

### DIFF
--- a/apps/website/src/components/navbar.tsx
+++ b/apps/website/src/components/navbar.tsx
@@ -21,15 +21,14 @@ const navLinks = [
 const PROD_DAPP_URL = "https://nesterdapp.netlify.app"
 const LOCAL_DAPP_URL = "http://localhost:3001"
 
-function openDapp(e: React.MouseEvent) {
-    e.preventDefault()
-    const host = window.location.hostname
-    const url = host === "localhost" || host === "127.0.0.1" ? LOCAL_DAPP_URL : PROD_DAPP_URL
-    window.open(url, "_blank", "noopener,noreferrer")
-}
-
 export function Navbar() {
     const [isScrolled, setIsScrolled] = React.useState(false)
+    const [dappUrl, setDappUrl] = React.useState(PROD_DAPP_URL)
+
+    React.useEffect(() => {
+        const host = window.location.hostname
+        setDappUrl(host === "localhost" || host === "127.0.0.1" ? LOCAL_DAPP_URL : PROD_DAPP_URL)
+    }, [])
 
     React.useEffect(() => {
         const handleScroll = () => {
@@ -65,7 +64,7 @@ export function Navbar() {
                             </Link>
                         ))}
                     </div>
-                    <a href={PROD_DAPP_URL} onClick={openDapp}>
+                    <a href={dappUrl} target="_blank" rel="noopener noreferrer">
                         <Button
                             className="bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full px-6 font-medium text-sm transition-all shadow-none"
                         >
@@ -97,7 +96,7 @@ export function Navbar() {
                                 ))}
                             </div>
                             <div className="mt-auto mb-8">
-                                <a href={PROD_DAPP_URL} onClick={openDapp} className="w-full">
+                                <a href={dappUrl} target="_blank" rel="noopener noreferrer" className="w-full">
                                     <Button className="w-full bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full">
                                         Nester for Web
                                     </Button>

--- a/apps/website/src/components/navbar.tsx
+++ b/apps/website/src/components/navbar.tsx
@@ -21,18 +21,15 @@ const navLinks = [
 const PROD_DAPP_URL = "https://nesterdapp.netlify.app"
 const LOCAL_DAPP_URL = "http://localhost:3001"
 
-function useDappUrl() {
-    const [url, setUrl] = React.useState(PROD_DAPP_URL)
-    React.useEffect(() => {
-        const host = window.location.hostname
-        setUrl(host === "localhost" || host === "127.0.0.1" ? LOCAL_DAPP_URL : PROD_DAPP_URL)
-    }, [])
-    return url
+function openDapp(e: React.MouseEvent) {
+    e.preventDefault()
+    const host = window.location.hostname
+    const url = host === "localhost" || host === "127.0.0.1" ? LOCAL_DAPP_URL : PROD_DAPP_URL
+    window.open(url, "_blank", "noopener,noreferrer")
 }
 
 export function Navbar() {
     const [isScrolled, setIsScrolled] = React.useState(false)
-    const dappUrl = useDappUrl()
 
     React.useEffect(() => {
         const handleScroll = () => {
@@ -68,13 +65,13 @@ export function Navbar() {
                             </Link>
                         ))}
                     </div>
-                    <Link href={dappUrl} target="_blank">
+                    <a href={PROD_DAPP_URL} onClick={openDapp}>
                         <Button
                             className="bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full px-6 font-medium text-sm transition-all shadow-none"
                         >
                             Nester for Web
                         </Button>
-                    </Link>
+                    </a>
                 </div>
 
                 <Sheet>
@@ -100,11 +97,11 @@ export function Navbar() {
                                 ))}
                             </div>
                             <div className="mt-auto mb-8">
-                                <Link href={dappUrl} target="_blank" className="w-full">
+                                <a href={PROD_DAPP_URL} onClick={openDapp} className="w-full">
                                     <Button className="w-full bg-[#0D0E1C] hover:bg-[#0D0E1C]/90 text-white rounded-full">
                                         Nester for Web
                                     </Button>
-                                </Link>
+                                </a>
                             </div>
                         </div>
                     </SheetContent>


### PR DESCRIPTION
The hostname check ran inside useEffect and seeded state from the prod URL, so a click before/during hydration or a stale Turbopack HMR frame could route to Netlify from localhost. Now the click handler reads window.location.hostname directly and opens the correct URL — localhost on dev, Netlify in production.