### PR TITLE
fix: resolve security, contract, and chain-integration issues

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -78,6 +78,7 @@ func run() error {
 			return fmt.Errorf("init chain invoker: %w", err)
 		}
 		chainInvoker = inv
+		vaultService.SetDepositInvoker(inv)
 	}
 
 	adminService := service.NewAdminService(

--- a/apps/api/internal/service/admin_service.go
+++ b/apps/api/internal/service/admin_service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -280,20 +279,3 @@ func (s *AdminService) checkEventIndexer(ctx context.Context) admindomain.Health
 	}
 }
 
-func diskUsage() string {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs("/", &stat); err != nil {
-		return "n/a"
-	}
-
-	total := stat.Blocks * uint64(stat.Bsize)
-	free := stat.Bavail * uint64(stat.Bsize)
-	used := total - free
-
-	if total == 0 {
-		return "n/a"
-	}
-
-	usedPct := (float64(used) / float64(total)) * 100
-	return fmt.Sprintf("%.1f%%", usedPct)
-}

--- a/apps/api/internal/service/disk_unix.go
+++ b/apps/api/internal/service/disk_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package service
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func diskUsage() string {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs("/", &stat); err != nil {
+		return "n/a"
+	}
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bavail * uint64(stat.Bsize)
+	used := total - free
+	if total == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", (float64(used)/float64(total))*100)
+}

--- a/apps/api/internal/service/disk_windows.go
+++ b/apps/api/internal/service/disk_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package service
+
+func diskUsage() string {
+	return "n/a"
+}

--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -29,3 +29,17 @@ func (s *SorobanVaultChainInvoker) PauseVault(ctx context.Context, contractAddre
 func (s *SorobanVaultChainInvoker) UnpauseVault(ctx context.Context, contractAddress string) error {
 	return s.invoker.InvokeVoidFunction(ctx, contractAddress, "unpause")
 }
+
+// DepositToVault invokes the vault contract's deposit function with the
+// operator as both caller and depositing user, passing amount and zero
+// as the minimum-shares-out slippage guard.
+func (s *SorobanVaultChainInvoker) DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error {
+	return s.invoker.InvokeWithI128Pair(ctx, contractAddress, "deposit", amountStroops, 0)
+}
+
+// WithdrawFromVault invokes the vault contract's withdraw function with the
+// operator as both caller and withdrawing user, passing shares and zero
+// as the minimum-assets-out slippage guard.
+func (s *SorobanVaultChainInvoker) WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64) error {
+	return s.invoker.InvokeWithI128Pair(ctx, contractAddress, "withdraw", sharesStroops, 0)
+}

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -11,8 +12,24 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 )
 
+// VaultDepositInvoker handles on-chain deposit and withdrawal operations.
+// Implementations invoke the Soroban vault contract; the noop is used when
+// no operator secret is configured.
+type VaultDepositInvoker interface {
+	DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error
+	WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64) error
+}
+
+// NoopVaultDepositInvoker satisfies VaultDepositInvoker without making any
+// on-chain calls. Used when chain integration is not configured.
+type NoopVaultDepositInvoker struct{}
+
+func (NoopVaultDepositInvoker) DepositToVault(_ context.Context, _ string, _ int64) error    { return nil }
+func (NoopVaultDepositInvoker) WithdrawFromVault(_ context.Context, _ string, _ int64) error { return nil }
+
 type VaultService struct {
-	repository vault.Repository
+	repository     vault.Repository
+	depositInvoker VaultDepositInvoker
 }
 
 // ── Input types ──────────────────────────────────────────────────────────────
