### PR TITLE
feat(oracle): add exchange rate oracle for real-time fiat value conversion

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
 	"github.com/suncrestlabs/nester/apps/api/internal/handler"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
@@ -73,6 +74,9 @@ func run() error {
 	authService := service.NewAuthService(userService, cfg.Auth())
 	authHandler := handler.NewAuthHandler(authService)
 
+	oracleService := oracle.NewRateService(cfg.Stellar().HorizonURL())
+	rateHandler := handler.NewRateHandler(oracleService)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
 	mux.HandleFunc("GET /healthz", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
@@ -82,6 +86,7 @@ func run() error {
 	userHandler.Register(mux)
 	adminHandler.Register(mux)
 	authHandler.Register(mux)
+	rateHandler.Register(mux)
 
 	authRules := []middleware.RouteRule{
 		{PathPrefix: "/health", Public: true},

--- a/apps/api/internal/handler/rate_handler.go
+++ b/apps/api/internal/handler/rate_handler.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// RateHandler serves GET /api/v1/rates.
+type RateHandler struct {
+	oracle *oracle.RateService
+}
+
+// NewRateHandler returns a RateHandler backed by the given RateService.
+func NewRateHandler(svc *oracle.RateService) *RateHandler {
+	return &RateHandler{oracle: svc}
+}
+
+// Register wires the handler's routes into mux.
+func (h *RateHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/rates", h.getRate)
+}
+
+type rateResponse struct {
+	Base      string  `json:"base"`
+	Quote     string  `json:"quote"`
+	Rate      float64 `json:"rate"`
+	Source    string  `json:"source"`
+	FetchedAt string  `json:"fetched_at"`
+	ExpiresAt string  `json:"expires_at"`
+	Stale     bool    `json:"stale,omitempty"`
+}
+
+func (h *RateHandler) getRate(w http.ResponseWriter, r *http.Request) {
+	base := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("base")))
+	quote := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("quote")))
+
+	if base == "" || quote == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("base and quote query parameters are required"))
+		return
+	}
+
+	rate, err := h.oracle.GetRate(r.Context(), base, quote)
+	if err != nil {
+		switch {
+		case errors.Is(err, oracle.ErrUnsupportedPair):
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("unsupported currency pair: "+base+"/"+quote))
+		default:
+			logpkg.FromContext(r.Context()).Error("rate handler failed", "error", err.Error(), "pair", base+"/"+quote)
+			response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(
+				http.StatusServiceUnavailable,
+				"RATE_UNAVAILABLE",
+				"exchange rate temporarily unavailable",
+			))
+		}
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(rateResponse{
+		Base:      rate.Base,
+		Quote:     rate.Quote,
+		Rate:      rate.Rate,
+		Source:    rate.Source,
+		FetchedAt: rate.FetchedAt.Format(time.RFC3339),
+		ExpiresAt: rate.ExpiresAt.Format(time.RFC3339),
+		Stale:     rate.Stale,
+	}))
+}

--- a/apps/api/internal/oracle/cache.go
+++ b/apps/api/internal/oracle/cache.go
@@ -1,0 +1,50 @@
+package oracle
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	rate ExchangeRate
+}
+
+// RateCache is a thread-safe in-memory store for ExchangeRate values.
+type RateCache struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+// NewRateCache returns an empty cache.
+func NewRateCache() *RateCache {
+	return &RateCache{entries: make(map[string]cacheEntry)}
+}
+
+func key(base, quote string) string { return base + "/" + quote }
+
+// Get returns the cached rate for base→quote regardless of freshness.
+// The second return value is false when no entry exists at all.
+func (c *RateCache) Get(base, quote string) (ExchangeRate, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key(base, quote)]
+	return e.rate, ok
+}
+
+// Set stores or overwrites the rate for base→quote.
+func (c *RateCache) Set(r ExchangeRate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key(r.Base, r.Quote)] = cacheEntry{rate: r}
+}
+
+// IsFresh reports whether the cached entry for base→quote exists and has not expired.
+func (c *RateCache) IsFresh(base, quote string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key(base, quote)]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(e.rate.ExpiresAt)
+}

