### PR TITLE
fix(auth): populate Roles in JWT claims to restore admin RBAC (#241)

### DIFF
--- a/apps/api/cmd/bootstrap-admin/main.go
+++ b/apps/api/cmd/bootstrap-admin/main.go
@@ -1,0 +1,71 @@
+// bootstrap-admin grants the admin role to a user identified by wallet address.
+// Run once to seed the first administrator after deploying a fresh database.
+//
+// Usage:
+//
+//	go run ./cmd/bootstrap-admin --wallet=G... [--dsn=postgres://...]
+//
+// The DSN defaults to the DATABASE_DSN environment variable.
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "bootstrap-admin:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	wallet := flag.String("wallet", "", "Stellar wallet address to grant admin role (required)")
+	dsn := flag.String("dsn", "", "PostgreSQL DSN (defaults to DATABASE_DSN env var)")
+	flag.Parse()
+
+	if *wallet == "" {
+		flag.Usage()
+		return fmt.Errorf("--wallet is required")
+	}
+
+	_ = godotenv.Load()
+	if *dsn == "" {
+		*dsn = os.Getenv("DATABASE_DSN")
+	}
+	if *dsn == "" {
+		return fmt.Errorf("DATABASE_DSN environment variable or --dsn flag is required")
+	}
+
+	db, err := sql.Open("pgx", *dsn)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	var userID string
+	err = db.QueryRow(`SELECT id FROM users WHERE wallet_address = $1`, *wallet).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("no user found with wallet address %q", *wallet)
+	}
+	if err != nil {
+		return fmt.Errorf("query user: %w", err)
+	}
+
+	_, err = db.Exec(
+		`INSERT INTO user_roles (user_id, role) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`,
+		userID,
+	)
+	if err != nil {
+		return fmt.Errorf("insert role: %w", err)
+	}
+
+	fmt.Printf("granted admin role to user %s (wallet %s)\n", userID, *wallet)
+	return nil
+}

--- a/apps/api/internal/domain/user/model.go
+++ b/apps/api/internal/domain/user/model.go
@@ -35,4 +35,5 @@ type UserRepository interface {
 	Create(ctx context.Context, user *User) error
 	GetByID(ctx context.Context, id uuid.UUID) (*User, error)
 	GetByWalletAddress(ctx context.Context, addr string) (*User, error)
+	GetRoles(ctx context.Context, id uuid.UUID) ([]string, error)
 }

--- a/apps/api/internal/handler/user_handler_test.go
+++ b/apps/api/internal/handler/user_handler_test.go
@@ -51,6 +51,10 @@ func (m *mockUserRepository) GetByWalletAddress(ctx context.Context, addr string
 	return nil, user.ErrUserNotFound
 }
 
+func (m *mockUserRepository) GetRoles(_ context.Context, _ uuid.UUID) ([]string, error) {
+	return []string{}, nil
+}
+
 func TestUserHandler_Register(t *testing.T) {
 	repo := newMockUserRepository()
 	svc := service.NewUserService(repo)

--- a/apps/api/internal/repository/postgres/user_repository.go
+++ b/apps/api/internal/repository/postgres/user_repository.go
@@ -104,6 +104,27 @@ func scanUser(row userScanner) (*user.User, error) {
 	}, nil
 }
 