@@ -56,6 +73,12 @@ type RecordWithdrawalInput struct {
 
 func NewVaultService(repository vault.Repository) *VaultService {
 	return &VaultService{repository: repository}
+}
+
+// SetDepositInvoker wires an optional on-chain invoker into the vault service.
+// Call this after NewVaultService when an operator key is available.
+func (s *VaultService) SetDepositInvoker(invoker VaultDepositInvoker) {
+	s.depositInvoker = invoker
 }
 
 // ── Existing methods ─────────────────────────────────────────────────────────
@@ -150,6 +173,17 @@ func (s *VaultService) RecordDeposit(ctx context.Context, input RecordDepositInp
 	}
 	if decimalScale(input.Amount) > vault.MaxAmountScale {
 		return vault.Vault{}, vault.ErrInvalidPrecision
+	}
+
+	if s.depositInvoker != nil {
+		existing, err := s.repository.GetVault(ctx, input.VaultID)
+		if err != nil {
+			return vault.Vault{}, err
+		}
+		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).IntPart()
+		if err := s.depositInvoker.DepositToVault(ctx, existing.ContractAddress, stroops); err != nil {
+			return vault.Vault{}, fmt.Errorf("on-chain deposit failed: %w", err)
+		}
 	}
 
 	if err := s.repository.RecordDeposit(ctx, input.VaultID, input.Amount); err != nil {
@@ -338,6 +372,13 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 	}
 	if existing.CurrentBalance.LessThan(input.Amount) {
 		return vault.Vault{}, vault.ErrInsufficientBalance
+	}
+
+	if s.depositInvoker != nil {
+		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).IntPart()
+		if err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, stroops); err != nil {
+			return vault.Vault{}, fmt.Errorf("on-chain withdrawal failed: %w", err)
+		}
 	}
 
 	if err := s.repository.RecordWithdrawal(ctx, input.VaultID, input.Amount); err != nil {

--- a/apps/api/internal/stellar/invoker.go
+++ b/apps/api/internal/stellar/invoker.go
@@ -300,6 +300,123 @@ func (c *ContractInvoker) getSequenceNumber(ctx context.Context) (int64, error) 
 	return seq, nil
 }
 
+// InvokeWithI128Pair calls a contract function with signature
+// (caller: Address, arg0: i128, arg1: i128). Suitable for deposit and withdraw
+// where the operator acts as the transaction source and user.
+func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddress, functionName string, arg0, arg1 int64) error {
+	contractScAddr, err := contractAddressToXDR(contractAddress)
+	if err != nil {
+		return err
+	}
+
+	callerScAddr, err := accountAddressToXDR(c.kp.Address())
+	if err != nil {
+		return err
+	}
+
+	hostFn := xdr.HostFunction{
+		Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
+		InvokeContract: &xdr.InvokeContractArgs{
+			ContractAddress: contractScAddr,
+			FunctionName:    xdr.ScSymbol(functionName),
+			Args: []xdr.ScVal{
+				{Type: xdr.ScValTypeScvAddress, Address: &callerScAddr},
+				int64ToI128ScVal(arg0),
+				int64ToI128ScVal(arg1),
+			},
+		},
+	}
+
+	seq, err := c.getSequenceNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("get sequence number: %w", err)
+	}
+
+	sourceAccount := txnbuild.NewSimpleAccount(c.kp.Address(), seq)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &sourceAccount,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.InvokeHostFunction{
+				HostFunction: hostFn,
+			},
+		},
+		BaseFee:       txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+	})
+	if err != nil {
+		return fmt.Errorf("build transaction: %w", err)
+	}
+
+	txB64, err := tx.Base64()
+	if err != nil {
+		return fmt.Errorf("encode transaction: %w", err)
+	}
+
+	simResult, err := c.simulate(ctx, txB64)
+	if err != nil {
+		return err
+	}
+
+	var sorobanData xdr.SorobanTransactionData
+	if err := xdr.SafeUnmarshalBase64(simResult.TransactionData, &sorobanData); err != nil {
+		return fmt.Errorf("decode soroban data: %w", err)
+	}
+
+	envelope := tx.ToXDR()
+	envelope.V1.Tx.Ext = xdr.TransactionExt{
+		V:           1,
+		SorobanData: &sorobanData,
+	}
+	minFee, _ := strconv.ParseInt(simResult.MinResourceFee, 10, 64)
+	envelope.V1.Tx.Fee = xdr.Uint32(txnbuild.MinBaseFee + minFee)
+
+	envB64, err := xdr.MarshalBase64(envelope)
+	if err != nil {
+		return fmt.Errorf("encode patched envelope: %w", err)
+	}
+
+	generic, err := txnbuild.TransactionFromXDR(envB64)
+	if err != nil {
+		return fmt.Errorf("parse patched tx: %w", err)
+	}
+
+	inner, ok := generic.Transaction()
+	if !ok {
+		return errors.New("expected a transaction, got fee-bump")
+	}
+
+	signed, err := inner.Sign(c.networkPassphrase, c.kp)
+	if err != nil {
+		return fmt.Errorf("sign transaction: %w", err)
+	}
+
+	signedB64, err := signed.Base64()
+	if err != nil {
+		return fmt.Errorf("encode signed transaction: %w", err)
+	}
+
+	hash, err := c.send(ctx, signedB64)
+	if err != nil {
+		return err
+	}
+
+	return c.waitForTx(ctx, hash)
+}
+
+func int64ToI128ScVal(n int64) xdr.ScVal {
+	hi := xdr.Int64(0)
+	lo := xdr.Uint64(uint64(n))
+	if n < 0 {
+		hi = xdr.Int64(-1)
+	}
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvI128,
+		I128: &xdr.Int128Parts{Hi: hi, Lo: lo},
+	}
+}
+
 // ── XDR helpers ───────────────────────────────────────────────────────────────
 
 func contractAddressToXDR(address string) (xdr.ScAddress, error) {

--- a/apps/api/internal/stellar/invoker.go
+++ b/apps/api/internal/stellar/invoker.go
@@ -88,7 +88,7 @@ func (c *ContractInvoker) InvokeVoidFunction(ctx context.Context, contractAddres
 			},
 		},
 		BaseFee:       txnbuild.MinBaseFee,
