### PR TITLE
fix(dapp): replace localStorage with sessionStorage for wallet session — XSS mitigation

### DIFF
--- a/apps/dapp/frontend/components/wallet-provider.tsx
+++ b/apps/dapp/frontend/components/wallet-provider.tsx
@@ -112,11 +112,13 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                 setWallets(walletList);
                 setWalletsLoaded(true);
 
-                // Check if there's a previously saved session
+                // Rehydrate session from sessionStorage (cleared on tab close;
+                // never persisted to localStorage which is accessible to all
+                // scripts on the page and therefore an XSS risk).
                 const savedWalletId =
-                    localStorage.getItem("nester_wallet_id");
+                    sessionStorage.getItem("nester_wallet_id");
                 const savedAddress =
-                    localStorage.getItem("nester_wallet_addr");
+                    sessionStorage.getItem("nester_wallet_addr");
                 if (savedWalletId && savedAddress) {
                     const savedWallet = walletList.find(
                         (w) => w.id === savedWalletId && w.isAvailable
@@ -124,12 +126,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                     if (savedWallet) {
                         try {
                             StellarWalletsKit.setWallet(savedWalletId);
-                            // Use the module directly to request the address
                             const walletModule = StellarWalletsKit.selectedModule;
                             const { address: addr } =
                                 await walletModule.getAddress();
                             if (addr) {
-                                // Update the kit's internal state
                                 const { activeAddress } = await import(
                                     "@creit.tech/stellar-wallets-kit/state"
                                 );
@@ -138,8 +138,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
                                 setSelectedWalletId(savedWalletId);
                             }
                         } catch {
-                            localStorage.removeItem("nester_wallet_id");
-                            localStorage.removeItem("nester_wallet_addr");
+                            sessionStorage.removeItem("nester_wallet_id");
+                            sessionStorage.removeItem("nester_wallet_addr");
                         }
                     }
                 }
@@ -190,8 +190,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
                     setAddress(addr);
                     setSelectedWalletId(walletId);
-                    localStorage.setItem("nester_wallet_id", walletId);
-                    localStorage.setItem("nester_wallet_addr", addr);
+                    sessionStorage.setItem("nester_wallet_id", walletId);
+                    sessionStorage.setItem("nester_wallet_addr", addr);
                 }
             } catch (err) {
                 const message = extractErrorMessage(err);
@@ -215,8 +215,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         }
         setAddress(null);
         setSelectedWalletId(null);
-        localStorage.removeItem("nester_wallet_id");
-        localStorage.removeItem("nester_wallet_addr");
+        sessionStorage.removeItem("nester_wallet_id");
+        sessionStorage.removeItem("nester_wallet_addr");
     }, []);
 
     return (


### PR DESCRIPTION
## Summary

`localStorage` is readable by any JavaScript on the page. A single XSS vector in any dependency or injected script could silently exfiltrate the saved wallet address and wallet ID, then impersonate the session on page reload.

`sessionStorage` is the correct boundary: it survives in-tab page reloads (so the UX is identical) but is cleared automatically when the tab closes, meaning no wallet data outlasts the browsing session it was created in.

**Changes** — all in `apps/dapp/frontend/components/wallet-provider.tsx`, no other files touched:

| Location | Before | After |
|---|---|---|
| `initKit` rehydration | `localStorage.getItem` ×2 | `sessionStorage.getItem` ×2 |
| `connect` success | `localStorage.setItem` ×2 | `sessionStorage.setItem` ×2 |
| `initKit` error cleanup | `localStorage.removeItem` ×2 | `sessionStorage.removeItem` ×2 |
| `disconnect` | `localStorage.removeItem` ×2 | `sessionStorage.removeItem` ×2 |

## Approach chosen

`sessionStorage` — cleared on tab close, inaccessible to other tabs, not readable after browser restart. This matches the expected lifetime of a wallet connection and requires no server-side changes. An `HttpOnly; SameSite=Strict` cookie backed by a server session would give stronger guarantees but requires API changes out of scope for this fix.

## Test plan

- [ ] Connect a wallet → address shows correctly
- [ ] Reload the page within the same tab → session is restored (sessionStorage persists across reloads)
- [ ] Close the tab and reopen the app → wallet is disconnected (sessionStorage cleared)
- [ ] `localStorage` contains no `nester_wallet_id` or `nester_wallet_addr` keys after connecting
- [ ] Disconnect clears the session

Closes #254