+func (r *UserRepository) GetRoles(ctx context.Context, id uuid.UUID) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT role FROM user_roles WHERE user_id = $1 ORDER BY role`,
+		id.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var roles []string
+	for rows.Next() {
+		var role string
+		if err := rows.Scan(&role); err != nil {
+			return nil, err
+		}
+		roles = append(roles, role)
+	}
+	return roles, rows.Err()
+}
+
 func mapUserError(err error) error {
 	if err == nil {
 		return nil

--- a/apps/api/internal/service/auth_service.go
+++ b/apps/api/internal/service/auth_service.go
@@ -109,11 +109,17 @@ func (s *authService) VerifyAndIssue(ctx context.Context, walletAddress, signatu
 		}
 	}
 
+	roles, err := s.userService.GetUserRoles(ctx, user.ID)
+	if err != nil {
+		return "", err
+	}
+
 	claims := auth.Claims{
 		Subject:       user.ID.String(),
 		WalletAddress: walletAddress,
 		IssuedAt:      time.Now().Unix(),
 		ExpiresAt:     time.Now().Add(s.config.TokenExpiry()).Unix(),
+		Roles:         roles,
 	}
 
 	token, err := auth.MakeJWT(claims, s.config.Secret())

--- a/apps/api/internal/service/auth_service_test.go
+++ b/apps/api/internal/service/auth_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
 )
 
@@ -21,12 +22,13 @@ type mockAuthConfig struct {
 	challengeExpiry time.Duration
 }
 
-func (m mockAuthConfig) Secret() string            { return m.secret }
-func (m mockAuthConfig) TokenExpiry() time.Duration { return m.tokenExpiry }
+func (m mockAuthConfig) Secret() string             { return m.secret }
+func (m mockAuthConfig) TokenExpiry() time.Duration  { return m.tokenExpiry }
 func (m mockAuthConfig) ChallengeExpiry() time.Duration { return m.challengeExpiry }
 
 type mockAuthUserRepository struct {
 	users map[string]*user.User
+	roles map[uuid.UUID][]string
 }
 
 func (m *mockAuthUserRepository) Create(ctx context.Context, u *user.User) error {
@@ -45,6 +47,20 @@ func (m *mockAuthUserRepository) GetByWalletAddress(ctx context.Context, address
 	return nil, errors.New("not found")
 }
 
+func (m *mockAuthUserRepository) GetRoles(ctx context.Context, id uuid.UUID) ([]string, error) {
+	if roles, ok := m.roles[id]; ok {
+		return roles, nil
+	}
+	return []string{}, nil
+}
+
+func newMockRepo() *mockAuthUserRepository {
+	return &mockAuthUserRepository{
+		users: make(map[string]*user.User),
+		roles: make(map[uuid.UUID][]string),
+	}
+}
+
 func setupAuthService() (AuthService, *keypair.Full) {
 	cfg := mockAuthConfig{
 		secret:          "test-super-secret-key-that-is-32-bytes-long",
@@ -52,7 +68,7 @@ func setupAuthService() (AuthService, *keypair.Full) {
 		challengeExpiry: 5 * time.Minute,
 	}
 
-	repo := &mockAuthUserRepository{users: make(map[string]*user.User)}
+	repo := newMockRepo()
 	userService := NewUserService(repo)
 	authSvc := NewAuthService(userService, cfg)
 
@@ -111,10 +127,9 @@ func TestAuthService_VerifyAndIssue_ExpiredChallenge(t *testing.T) {
 	cfg := mockAuthConfig{
 		secret:          "test-super-secret-key",
 		tokenExpiry:     1 * time.Hour,
-		// Instantly expire
 		challengeExpiry: -1 * time.Second,
 	}
-	repo := &mockAuthUserRepository{users: make(map[string]*user.User)}
+	repo := newMockRepo()
 	svc := NewAuthService(NewUserService(repo), cfg)
 
 	kp, _ := keypair.Random()
@@ -125,4 +140,65 @@ func TestAuthService_VerifyAndIssue_ExpiredChallenge(t *testing.T) {
 
 	_, err := svc.VerifyAndIssue(context.Background(), kp.Address(), sigStr, challenge)
 	assert.ErrorIs(t, err, ErrChallengeExpired)
+}
+
+func TestAuthService_VerifyAndIssue_AdminRolePopulatedInToken(t *testing.T) {
+	cfg := mockAuthConfig{
+		secret:          "test-super-secret-key-that-is-32-bytes-long",
+		tokenExpiry:     1 * time.Hour,
+		challengeExpiry: 5 * time.Minute,
+	}
+	repo := newMockRepo()
+	kp, _ := keypair.Random()
+
+	// Pre-seed the user so we know their ID, then assign admin role.
+	adminUser := &user.User{
+		ID:            uuid.New(),
+		WalletAddress: kp.Address(),
+		DisplayName:   kp.Address()[:8],
+		KYCStatus:     user.KYCStatusPending,
+	}
+	repo.users[kp.Address()] = adminUser
+	repo.roles[adminUser.ID] = []string{"admin"}
+
+	svc := NewAuthService(NewUserService(repo), cfg)
+
+	challenge, err := svc.GenerateChallenge(context.Background(), kp.Address())
+	require.NoError(t, err)
+
+	sigBytes, err := kp.Sign([]byte(challenge))
+	require.NoError(t, err)
+
+	token, err := svc.VerifyAndIssue(context.Background(), kp.Address(), base64.StdEncoding.EncodeToString(sigBytes), challenge)
+	require.NoError(t, err)
+
+	claims, err := auth.ParseJWT(token, cfg.secret)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"admin"}, claims.Roles, "admin role must be present in issued token")
+}
+
+func TestAuthService_VerifyAndIssue_RegularUserHasEmptyRoles(t *testing.T) {
+	cfg := mockAuthConfig{
+		secret:          "test-super-secret-key-that-is-32-bytes-long",
+		tokenExpiry:     1 * time.Hour,
+		challengeExpiry: 5 * time.Minute,
+	}
+	repo := newMockRepo()
+	kp, _ := keypair.Random()
+	svc := NewAuthService(NewUserService(repo), cfg)
+
+	challenge, err := svc.GenerateChallenge(context.Background(), kp.Address())
+	require.NoError(t, err)
+
+	sigBytes, err := kp.Sign([]byte(challenge))
+	require.NoError(t, err)
+
+	token, err := svc.VerifyAndIssue(context.Background(), kp.Address(), base64.StdEncoding.EncodeToString(sigBytes), challenge)
+	require.NoError(t, err)
+
+	claims, err := auth.ParseJWT(token, cfg.secret)
+	require.NoError(t, err)
+
+	assert.Empty(t, claims.Roles, "regular user must have no roles in issued token")
 }

--- a/apps/api/internal/service/user_service.go
+++ b/apps/api/internal/service/user_service.go
@@ -38,3 +38,7 @@ func (s *UserService) GetUser(ctx context.Context, id uuid.UUID) (*user.User, er
 func (s *UserService) GetUserByWallet(ctx context.Context, address string) (*user.User, error) {
 	return s.repo.GetByWalletAddress(ctx, address)
 }
+
+func (s *UserService) GetUserRoles(ctx context.Context, id uuid.UUID) ([]string, error) {
+	return s.repo.GetRoles(ctx, id)
+}

--- a/apps/api/internal/service/user_service_test.go
+++ b/apps/api/internal/service/user_service_test.go
@@ -47,6 +47,10 @@ func (m *mockUserRepository) GetByWalletAddress(ctx context.Context, addr string
 	return nil, user.ErrUserNotFound
 }
 
+func (m *mockUserRepository) GetRoles(_ context.Context, _ uuid.UUID) ([]string, error) {
+	return []string{}, nil
+}
+
 func TestUserService_RegisterUser(t *testing.T) {
 	ctx := context.Background()
 	repo := newMockUserRepository()

--- a/apps/api/migrations/009_add_user_roles.down.sql
+++ b/apps/api/migrations/009_add_user_roles.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_roles;

--- a/apps/api/migrations/009_add_user_roles.up.sql
+++ b/apps/api/migrations/009_add_user_roles.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role       VARCHAR(50) NOT NULL,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    granted_by UUID        REFERENCES users(id),
+    PRIMARY KEY (user_id, role)
+);


### PR DESCRIPTION
Closes #241 

  Problem

  Every JWT ever issued by this API had an empty Roles slice. The IssueToken path built auth.Claims with Subject,
  WalletAddress, IssuedAt, and ExpiresAt — but never queried or set Roles. The admin middleware's check
  !user.HasRole("admin") was therefore always true, causing every request to /api/v1/admin/… to return 403 Forbidden,
  including requests from actual administrators. The admin panel has been permanently inaccessible since the middleware
  was introduced.

  Root Cause

  Claims.Roles was defined in the struct but AuthService.VerifyAndIssue had no code to fetch roles from the database and
   populate the field. There was also no user_roles table for roles to live in.

  Changes

  Migration (009_add_user_roles)

  - Creates user_roles(user_id, role, granted_at, granted_by) with a composite primary key and a cascade-delete foreign
  key to users
  - Includes a down migration (DROP TABLE user_roles)

  Repository & Service

  - Added GetRoles(ctx, userID) ([]string, error) to the UserRepository interface
  - Implemented it in postgres.UserRepository with a SELECT role FROM user_roles WHERE user_id = $1 query
  - Added GetUserRoles to UserService as a thin wrapper

  Auth fix

  - AuthService.VerifyAndIssue now calls GetUserRoles after resolving the user and populates claims.Roles before signing
   the token

  Bootstrap CLI (cmd/bootstrap-admin)

  - One-shot tool to grant the admin role to a wallet address:
  go run ./cmd/bootstrap-admin --wallet=G... [--dsn=postgres://...]
  - Required to seed the first administrator on any existing or fresh deployment

  Tests

  - TestAuthService_VerifyAndIssue_AdminRolePopulatedInToken — verifies the issued JWT contains ["admin"] when the user
  has the admin role in the repository
  - TestAuthService_VerifyAndIssue_RegularUserHasEmptyRoles — verifies a newly registered user's token has no roles
  - Updated all UserRepository mocks in service and handler test packages to satisfy the extended interface

  Testing

  # Unit tests (no database required)
  go test ./internal/auth/... ./internal/middleware/... ./internal/service/... ./internal/handler/...

  # Bootstrap admin on a running instance
  go run ./cmd/bootstrap-admin --wallet=<ADMIN_STELLAR_ADDRESS>

  Migration path for existing deployments

  # Apply migration 009
  # (the server runs MigrateUp automatically on startup)

  # Grant admin role to the first operator
  go run ./cmd/bootstrap-admin --wallet=G<YOUR_ADMIN_WALLET>

  All previously issued tokens will remain valid but will not carry roles. Users must re-authenticate after the
  migration to receive a token with their roles.