--- a/apps/api/internal/oracle/cache_test.go
+++ b/apps/api/internal/oracle/cache_test.go
@@ -1,0 +1,106 @@
+package oracle_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
+)
+
+func TestRateCache_MissOnEmptyCache(t *testing.T) {
+	c := oracle.NewRateCache()
+
+	_, ok := c.Get("USDC", "NGN")
+	if ok {
+		t.Error("expected miss on empty cache")
+	}
+	if c.IsFresh("USDC", "NGN") {
+		t.Error("expected not-fresh on empty cache")
+	}
+}
+
+func TestRateCache_StoresAndRetrieves(t *testing.T) {
+	c := oracle.NewRateCache()
+	r := oracle.ExchangeRate{
+		Base:      "USDC",
+		Quote:     "NGN",
+		Rate:      1650.0,
+		Source:    "test",
+		FetchedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(5 * time.Minute),
+	}
+	c.Set(r)
+
+	got, ok := c.Get("USDC", "NGN")
+	if !ok {
+		t.Fatal("expected cache hit after Set")
+	}
+	if got.Rate != r.Rate {
+		t.Errorf("want rate %.2f, got %.2f", r.Rate, got.Rate)
+	}
+	if got.Source != r.Source {
+		t.Errorf("want source %q, got %q", r.Source, got.Source)
+	}
+}
+
+func TestRateCache_IsFreshBeforeExpiry(t *testing.T) {
+	c := oracle.NewRateCache()
+	c.Set(oracle.ExchangeRate{
+		Base:      "XLM",
+		Quote:     "USD",
+		Rate:      0.12,
+		Source:    "test",
+		FetchedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	})
+
+	if !c.IsFresh("XLM", "USD") {
+		t.Error("expected entry to be fresh before expiry")
+	}
+}
+
+func TestRateCache_NotFreshAfterExpiry(t *testing.T) {
+	c := oracle.NewRateCache()
+	c.Set(oracle.ExchangeRate{
+		Base:      "XLM",
+		Quote:     "USD",
+		Rate:      0.12,
+		Source:    "test",
+		FetchedAt: time.Now().UTC().Add(-2 * time.Minute),
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Second), // already expired
+	})
+
+	if c.IsFresh("XLM", "USD") {
+		t.Error("expected expired entry to be not-fresh")
+	}
+
+	// Stale entry should still be retrievable for fallback serving.
+	_, ok := c.Get("XLM", "USD")
+	if !ok {
+		t.Error("expected expired entry to still be retrievable via Get")
+	}
+}
+
+func TestRateCache_OverwritesExistingEntry(t *testing.T) {
+	c := oracle.NewRateCache()
+	c.Set(oracle.ExchangeRate{Base: "USDC", Quote: "KES", Rate: 130.0, ExpiresAt: time.Now().Add(time.Minute)})
+	c.Set(oracle.ExchangeRate{Base: "USDC", Quote: "KES", Rate: 135.5, ExpiresAt: time.Now().Add(time.Minute)})
+
+	got, _ := c.Get("USDC", "KES")
+	if got.Rate != 135.5 {
+		t.Errorf("want updated rate 135.5, got %f", got.Rate)
+	}
+}
+
+func TestRateCache_IndependentKeys(t *testing.T) {
+	c := oracle.NewRateCache()
+	c.Set(oracle.ExchangeRate{Base: "USDC", Quote: "NGN", Rate: 1650.0, ExpiresAt: time.Now().Add(time.Minute)})
+	c.Set(oracle.ExchangeRate{Base: "USDC", Quote: "GHS", Rate: 15.5, ExpiresAt: time.Now().Add(time.Minute)})
+
+	ngn, _ := c.Get("USDC", "NGN")
+	ghs, _ := c.Get("USDC", "GHS")
+
+	if ngn.Rate == ghs.Rate {
+		t.Error("different pairs should store independently")
+	}
+}

