### PR TITLE
fix(settlements): enforce ownership check on PATCH status endpoint (#239)

### DIFF
--- a/apps/api/internal/domain/offramp/model.go
+++ b/apps/api/internal/domain/offramp/model.go
@@ -39,6 +39,7 @@ var (
 	ErrInvalidStatus         = errors.New("invalid settlement status")
 	ErrInvalidTransition     = errors.New("invalid status transition")
 	ErrInvalidPrecision      = errors.New("decimal precision exceeds supported scale")
+	ErrForbidden             = errors.New("caller does not own this settlement")
 )
 
 const MaxAmountScale = int32(8)

--- a/apps/api/internal/handler/settlement_handler.go
+++ b/apps/api/internal/handler/settlement_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
@@ -169,6 +170,17 @@ func (h *SettlementHandler) updateStatus(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	caller, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+	callerID, err := uuid.Parse(caller.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid caller identity"))
+		return
+	}
+
 	var req updateStatusRequest
 	if err := decodeJSON(r, &req); err != nil {
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
@@ -177,6 +189,7 @@ func (h *SettlementHandler) updateStatus(w http.ResponseWriter, r *http.Request)
 
 	model, err := h.service.UpdateStatus(r.Context(), service.UpdateStatusInput{
 		SettlementID: id,
+		CallerID:     callerID,
 		NewStatus:    offramp.SettlementStatus(req.Status),
 	})
 	if err != nil {
@@ -191,6 +204,8 @@ func (h *SettlementHandler) updateStatus(w http.ResponseWriter, r *http.Request)
 
 func (h *SettlementHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
+	case errors.Is(err, offramp.ErrForbidden):
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "you do not own this settlement"))
 	case errors.Is(err, offramp.ErrSettlementNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("settlement"))
 	case errors.Is(err, offramp.ErrUserNotFound):

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -13,10 +13,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 )
+
+// injectAuthUser wraps h with a middleware that injects u into the request
+// context, simulating what the production auth middleware does.
+func injectAuthUser(u auth.User, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), u)))
+	})
+}
 
 type settlementStubRepo struct {
 	data map[uuid.UUID]*offramp.Settlement
@@ -236,7 +245,8 @@ func TestSettlementHandler_PatchStatus200(t *testing.T) {
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
-	server := httptest.NewServer(mux)
+	// Inject the settlement owner as the authenticated caller.
+	server := httptest.NewServer(injectAuthUser(auth.User{ID: userID.String()}, mux))
 	defer server.Close()
 
 	body := bytes.NewBufferString(`{"status":"liquidity_matched"}`)
@@ -257,6 +267,80 @@ func TestSettlementHandler_PatchStatus200(t *testing.T) {
 	out := decodeAPIData[offramp.Settlement](t, resp.Body)
 	if out.Status != offramp.StatusLiquidityMatched {
 		t.Fatalf("want liquidity_matched, got %s", out.Status)
+	}
+}
+
+func TestSettlementHandler_PatchStatus403NonOwner(t *testing.T) {
+	ownerID := uuid.New()
+	vaultID := uuid.New()
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
+		UserID:       ownerID,
+		VaultID:      vaultID,
+		Amount:       decimal.RequireFromString("10"),
+		Currency:     "USDC",
+		FiatCurrency: "NGN",
+		FiatAmount:   decimal.RequireFromString("100"),
+		ExchangeRate: decimal.RequireFromString("10"),
+		Destination: offramp.Destination{
+			Type:          "mobile_money",
+			Provider:      "mpesa",
+			AccountNumber: "0712345678",
+			AccountName:   "Jane",
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitiateSettlement: %v", err)
+	}
+
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	// Inject a different user — not the settlement owner.
+	attacker := auth.User{ID: uuid.New().String()}
+	server := httptest.NewServer(injectAuthUser(attacker, mux))
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"status":"liquidity_matched"}`)
+	req, err := http.NewRequest(http.MethodPatch, server.URL+"/api/v1/settlements/"+created.ID.String()+"/status", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("want 403 for non-owner, got %d", resp.StatusCode)
+	}
+}
+
+func TestSettlementHandler_PatchStatus401NoAuth(t *testing.T) {
+	svc := service.NewSettlementService(newSettlementStubRepo())
+	h := NewSettlementHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	// No auth injection — handler must return 401.
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"status":"liquidity_matched"}`)
+	req, err := http.NewRequest(http.MethodPatch, server.URL+"/api/v1/settlements/"+uuid.New().String()+"/status", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401 when no auth context, got %d", resp.StatusCode)
 	}
 }
 

