### PR TITLE
fix: Performance fee calculation compares assets to shares — users charged fees on principal, not yield

### DIFF
--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -703,6 +703,8 @@ impl VaultContract {
         let total_assets = get_total_assets(&env);
         let accrued_fees = get_accrued_fees(&env);
         let mut assets_to_withdraw = vault_token_client(&env).amount_for_shares(&shares);
+        let current_principal = get_user_principal(&env, &user);
+        let principal_to_remove = current_principal * shares / current_shares;
 
         // Trigger circuit breaker check
         check_circuit_breaker(&env, assets_to_withdraw);
@@ -711,8 +713,8 @@ impl VaultContract {
         let config = get_fee_config(&env);
         let mut total_fee = 0_i128;
 
-        // 1. Performance fee (10% of yield)
-        let yield_part = assets_to_withdraw - shares;
+        // 1. Performance fee applies only to realized gain above user cost basis.
+        let yield_part = assets_to_withdraw - principal_to_remove;
         if yield_part > 0 {
             let perf_fee = nester_common::fees::calculate_performance_fee(
                 yield_part,
@@ -756,12 +758,6 @@ impl VaultContract {
         let new_user_shares = current_shares - shares;
         set_total_assets(&env, total_assets - assets_to_withdraw);
 
-        let current_principal = get_user_principal(&env, &user);
-        let principal_to_remove = if current_shares > 0 {
-            current_principal * shares / current_shares
-        } else {
-            0
-        };
         set_user_principal(&env, &user, current_principal - principal_to_remove);
 
         let current_reserves = get_vault_liquid_reserves(&env);

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     token, Address, Env, String,
 };
+use nester_access_control::Role;
 use vault_token::{VaultTokenContract, VaultTokenContractClient};
 
 use crate::{VaultContract, VaultContractClient, VaultStatus};
@@ -299,6 +300,55 @@ fn withdrawal_after_yield_returns_principal_plus_yield() {
     vault.withdraw(&user, &(1_000 * XLM));
     assert_eq!(vault.get_balance(&user), 0);
     assert_eq!(vault.get_total_deposits(), 0);
+}
+
+#[test]
+fn withdrawal_does_not_charge_perf_fee_on_preexisting_yield() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let alice_deposit = 1_000 * XLM;
+    let bob_deposit = 1_000 * XLM;
+
+    mint(&token, &alice, alice_deposit);
+    mint(&token, &bob, bob_deposit);
+
+    vault.deposit(&alice, &alice_deposit);
+    vault.grant_role(&admin, &admin, &Role::Manager);
+
+    // Simulate accounting yield that belongs to Alice's holding period.
+    vault.report_yield(&admin, &(100 * XLM));
+
+    vault.deposit(&bob, &bob_deposit);
+    let bob_shares = vault.get_shares(&bob);
+    vault.withdraw(&bob, &bob_shares);
+
+    // Bob only pays early-withdrawal fee (0.1% of 1000 = 1), no performance fee.
+    assert_eq!(token::Client::new(&env, &token.address).balance(&bob), 999 * XLM);
+}
+
+#[test]
+fn withdrawal_charges_perf_fee_only_on_realized_user_yield() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    let liquidity_provider = Address::generate(&env);
+    let deposit = 1_000 * XLM;
+
+    mint(&token, &user, deposit);
+    mint(&token, &liquidity_provider, deposit);
+    vault.deposit(&user, &deposit);
+    vault.grant_role(&admin, &admin, &Role::Manager);
+
+    // Double share price in accounting so user has 1000 of realized yield.
+    vault.report_yield(&admin, &deposit);
+    // Add liquid reserves so transfer can satisfy the larger withdrawal amount.
+    vault.deposit(&liquidity_provider, &deposit);
+
+    let shares = vault.get_shares(&user);
+    vault.withdraw(&user, &shares);
+
+    // Gross assets = 2000, performance fee = 100, early fee = 2, net = 1898.
+    assert_eq!(token::Client::new(&env, &token.address).balance(&user), 1_898 * XLM);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- #236: Performance fee calculation compares assets to shares — users charged fees on principal, not yield

## Implementation notes
- Issue #236: validate root cause and apply focused changes only

## Closing
Closes Suncrest-Labs/nester#236
