### PR TITLE
feat(devops): add Docker Compose local development environment (#154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in required values
+# .env is gitignored — never commit it
+
+# Required: Anthropic API key for the intelligence service
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional: Stellar testnet signing key (leave blank to use read-only mode)
+STELLAR_SOURCE_KEY=S...

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pnpm-debug.log*
 
 # Env files
 .env*
+!.env.example
 !apps/api/.env.example
 
 # Vercel

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check clippy build test integration-test clean
+.PHONY: fmt fmt-check clippy build test integration-test clean dev dev-down dev-reset dev-logs dev-db
 
 CARGO := cargo
 CONTRACTS_DIR := packages/contracts
@@ -24,3 +24,20 @@ integration-test:
 
 clean:
 	cd $(CONTRACTS_DIR) && $(CARGO) clean
+
+# Docker Compose — local development
+
+dev: ## Start all services with Docker Compose
+	docker compose up --build
+
+dev-down: ## Stop all services
+	docker compose down
+
+dev-reset: ## Reset database volumes and restart
+	docker compose down -v && docker compose up --build
+
+dev-logs: ## Tail logs for all services
+	docker compose logs -f
+
+dev-db: ## Open a psql shell in the dev database
+	docker compose exec postgres psql -U nester nester_dev

--- a/README.md
+++ b/README.md
@@ -105,6 +105,68 @@ Nester is non-custodial. Users maintain full ownership of assets through smart c
 
 ---
 
+## Getting Started
+
+The fastest way to run the full stack locally is Docker Compose. You only need Docker and Docker Compose installed — no Go, Node, or Python required on your host.
+
+### Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Docker Compose v2)
+- An Anthropic API key (optional — intelligence service falls back to a placeholder)
+
+### 1. Clone and configure
+
+```bash
+git clone https://github.com/suncrestlabs/nester.git
+cd nester
+cp .env.example .env
+# Edit .env and set ANTHROPIC_API_KEY if you want the intelligence service
+```
+
+### 2. Start all services
+
+```bash
+make dev
+```
+
+This builds and starts PostgreSQL, the Go API, the Next.js frontend, and the FastAPI intelligence service. On first run Docker pulls base images and compiles everything — expect 2–5 minutes.
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost:3001 |
+| API | http://localhost:8080 |
+| API health | http://localhost:8080/health |
+| Intelligence | http://localhost:8000 |
+| PostgreSQL | localhost:5432 |
+
+The database is seeded automatically with a test user, two vaults, allocations, and settlements in various states.
+
+### 3. Useful commands
+
+```bash
+make dev-logs    # tail logs from all services
+make dev-db      # open a psql shell in the dev database
+make dev-down    # stop all services
+make dev-reset   # wipe volumes and restart fresh
+```
+
+### Hot reload
+
+- **Go API** — [air](https://github.com/air-verse/air) watches `apps/api/` and recompiles on every `.go` file save.
+- **Next.js** — standard Next.js fast refresh works via the volume mount.
+
+### Connecting to the database manually
+
+```bash
+make dev-db
+# or
+docker compose exec postgres psql -U nester nester_dev
+```
+
+Test credentials: user `550e8400-e29b-41d4-a716-446655440001` / `testuser@nester.dev`.
+
+---
+
 ## Roadmap
 
 | Phase | Focus | Status |

--- a/apps/api/.air.toml
+++ b/apps/api/.air.toml
@@ -1,0 +1,17 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/server ./cmd/api"
+  bin = "./tmp/server"
+  include_ext = ["go"]
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  delay = 1000
+  kill_delay = "0s"
+  send_interrupt = false
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = true

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /server ./cmd/api
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /server /server
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM golang:1.24-alpine
+RUN go install github.com/air-verse/air@latest
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+EXPOSE 8080
+CMD ["air"]

--- a/apps/dapp/frontend/Dockerfile.dev
+++ b/apps/dapp/frontend/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+EXPOSE 3001
+CMD ["npm", "run", "dev"]

--- a/apps/dapp/frontend/Dockerfile.dev
+++ b/apps/dapp/frontend/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM node:22-alpine
 WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm ci
+COPY package.json ./
+RUN npm install
 COPY . .
 EXPOSE 3001
 CMD ["npm", "run", "dev"]

--- a/apps/intelligence/Dockerfile
+++ b/apps/intelligence/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: nester_dev
+      POSTGRES_USER: nester
+      POSTGRES_PASSWORD: nester_dev_password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./scripts/seed.sql:/docker-entrypoint-initdb.d/seed.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nester"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    environment:
+      APP_ENV: development
+      DATABASE_DSN: postgres://nester:nester_dev_password@postgres:5432/nester_dev?sslmode=disable
+      STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      LOG_LEVEL: info
+      LOG_FORMAT: text
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./apps/api:/app
+      - go_mod_cache:/go/pkg/mod
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  frontend:
+    build:
+      context: ./apps/dapp/frontend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3001:3001"
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8080
+      NEXT_PUBLIC_WS_URL: ws://localhost:8080/ws
+      NEXT_PUBLIC_NETWORK: testnet
+    volumes:
+      - ./apps/dapp/frontend:/app
+      - /app/node_modules
+      - /app/.next
+
+  intelligence:
+    build:
+      context: ./apps/intelligence
+    ports:
+      - "8000:8000"
+    environment:
+      INTELLIGENCE_ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-sk-placeholder}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  postgres_data:
+  go_mod_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - ./apps/api:/app
       - go_mod_cache:/go/pkg/mod
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -1,0 +1,119 @@
+-- Schema (mirrors apps/api/migrations in order)
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS vaults (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    contract_address TEXT NOT NULL CHECK (char_length(contract_address) > 0),
+    total_deposited NUMERIC(20,8) NOT NULL DEFAULT 0 CHECK (total_deposited >= 0),
+    current_balance NUMERIC(20,8) NOT NULL DEFAULT 0 CHECK (current_balance >= 0),
+    currency TEXT NOT NULL CHECK (char_length(currency) > 0),
+    status TEXT NOT NULL CHECK (status IN ('active', 'paused', 'closed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vaults_user_id ON vaults (user_id);
+
+CREATE TABLE IF NOT EXISTS allocations (
+    id UUID PRIMARY KEY,
+    vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    protocol TEXT NOT NULL CHECK (char_length(protocol) > 0),
+    amount NUMERIC(20,8) NOT NULL CHECK (amount >= 0),
+    apy NUMERIC(10,4) NOT NULL CHECK (apy >= 0),
+    allocated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_allocations_vault_id ON allocations (vault_id);
+
+CREATE TABLE IF NOT EXISTS settlements (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE RESTRICT,
+    amount NUMERIC(20,8) NOT NULL CHECK (amount > 0),
+    currency VARCHAR(10) NOT NULL,
+    fiat_currency VARCHAR(10) NOT NULL,
+    fiat_amount NUMERIC(20,8) NOT NULL CHECK (fiat_amount > 0),
+    exchange_rate NUMERIC(20,8) NOT NULL CHECK (exchange_rate > 0),
+    destination_type VARCHAR(50) NOT NULL,
+    destination_provider VARCHAR(50) NOT NULL,
+    destination_account_number VARCHAR(100) NOT NULL,
+    destination_account_name VARCHAR(200) NOT NULL,
+    destination_bank_code VARCHAR(20) NOT NULL DEFAULT '',
+    status VARCHAR(30) NOT NULL DEFAULT 'initiated'
+        CHECK (status IN (
+            'initiated',
+            'liquidity_matched',
+            'fiat_dispatched',
+            'confirmed',
+            'failed'
+        )),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlements_user_id ON settlements(user_id);
+CREATE INDEX IF NOT EXISTS idx_settlements_vault_id ON settlements(vault_id);
+CREATE INDEX IF NOT EXISTS idx_settlements_status ON settlements(status);
+
+-- Seed data
+
+INSERT INTO users (id, email, name, created_at, updated_at) VALUES
+    ('550e8400-e29b-41d4-a716-446655440001', 'testuser@nester.dev', 'Test User', NOW(), NOW());
+
+INSERT INTO vaults (id, user_id, contract_address, total_deposited, current_balance, currency, status) VALUES
+    ('550e8400-e29b-41d4-a716-446655440010',
+     '550e8400-e29b-41d4-a716-446655440001',
+     'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCFW3',
+     10000.00, 10234.56, 'USDC', 'active'),
+    ('550e8400-e29b-41d4-a716-446655440011',
+     '550e8400-e29b-41d4-a716-446655440001',
+     'CCLQBFQKIIASLN7MXDQFAUXHQXPKR5ZVGKIMKNBZMKWL4LNKQXQXQAB',
+     5000.00, 5150.25, 'USDC', 'active');
+
+INSERT INTO allocations (id, vault_id, protocol, amount, apy, allocated_at) VALUES
+    ('550e8400-e29b-41d4-a716-446655440020',
+     '550e8400-e29b-41d4-a716-446655440010',
+     'Blend', 6000.00, 8.5000, NOW()),
+    ('550e8400-e29b-41d4-a716-446655440021',
+     '550e8400-e29b-41d4-a716-446655440010',
+     'Aave', 4000.00, 7.2500, NOW()),
+    ('550e8400-e29b-41d4-a716-446655440022',
+     '550e8400-e29b-41d4-a716-446655440011',
+     'Compound', 5000.00, 6.8000, NOW());
+
+INSERT INTO settlements (
+    id, user_id, vault_id, amount, currency, fiat_currency, fiat_amount,
+    exchange_rate, destination_type, destination_provider,
+    destination_account_number, destination_account_name, destination_bank_code,
+    status, created_at, completed_at
+) VALUES
+    ('550e8400-e29b-41d4-a716-446655440030',
+     '550e8400-e29b-41d4-a716-446655440001',
+     '550e8400-e29b-41d4-a716-446655440010',
+     100.00, 'USDC', 'NGN', 165000.00, 1650.00,
+     'bank_transfer', 'paystack', '0123456789', 'Test User', '044',
+     'confirmed',
+     NOW() - INTERVAL '2 days',
+     NOW() - INTERVAL '2 days' + INTERVAL '10 seconds'),
+    ('550e8400-e29b-41d4-a716-446655440031',
+     '550e8400-e29b-41d4-a716-446655440001',
+     '550e8400-e29b-41d4-a716-446655440010',
+     50.00, 'USDC', 'NGN', 82500.00, 1650.00,
+     'bank_transfer', 'paystack', '0123456789', 'Test User', '044',
+     'initiated',
+     NOW(), NULL),
+    ('550e8400-e29b-41d4-a716-446655440032',
+     '550e8400-e29b-41d4-a716-446655440001',
+     '550e8400-e29b-41d4-a716-446655440011',
+     200.00, 'USDC', 'NGN', 330000.00, 1650.00,
+     'bank_transfer', 'paystack', '9876543210', 'Test User', '058',
+     'fiat_dispatched',
+     NOW() - INTERVAL '1 hour', NULL);

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -2,8 +2,9 @@
 
 CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY,
-    email TEXT NOT NULL UNIQUE,
-    name TEXT NOT NULL,
+    wallet_address TEXT NOT NULL UNIQUE CHECK (length(btrim(wallet_address)) > 0),
+    display_name TEXT NOT NULL,
+    kyc_status TEXT NOT NULL DEFAULT 'pending',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -65,8 +66,8 @@ CREATE INDEX IF NOT EXISTS idx_settlements_status ON settlements(status);
 
 -- Seed data
 
-INSERT INTO users (id, email, name, created_at, updated_at) VALUES
-    ('550e8400-e29b-41d4-a716-446655440001', 'testuser@nester.dev', 'Test User', NOW(), NOW());
+INSERT INTO users (id, wallet_address, display_name, kyc_status, created_at, updated_at) VALUES
+    ('550e8400-e29b-41d4-a716-446655440001', 'GDUMMYWALLET000000000000000000000000000000000000000000001', 'Test User', 'approved', NOW(), NOW());
 
 INSERT INTO vaults (id, user_id, contract_address, total_deposited, current_balance, currency, status) VALUES
     ('550e8400-e29b-41d4-a716-446655440010',


### PR DESCRIPTION
Summary

  This PR implements a single-command local development environment for the full Nester stack. Before this change,
  contributors had to manually install Go, Node, Python, and PostgreSQL, read multiple READMEs, and configure each
  service individually. Now the entire stack starts with make dev.

Closes #154 
  ---
  What was added

  docker-compose.yml — Orchestrates four services:
  - postgres (16-alpine) on port 5432, with a health check and automatic seeding on first start
  - api (Go, port 8080) — built with Dockerfile.dev, hot-reloaded via air, waits for postgres to be healthy before
  starting
  - frontend (Next.js, port 3001) — built with Dockerfile.dev, volume-mounted for fast refresh
  - intelligence (FastAPI, port 8000) — uses the existing Dockerfile, picks up ANTHROPIC_API_KEY from the environment

  apps/api/Dockerfile — Production multi-stage build: compiles the Go binary in golang:1.24-alpine and runs it in a
  distroless/static:nonroot image with no shell or OS overhead.

  apps/api/Dockerfile.dev — Development image that installs air and volume-mounts the source, so any .go file save
  triggers a recompile and restart inside the container without rebuilding the image.

  apps/api/.air.toml — Air configuration: builds ./cmd/api → ./tmp/server, watches only .go files, excludes tmp/ and
  vendor/.

  apps/dapp/frontend/Dockerfile.dev — Node 22 Alpine image running npm run dev. Anonymous volumes for node_modules and
  .next ensure container-installed packages survive the source mount.

  apps/intelligence/Dockerfile — Added curl installation (required by the Docker Compose health check at GET /health).
  No other changes to the existing file.

  scripts/seed.sql — Runs automatically on postgres first-start via docker-entrypoint-initdb.d. Contains the full schema
   (mirrors all four migration files in order) plus test fixtures: one user, two active USDC vaults, three allocations
  across protocols (Blend, Aave, Compound), and three settlements covering confirmed, initiated, and fiat_dispatched
  states.

  .env.example — Documents the two environment variables contributors may need to set: ANTHROPIC_API_KEY (for the
  intelligence service) and STELLAR_SOURCE_KEY (optional testnet signing key).

  Makefile — Five new targets appended after the existing Rust/contract targets:
  - make dev — build and start all services
  - make dev-down — stop all services
  - make dev-reset — wipe volumes and restart clean
  - make dev-logs — tail logs from all services
  - make dev-db — open a psql shell in nester_dev

  README.md — New "Getting Started" section inserted before the Roadmap. Covers prerequisites, clone/configure steps,
  service URL table, the four make commands, hot-reload behaviour for both Go and Next.js, and database access
  instructions.

  .gitignore — Added !.env.example exception so the root example file is tracked alongside the existing
  !apps/api/.env.example.

  ---
  Notes for reviewers

  - The frontend runs on port 3001 (matching the existing "dev": "next dev -p 3001" in apps/dapp/frontend/package.json).
   The issue listed port 3000 but that appears to be outdated.
  - The API environment uses DATABASE_DSN (not DATABASE_URL) to match the variable name expected by
  apps/api/internal/config/config.go.
  - apps/api/go.mod targets Go 1.25.0. The Dockerfiles use golang:1.24-alpine since 1.25 may not yet have a published
  Docker image. Once Go 1.25 is available on Docker Hub, both apps/api/Dockerfile and apps/api/Dockerfile.dev should be
  bumped.
  - Since apps/api has no built-in migration runner, the schema is created by scripts/seed.sql on postgres
  initialisation. Migrations in apps/api/migrations/ remain the source of truth; seed.sql mirrors them and should be
  kept in sync as new migrations are added.

  ---
  Testing

  cp .env.example .env          # optionally add ANTHROPIC_API_KEY
  make dev                       # all four services come up
  curl http://localhost:8080/health   # → 200 ok
  curl http://localhost:8000/health   # → {"status":"ok"}
  open http://localhost:3001     # Next.js dev server
  make dev-db                    # psql — verify seed rows in users/vaults/settlements
  make dev-reset                 # confirms clean wipe and re-seed