--- a/apps/api/internal/service/settlement_service.go
+++ b/apps/api/internal/service/settlement_service.go
@@ -34,7 +34,10 @@ type InitiateSettlementInput struct {
 // UpdateStatusInput carries the target state for a status transition.
 type UpdateStatusInput struct {
 	SettlementID uuid.UUID
-	NewStatus    offramp.SettlementStatus
+	// CallerID is the authenticated user's UUID from the JWT. The service
+	// verifies it matches the settlement's UserID before applying the update.
+	CallerID  uuid.UUID
+	NewStatus offramp.SettlementStatus
 }
 
 // InitiateSettlement validates input, creates a settlement in the `initiated`
@@ -125,6 +128,10 @@ func (s *SettlementService) UpdateStatus(ctx context.Context, input UpdateStatus
 	current, err := s.repository.GetByID(ctx, input.SettlementID)
 	if err != nil {
 		return offramp.Settlement{}, err
+	}
+
+	if current.UserID != input.CallerID {
+		return offramp.Settlement{}, offramp.ErrForbidden
 	}
 
 	if !current.CanTransitionTo(input.NewStatus) {

--- a/apps/api/internal/service/settlement_service_test.go
+++ b/apps/api/internal/service/settlement_service_test.go
@@ -233,6 +233,7 @@ func TestGetUserSettlements_FilterByStatus(t *testing.T) {
 	// Advance s1 to liquidity_matched
 	svc.UpdateStatus(context.Background(), service.UpdateStatusInput{
 		SettlementID: s1.ID,
+		CallerID:     in.UserID,
 		NewStatus:    offramp.StatusLiquidityMatched,
 	})
 
@@ -276,6 +277,7 @@ func TestUpdateStatus_FullLifecycleToConfirmed(t *testing.T) {
 	for _, next := range transitions {
 		updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 			SettlementID: s.ID,
+			CallerID:     s.UserID,
 			NewStatus:    next,
 		})
 		if err != nil {
@@ -300,6 +302,7 @@ func TestUpdateStatus_FullLifecycleToFailed(t *testing.T) {
 
 	updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 		SettlementID: s.ID,
+		CallerID:     s.UserID,
 		NewStatus:    offramp.StatusFailed,
 	})
 	if err != nil {
@@ -318,10 +321,11 @@ func TestUpdateStatus_FailedAfterLiquidityMatched(t *testing.T) {
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
-	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusLiquidityMatched})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, CallerID: s.UserID, NewStatus: offramp.StatusLiquidityMatched})
 
 	updated, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 		SettlementID: s.ID,
+		CallerID:     s.UserID,
 		NewStatus:    offramp.StatusFailed,
 	})
 	if err != nil {
@@ -341,6 +345,7 @@ func TestUpdateStatus_InvalidTransitionRejected(t *testing.T) {
 	// initiated → fiat_dispatched is not a valid transition
 	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 		SettlementID: s.ID,
+		CallerID:     s.UserID,
 		NewStatus:    offramp.StatusFiatDispatched,
 	})
 	if !errors.Is(err, offramp.ErrInvalidTransition) {
@@ -353,12 +358,13 @@ func TestUpdateStatus_CannotLeaveConfirmed(t *testing.T) {
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
-	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusLiquidityMatched})
-	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusFiatDispatched})
-	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusConfirmed})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, CallerID: s.UserID, NewStatus: offramp.StatusLiquidityMatched})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, CallerID: s.UserID, NewStatus: offramp.StatusFiatDispatched})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, CallerID: s.UserID, NewStatus: offramp.StatusConfirmed})
 
 	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 		SettlementID: s.ID,
