### PR TITLE
fix: preserve vault token accounting

### DIFF
--- a/packages/contracts/contracts/vault_token/src/lib.rs
+++ b/packages/contracts/contracts/vault_token/src/lib.rs
@@ -147,8 +147,16 @@ impl VaultTokenContract {
     /// Burn `amount` of `from`'s own shares (SEP-41 user-initiated burn).
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
+        let total_supply = get_total_supply(&env);
+        let total_assets = get_total_assets(&env);
+        let assets_to_reduce = if total_supply > 0 && total_assets > 0 {
+            amount * total_assets / total_supply
+        } else {
+            0
+        };
         spend_balance(&env, &from, amount);
-        set_total_supply(&env, get_total_supply(&env) - amount);
+        set_total_supply(&env, total_supply - amount);
+        set_total_assets(&env, total_assets - assets_to_reduce);
         env.events().publish((symbol_short!("burn"), from), amount);
     }
 
@@ -156,8 +164,16 @@ impl VaultTokenContract {
     pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
         spender.require_auth();
         spend_allowance(&env, &from, &spender, amount);
+        let total_supply = get_total_supply(&env);
+        let total_assets = get_total_assets(&env);
+        let assets_to_reduce = if total_supply > 0 && total_assets > 0 {
+            amount * total_assets / total_supply
+        } else {
+            0
+        };
         spend_balance(&env, &from, amount);
-        set_total_supply(&env, get_total_supply(&env) - amount);
+        set_total_supply(&env, total_supply - amount);
+        set_total_assets(&env, total_assets - assets_to_reduce);
         env.events()
             .publish((symbol_short!("burn_frm"), spender, from), amount);
     }

--- a/packages/contracts/contracts/vault_token/src/test.rs
+++ b/packages/contracts/contracts/vault_token/src/test.rs
@@ -391,7 +391,7 @@ fn burn_reduces_supply() {
 
     assert_eq!(client.balance(&user), 3_000);
     assert_eq!(client.total_supply(), 3_000);
-    // Note: SEP-41 burn does NOT update total_assets; that's vault logic
+    assert_eq!(client.total_assets(), 3_000);
 }
 
 #[test]
@@ -409,6 +409,7 @@ fn burn_from_uses_allowance() {
 
     assert_eq!(client.balance(&user), 4_000);
     assert_eq!(client.total_supply(), 4_000);
+    assert_eq!(client.total_assets(), 4_000);
     assert_eq!(client.allowance(&user, &spender), 2_000);
 }
 


### PR DESCRIPTION
## Summary

Fixes the vault token burn accounting bug by reducing total assets along with total supply when users burn shares.

## Changes
- Update `burn()` to decrement `TotalAssets` proportionally.
- Update `burn_from()` to preserve the same accounting invariant.
- Adjust contract tests to cover the corrected exchange-rate behavior.

## Notes
- This branch is isolated to the vault-token accounting fix only.

Closes #238
