### PR TITLE
fix(api): replace wildcard CORS with origin allowlist

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -43,3 +43,10 @@ LOG_LEVEL=info
 
 # Log output format: text or json. Defaults to text outside production/staging.
 LOG_FORMAT=text
+
+# Comma-separated list of origins permitted to make cross-origin browser
+# requests to the API. Entries must be full origins (scheme://host[:port])
+# with no path or trailing slash. Wildcards are rejected.
+# Required in production and staging.
+# Example (production): https://app.nester.finance,https://nester.finance
+ALLOWED_ORIGINS=http://localhost:3000

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -127,15 +127,21 @@ func run() error {
 	globalLimiter := middleware.IPRateLimiter(cfg.RateLimit().GlobalLimit(), cfg.RateLimit().GlobalWindow())
 	// Write rate limit is stricter and applies only to mutating methods (POST/PUT/PATCH/DELETE).
 	writeLimiter := middleware.WriteMethodRateLimiter(cfg.RateLimit().WriteLimit(), cfg.RateLimit().WriteWindow())
+	// CORS sits inside rate limiting (preflights count against the bucket) and
+	// outside auth (preflights don't carry credentials and must short-circuit
+	// before Authenticate rejects them).
+	cors := middleware.CORS(cfg.AllowedOrigins())
 
 	server := &http.Server{
 		Addr: cfg.Server().Address(),
 		Handler: middleware.RecoverPanic(baseLogger)(
 			globalLimiter(
-				writeLimiter(
-					authenticator(
-						middleware.LimitRequestBody(1 * 1024 * 1024)(
-							middleware.Logging(baseLogger)(mux),
+				cors(
+					writeLimiter(
+						authenticator(
+							middleware.LimitRequestBody(1 * 1024 * 1024)(
+								middleware.Logging(baseLogger)(mux),
+							),
 						),
 					),
 				),

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	auth                  AuthConfig
 	rateLimit             RateLimitConfig
 	log                   LogConfig
+	allowedOrigins        []string
 }
 
 type ServerConfig struct {
@@ -123,6 +124,7 @@ func Load() (*Config, error) {
 			level:  strings.ToLower(loader.stringDefault("LOG_LEVEL", "info")),
 			format: strings.ToLower(loader.stringDefault("LOG_FORMAT", defaultLogFormat(environment))),
 		},
+		allowedOrigins: loader.stringSliceDefault("ALLOWED_ORIGINS", nil),
 	}
 
 	cfg.validate(&loader)
@@ -168,6 +170,14 @@ func (c Config) Log() LogConfig {
 
 func (c Config) Redis() RedisConfig {
 	return c.redis
+}
+
+// AllowedOrigins returns the list of origins permitted to make cross-origin
+// requests to the API. An empty slice disables cross-origin access.
+func (c Config) AllowedOrigins() []string {
+	out := make([]string, len(c.allowedOrigins))
+	copy(out, c.allowedOrigins)
+	return out
 }
 
 func (r RedisConfig) Addr() string {
@@ -237,6 +247,29 @@ func (c *Config) validate(loader *envLoader) {
 
 	if !isOneOf(c.log.format, "json", "text") {
 		loader.addError("LOG_FORMAT must be one of json, text")
+	}
+
+	validateAllowedOrigins(c.environment, c.allowedOrigins, loader)
+}
+
+func validateAllowedOrigins(environment string, origins []string, loader *envLoader) {
+	if (environment == "production" || environment == "staging") && len(origins) == 0 {
+		loader.addError("ALLOWED_ORIGINS must list at least one origin in production or staging")
+	}
+
+	for _, origin := range origins {
+		if origin == "*" {
+			loader.addError("ALLOWED_ORIGINS must not contain wildcard \"*\"; list explicit origins instead")
+			continue
+		}
+		parsed, err := url.Parse(origin)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			loader.addError(fmt.Sprintf("ALLOWED_ORIGINS entry %q is not a valid origin (expected scheme://host[:port])", origin))
+			continue
+		}
+		if parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+			loader.addError(fmt.Sprintf("ALLOWED_ORIGINS entry %q must not contain a path, query, or fragment", origin))
+		}
 	}
 }
 
@@ -373,6 +406,21 @@ func (l *envLoader) intDefault(key string, fallback int) int {
 		return fallback
 	}
 	return value
+}
+
+func (l *envLoader) stringSliceDefault(key string, fallback []string) []string {
+	raw, ok := l.lookup(key)
+	if !ok {
+		return fallback
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func (l *envLoader) durationDefault(key string, fallback time.Duration) time.Duration {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -22,6 +22,7 @@ func baseEnv(t *testing.T) {
 		"AUTH_JWT_SECRET", "AUTH_TOKEN_EXPIRY", "AUTH_CHALLENGE_EXPIRY",
 		"RATELIMIT_GLOBAL_LIMIT", "RATELIMIT_GLOBAL_WINDOW", "RATELIMIT_WRITE_LIMIT", "RATELIMIT_WRITE_WINDOW",
 		"LOG_LEVEL", "LOG_FORMAT",
+		"ALLOWED_ORIGINS",
 	} {
 		t.Setenv(key, "")
 	}
@@ -54,6 +55,7 @@ func TestLoadFromDotEnv(t *testing.T) {
 		"STELLAR_RPC_URL=https://rpc.example.com",
 		"STELLAR_HORIZON_URL=https://horizon.example.com",
 		"AUTH_JWT_SECRET=this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes",
+		"ALLOWED_ORIGINS=https://app.example.com",
 	}, "\n"))
 
 	chdir(t, dir)
@@ -171,6 +173,7 @@ func TestLoadEnvVarsTakePrecedenceOverDotEnv(t *testing.T) {
 	t.Setenv("STELLAR_NETWORK_PASSPHRASE", "From EnvVar")
 	t.Setenv("STELLAR_RPC_URL", "https://envvar-rpc.example.com")
 	t.Setenv("STELLAR_HORIZON_URL", "https://envvar-horizon.example.com")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
 
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".env"), strings.Join([]string{
@@ -214,6 +217,7 @@ func TestLoadConcurrentCalls(t *testing.T) {
 		"STELLAR_RPC_URL=https://rpc.example.com",
 		"STELLAR_HORIZON_URL=https://horizon.example.com",
 		"AUTH_JWT_SECRET=this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes",
+		"ALLOWED_ORIGINS=https://app.example.com",
 	}, "\n"))
 	chdir(t, dir)
 
@@ -263,6 +267,7 @@ func TestLoadProcessEnvOverridesDotEnvAndFallsBack(t *testing.T) {
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("SERVER_PORT", "9091")
 	t.Setenv("DATABASE_DSN", "postgres://env:secret@localhost:5432/nester?sslmode=disable")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
 
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".env"), strings.Join([]string{
@@ -430,6 +435,7 @@ func TestLoadProductionMode(t *testing.T) {
 	baseEnv(t)
 	requiredEnv(t)
 	t.Setenv("APP_ENV", "production")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
 
 	chdir(t, t.TempDir())
 
@@ -680,6 +686,120 @@ func TestLoadMultipleValidationErrors(t *testing.T) {
 		if !strings.Contains(message, expected) {
 			t.Errorf("expected error to contain %q, got:\n%s", expected, message)
 		}
+	}
+}
+
+// TestLoadAllowedOriginsParsed verifies ALLOWED_ORIGINS is split on commas
+// with whitespace trimmed and empty entries dropped.
+func TestLoadAllowedOriginsParsed(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com, https://example.com ,,http://localhost:3000")
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	got := cfg.AllowedOrigins()
+	want := []string{"https://app.example.com", "https://example.com", "http://localhost:3000"}
+	if len(got) != len(want) {
+		t.Fatalf("AllowedOrigins() = %v, want %v", got, want)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("AllowedOrigins()[%d] = %q, want %q", i, got[i], v)
+		}
+	}
+}
+
+// TestLoadAllowedOriginsRequiredInProduction verifies production requires
+// ALLOWED_ORIGINS to be populated.
+func TestLoadAllowedOriginsRequiredInProduction(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "production")
+
+	chdir(t, t.TempDir())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail when ALLOWED_ORIGINS is empty in production")
+	}
+	if !strings.Contains(err.Error(), "ALLOWED_ORIGINS") {
+		t.Fatalf("expected error to mention ALLOWED_ORIGINS, got %q", err.Error())
+	}
+}
+
+// TestLoadAllowedOriginsRejectsWildcard verifies "*" is rejected explicitly.
+func TestLoadAllowedOriginsRejectsWildcard(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("ALLOWED_ORIGINS", "*")
+
+	chdir(t, t.TempDir())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail when ALLOWED_ORIGINS contains a wildcard")
+	}
+	if !strings.Contains(err.Error(), "wildcard") {
+		t.Fatalf("expected wildcard error, got %q", err.Error())
+	}
+}
+
+// TestLoadAllowedOriginsRejectsMalformed verifies malformed origins are rejected.
+func TestLoadAllowedOriginsRejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin string
+	}{
+		{"missing scheme", "app.example.com"},
+		{"unsupported scheme", "ftp://example.com"},
+		{"has path", "https://example.com/api"},
+		{"has query", "https://example.com?foo=1"},
+		{"trailing slash", "https://example.com/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			t.Setenv("ALLOWED_ORIGINS", tc.origin)
+
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to fail for malformed origin %q", tc.origin)
+			}
+			if !strings.Contains(err.Error(), "ALLOWED_ORIGINS") {
+				t.Fatalf("expected error to mention ALLOWED_ORIGINS, got %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestLoadAllowedOriginsOptionalInDevelopment verifies development loads
+// successfully with no ALLOWED_ORIGINS set.
+func TestLoadAllowedOriginsOptionalInDevelopment(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.AllowedOrigins()) != 0 {
+		t.Fatalf("expected empty AllowedOrigins() in dev with no env, got %v", cfg.AllowedOrigins())
 	}
 }
 

--- a/apps/api/internal/middleware/cors.go
+++ b/apps/api/internal/middleware/cors.go
@@ -2,19 +2,44 @@ package middleware
 
 import "net/http"
 
-// CORS adds standard cross-origin headers to every response and handles
-// preflight OPTIONS requests.
-func CORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+// CORS returns a middleware that echoes the request's Origin header back in
+// Access-Control-Allow-Origin only when the origin is in allowedOrigins.
+// Cross-origin responses to other origins carry no CORS headers, so browsers
+// block them. Preflight OPTIONS requests short-circuit with 204.
+//
+// An empty allowedOrigins slice disables cross-origin access entirely: no
+// Access-Control-Allow-Origin header is ever emitted.
+func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		allowed[o] = struct{}{}
+	}
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Vary ensures caches don't serve a response built for one origin
+			// to a request from a different origin.
+			w.Header().Set("Vary", "Origin")
 
-		next.ServeHTTP(w, r)
-	})
+			origin := r.Header.Get("Origin")
+			if origin != "" {
+				if _, ok := allowed[origin]; ok {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+					if r.Method == http.MethodOptions {
+						w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+						w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+					}
+				}
+			}
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -17,11 +17,13 @@ const defaultMaxBodyBytes int64 = 1 << 20 // 1 MiB
 // Callers may supply a database ping, a no-op, or a stub for tests.
 type HealthChecker func(ctx context.Context) error
 
-// New assembles the full HTTP handler: panic recovery → request-size limit →
-// structured logging → mux.  Routes are registered via the returned *Mux.
+// New assembles the full HTTP handler: panic recovery → CORS → request-size
+// limit → structured logging → mux.  Routes are registered via the returned
+// *Mux. allowedOrigins is the list of origins permitted to make cross-origin
+// requests; an empty slice disables cross-origin access.
 //
 // The returned http.Handler is ready to pass to http.Server.
-func New(logger *slog.Logger, checker HealthChecker) (http.Handler, *http.ServeMux) {
+func New(logger *slog.Logger, checker HealthChecker, allowedOrigins []string) (http.Handler, *http.ServeMux) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler(checker))
 	mux.HandleFunc("GET /healthz", healthHandler(checker))
@@ -29,7 +31,7 @@ func New(logger *slog.Logger, checker HealthChecker) (http.Handler, *http.ServeM
 	// Build the middleware stack (outermost first):
 	// RecoverPanic → CORS → LimitRequestBody → Logging → mux
 	handler := middleware.RecoverPanic(logger)(
-		middleware.CORS(
+		middleware.CORS(allowedOrigins)(
 			middleware.LimitRequestBody(defaultMaxBodyBytes)(
 				middleware.Logging(logger)(mux),
 			),

--- a/apps/api/internal/server/server_test.go
+++ b/apps/api/internal/server/server_test.go
@@ -28,11 +28,15 @@ func silentLogger() *slog.Logger {
 
 func noopChecker(_ context.Context) error { return nil }
 
+// defaultTestOrigins is the allowlist used by most tests. Tests that need a
+// different allowlist build their own server via server.New directly.
+var defaultTestOrigins = []string{"https://example.com"}
+
 // newTestServer returns a running httptest.Server backed by the full
 // middleware stack.  Callers must defer Close().
 func newTestServer(t *testing.T, extra func(*http.ServeMux)) *httptest.Server {
 	t.Helper()
-	handler, mux := server.New(silentLogger(), noopChecker)
+	handler, mux := server.New(silentLogger(), noopChecker, defaultTestOrigins)
 	if extra != nil {
 		extra(mux)
 	}
@@ -70,7 +74,7 @@ func TestHealthCheck_Returns200WithStatusOK(t *testing.T) {
 
 func TestHealthCheck_Returns503WhenCheckerFails(t *testing.T) {
 	checker := func(_ context.Context) error { return errors.New("db down") }
-	handler, _ := server.New(silentLogger(), checker)
+	handler, _ := server.New(silentLogger(), checker, defaultTestOrigins)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -152,7 +156,7 @@ func TestMiddleware_RequestIDIsPropagatedThroughContext(t *testing.T) {
 	var capturedBuf bytes.Buffer
 	log := slog.New(slog.NewJSONHandler(&capturedBuf, nil))
 
-	handler, mux := server.New(log, noopChecker)
+	handler, mux := server.New(log, noopChecker, defaultTestOrigins)
 	mux.HandleFunc("GET /api/v1/echo", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -202,7 +206,7 @@ func TestPanicInHandler_Returns500NotCrash(t *testing.T) {
 func TestPanicInHandler_StackTraceIsLogged(t *testing.T) {
 	var logBuf bytes.Buffer
 	log := slog.New(slog.NewJSONHandler(&logBuf, nil))
-	handler, mux := server.New(log, noopChecker)
+	handler, mux := server.New(log, noopChecker, defaultTestOrigins)
 	mux.HandleFunc("GET /api/v1/panic", func(_ http.ResponseWriter, _ *http.Request) {
 		panic("stack trace test")
 	})
@@ -257,7 +261,7 @@ func TestGracefulShutdown_InFlightRequestCompletes(t *testing.T) {
 	requestStarted := make(chan struct{})
 	requestCanFinish := make(chan struct{})
 
-	handler, mux := server.New(silentLogger(), noopChecker)
+	handler, mux := server.New(silentLogger(), noopChecker, defaultTestOrigins)
 	mux.HandleFunc("GET /api/v1/slow", func(w http.ResponseWriter, _ *http.Request) {
 		close(requestStarted) // signal: request is inside the handler
 		<-requestCanFinish    // wait until test unblocks us
@@ -329,7 +333,7 @@ func TestGracefulShutdown_NewConnectionsRejectedAfterShutdown(t *testing.T) {
 		t.Fatalf("net.Listen error = %v", err)
 	}
 
-	handler, _ := server.New(silentLogger(), noopChecker)
+	handler, _ := server.New(silentLogger(), noopChecker, defaultTestOrigins)
 	srv := &http.Server{Handler: handler}
 	go srv.Serve(ln) //nolint:errcheck
 
@@ -361,7 +365,7 @@ func TestGracefulShutdown_NewConnectionsRejectedAfterShutdown(t *testing.T) {
 // CORS headers
 // ---------------------------------------------------------------------------
 
-func TestCORS_HeadersPresentOnCrossOriginRequests(t *testing.T) {
+func TestCORS_AllowedOriginIsEchoedBack(t *testing.T) {
 	srv := newTestServer(t, nil)
 	defer srv.Close()
 
@@ -373,17 +377,57 @@ func TestCORS_HeadersPresentOnCrossOriginRequests(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	acao := resp.Header.Get("Access-Control-Allow-Origin")
-	if acao == "" {
-		t.Error("expected Access-Control-Allow-Origin header, got empty")
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "https://example.com")
 	}
-	acam := resp.Header.Get("Access-Control-Allow-Methods")
-	if acam == "" {
-		t.Error("expected Access-Control-Allow-Methods header, got empty")
+	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want %q", got, "true")
+	}
+	if got := resp.Header.Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want %q", got, "Origin")
 	}
 }
 
-func TestCORS_PreflightOptionsReturns204(t *testing.T) {
+func TestCORS_DisallowedOriginReceivesNoACAO(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/health", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin should be unset for disallowed origin, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("Access-Control-Allow-Credentials should be unset for disallowed origin, got %q", got)
+	}
+	if got := resp.Header.Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want %q", got, "Origin")
+	}
+}
+
+func TestCORS_SameOriginRequestEmitsNoACAO(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	// No Origin header — same-origin browser requests or non-browser clients.
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin should be unset when Origin is absent, got %q", got)
+	}
+}
+
+func TestCORS_PreflightFromAllowedOriginReturns204WithHeaders(t *testing.T) {
 	srv := newTestServer(t, nil)
 	defer srv.Close()
 
@@ -397,6 +441,53 @@ func TestCORS_PreflightOptionsReturns204(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("expected 204 for preflight OPTIONS, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Errorf("preflight Access-Control-Allow-Origin = %q, want %q", got, "https://example.com")
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Methods"); got == "" {
+		t.Error("preflight Access-Control-Allow-Methods should be set for allowed origin")
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Headers"); got == "" {
+		t.Error("preflight Access-Control-Allow-Headers should be set for allowed origin")
+	}
+}
+
+func TestCORS_PreflightFromDisallowedOriginReturns204WithoutACAO(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/health", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("OPTIONS /health error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected 204 for preflight OPTIONS, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("preflight ACAO should be unset for disallowed origin, got %q", got)
+	}
+}
+
+func TestCORS_EmptyAllowlistBlocksAllOrigins(t *testing.T) {
+	handler, _ := server.New(silentLogger(), noopChecker, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/health", nil)
+	req.Header.Set("Origin", "https://example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin should be unset with empty allowlist, got %q", got)
 	}
 }
 
@@ -416,7 +507,7 @@ func TestMiddleware_ExecutesInCorrectOrder(t *testing.T) {
 	var logBuf bytes.Buffer
 	log := slog.New(slog.NewJSONHandler(&logBuf, nil))
 
-	handler, mux := server.New(log, noopChecker)
+	handler, mux := server.New(log, noopChecker, defaultTestOrigins)
 	mux.HandleFunc("GET /api/v1/order-test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -455,7 +546,7 @@ func TestGracefulShutdown_ExitsWithinConfiguredTimeout(t *testing.T) {
 		t.Fatalf("net.Listen error = %v", err)
 	}
 
-	handler, _ := server.New(silentLogger(), noopChecker)
+	handler, _ := server.New(silentLogger(), noopChecker, defaultTestOrigins)
 	srv := &http.Server{Handler: handler}
 	go srv.Serve(ln) //nolint:errcheck
 


### PR DESCRIPTION
  - Replaces the wildcard Access-Control-Allow-Origin: * in apps/api/internal/middleware/cors.go with an origin allowlist: the request's Origin is echoed back only when it matches ALLOWED_ORIGINS, Vary: Origin is always set, and Access-Control-Allow-Credentials: true plus the preflight method/header hints are emitted only for allowed origins.
  - Adds ALLOWED_ORIGINS to config.go (comma-separated). Validation rejects *, non-http(s) schemes, and any path/query/fragment. A non-empty list is required in production/staging; development/test may leave it empty (CORS disabled).
  - Wires middleware.CORS into the production chain in cmd/api/main.go: it was previously only reachable via the test-only server.New constructor. CORS sits inside rate limiting (preflights count against the bucket) and outside auth (preflights short-circuit with 204 before Authenticate can reject them).
  - Updates .env.example with ALLOWED_ORIGINS and a production example.

  Test plan
  
  - go build ./... in apps/api
  - go test ./... in apps/api 
  - New middleware tests: allowed origin echoed, disallowed origin gets no ACAO, same-origin (no Origin header) gets no ACAO, preflight from allowed origin returns 204 with headers, preflight from disallowed origin returns 204 without ACAO, empty allowlist blocks all

closes #251 