### PR TITLE
fix: derive user ID from auth context instead of request body.

### DIFF
--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
@@ -21,7 +22,6 @@ type VaultHandler struct {
 }
 
 type createVaultRequest struct {
-	UserID          string `json:"user_id"`
 	ContractAddress string `json:"contract_address"`
 	Currency        string `json:"currency"`
 	Status          string `json:"status,omitempty"`
@@ -45,9 +45,15 @@ func (h *VaultHandler) createVault(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, err := uuid.Parse(request.UserID)
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	userID, err := uuid.Parse(user.ID)
 	if err != nil {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("user_id must be a valid UUID"))
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid token subject"))
 		return
 	}
 
@@ -90,6 +96,17 @@ func (h *VaultHandler) listUserVaults(w http.ResponseWriter, r *http.Request) {
 	userID, err := uuid.Parse(r.PathValue("userId"))
 	if err != nil {
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("user id must be a valid UUID"))
+		return
+	}
+
+	authUser, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	if authUser.ID != userID.String() {
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
 		return
 	}
 

--- a/apps/api/internal/handler/vault_handler_extended_test.go
+++ b/apps/api/internal/handler/vault_handler_extended_test.go
@@ -34,11 +34,11 @@ func TestVaultHandlerGetVaultReturns200WithAllocations(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Create vault
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-GET-ALLOC-001","currency":"USDC"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-GET-ALLOC-001","currency":"USDC"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -96,7 +96,7 @@ func TestVaultHandlerGetVaultReturns404WhenNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(uuid.New())(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Get non-existent vault
@@ -127,7 +127,7 @@ func TestVaultHandlerGetVaultReturns400ForInvalidID(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(uuid.New())(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Get vault with invalid ID
@@ -150,11 +150,11 @@ func TestVaultHandlerListUserVaultsReturns200WithAllocations(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Create first vault with allocations
-	body1 := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-LIST-001","currency":"USDC"}`)
+	body1 := bytes.NewBufferString(`{"contract_address":"CA-LIST-001","currency":"USDC"}`)
 	response1, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body1)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -174,7 +174,7 @@ func TestVaultHandlerListUserVaultsReturns200WithAllocations(t *testing.T) {
 	}
 
 	// Create second vault with allocations
-	body2 := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-LIST-002","currency":"USDC"}`)
+	body2 := bytes.NewBufferString(`{"contract_address":"CA-LIST-002","currency":"USDC"}`)
 	response2, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body2)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -233,10 +233,10 @@ func TestVaultHandlerCreateVaultReturns201OnSuccess(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-CREATE-001","currency":"USDC"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-CREATE-001","currency":"USDC"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -274,7 +274,7 @@ func TestVaultHandlerCreateVaultReturns422OnInvalidInput(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	tests := []struct {
@@ -284,27 +284,27 @@ func TestVaultHandlerCreateVaultReturns422OnInvalidInput(t *testing.T) {
 	}{
 		{
 			name:           "empty contract_address",
-			body:           `{"user_id":"` + userID.String() + `","contract_address":"","currency":"USDC"}`,
+			body:           `{"contract_address":"","currency":"USDC"}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "invalid currency",
-			body:           `{"user_id":"` + userID.String() + `","contract_address":"CA-001","currency":"INVALID"}`,
+			body:           `{"contract_address":"CA-001","currency":"INVALID"}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "currency too short",
-			body:           `{"user_id":"` + userID.String() + `","contract_address":"CA-001","currency":"US"}`,
+			body:           `{"contract_address":"CA-001","currency":"US"}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "currency too long",
-			body:           `{"user_id":"` + userID.String() + `","contract_address":"CA-001","currency":"USDCX"}`,
+			body:           `{"contract_address":"CA-001","currency":"USDCX"}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "currency with numbers",
-			body:           `{"user_id":"` + userID.String() + `","contract_address":"CA-001","currency":"US1C"}`,
+			body:           `{"contract_address":"CA-001","currency":"US1C"}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 	}
@@ -332,12 +332,12 @@ func TestVaultHandlerCreateVaultReturns404ForNonExistentUser(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
-	defer server.Close()
-
 	// Try to create vault for non-existent user
 	nonExistentUserID := uuid.New()
-	body := bytes.NewBufferString(`{"user_id":"` + nonExistentUserID.String() + `","contract_address":"CA-001","currency":"USDC"}`)
+	server := httptest.NewServer(fakeAuthMiddleware(nonExistentUserID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"contract_address":"CA-001","currency":"USDC"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -356,7 +356,7 @@ func TestVaultHandlerListUserVaultsReturns400ForInvalidUserID(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(uuid.New())(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// List vaults with invalid user ID
@@ -379,10 +379,10 @@ func TestVaultHandlerCreateVaultWithCustomStatus(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-STATUS-001","currency":"USDC","status":"paused"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-STATUS-001","currency":"USDC","status":"paused"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -408,10 +408,10 @@ func TestVaultHandlerCreateVaultNormalizesCurrency(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-NORM-001","currency":"usdc"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-NORM-001","currency":"usdc"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -437,10 +437,10 @@ func TestVaultHandlerCreateVaultTrimsWhitespace(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"  CA-TRIM-001  ","currency":"  USDC  "}`)
+	body := bytes.NewBufferString(`{"contract_address":"  CA-TRIM-001  ","currency":"  USDC  "}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -469,11 +469,11 @@ func TestVaultHandler_GetAllocations_Returns200(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Create vault
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-ALLOC-GET-001","currency":"USDC"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-ALLOC-GET-001","currency":"USDC"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -535,7 +535,7 @@ func TestVaultHandler_GetAllocations_NotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(uuid.New())(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	// Get allocations for non-existent vault

--- a/apps/api/internal/handler/vault_handler_integration_test.go
+++ b/apps/api/internal/handler/vault_handler_integration_test.go
@@ -39,13 +39,13 @@ func TestVaultHandlerIntegrationCreateGetListAndErrors(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	response, err := http.Post(
 		server.URL+"/api/v1/vaults",
 		"application/json",
-		bytes.NewBufferString(`{"user_id":"`+userID.String()+`","contract_address":"CA-H-001","currency":"USDC"}`),
+		bytes.NewBufferString(`{"contract_address":"CA-H-001","currency":"USDC"}`),
 	)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -14,10 +14,21 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 )
+
+// fakeAuthMiddleware injects an auth.User into the request context for testing.
+func fakeAuthMiddleware(userID uuid.UUID) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := auth.NewContext(r.Context(), auth.User{ID: userID.String()})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
 
 // decodeAPIData unwraps the API envelope {"success":true,"data":...} and decodes
 // the inner data field into T.
@@ -46,10 +57,10 @@ func TestVaultHandlerCreateGetAndList(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
-	body := bytes.NewBufferString(`{"user_id":"` + userID.String() + `","contract_address":"CA-001","currency":"USDC"}`)
+	body := bytes.NewBufferString(`{"contract_address":"CA-001","currency":"USDC"}`)
 	response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST /api/v1/vaults error = %v", err)
@@ -102,6 +113,7 @@ func TestVaultHandlerCreateGetAndList(t *testing.T) {
 		t.Fatalf("CreateVault(other user) error = %v", err)
 	}
 
+	// Note: fakeAuthMiddleware uses userID, so the auth check in listUserVaults will pass
 	listResponse, err := http.Get(server.URL + "/api/v1/users/" + userID.String() + "/vaults")
 	if err != nil {
 		t.Fatalf("GET /api/v1/users/{userId}/vaults error = %v", err)
@@ -121,7 +133,7 @@ func TestVaultHandlerNotFoundAndInvalidUser(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	server := httptest.NewServer(fakeAuthMiddleware(uuid.New())(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
 	defer server.Close()
 
 	notFoundResponse, err := http.Get(server.URL + "/api/v1/vaults/" + uuid.New().String())


### PR DESCRIPTION
## Fix: Broken Object Level Authorization (BOLA) in Vault Endpoints

### Summary

This PR resolves a critical BOLA vulnerability where the API trusted the `user_id` provided in the request body/URL rather than deriving it from the authenticated caller's JWT. This allowed any authenticated user to create vaults on behalf of other users and view their vaults without permission.

### Changes

- **Imported** `auth` package into `vault_handler.go` to access `auth.GetUserFromContext`.
- **Removed** `user_id` from the `createVaultRequest` struct — the field is no longer accepted from clients.
- **`createVault`** — now extracts the user identity from the request context (set by the JWT auth middleware) instead of the request body. Returns `401 Unauthorized` if no valid user is present.
- **`listUserVaults`** — added an authorization check verifying the URL path `{userId}` matches the authenticated caller's ID. Returns `403 Forbidden` on mismatch.

### Testing

- Ran `go test ./...` — all tests pass.

Closes #240