-		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64((5 * time.Minute).Seconds()))},
 	})
 	if err != nil {
 		return fmt.Errorf("build transaction: %w", err)
@@ -343,7 +343,7 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 			},
 		},
 		BaseFee:       txnbuild.MinBaseFee,
-		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64((5 * time.Minute).Seconds()))},
 	})
 	if err != nil {
 		return fmt.Errorf("build transaction: %w", err)

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -102,7 +102,16 @@ export class TransactionTimeoutError extends Error {
 // ── Soroban RPC client ────────────────────────────────────────────────────────
 
 function getServer(rpcUrl: string): SorobanRpc.Server {
-  return new SorobanRpc.Server(rpcUrl, { allowHttp: true });
+  const isProd = process.env.NODE_ENV === "production";
+
+  if (isProd && !rpcUrl.startsWith("https://")) {
+    throw new Error(
+      `Production Soroban RPC URL must use HTTPS. Got: ${rpcUrl}. ` +
+        `Set NEXT_PUBLIC_STELLAR_RPC_URL to a valid https:// endpoint.`
+    );
+  }
+
+  return new SorobanRpc.Server(rpcUrl, { allowHttp: !isProd });
 }
 
 // ── Transaction builders ──────────────────────────────────────────────────────

--- a/internal/stellar/apy_relayer.go
+++ b/internal/stellar/apy_relayer.go
@@ -5,11 +5,69 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 )
+
+// validProtocolID matches safe protocol identifiers (alphanumeric, dash, underscore, 1–64 chars).
+var validProtocolID = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// privateIPBlocks lists all RFC-reserved private and loopback ranges used for SSRF prevention.
+var privateIPBlocks = func() []*net.IPNet {
+	blocks := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"::1/128",
+		"fc00::/7",
+		"169.254.0.0/16", // link-local / AWS IMDS
+	}
+	nets := make([]*net.IPNet, 0, len(blocks))
+	for _, b := range blocks {
+		_, network, _ := net.ParseCIDR(b)
+		nets = append(nets, network)
+	}
+	return nets
+}()
+
+func isPrivateIP(ip net.IP) bool {
+	for _, block := range privateIPBlocks {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ssrfSafeTransport returns an *http.Transport whose DialContext blocks requests
+// to private/loopback IP ranges to prevent SSRF.
+func ssrfSafeTransport() *http.Transport {
+	dialer := &net.Dialer{}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+			}
+			ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+			if err != nil {
+				return nil, fmt.Errorf("DNS lookup failed for %q: %w", host, err)
+			}
+			for _, ip := range ips {
+				if isPrivateIP(ip) {
+					return nil, fmt.Errorf("SSRF protection: blocked request to private/reserved IP %s", ip)
+				}
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+}
 
 const defaultAPYStalenessThreshold = time.Hour
 
@@ -313,19 +371,39 @@ type protocolAPYResponse struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
-func NewProtocolRPCClient(httpClient *http.Client, baseURL string) *ProtocolRPCClient {
+func NewProtocolRPCClient(httpClient *http.Client, baseURL string) (*ProtocolRPCClient, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if trimmed == "" {
+		return nil, errors.New("protocol RPC base URL is required")
+	}
+
+	parsed, err := url.ParseRequestURI(trimmed)
+	if err != nil || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid protocol RPC base URL %q: must be a valid absolute URL", trimmed)
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("protocol RPC base URL must use HTTPS, got scheme %q", parsed.Scheme)
+	}
+
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
+		httpClient = &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: ssrfSafeTransport(),
+		}
 	}
 	return &ProtocolRPCClient{
-		baseURL:    strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		baseURL:    trimmed,
 		httpClient: httpClient,
-	}
+	}, nil
 }
 
 func (c *ProtocolRPCClient) FetchProtocolAPY(ctx context.Context, protocolID string) (APYSnapshot, error) {
-	url := fmt.Sprintf("%s/v1/protocols/%s/apy", c.baseURL, protocolID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if !validProtocolID.MatchString(protocolID) {
+		return APYSnapshot{}, fmt.Errorf("invalid protocolID format: %q — must match [a-zA-Z0-9_-]{1,64}", protocolID)
+	}
+
+	apiURL := fmt.Sprintf("%s/v1/protocols/%s/apy", c.baseURL, url.PathEscape(protocolID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return APYSnapshot{}, err
 	}
@@ -337,7 +415,7 @@ func (c *ProtocolRPCClient) FetchProtocolAPY(ctx context.Context, protocolID str
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return APYSnapshot{}, fmt.Errorf("protocol RPC returned status %d for %s", resp.StatusCode, protocolID)
+		return APYSnapshot{}, fmt.Errorf("protocol RPC returned status %d for %q", resp.StatusCode, protocolID)
 	}
 
 	var payload protocolAPYResponse

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -156,6 +156,7 @@ enum DataKey {
     EmergencyFeeBps,
     VaultLiquidReserves,
     EmergencyQueue,
+    LiquidReserved, // total amount committed to the emergency queue but not yet paid
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +252,19 @@ fn set_vault_liquid_reserves(env: &Env, amount: i128) {
     env.storage()
         .instance()
         .set(&DataKey::VaultLiquidReserves, &amount);
+}
+
+fn get_liquid_reserved(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LiquidReserved)
+        .unwrap_or(0)
+}
+
+fn set_liquid_reserved(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LiquidReserved, &amount);
 }
 
 fn get_emergency_queue(env: &Env) -> soroban_sdk::Vec<EmergencyRequest> {
@@ -539,7 +553,6 @@ impl VaultContract {
 
     pub fn collect_fees(env: Env, caller: Address) {
         caller.require_auth();
-        // Allow ADMIN or MANAGER to collect fees
         if !AccessControl::has_role(&env, &caller, Role::Admin)
             && !AccessControl::has_role(&env, &caller, Role::Manager)
         {
@@ -549,33 +562,40 @@ impl VaultContract {
         accrue_management_fee(&env);
         let fees = get_accrued_fees(&env);
         if fees > 0 {
+            // Only transfer the portion of liquid reserves that is not already
+            // committed to the emergency queue, preventing over-drawing funds
+            // that are owed to queued withdrawal requests.
+            let current_reserves = get_vault_liquid_reserves(&env);
+            let reserved = get_liquid_reserved(&env);
+            let available = current_reserves.saturating_sub(reserved);
+            let collectable = fees.min(available);
+
+            if collectable == 0 {
+                return;
+            }
+
             let config = get_fee_config(&env);
             let token_address = self::VaultContract::get_token(env.clone());
 
             token::Client::new(&env, &token_address).transfer(
                 &env.current_contract_address(),
                 &config.treasury_address,
-                &fees,
+                &collectable,
             );
 
-            // Notify treasury - assuming it has receive_fees method
-            // We'll use a raw invoke to avoid dependency on Treasury client here for simplicity
-            // Or just rely on token transfer being enough if treasury tracks its own balance.
-            // The treasury contract I wrote has receive_fees(amount).
             env.invoke_contract::<()>(
                 &config.treasury_address,
                 &Symbol::new(&env, "receive_fees"),
-                (fees,).into_val(&env),
+                (collectable,).into_val(&env),
             );
 
-            set_accrued_fees(&env, 0);
+            set_accrued_fees(&env, fees - collectable);
 
             let total_assets = get_total_assets(&env);
-            set_total_assets(&env, total_assets - fees);
+            set_total_assets(&env, total_assets - collectable);
             sync_vault_token_total_assets(&env);
 
-            let current_reserves = get_vault_liquid_reserves(&env);
-            set_vault_liquid_reserves(&env, current_reserves - fees);
+            set_vault_liquid_reserves(&env, current_reserves - collectable);
         }
     }
 
@@ -653,6 +673,7 @@ impl VaultContract {
         }
 
         let mut liquid_reserves = get_vault_liquid_reserves(&env);
+        let mut liquid_reserved = get_liquid_reserved(&env);
         let token_address = self::VaultContract::get_token(env.clone());
         let contract_address = env.current_contract_address();
         let token_client = token::Client::new(&env, &token_address);
@@ -663,6 +684,8 @@ impl VaultContract {
             if liquid_reserves >= req.amount {
                 token_client.transfer(&contract_address, &req.user, &req.amount);
                 liquid_reserves -= req.amount;
+                // Release the reservation now that the payment has been made.
+                liquid_reserved = liquid_reserved.saturating_sub(req.amount);
 
                 emit_event(
                     &env,
@@ -687,6 +710,7 @@ impl VaultContract {
         }
 
         set_vault_liquid_reserves(&env, liquid_reserves);
+        set_liquid_reserved(&env, liquid_reserved);
         set_emergency_queue(&env, &new_queue);
     }
 
@@ -871,6 +895,11 @@ impl VaultContract {
                 amount: return_amount,
             });
             set_emergency_queue(&env, &queue);
+
+            // Reserve these funds so collect_fees cannot draw them away
+            // before the queued request is processed.
+            let currently_reserved = get_liquid_reserved(&env);
+            set_liquid_reserved(&env, currently_reserved + return_amount);
 
             let position = queue.len();
             emit_event(

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -714,3 +714,113 @@ fn emergency_withdraw_queue_processed_on_deposit() {
         1_000 * XLM
     );
 }
+
+// ---------------------------------------------------------------------------
+// LiquidReserved tests — verifies collect_fees cannot over-draw committed funds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn collect_fees_capped_when_emergency_queue_commits_all_reserves() {
+    // Deposit, accrue fees, then queue an emergency withdrawal that commits
+    // all liquid reserves.  collect_fees must transfer nothing.
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    // Accrue a full year of management fee
+    advance_time(&env, 365 * DAY);
+    vault.pause(&admin);
+
+    // User queues an emergency withdrawal, which reserves their principal
+    vault.emergency_withdraw(&user);
+
+    // Now all liquid reserves are committed to the queue.
+    // collect_fees should transfer 0 — fees exist but available = 0.
+    let treasury_before = token::Client::new(&env, &token.address).balance(&_treasury);
+    vault.unpause(&admin);
+    vault.collect_fees(&admin);
+    let treasury_after = token::Client::new(&env, &token.address).balance(&_treasury);
+
+    assert_eq!(
+        treasury_after, treasury_before,
+        "collect_fees must not transfer when all reserves are committed to the queue"
+    );
+}
+
+#[test]
+fn collect_fees_transfers_only_unreserved_portion() {
+    // Two users deposit.  One queues an emergency withdrawal (reserving half
+    // the pool).  collect_fees should be capped to the unreserved half.
+    let (env, admin, token, vault, _treasury) = setup();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    mint(&token, &user1, 500 * XLM);
+    mint(&token, &user2, 500 * XLM);
+
+    vault.deposit(&user1, &(500 * XLM), &0);
+    vault.deposit(&user2, &(500 * XLM), &0);
+
+    advance_time(&env, 365 * DAY);
+    vault.pause(&admin);
+
+    // user1's emergency withdrawal reserves ~500 XLM from the pool
+    vault.emergency_withdraw(&user1);
+
+    vault.unpause(&admin);
+
+    let treasury_before = token::Client::new(&env, &token.address).balance(&_treasury);
+    vault.collect_fees(&admin);
+    let treasury_after = token::Client::new(&env, &token.address).balance(&_treasury);
+
+    let fees_collected = treasury_after - treasury_before;
+
+    // The reserved portion (user1's principal, ~500 XLM) must not be touched.
+    // Fees collected must be strictly less than the total accrued fees.
+    let total_reserves = token::Client::new(&env, &token.address).balance(&vault.address);
+    assert!(
+        fees_collected < total_reserves,
+        "collect_fees must not exceed unreserved liquid reserves"
+    );
+}
+
+#[test]
+fn process_emergency_queue_decrements_liquid_reserved() {
+    // After a queued withdrawal is processed, LiquidReserved must decrease
+    // so that subsequent collect_fees calls can access those funds again.
+    let (env, admin, token, vault, _treasury) = setup();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    mint(&token, &user1, 1_000 * XLM);
+    mint(&token, &user2, 2_000 * XLM);
+
+    vault.deposit(&user1, &(1_000 * XLM), &0);
+    advance_time(&env, 365 * DAY);
+    vault.pause(&admin);
+
+    vault.emergency_withdraw(&user1);
+    // user1 is now queued; reserved = ~1000 XLM
+
+    // user2 deposits, providing liquidity and processing the queue
+    vault.unpause(&admin);
+    vault.deposit(&user2, &(2_000 * XLM), &0);
+
+    // user1 should have received their principal
+    assert_eq!(
+        token::Client::new(&env, &token.address).balance(&user1),
+        1_000 * XLM,
+        "queued user should receive principal after queue is processed"
+    );
+
+    // After the queue is processed, collect_fees should succeed (reserved = 0)
+    advance_time(&env, 30 * DAY);
+    let treasury_before = token::Client::new(&env, &token.address).balance(&_treasury);
+    vault.collect_fees(&admin);
+    let treasury_after = token::Client::new(&env, &token.address).balance(&_treasury);
+
+    assert!(
+        treasury_after > treasury_before,
+        "collect_fees should transfer fees once LiquidReserved is decremented after queue processing"
+    );
+}


### PR DESCRIPTION
## Summary

- Enforce HTTPS for Soroban RPC client in production; `allowHttp` is now only set in non-production environments to prevent plaintext RPC calls on mainnet
- Sanitize `protocolID` path segment with a regex allowlist and apply `url.PathEscape` before URL construction; add SSRF protection to `ProtocolRPCClient` via a custom `http.Transport` that blocks requests to private/reserved IP ranges
- Wire Soroban contract interactions into the vault service: introduce `VaultDepositInvoker` interface backed by `SorobanVaultChainInvoker`; `RecordDeposit` and `RecordWithdrawal` now invoke the on-chain vault contract before persisting to the database when an operator key is configured
- Fix emergency withdrawal queue over-commit in the vault contract: add `LiquidReserved` storage to track funds committed to the queue; `collect_fees` is capped to unreserved liquid, and `process_emergency_queue` releases reservations as requests are fulfilled

## Test plan

- [ ] Verify `allowHttp` is `false` when `NODE_ENV=production` in transaction.ts
- [ ] Confirm `ProtocolRPCClient` rejects non-HTTPS base URLs and blocks private-IP targets
- [ ] Start API with `STELLAR_OPERATOR_SECRET` set; confirm `SetDepositInvoker` is wired and deposit/withdraw flow reaches `InvokeWithI128Pair`
- [ ] Without operator secret, confirm no-op path leaves existing DB-only behaviour unchanged
- [ ] Deploy updated vault contract to testnet; queue an emergency withdrawal that exceeds liquid reserves and confirm `collect_fees` cannot drain the reserved amount
- [ ] Confirm `process_emergency_queue` pays out queued requests and decrements `LiquidReserved` correctly

Closes #256
Closes #262
Closes #99
Closes #263