+		CallerID:     s.UserID,
 		NewStatus:    offramp.StatusInitiated,
 	})
 	if !errors.Is(err, offramp.ErrInvalidTransition) {
@@ -371,13 +377,31 @@ func TestUpdateStatus_CannotLeaveFailed(t *testing.T) {
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
-	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, NewStatus: offramp.StatusFailed})
+	svc.UpdateStatus(ctx, service.UpdateStatusInput{SettlementID: s.ID, CallerID: s.UserID, NewStatus: offramp.StatusFailed})
 
 	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
 		SettlementID: s.ID,
+		CallerID:     s.UserID,
 		NewStatus:    offramp.StatusInitiated,
 	})
 	if !errors.Is(err, offramp.ErrInvalidTransition) {
 		t.Errorf("expected ErrInvalidTransition from terminal state, got %v", err)
+	}
+}
+
+func TestUpdateStatus_ForbiddenForNonOwner(t *testing.T) {
+	svc := service.NewSettlementService(newStubRepo())
+	ctx := context.Background()
+
+	s, _ := svc.InitiateSettlement(ctx, validInput())
+	attacker := uuid.New() // different from s.UserID
+
+	_, err := svc.UpdateStatus(ctx, service.UpdateStatusInput{
+		SettlementID: s.ID,
+		CallerID:     attacker,
+		NewStatus:    offramp.StatusLiquidityMatched,
+	})
+	if !errors.Is(err, offramp.ErrForbidden) {
+		t.Errorf("expected ErrForbidden for non-owner, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #239 

Problem

  PATCH /api/v1/settlements/{id}/status verified the caller's JWT but never checked whether the authenticated user owned
  the settlement being modified. Any authenticated wallet holder could update any other user's settlement status to any
  value — a BOLA/IDOR vulnerability (OWASP API Security Top 10, API1).

  Concretely: attacker authenticates → discovers or guesses a victim's settlement UUID → sends PATCH
  /api/v1/settlements/<victim-uuid>/status {"status":"cancelled"} → victim's off-ramp is cancelled. The UUID is often
  exposed in API list responses, making enumeration trivial.

  Root Cause

  UpdateStatus in the service fetched the settlement by ID and immediately applied the transition. The authenticated
  caller's identity was stored in the request context by the auth middleware but was never read in either the handler or
  service layer.

  Changes

  Domain (offramp/model.go)

  - Added ErrForbidden = errors.New("caller does not own this settlement")

  Service (settlement_service.go)

  - Added CallerID uuid.UUID to UpdateStatusInput
  - After fetching the settlement, checks settlement.UserID != input.CallerID and returns ErrForbidden before any
  transition logic runs

  Handler (settlement_handler.go)

  - Calls auth.GetUserFromContext to extract the authenticated user from context; returns 401 if absent (defense-in-depth
  — the auth middleware normally guarantees this is populated, but the check guards against misconfiguration)
  - Parses caller.ID as a UUID and passes it in UpdateStatusInput.CallerID
  - writeDomainError now maps ErrForbidden → HTTP 403

  Tests

  Service layer:
  - TestUpdateStatus_ForbiddenForNonOwner — a different user's ID as CallerID returns ErrForbidden
  - All existing UpdateStatus call sites updated with CallerID: s.UserID

  Handler layer:
  - injectAuthUser test helper — wraps a mux with middleware that plants an auth.User in context, simulating production
  auth middleware
  - TestSettlementHandler_PatchStatus200 — updated to inject the settlement owner's identity; still passes
  - TestSettlementHandler_PatchStatus403NonOwner — a different authenticated user gets 403
  - TestSettlementHandler_PatchStatus401NoAuth — no auth context at all gets 401

  Testing

  go test ./internal/domain/offramp/... ./internal/service/... ./internal/handler/...