### PR TITLE
fix(ci): add -race flag to Go API test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           cache: true
 
       - name: Test
-        run: go test ./...
+        run: go test -race -timeout 120s -count=1 ./...
 
   internal-stellar:
     name: Internal (Go)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check clippy build test integration-test clean dev dev-down dev-reset dev-logs dev-db
+.PHONY: fmt fmt-check clippy build test test-short integration-test clean dev dev-down dev-reset dev-logs dev-db go-test go-test-short
 
 CARGO := cargo
 CONTRACTS_DIR := packages/contracts
@@ -21,6 +21,12 @@ test:
 
 integration-test:
 	cd $(CONTRACTS_DIR) && $(CARGO) test --all --lib
+
+go-test:
+	cd apps/api && go test -race -timeout 120s ./...
+
+go-test-short:
+	cd apps/api && go test -race -short -timeout 60s ./...
 
 clean:
 	cd $(CONTRACTS_DIR) && $(CARGO) clean

--- a/apps/api/internal/service/challenge_store_test.go
+++ b/apps/api/internal/service/challenge_store_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -76,4 +78,49 @@ func TestInMemoryChallengeStore_IsolatesWallets(t *testing.T) {
 	gotB, err := store.GetAndDelete(ctx, "WALLET_B")
 	require.NoError(t, err)
 	assert.Equal(t, "bbbb", gotB)
+}
+
+// TestChallengeStore_ConcurrentAccess verifies that InMemoryChallengeStore is
+// safe for concurrent use. 100 goroutines each perform Set, GetAndDelete, and
+// a subsequent GetAndDelete (which must return ErrChallengeNotFound) without
+// data races. Run with -race to detect any mutex violations.
+func TestChallengeStore_ConcurrentAccess(t *testing.T) {
+	store := NewInMemoryChallengeStore(5 * time.Minute)
+	ctx := context.Background()
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			wallet := fmt.Sprintf("CONCURRENT_WALLET_%d", i)
+			challenge := fmt.Sprintf("challenge_%d", i)
+
+			// Set a challenge for this wallet.
+			if err := store.Set(ctx, wallet, challenge); err != nil {
+				t.Errorf("goroutine %d: Set failed: %v", i, err)
+				return
+			}
+
+			// Retrieve and delete — must return the challenge we stored.
+			got, err := store.GetAndDelete(ctx, wallet)
+			if err != nil {
+				t.Errorf("goroutine %d: GetAndDelete failed: %v", i, err)
+				return
+			}
+			if got != challenge {
+				t.Errorf("goroutine %d: got %q, want %q", i, got, challenge)
+			}
+
+			// Second retrieval must return ErrChallengeNotFound (one-time use).
+			_, err = store.GetAndDelete(ctx, wallet)
+			if err == nil {
+				t.Errorf("goroutine %d: expected ErrChallengeNotFound on second GetAndDelete", i)
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- **CI**: changes `go test ./...` to `go test -race -timeout 120s -count=1 ./...` in the `apps/api` job — catches data races on every PR
- **Makefile**: adds `go-test` and `go-test-short` targets with the same flags so developers can reproduce CI locally (`make go-test`)
- **Concurrent test**: adds `TestChallengeStore_ConcurrentAccess` to `internal/service/challenge_store_test.go` — 100 goroutines each call `Set` → `GetAndDelete` → `GetAndDelete` simultaneously to prove the `InMemoryChallengeStore` mutex is correct; run passes cleanly under `-race`

## Test plan

- [ ] CI `apps-api` job passes with `-race` flag
- [ ] `TestChallengeStore_ConcurrentAccess` passes (`go test -race ./internal/service/...` on Linux)
- [ ] `make go-test` and `make go-test-short` are available and run correctly
- [ ] No data-race warnings reported

Closes #260