### PR TITLE
chore: add environment variable configuration template for API service

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -38,6 +38,24 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Horizon API endpoint.
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# Stellar account secret used to sign on-chain operations from the API
+# (e.g. vault deposits). Leave empty to disable on-chain invocation.
+STELLAR_OPERATOR_SECRET=
+
+# Settlement provider URL used by the admin service for off-chain settlement.
+# Leave empty to disable.
+SETTLEMENT_PROVIDER_URL=
+
+# JWT signing secret used to mint and validate API access tokens.
+# Must be at least 32 characters. Generate a strong random value in production.
+AUTH_JWT_SECRET=replace-with-a-strong-random-32-plus-character-secret
+
+# Lifetime of issued JWT access tokens.
+AUTH_TOKEN_EXPIRY=24h
+
+# Lifetime of authentication challenges (sign-in nonces).
+AUTH_CHALLENGE_EXPIRY=5m
+
 # Log level: debug, info, warn, or error.
 LOG_LEVEL=info
 
@@ -51,8 +69,20 @@ LOG_FORMAT=text
 # Example (production): https://app.nester.finance,https://nester.finance
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Global per-IP rate limit applied to every request before auth runs.
+RATELIMIT_GLOBAL_LIMIT=100
+RATELIMIT_GLOBAL_WINDOW=1m
+
+# Stricter per-IP rate limit applied only to mutating methods
+# (POST/PUT/PATCH/DELETE).
+RATELIMIT_WRITE_LIMIT=20
+RATELIMIT_WRITE_WINDOW=1m
+
 # Per-wallet rate limit for authenticated requests. Buckets are keyed by the
 # wallet address in JWT claims, so a single wallet cannot bypass the limit by
 # rotating IPs. Unauthenticated requests are unaffected.
 RATELIMIT_WALLET_LIMIT=60
 RATELIMIT_WALLET_WINDOW=1m
+
+# How often the performance tracker writes vault performance snapshots.
+PERFORMANCE_SNAPSHOT_INTERVAL=1h


### PR DESCRIPTION
Those build errors are pre-existing (missing module deps in go.sum) and unrelated to the .env.example doc change.

Closes #164 

Summary
The middleware wiring requested in the issue is already merged on main:

[apps/api/cmd/api/main.go:201-217](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/cmd/api/main.go#L201-L217) — chain: SecurityHeaders → RecoverPanic → IPRateLimiter → CORS → WriteRateLimiter → Authenticate → WalletRateLimiter → LimitRequestBody → Logging → mux
[apps/api/cmd/api/main.go:172-180](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/cmd/api/main.go#L172-L180) — RouteRule table (health/healthz/readyz/ws/auth public; admin requires role; rest of /api/v1/ requires auth)
[apps/api/internal/config/config.go](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/internal/config/config.go) — AUTH_JWT_SECRET, RATELIMIT_GLOBAL_*/WRITE_*/WALLET_*, ALLOWED_ORIGINS all defined and validated; * wildcard explicitly rejected at [line 293-296](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/internal/config/config.go#L293-L296)
[apps/api/internal/middleware/cors.go](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/internal/middleware/cors.go) — uses configured origin allowlist; no wildcard
What I changed: [apps/api/.env.example](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/.env.example) — added the previously undocumented variables required by config.Load(): AUTH_JWT_SECRET (required, would fail startup without it), AUTH_TOKEN_EXPIRY, AUTH_CHALLENGE_EXPIRY, STELLAR_OPERATOR_SECRET, SETTLEMENT_PROVIDER_URL, RATELIMIT_GLOBAL_*, RATELIMIT_WRITE_*, PERFORMANCE_SNAPSHOT_INTERVAL.