--- a/apps/api/internal/oracle/defillama.go
+++ b/apps/api/internal/oracle/defillama.go
@@ -1,0 +1,63 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DefiLlamaProvider fetches the XLM/USD price from the DeFiLlama coins API.
+// It requires no API key and serves as the fallback when Horizon is unavailable.
+type DefiLlamaProvider struct {
+	client *http.Client
+}
+
+// NewDefiLlamaProvider returns a DefiLlamaProvider with a default HTTP client.
+func NewDefiLlamaProvider() *DefiLlamaProvider {
+	return &DefiLlamaProvider{
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (p *DefiLlamaProvider) Name() string { return "defillama" }
+
+func (p *DefiLlamaProvider) Fetch(ctx context.Context, base, quote string) (float64, error) {
+	if base != "XLM" || quote != "USD" {
+		return 0, ErrUnsupportedPair
+	}
+
+	const url = "https://coins.llama.fi/prices/current/coingecko:stellar"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("defillama: build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("defillama: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("defillama: unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Coins map[string]struct {
+			Price float64 `json:"price"`
+		} `json:"coins"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0, fmt.Errorf("defillama: decode: %w", err)
+	}
+
+	coin, ok := body.Coins["coingecko:stellar"]
+	if !ok || coin.Price <= 0 {
+		return 0, fmt.Errorf("defillama: XLM price not available")
+	}
+
+	return coin.Price, nil
+}

--- a/apps/api/internal/oracle/fiat.go
+++ b/apps/api/internal/oracle/fiat.go
@@ -1,0 +1,80 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// supportedFiatQuotes are the fiat currencies supported as quote against USD.
+var supportedFiatQuotes = map[string]bool{
+	"NGN": true,
+	"GHS": true,
+	"KES": true,
+	"USD": true,
+}
+
+// FiatProvider fetches USD-based fiat exchange rates from the open.er-api.com
+// free tier (no API key required).
+type FiatProvider struct {
+	client *http.Client
+}
+
+// NewFiatProvider returns a FiatProvider with a default HTTP client.
+func NewFiatProvider() *FiatProvider {
+	return &FiatProvider{
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (p *FiatProvider) Name() string { return "forex" }
+
+func (p *FiatProvider) Fetch(ctx context.Context, base, quote string) (float64, error) {
+	if base != "USD" {
+		return 0, ErrUnsupportedPair
+	}
+	if !supportedFiatQuotes[quote] {
+		return 0, ErrUnsupportedPair
+	}
+	if quote == "USD" {
+		return 1.0, nil
+	}
+
+	const url = "https://open.er-api.com/v6/latest/USD"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("forex: build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("forex: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("forex: unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Result string             `json:"result"`
+		Rates  map[string]float64 `json:"rates"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0, fmt.Errorf("forex: decode: %w", err)
+	}
+
+	if body.Result != "success" {
+		return 0, fmt.Errorf("forex: API returned result=%q", body.Result)
+	}
+
+	rate, ok := body.Rates[quote]
+	if !ok || rate <= 0 {
+		return 0, fmt.Errorf("forex: rate not found for %s", quote)
+	}
+
+	return rate, nil
+}

--- a/apps/api/internal/oracle/rate.go
+++ b/apps/api/internal/oracle/rate.go
@@ -1,0 +1,44 @@
+package oracle
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrUnsupportedPair = errors.New("unsupported currency pair")
+	ErrNoSource        = errors.New("no source available for pair")
+)
+
+// ExchangeRate holds the result of a single rate lookup.
+type ExchangeRate struct {
+	Base      string
+	Quote     string
+	Rate      float64
+	Source    string
+	FetchedAt time.Time
+	ExpiresAt time.Time
+	Stale     bool
+}
+
+// Provider fetches a numeric rate for a given base/quote pair.
+type Provider interface {
+	Name() string
+	Fetch(ctx context.Context, base, quote string) (float64, error)
+}
+
+// supportedPairs lists every base→quote combination this oracle handles.
+var supportedPairs = map[string]map[string]bool{
+	"USDC": {"NGN": true, "GHS": true, "KES": true, "USD": true},
+	"XLM":  {"USD": true},
+}
+
+// IsSupported reports whether base→quote is a known pair.
+func IsSupported(base, quote string) bool {
+	quotes, ok := supportedPairs[base]
+	if !ok {
+		return false
+	}
+	return quotes[quote]
+}

--- a/apps/api/internal/oracle/service.go
+++ b/apps/api/internal/oracle/service.go
@@ -1,0 +1,126 @@
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	cryptoTTL = 30 * time.Second
+	fiatTTL   = 5 * time.Minute
+)
+
+// RateService resolves exchange rates using a priority-ordered set of providers
+// and an in-memory TTL cache. On source failure it serves stale cached data
+// rather than propagating an error.
+type RateService struct {
+	cache       *RateCache
+	xlmFetchers []Provider // tried in order: first success wins
+	fiatFetcher Provider
+}
+
+// NewRateService constructs a RateService with Horizon (primary) and DeFiLlama
+// (fallback) for crypto rates and the open.er-api.com feed for fiat rates.
+func NewRateService(horizonURL string) *RateService {
+	return NewRateServiceWithFetchers(
+		[]Provider{NewStellarProvider(horizonURL), NewDefiLlamaProvider()},
+		NewFiatProvider(),
+	)
+}
+
+// NewRateServiceWithFetchers allows injecting custom providers for testing.
+func NewRateServiceWithFetchers(xlmFetchers []Provider, fiatFetcher Provider) *RateService {
+	return &RateService{
+		cache:       NewRateCache(),
+		xlmFetchers: xlmFetchers,
+		fiatFetcher: fiatFetcher,
+	}
+}
+
+// Cache returns the underlying cache so tests can pre-fill or inspect entries.
+func (s *RateService) Cache() *RateCache { return s.cache }
+
+// GetRate returns the exchange rate for base→quote. It serves a cached value
+// when fresh, fetches a new one otherwise, and falls back to stale cache data
+// (marked with Stale: true) when all live sources fail.
+func (s *RateService) GetRate(ctx context.Context, base, quote string) (ExchangeRate, error) {
+	if !IsSupported(base, quote) {
+		return ExchangeRate{}, ErrUnsupportedPair
+	}
+
+	if s.cache.IsFresh(base, quote) {
+		r, _ := s.cache.Get(base, quote)
+		return r, nil
+	}
+
+	fresh, err := s.fetch(ctx, base, quote)
+	if err != nil {
+		if stale, ok := s.cache.Get(base, quote); ok {
+			stale.Stale = true
+			return stale, nil
+		}
+		return ExchangeRate{}, err
+	}
+
+	s.cache.Set(fresh)
+	return fresh, nil
+}
+
+func (s *RateService) fetch(ctx context.Context, base, quote string) (ExchangeRate, error) {
+	now := time.Now().UTC()
+
+	switch {
+	case base == "USDC" && quote == "USD":
+		return ExchangeRate{
+			Base: "USDC", Quote: "USD", Rate: 1.0,
+			Source: "fixed", FetchedAt: now, ExpiresAt: now.Add(cryptoTTL),
+		}, nil
+
+	case base == "USDC":
+		// USDC is pegged 1:1 to USD; obtain the USD→quote forex rate.
+		rate, source, err := s.fetchFiat(ctx, quote)
+		if err != nil {
+			return ExchangeRate{}, err
+		}
+		return ExchangeRate{
+			Base: "USDC", Quote: quote, Rate: rate,
+			Source: source, FetchedAt: now, ExpiresAt: now.Add(fiatTTL),
+		}, nil
+
+	case base == "XLM" && quote == "USD":
+		return s.fetchXLM(ctx)
+
+	default:
+		return ExchangeRate{}, ErrUnsupportedPair
+	}
+}
+
+func (s *RateService) fetchXLM(ctx context.Context) (ExchangeRate, error) {
+	var lastErr error
+	for _, p := range s.xlmFetchers {
+		rate, err := p.Fetch(ctx, "XLM", "USD")
+		if err == nil && rate > 0 {
+			now := time.Now().UTC()
+			return ExchangeRate{
+				Base: "XLM", Quote: "USD", Rate: rate,
+				Source: p.Name(), FetchedAt: now, ExpiresAt: now.Add(cryptoTTL),
+			}, nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+	}
+	if lastErr == nil {
+		lastErr = ErrNoSource
+	}
+	return ExchangeRate{}, fmt.Errorf("xlm: all sources failed: %w", lastErr)
+}
+
+func (s *RateService) fetchFiat(ctx context.Context, quote string) (float64, string, error) {
+	rate, err := s.fiatFetcher.Fetch(ctx, "USD", quote)
+	if err != nil {
+		return 0, "", err
+	}
+	return rate, s.fiatFetcher.Name(), nil
+}

--- a/apps/api/internal/oracle/service_test.go
+++ b/apps/api/internal/oracle/service_test.go
@@ -1,0 +1,194 @@
+package oracle_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
+)
+
+// ── stub Provider ────────────────────────────────────────────────────────────
+
+type stubProvider struct {
+	name      string
+	rate      float64
+	err       error
+	callCount int
+}
+
+func (p *stubProvider) Name() string { return p.name }
+
+func (p *stubProvider) Fetch(_ context.Context, _, _ string) (float64, error) {
+	p.callCount++
+	return p.rate, p.err
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func expiredRate(base, quote string, rate float64) oracle.ExchangeRate {
+	return oracle.ExchangeRate{
+		Base:      base,
+		Quote:     quote,
+		Rate:      rate,
+		Source:    "stale-source",
+		FetchedAt: time.Now().UTC().Add(-10 * time.Minute),
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Second),
+	}
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+func TestRateService_USDCToUSDIsFixed(t *testing.T) {
+	svc := oracle.NewRateServiceWithFetchers(nil, &stubProvider{name: "fiat", rate: 1.0})
+
+	r, err := svc.GetRate(context.Background(), "USDC", "USD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Rate != 1.0 {
+		t.Errorf("USDC→USD: want 1.0, got %f", r.Rate)
+	}
+	if r.Source != "fixed" {
+		t.Errorf("want source 'fixed', got %q", r.Source)
+	}
+}
+
+func TestRateService_UnsupportedPairReturnsError(t *testing.T) {
+	svc := oracle.NewRateServiceWithFetchers(nil, &stubProvider{})
+
+	_, err := svc.GetRate(context.Background(), "BTC", "USD")
+	if !errors.Is(err, oracle.ErrUnsupportedPair) {
+		t.Errorf("expected ErrUnsupportedPair, got %v", err)
+	}
+}
+
+func TestRateService_XLMUsesFirstSucceedingProvider(t *testing.T) {
+	failing := &stubProvider{name: "p1", err: errors.New("timeout")}
+	succeeding := &stubProvider{name: "p2", rate: 0.15}
+
+	svc := oracle.NewRateServiceWithFetchers(
+		[]oracle.Provider{failing, succeeding},
+		&stubProvider{name: "fiat"},
+	)
+
+	r, err := svc.GetRate(context.Background(), "XLM", "USD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Rate != 0.15 {
+		t.Errorf("want rate 0.15 from second provider, got %f", r.Rate)
+	}
+	if r.Source != "p2" {
+		t.Errorf("want source 'p2', got %q", r.Source)
+	}
+	if failing.callCount != 1 {
+		t.Errorf("first provider should be called once, got %d", failing.callCount)
+	}
+	if succeeding.callCount != 1 {
+		t.Errorf("second provider should be called once, got %d", succeeding.callCount)
+	}
+}
+
+func TestRateService_XLMAllProvidersFail_ReturnsStaleCached(t *testing.T) {
+	svc := oracle.NewRateServiceWithFetchers(
+		[]oracle.Provider{
+			&stubProvider{name: "p1", err: errors.New("network error")},
+			&stubProvider{name: "p2", err: errors.New("network error")},
+		},
+		&stubProvider{name: "fiat"},
+	)
+
+	// Pre-fill with an expired (stale) entry.
+	svc.Cache().Set(expiredRate("XLM", "USD", 0.12))
+
+	r, err := svc.GetRate(context.Background(), "XLM", "USD")
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if !r.Stale {
+		t.Error("expected Stale=true when served from expired cache")
+	}
+	if r.Rate != 0.12 {
+		t.Errorf("expected stale rate 0.12, got %f", r.Rate)
+	}
+}
+
+func TestRateService_XLMAllProvidersFail_NoCacheReturnsError(t *testing.T) {
+	svc := oracle.NewRateServiceWithFetchers(
+		[]oracle.Provider{
+			&stubProvider{name: "p1", err: errors.New("unreachable")},
+		},
+		&stubProvider{name: "fiat"},
+	)
+
+	_, err := svc.GetRate(context.Background(), "XLM", "USD")
+	if err == nil {
+		t.Fatal("expected an error when all providers fail and cache is empty")
+	}
+}
+
+func TestRateService_USDCToFiatUsesFiatProvider(t *testing.T) {
+	fiat := &stubProvider{name: "forex", rate: 1650.0}
+	svc := oracle.NewRateServiceWithFetchers(nil, fiat)
+
+	r, err := svc.GetRate(context.Background(), "USDC", "NGN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Rate != 1650.0 {
+		t.Errorf("want rate 1650.0, got %f", r.Rate)
+	}
+	if r.Source != "forex" {
+		t.Errorf("want source 'forex', got %q", r.Source)
+	}
+	if fiat.callCount != 1 {
+		t.Errorf("fiat provider should be called once, got %d", fiat.callCount)
+	}
+}
+
+func TestRateService_USDCToFiatFails_ReturnsStaleCached(t *testing.T) {
+	svc := oracle.NewRateServiceWithFetchers(
+		nil,
+		&stubProvider{name: "forex", err: errors.New("forex unavailable")},
+	)
+	svc.Cache().Set(expiredRate("USDC", "NGN", 1600.0))
+
+	r, err := svc.GetRate(context.Background(), "USDC", "NGN")
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if !r.Stale {
+		t.Error("expected Stale=true when served from expired cache")
+	}
+	if r.Rate != 1600.0 {
+		t.Errorf("expected stale rate 1600.0, got %f", r.Rate)
+	}
+}
+
+func TestRateService_CacheHitSkipsProviders(t *testing.T) {
+	p := &stubProvider{name: "xlm", rate: 0.20}
+	svc := oracle.NewRateServiceWithFetchers([]oracle.Provider{p}, &stubProvider{name: "fiat"})
+
+	// Prime a fresh cache entry.
+	svc.Cache().Set(oracle.ExchangeRate{
+		Base:      "XLM",
+		Quote:     "USD",
+		Rate:      0.18,
+		Source:    "cached",
+		FetchedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	})
+
+	r, err := svc.GetRate(context.Background(), "XLM", "USD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Rate != 0.18 {
+		t.Errorf("want cached rate 0.18, got %f", r.Rate)
+	}
+	if p.callCount != 0 {
+		t.Errorf("provider should not be called on cache hit, got %d calls", p.callCount)
+	}
+}

--- a/apps/api/internal/oracle/stellar.go
+++ b/apps/api/internal/oracle/stellar.go
@@ -1,0 +1,87 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// usdcIssuer is Circle's USDC issuer on the Stellar network.
+const usdcIssuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+
+// StellarProvider fetches the XLM/USDC mid-market rate from Horizon's order book.
+type StellarProvider struct {
+	horizonURL string
+	client     *http.Client
+}
+
+// NewStellarProvider returns a StellarProvider using the given Horizon base URL.
+func NewStellarProvider(horizonURL string) *StellarProvider {
+	return &StellarProvider{
+		horizonURL: horizonURL,
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (p *StellarProvider) Name() string { return "horizon" }
+
+func (p *StellarProvider) Fetch(ctx context.Context, base, quote string) (float64, error) {
+	if base != "XLM" || quote != "USD" {
+		return 0, ErrUnsupportedPair
+	}
+
+	url := fmt.Sprintf(
+		"%s/order_book?selling_asset_type=native"+
+			"&buying_asset_type=credit_alphanum4"+
+			"&buying_asset_code=USDC"+
+			"&buying_asset_issuer=%s"+
+			"&limit=1",
+		p.horizonURL, usdcIssuer,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("stellar: build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("stellar: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("stellar: unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Bids []struct {
+			Price string `json:"price"`
+		} `json:"bids"`
+		Asks []struct {
+			Price string `json:"price"`
+		} `json:"asks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0, fmt.Errorf("stellar: decode: %w", err)
+	}
+
+	if len(body.Bids) == 0 || len(body.Asks) == 0 {
+		return 0, fmt.Errorf("stellar: order book is empty")
+	}
+
+	bid, err := strconv.ParseFloat(body.Bids[0].Price, 64)
+	if err != nil {
+		return 0, fmt.Errorf("stellar: parse bid: %w", err)
+	}
+	ask, err := strconv.ParseFloat(body.Asks[0].Price, 64)
+	if err != nil {
+		return 0, fmt.Errorf("stellar: parse ask: %w", err)
+	}
+
+	// Mid-market: price is USDC per XLM ≈ USD per XLM since USDC is pegged 1:1.
+	return (bid + ask) / 2, nil
+}


### PR DESCRIPTION
Closes #211

## Summary

- New `apps/api/internal/oracle/` package with five files: `rate.go` (types/errors), `cache.go` (TTL cache), `stellar.go` (Horizon order book), `defillama.go` (DeFiLlama fallback), `fiat.go` (open.er-api.com forex), `service.go` (aggregation + fallback)
- New endpoint `GET /api/v1/rates?base=USDC&quote=NGN` returning `{ base, quote, rate, source, fetched_at, expires_at, stale? }`
- Supported pairs: `USDC→NGN`, `USDC→GHS`, `USDC→KES`, `USDC→USD` (fixed 1.0), `XLM→USD`

## Caching / resilience

| Rate type | TTL | On all-sources-fail |
|---|---|---|
| Crypto (XLM/USD) | 30 s | Serve stale + `stale: true` |
| Fiat (USDC/NGN etc.) | 5 min | Serve stale + `stale: true` |

Provider priority for XLM/USD: Stellar Horizon → DeFiLlama. No API key is required for any source.

## Test plan

- [x] 6 cache unit tests (`cache_test.go`): miss, store/retrieve, freshness before/after expiry, overwrite, independent keys
- [x] 8 service unit tests (`service_test.go`): fixed USDC/USD, unsupported pair error, XLM fallback chain, stale serve on all-fail, no-cache error path, fiat provider, fiat stale fallback, cache-hit skips providers
- [x] `GOOS=linux go build ./...` — clean build

## Response shape

```json
{
  "success": true,
  "data": {
    "base": "USDC",
    "quote": "NGN",
    "rate": 1647.50,
    "source": "forex",
    "fetched_at": "2026-04-23T12:00:00Z",
    "expires_at": "2026-04-23T12:05:00Z"
  }
}
```