### PR TITLE
fix(intelligence): add JWT authentication to all AI endpoints

### DIFF
--- a/apps/intelligence/app/config.py
+++ b/apps/intelligence/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     port: int = 8000
     anthropic_api_key: str = ""
     anthropic_model: str = "claude-sonnet-4-6"
+    jwt_secret: str = ""
 
     model_config = SettingsConfigDict(
         env_prefix="INTELLIGENCE_",

--- a/apps/intelligence/app/dependencies/auth.py
+++ b/apps/intelligence/app/dependencies/auth.py
@@ -1,0 +1,42 @@
+"""JWT authentication dependency for all protected intelligence endpoints."""
+
+from typing import Any
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.config import settings
+
+_bearer = HTTPBearer()
+
+
+def verify_jwt(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> dict[str, Any]:
+    """Validate a Bearer JWT and return its claims.
+
+    Raises 401 if the token is missing, expired, or has an invalid signature.
+    The secret must match INTELLIGENCE_JWT_SECRET, which must equal
+    AUTH_JWT_SECRET in the Go API so tokens issued there are accepted here.
+    """
+    token = credentials.credentials
+    try:
+        claims: dict[str, Any] = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=["HS256"],
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return claims

--- a/apps/intelligence/app/routers/analyze.py
+++ b/apps/intelligence/app/routers/analyze.py
@@ -2,20 +2,33 @@
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
 
+from app.dependencies.auth import verify_jwt
 from app.services.prometheus import (
     get_market_sentiment,
     get_portfolio_insights,
     get_vault_recommendations,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(verify_jwt)])
 
 
 @router.get("/portfolio/{user_id}/insights")
-async def portfolio_insights(user_id: str) -> list[dict[str, Any]]:
-    """Return AI-generated portfolio insight cards for a user."""
+async def portfolio_insights(
+    user_id: str,
+    claims: dict[str, Any] = Depends(verify_jwt),
+) -> list[dict[str, Any]]:
+    """Return AI-generated portfolio insight cards for a user.
+
+    The path ``user_id`` must match the authenticated subject to prevent
+    one user querying another's insights.
+    """
+    if claims.get("sub") != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorised to access this user's insights",
+        )
     return await get_portfolio_insights(user_id)
 
 

--- a/apps/intelligence/app/routers/chat.py
+++ b/apps/intelligence/app/routers/chat.py
@@ -1,29 +1,38 @@
 """Streaming SSE chat endpoint for Prometheus AI."""
 
-from fastapi import APIRouter, Query
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
+from app.dependencies.auth import verify_jwt
 from app.services.prometheus import stream_chat
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(verify_jwt)])
 
 
 @router.get("/chat")
 async def chat(
-    userId: str = Query(..., description="Nester user ID or wallet address"),
     message: str = Query(..., description="User message to Prometheus"),
+    claims: dict[str, Any] = Depends(verify_jwt),
 ) -> StreamingResponse:
     """Stream a Prometheus AI response as Server-Sent Events.
 
-    The client should open this with `EventSource` or `fetch` + `ReadableStream`.
-    Each event is `data: <text chunk>\\n\\n`.
-    The stream terminates with `data: [DONE]\\n\\n`.
+    The user ID is sourced from the JWT subject claim — never from the caller.
+    Each event is ``data: <text chunk>\\n\\n``.
+    The stream terminates with ``data: [DONE]\\n\\n``.
     """
+    user_id: str = claims.get("sub", "")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing subject claim",
+        )
     return StreamingResponse(
-        stream_chat(userId, message),
+        stream_chat(user_id, message),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",  # disable Nginx buffering for SSE
+            "X-Accel-Buffering": "no",
         },
     )

--- a/apps/intelligence/requirements.txt
+++ b/apps/intelligence/requirements.txt
@@ -4,3 +4,4 @@ httpx==0.28.1
 anthropic==0.42.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
+PyJWT==2.10.1


### PR DESCRIPTION
## Summary

All intelligence endpoints were publicly accessible — any unauthenticated caller could invoke the Anthropic API at the operator's expense and read any user's portfolio data by supplying an arbitrary `userId`.

**Changes:**

- **`PyJWT==2.10.1`** added to `requirements.txt`
- **`app/dependencies/auth.py`** (new): `verify_jwt` FastAPI dependency — validates HS256 Bearer token against `INTELLIGENCE_JWT_SECRET`; raises `401` on expiry or invalid signature
- **`app/config.py`**: adds `jwt_secret` field (`INTELLIGENCE_JWT_SECRET` env var, must equal `AUTH_JWT_SECRET` from the Go API)
- **`app/routers/chat.py`**: router-level `dependencies=[Depends(verify_jwt)]`; removes caller-supplied `userId` param and replaces with `claims["sub"]` — callers can no longer impersonate other users
- **`app/routers/analyze.py`**: router-level `dependencies=[Depends(verify_jwt)]`; `portfolio_insights` raises `403` if `path user_id != claims["sub"]`
- **`app/routers/health.py`**: unchanged — `/health` intentionally unauthenticated for liveness probes
- **`apps/intelligence/.env.example`**: (added in NE-1) already documents `INTELLIGENCE_JWT_SECRET`

## Test plan

- [ ] `GET /intelligence/chat?message=hello` without token → `403` (no credentials) / `401` (invalid token)
- [ ] Same request with a valid HS256 JWT signed with `INTELLIGENCE_JWT_SECRET` → streams response using `sub` as user ID
- [ ] `GET /portfolio/{user_id}/insights` with JWT whose `sub` != `user_id` → `403`
- [ ] `GET /portfolio/{user_id}/insights` with matching `sub` → `200`
- [ ] `GET /health` without token → `200` (unauthenticated)
- [ ] Expired token → `401 Token has expired`

Closes #232