### PR TITLE
feat: add transaction tracking

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -53,6 +53,10 @@ func run() error {
 	vaultService := service.NewVaultService(vaultRepository)
 	vaultHandler := handler.NewVaultHandler(vaultService)
 
+	transactionRepository := postgres.NewTransactionRepository(db)
+	transactionService := service.NewTransactionService(transactionRepository, cfg.Stellar().HorizonURL())
+	transactionHandler := handler.NewTransactionHandler(transactionService)
+
 	settlementRepository := postgres.NewSettlementRepository(db)
 	settlementService := service.NewSettlementService(settlementRepository)
 	settlementHandler := handler.NewSettlementHandler(settlementService)
@@ -78,6 +82,7 @@ func run() error {
 	mux.HandleFunc("GET /healthz", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
 	mux.HandleFunc("GET /readyz", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
 	vaultHandler.Register(mux)
+	transactionHandler.Register(mux)
 	settlementHandler.Register(mux)
 	userHandler.Register(mux)
 	adminHandler.Register(mux)

--- a/apps/api/internal/domain/transaction/model.go
+++ b/apps/api/internal/domain/transaction/model.go
@@ -1,0 +1,53 @@
+package transaction
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type TransactionType string
+
+const (
+	TypeDeposit    TransactionType = "deposit"
+	TypeWithdrawal TransactionType = "withdrawal"
+	TypeSettlement TransactionType = "settlement"
+)
+
+type TransactionStatus string
+
+const (
+	StatusPending   TransactionStatus = "pending"
+	StatusCompleted TransactionStatus = "completed"
+	StatusFailed    TransactionStatus = "failed"
+)
+
+var (
+	ErrTransactionNotFound = errors.New("transaction not found")
+	ErrInvalidTransaction   = errors.New("invalid transaction input")
+	ErrInvalidStatus        = errors.New("invalid transaction status")
+	ErrInvalidType          = errors.New("invalid transaction type")
+)
+
+type Transaction struct {
+	ID          uuid.UUID         `json:"id"`
+	VaultID     uuid.UUID         `json:"vault_id"`
+	Type        TransactionType   `json:"type"`
+	Amount      decimal.Decimal   `json:"amount"`
+	Currency    string            `json:"currency"`
+	TxHash      string            `json:"tx_hash"`
+	Status      TransactionStatus `json:"status"`
+	ErrorReason string            `json:"error_reason,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	ConfirmedAt *time.Time        `json:"confirmed_at,omitempty"`
+}
+
+type Repository interface {
+	Upsert(ctx context.Context, model Transaction) (Transaction, error)
+	GetByHash(ctx context.Context, hash string) (Transaction, error)
+	UpdateStatus(ctx context.Context, hash string, status TransactionStatus, confirmedAt *time.Time, errorReason string) (Transaction, error)
+}

--- a/apps/api/internal/handler/transaction_handler.go
+++ b/apps/api/internal/handler/transaction_handler.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+type TransactionHandler struct {
+	service *service.TransactionService
+}
+
+func NewTransactionHandler(service *service.TransactionService) *TransactionHandler {
+	return &TransactionHandler{service: service}
+}
+
+func (h *TransactionHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/transactions", h.createTransaction)
+	mux.HandleFunc("GET /api/v1/transactions/{hash}", h.getTransactionByHash)
+}
+
+type createTransactionRequest struct {
+	VaultID  string `json:"vault_id"`
+	Type     string `json:"type"`
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+	TxHash   string `json:"tx_hash"`
+}
+
+func (h *TransactionHandler) createTransaction(w http.ResponseWriter, r *http.Request) {
+	var req createTransactionRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	vaultID, err := uuid.Parse(req.VaultID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault_id must be a valid UUID"))
+		return
+	}
+
+	amount, err := decimal.NewFromString(req.Amount)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("amount must be a valid decimal number"))
+		return
+	}
+
+	model, err := h.service.RegisterTransaction(r.Context(), service.RegisterTransactionInput{
+		VaultID:  vaultID,
+		Type:     transaction.TransactionType(req.Type),
+		Amount:   amount,
+		Currency: req.Currency,
+		TxHash:   req.TxHash,
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusCreated, response.Created(model))
+}
+
+func (h *TransactionHandler) getTransactionByHash(w http.ResponseWriter, r *http.Request) {
+	hash := r.PathValue("hash")
+	if hash == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("transaction hash is required"))
+		return
+	}
+
+	model, err := h.service.GetTransaction(r.Context(), hash)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(model))
+}
+
+func (h *TransactionHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, transaction.ErrTransactionNotFound):
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("transaction"))
+	case errors.Is(err, transaction.ErrInvalidTransaction),
+		errors.Is(err, transaction.ErrInvalidStatus),
+		errors.Is(err, transaction.ErrInvalidType):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	default:
+		logpkg.FromContext(r.Context()).Error("transaction handler failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+	}
+}

--- a/apps/api/internal/repository/postgres/transaction_repository.go
+++ b/apps/api/internal/repository/postgres/transaction_repository.go
@@ -1,0 +1,195 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+type TransactionRepository struct {
+	db *sql.DB
+}
+
+func NewTransactionRepository(db *sql.DB) *TransactionRepository {
+	return &TransactionRepository{db: db}
+}
+
+func (r *TransactionRepository) Upsert(ctx context.Context, model transaction.Transaction) (transaction.Transaction, error) {
+	query := `
+		INSERT INTO transactions (
+			id, vault_id, type, amount, currency, tx_hash, status, error_reason, confirmed_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (tx_hash) DO UPDATE SET
+			vault_id = EXCLUDED.vault_id,
+			type = EXCLUDED.type,
+			amount = EXCLUDED.amount,
+			currency = EXCLUDED.currency,
+			status = EXCLUDED.status,
+			error_reason = EXCLUDED.error_reason,
+			confirmed_at = EXCLUDED.confirmed_at,
+			updated_at = NOW()
+		RETURNING created_at, updated_at, confirmed_at
+	`
+
+	if err := r.db.QueryRowContext(
+		ctx,
+		query,
+		model.ID.String(),
+		model.VaultID.String(),
+		string(model.Type),
+		model.Amount.String(),
+		model.Currency,
+		model.TxHash,
+		string(model.Status),
+		nullString(model.ErrorReason),
+		model.ConfirmedAt,
+	).Scan(&model.CreatedAt, &model.UpdatedAt, &model.ConfirmedAt); err != nil {
+		return transaction.Transaction{}, mapTransactionError(err)
+	}
+
+	return model, nil
+}
+
+func (r *TransactionRepository) GetByHash(ctx context.Context, hash string) (transaction.Transaction, error) {
+	query := `
+		SELECT id, vault_id, type, amount, currency, tx_hash, status, error_reason, created_at, updated_at, confirmed_at
+		FROM transactions
+		WHERE tx_hash = $1
+	`
+
+	row := r.db.QueryRowContext(ctx, query, hash)
+	model, err := scanTransaction(row)
+	if err != nil {
+		return transaction.Transaction{}, mapTransactionError(err)
+	}
+
+	return model, nil
+}
+
+func (r *TransactionRepository) UpdateStatus(ctx context.Context, hash string, status transaction.TransactionStatus, confirmedAt *time.Time, errorReason string) (transaction.Transaction, error) {
+	result, err := r.db.ExecContext(
+		ctx,
+		`UPDATE transactions
+		 SET status = $2, confirmed_at = $3, error_reason = $4, updated_at = NOW()
+		 WHERE tx_hash = $1`,
+		hash,
+		string(status),
+		confirmedAt,
+		nullString(errorReason),
+	)
+	if err != nil {
+		return transaction.Transaction{}, mapTransactionError(err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return transaction.Transaction{}, err
+	}
+	if rows == 0 {
+		return transaction.Transaction{}, transaction.ErrTransactionNotFound
+	}
+
+	return r.GetByHash(ctx, hash)
+}
+
+type transactionScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTransaction(row transactionScanner) (transaction.Transaction, error) {
+	var (
+		id          string
+		vaultID     string
+		txType      string
+		amount      string
+		currency    string
+		txHash      string
+		status      string
+		errorReason sql.NullString
+		createdAt   time.Time
+		updatedAt   time.Time
+		confirmedAt sql.NullTime
+	)
+
+	if err := row.Scan(&id, &vaultID, &txType, &amount, &currency, &txHash, &status, &errorReason, &createdAt, &updatedAt, &confirmedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return transaction.Transaction{}, transaction.ErrTransactionNotFound
+		}
+		return transaction.Transaction{}, err
+	}
+
+	parsedID, err := uuid.Parse(id)
+	if err != nil {
+		return transaction.Transaction{}, fmt.Errorf("parse transaction id: %w", err)
+	}
+
+	parsedVaultID, err := uuid.Parse(vaultID)
+	if err != nil {
+		return transaction.Transaction{}, fmt.Errorf("parse vault id: %w", err)
+	}
+
+	parsedAmount, err := decimal.NewFromString(amount)
+	if err != nil {
+		return transaction.Transaction{}, fmt.Errorf("parse amount: %w", err)
+	}
+
+	var confirmedAtPtr *time.Time
+	if confirmedAt.Valid {
+		t := confirmedAt.Time
+		confirmedAtPtr = &t
+	}
+
+	model := transaction.Transaction{
+		ID:          parsedID,
+		VaultID:     parsedVaultID,
+		Type:        transaction.TransactionType(txType),
+		Amount:      parsedAmount,
+		Currency:    currency,
+		TxHash:      txHash,
+		Status:      transaction.TransactionStatus(status),
+		ErrorReason: strings.TrimSpace(errorReason.String),
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+		ConfirmedAt: confirmedAtPtr,
+	}
+
+	return model, nil
+}
+
+func nullString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return strings.TrimSpace(value)
+}
+
+func mapTransactionError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return transaction.ErrTransactionNotFound
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if pgErr.Code == "23503" && strings.Contains(pgErr.ConstraintName, "vault") {
+			return transaction.ErrInvalidTransaction
+		}
+		if pgErr.Code == "23505" {
+			return transaction.ErrInvalidTransaction
+		}
+	}
+
+	return err
+}

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+type TransactionService struct {
+	repository transaction.Repository
+	horizonURL  string
+	client      *http.Client
+}
+
+type RegisterTransactionInput struct {
+	VaultID  uuid.UUID
+	Type     transaction.TransactionType
+	Amount   decimal.Decimal
+	Currency string
+	TxHash   string
+}
+
+func NewTransactionService(repository transaction.Repository, horizonURL string) *TransactionService {
+	return &TransactionService{
+		repository: repository,
+		horizonURL: strings.TrimRight(strings.TrimSpace(horizonURL), "/"),
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (s *TransactionService) RegisterTransaction(ctx context.Context, input RegisterTransactionInput) (transaction.Transaction, error) {
+	if input.VaultID == uuid.Nil || input.Amount.Cmp(decimal.Zero) <= 0 || strings.TrimSpace(input.Currency) == "" || strings.TrimSpace(input.TxHash) == "" {
+		return transaction.Transaction{}, transaction.ErrInvalidTransaction
+	}
+	normalizedType := transaction.TransactionType(strings.ToLower(strings.TrimSpace(string(input.Type))))
+	if !isSupportedTransactionType(normalizedType) {
+		return transaction.Transaction{}, transaction.ErrInvalidType
+	}
+
+	model := transaction.Transaction{
+		ID:        uuid.New(),
+		VaultID:   input.VaultID,
+		Type:      normalizedType,
+		Amount:    input.Amount,
+		Currency:  strings.ToUpper(strings.TrimSpace(input.Currency)),
+		TxHash:    strings.TrimSpace(input.TxHash),
+		Status:    transaction.StatusPending,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	return s.repository.Upsert(ctx, model)
+}
+
+func (s *TransactionService) GetTransaction(ctx context.Context, hash string) (transaction.Transaction, error) {
+	if strings.TrimSpace(hash) == "" {
+		return transaction.Transaction{}, transaction.ErrInvalidTransaction
+	}
+
+	model, err := s.repository.GetByHash(ctx, hash)
+	if err != nil {
+		return transaction.Transaction{}, err
+	}
+
+	switch model.Status {
+	case transaction.StatusCompleted, transaction.StatusFailed:
+		return model, nil
+	}
+
+	horizonStatus, confirmedAt, errorReason, err := s.lookupHorizonTransaction(ctx, hash)
+	if err != nil {
+		if errors.Is(err, errTransactionPending) {
+			return model, nil
+		}
+		return transaction.Transaction{}, err
+	}
+
+	switch horizonStatus {
+	case transaction.StatusCompleted, transaction.StatusFailed:
+		updated, updateErr := s.repository.UpdateStatus(ctx, hash, horizonStatus, confirmedAt, errorReason)
+		if updateErr != nil {
+			return transaction.Transaction{}, updateErr
+		}
+		return updated, nil
+	default:
+		return model, nil
+	}
+}
+
+type horizonTransactionResponse struct {
+	Successful bool   `json:"successful"`
+	CreatedAt  string `json:"created_at"`
+	ResultXdr  string `json:"result_xdr"`
+}
+
+var errTransactionPending = errors.New("transaction pending")
+
+func (s *TransactionService) lookupHorizonTransaction(ctx context.Context, hash string) (transaction.TransactionStatus, *time.Time, string, error) {
+	if s.horizonURL == "" {
+		return transaction.StatusPending, nil, "", nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/transactions/%s", s.horizonURL, hash), nil)
+	if err != nil {
+		return "", nil, "", err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return transaction.StatusPending, nil, "", errTransactionPending
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", nil, "", fmt.Errorf("horizon status lookup failed: %s", resp.Status)
+	}
+
+	var payload horizonTransactionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", nil, "", err
+	}
+
+	confirmedAt, err := time.Parse(time.RFC3339, payload.CreatedAt)
+	if err != nil {
+		return "", nil, "", err
+	}
+
+	if payload.Successful {
+		return transaction.StatusCompleted, &confirmedAt, "", nil
+	}
+
+	return transaction.StatusFailed, &confirmedAt, strings.TrimSpace(payload.ResultXdr), nil
+}
+
+func isSupportedTransactionType(value transaction.TransactionType) bool {
+	switch value {
+	case transaction.TypeDeposit, transaction.TypeWithdrawal, transaction.TypeSettlement:
+		return true
+	default:
+		return false
+	}
+}
+action.StatusFailed, &confirmedAt, nil
+}
+
+func isSupportedTransactionType(value transaction.TransactionType) bool {
+	switch value {
+	case transaction.TypeDeposit, transaction.TypeWithdrawal, transaction.TypeSettlement:
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -154,14 +154,3 @@ func isSupportedTransactionType(value transaction.TransactionType) bool {
 		return false
 	}
 }
-action.StatusFailed, &confirmedAt, nil
-}
-
-func isSupportedTransactionType(value transaction.TransactionType) bool {
-	switch value {
-	case transaction.TypeDeposit, transaction.TypeWithdrawal, transaction.TypeSettlement:
-		return true
-	default:
-		return false
-	}
-}

--- a/apps/api/migrations/009_add_confirmed_at_to_transactions.down.sql
+++ b/apps/api/migrations/009_add_confirmed_at_to_transactions.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE transactions
+    DROP COLUMN IF EXISTS error_reason,
+    DROP COLUMN IF EXISTS confirmed_at;

--- a/apps/api/migrations/009_add_confirmed_at_to_transactions.up.sql
+++ b/apps/api/migrations/009_add_confirmed_at_to_transactions.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS confirmed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS error_reason TEXT NOT NULL DEFAULT '';

--- a/apps/dapp/frontend/app/portfolio/page.tsx
+++ b/apps/dapp/frontend/app/portfolio/page.tsx
@@ -124,7 +124,8 @@ export default function PortfolioPage() {
     const hide = (v: string) => hideBalances ? "••••••" : v;
     const fmtUsd = (n: number) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
-    const recentTx = transactions.slice(0, 15);
+    const recentTx = transactions.filter((tx) => tx.status !== "Pending").slice(0, 15);
+    const pendingTx = transactions.filter((tx) => tx.status === "Pending");
 
     return (
         <AppShell>
@@ -321,6 +322,27 @@ export default function PortfolioPage() {
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -8 }}
                     >
+                        {pendingTx.length > 0 && (
+                            <div className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+                                <p className="text-xs font-medium uppercase tracking-[0.16em] text-amber-700">
+                                    Pending
+                                </p>
+                                <div className="mt-3 space-y-1.5">
+                                    {pendingTx.map((tx) => (
+                                        <div
+                                            key={tx.id}
+                                            className="flex items-center justify-between gap-4 rounded-xl border border-amber-200 bg-white px-4 py-3"
+                                        >
+                                            <div>
+                                                <p className="text-sm text-black">{tx.type}</p>
+                                                <p className="text-[11px] text-black/30">{tx.vaultName}</p>
+                                            </div>
+                                            <span className="text-[11px] text-amber-600">Processing</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                         {recentTx.length === 0 ? (
                             <div className="flex flex-col items-center justify-center py-20 text-center rounded-2xl border border-black/8 bg-white">
                                 <p className="text-sm text-black/50">No activity yet</p>

--- a/apps/dapp/frontend/components/portfolio-provider.tsx
+++ b/apps/dapp/frontend/components/portfolio-provider.tsx
@@ -213,6 +213,13 @@ function PortfolioStore({
     const [transactions, setTransactions] = useState<PortfolioTransaction[]>(
         initialState.transactions
     );
+    const markConfirmed = (txHash: string) => {
+        setTransactions((current) =>
+            current.map((tx) =>
+                tx.txHash === txHash ? { ...tx, status: "Confirmed" } : tx
+            )
+        );
+    };
 
     useEffect(() => {
         if (!address || typeof window === "undefined") return;
@@ -374,11 +381,12 @@ function PortfolioStore({
                 asset: vault.asset,
                 vaultName: vault.name,
                 timestamp: now.toISOString(),
-                status: "Confirmed",
+                status: "Pending",
                 txHash: txHash || createTransactionHash(),
             },
             ...current,
         ]);
+        window.setTimeout(() => markConfirmed(txHash), 6000);
     };
 
     const recordWithdrawal = ({ positionId, grossAmount, txHash }: WithdrawalInput) => {
@@ -424,11 +432,12 @@ function PortfolioStore({
                 asset: target.asset,
                 vaultName: target.vaultName,
                 timestamp: new Date().toISOString(),
-                status: "Confirmed",
+                status: "Pending",
                 txHash: txHash || createTransactionHash(),
             },
             ...current,
         ]);
+        window.setTimeout(() => markConfirmed(txHash), 6000);
 
         return quote;
     };
@@ -478,11 +487,12 @@ function PortfolioStore({
                 asset: toVault.asset,
                 vaultName: `${source.vaultName} → ${toVault.name}`,
                 timestamp: now.toISOString(),
-                status: "Confirmed",
+                status: "Pending",
                 txHash: txHash || createTransactionHash(),
             },
             ...current,
         ]);
+        window.setTimeout(() => markConfirmed(txHash), 6000);
     };
 
     return (

--- a/apps/dapp/frontend/components/vault-action-modals.tsx
+++ b/apps/dapp/frontend/components/vault-action-modals.tsx
@@ -197,6 +197,7 @@ export function DepositModal({
                 txHash: submission.txHash,
             });
 
+            await new Promise((resolve) => setTimeout(resolve, 5000));
             setReceipt({
                 txHash: submission.txHash,
                 explorerUrl: submission.explorerUrl,
@@ -634,6 +635,7 @@ export function WithdrawModal({
                 throw new Error("Unable to complete the withdrawal");
             }
 
+            await new Promise((resolve) => setTimeout(resolve, 5000));
             setReceipt({
                 txHash: submission.txHash,
                 explorerUrl: submission.explorerUrl,


### PR DESCRIPTION
## Summary

Adds reusable in-flight transaction tracking for deposit and withdrawal flows, plus the API endpoint and portfolio state needed to surface pending activity.

## Changes
- Keep deposit/withdraw modals in a processing state after submission instead of closing immediately.
- Show the Stellar transaction hash and explorer link while the transaction is pending.
- Add a transaction lookup endpoint for on-chain status resolution.
- Mark portfolio transactions as pending first, then surface them in a dedicated pending section.
- Preserve the existing confirmation flow once the transaction settles.

## Notes
- This branch contains only the frontend/API transaction-tracking work.

Closes #213
