### PR TITLE
Feat(backend)  implement startup validation, graceful shutdown improvements, and enhanced health checks

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -38,6 +38,24 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Horizon API endpoint.
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# Stellar account secret used to sign on-chain operations from the API
+# (e.g. vault deposits). Leave empty to disable on-chain invocation.
+STELLAR_OPERATOR_SECRET=
+
+# Settlement provider URL used by the admin service for off-chain settlement.
+# Leave empty to disable.
+SETTLEMENT_PROVIDER_URL=
+
+# JWT signing secret used to mint and validate API access tokens.
+# Must be at least 32 characters. Generate a strong random value in production.
+AUTH_JWT_SECRET=replace-with-a-strong-random-32-plus-character-secret
+
+# Lifetime of issued JWT access tokens.
+AUTH_TOKEN_EXPIRY=24h
+
+# Lifetime of authentication challenges (sign-in nonces).
+AUTH_CHALLENGE_EXPIRY=5m
+
 # Log level: debug, info, warn, or error.
 LOG_LEVEL=info
 
@@ -51,8 +69,20 @@ LOG_FORMAT=text
 # Example (production): https://app.nester.finance,https://nester.finance
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Global per-IP rate limit applied to every request before auth runs.
+RATELIMIT_GLOBAL_LIMIT=100
+RATELIMIT_GLOBAL_WINDOW=1m
+
+# Stricter per-IP rate limit applied only to mutating methods
+# (POST/PUT/PATCH/DELETE).
+RATELIMIT_WRITE_LIMIT=20
+RATELIMIT_WRITE_WINDOW=1m
+
 # Per-wallet rate limit for authenticated requests. Buckets are keyed by the
 # wallet address in JWT claims, so a single wallet cannot bypass the limit by
 # rotating IPs. Unauthenticated requests are unaffected.
 RATELIMIT_WALLET_LIMIT=60
 RATELIMIT_WALLET_WINDOW=1m
+
+# How often the performance tracker writes vault performance snapshots.
+PERFORMANCE_SNAPSHOT_INTERVAL=1h

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -10,11 +10,20 @@ SERVER_PORT=8080
 # Maximum duration for reading the full request, including body.
 SERVER_READ_TIMEOUT=15s
 
+# Maximum duration to read request headers (slowloris protection).
+SERVER_READ_HEADER_TIMEOUT=10s
+
 # Maximum duration before timing out response writes.
 SERVER_WRITE_TIMEOUT=15s
 
+# How long an idle keep-alive connection is kept open.
+SERVER_IDLE_TIMEOUT=60s
+
 # Time allowed for graceful shutdown before forcefully stopping.
 SERVER_SHUTDOWN_TIMEOUT=20s
+
+# Cap on request header size (bytes). Protects against oversized-header DoS.
+SERVER_MAX_HEADER_BYTES=1048576
 
 # PostgreSQL connection string used by the API.
 DATABASE_DSN=postgres://postgres:postgres@localhost:5432/nester?sslmode=disable
@@ -86,3 +95,15 @@ RATELIMIT_WALLET_WINDOW=1m
 
 # How often the performance tracker writes vault performance snapshots.
 PERFORMANCE_SNAPSHOT_INTERVAL=1h
+
+# Run database migrations automatically at startup. Recommended in development;
+# disable in production if migrations are managed by a separate pipeline.
+ENABLE_AUTO_MIGRATE=true
+
+# Filesystem location of migration *.up.sql / *.down.sql files. Resolved
+# relative to the API working directory.
+MIGRATIONS_DIR=./migrations
+
+# Timeout for startup reachability probes against Horizon and Soroban RPC.
+# If a probe fails within this window, the API exits before serving traffic.
+STARTUP_DEPENDENCY_TIMEOUT=5s

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
+	dbpkg "github.com/suncrestlabs/nester/apps/api/internal/db"
 	"github.com/suncrestlabs/nester/apps/api/internal/handler"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
@@ -29,6 +31,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	performancesvc "github.com/suncrestlabs/nester/apps/api/internal/service/performance"
+	stellarpkg "github.com/suncrestlabs/nester/apps/api/internal/stellar"
 	"github.com/suncrestlabs/nester/apps/api/internal/ws"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
 )
@@ -43,6 +46,8 @@ func main() {
 }
 
 func run() error {
+	startedAt := time.Now()
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -61,6 +66,20 @@ func run() error {
 
 	db := stdlib.OpenDBFromPool(pgPool.Pool)
 	defer db.Close()
+
+	if cfg.Startup().EnableAutoMigrate() {
+		baseLogger.Info("running database migrations", "dir", cfg.Startup().MigrationsDir())
+		if err := dbpkg.MigrateUp(db, cfg.Startup().MigrationsDir()); err != nil {
+			return fmt.Errorf("auto-migrate: %w", err)
+		}
+		baseLogger.Info("database migrations complete")
+	} else {
+		baseLogger.Info("auto-migrate disabled; skipping migrations")
+	}
+
+	if err := pingStellarDependencies(baseLogger, cfg); err != nil {
+		return err
+	}
 
 	vaultRepository := postgres.NewVaultRepository(db)
 	vaultService := service.NewVaultService(vaultRepository)
@@ -154,10 +173,28 @@ func run() error {
 		}
 	}()
 
+	// ready tracks whether the server is accepting traffic. Flipped to false on
+	// shutdown so load balancers stop routing before in-flight drain begins.
+	var ready atomic.Bool
+	ready.Store(true)
+
+	depHTTPClient := &http.Client{Timeout: cfg.Startup().DependencyTimeout()}
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
-	mux.HandleFunc("GET /healthz", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
-	mux.HandleFunc("GET /readyz", healthHandler(pgPool, cfg.Database().ConnectionTimeout()))
+	mux.HandleFunc("GET /health", livenessHandler(&ready))
+	mux.HandleFunc("GET /healthz", livenessHandler(&ready))
+	mux.HandleFunc("GET /readyz", readinessHandler(&ready, pgPool, cfg.Database().ConnectionTimeout()))
+	mux.HandleFunc("GET /health/detailed", detailedHealthHandler(detailedHealthDeps{
+		ready:        &ready,
+		pgPool:       pgPool,
+		dbTimeout:    cfg.Database().ConnectionTimeout(),
+		httpClient:   depHTTPClient,
+		horizonURL:   cfg.Stellar().HorizonURL(),
+		rpcURL:       cfg.Stellar().RPCURL(),
+		startedAt:    startedAt,
+		environment:  cfg.Environment(),
+		buildVersion: version,
+	}))
 	vaultHandler.Register(mux)
 	transactionHandler.Register(mux)
 	settlementHandler.Register(mux)
@@ -215,11 +252,22 @@ func run() error {
 				),
 			),
 		),
-		ReadTimeout:  cfg.Server().ReadTimeout(),
-		WriteTimeout: cfg.Server().WriteTimeout(),
+		ReadTimeout:       cfg.Server().ReadTimeout(),
+		ReadHeaderTimeout: cfg.Server().ReadHeaderTimeout(),
+		WriteTimeout:      cfg.Server().WriteTimeout(),
+		IdleTimeout:       cfg.Server().IdleTimeout(),
+		MaxHeaderBytes:    cfg.Server().MaxHeaderBytes(),
 	}
 
-	baseLogger.Info("starting server", "addr", cfg.Server().Address(), "environment", cfg.Environment())
+	baseLogger.Info("starting server",
+		"addr", cfg.Server().Address(),
+		"environment", cfg.Environment(),
+		"version", version,
+		"horizon_url", cfg.Stellar().HorizonURL(),
+		"rpc_url", cfg.Stellar().RPCURL(),
+		"network_passphrase", cfg.Stellar().NetworkPassphrase(),
+		"auto_migrate", cfg.Startup().EnableAutoMigrate(),
+	)
 
 	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -240,15 +288,20 @@ func run() error {
 	case err := <-serverErr:
 		return err
 	case <-shutdownCtx.Done():
-		baseLogger.Info("shutdown signal received")
+		baseLogger.Info("shutdown signal received, draining")
 	}
 
 	stop()
+
+	// Flip readiness immediately so load balancers stop routing new traffic
+	// to this instance before we wait for in-flight requests to complete.
+	ready.Store(false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Server().GracefulShutdown())
 	defer cancel()
 
 	if err := server.Shutdown(ctx); err != nil {
+		baseLogger.Error("graceful shutdown timed out", "error", err.Error())
 		return err
 	}
 
@@ -256,7 +309,9 @@ func run() error {
 		return err
 	}
 
-	baseLogger.Info("server stopped")
+	baseLogger.Info("server stopped",
+		"uptime", time.Since(startedAt).String(),
+	)
 	return nil
 }
 
@@ -271,19 +326,180 @@ func walletKeyFromContext(r *http.Request) string {
 	return u.WalletAddress
 }
 
-func healthHandler(db *repository.PostgresDB, timeout time.Duration) http.HandlerFunc {
+// livenessHandler returns 200 while the process is healthy and 503 once
+// shutdown has begun. It performs no external calls so load balancers can
+// poll it cheaply.
+func livenessHandler(ready *atomic.Bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), timeout)
-		defer cancel()
-
-		if err := db.Ping(ctx); err != nil {
-			http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if !ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("draining"))
 			return
 		}
-
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}
+}
+
+// readinessHandler returns 200 only when the database is reachable and the
+// process is not draining. Used by orchestrators that need to know when this
+// instance can serve traffic.
+func readinessHandler(ready *atomic.Bool, db *repository.PostgresDB, timeout time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if !ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("draining"))
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		if err := db.Ping(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("database unavailable"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}
+}
+
+type detailedHealthDeps struct {
+	ready        *atomic.Bool
+	pgPool       *repository.PostgresDB
+	dbTimeout    time.Duration
+	httpClient   *http.Client
+	horizonURL   string
+	rpcURL       string
+	startedAt    time.Time
+	environment  string
+	buildVersion string
+}
+
+type dependencyStatus struct {
+	OK            bool   `json:"ok"`
+	Endpoint      string `json:"endpoint,omitempty"`
+	LatencyMillis int64  `json:"latency_ms,omitempty"`
+	Error         string `json:"error,omitempty"`
+	LatestLedger  uint64 `json:"latest_ledger,omitempty"`
+}
+
+type dbStatus struct {
+	OK            bool   `json:"ok"`
+	LatencyMillis int64  `json:"latency_ms,omitempty"`
+	Error         string `json:"error,omitempty"`
+	MaxConns      int32  `json:"max_conns"`
+	AcquiredConns int32  `json:"acquired_conns"`
+	IdleConns     int32  `json:"idle_conns"`
+	TotalConns    int32  `json:"total_conns"`
+}
+
+type detailedHealthResponse struct {
+	Status       string           `json:"status"`
+	Environment  string           `json:"environment"`
+	Version      string           `json:"version"`
+	UptimeSecs   int64            `json:"uptime_seconds"`
+	Database     dbStatus         `json:"database"`
+	Horizon      dependencyStatus `json:"horizon"`
+	SorobanRPC   dependencyStatus `json:"soroban_rpc"`
+	GeneratedAt  time.Time        `json:"generated_at"`
+}
+
+func detailedHealthHandler(deps detailedHealthDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := detailedHealthResponse{
+			Status:      "ok",
+			Environment: deps.environment,
+			Version:     deps.buildVersion,
+			UptimeSecs:  int64(time.Since(deps.startedAt).Seconds()),
+			GeneratedAt: time.Now().UTC(),
+		}
+
+		// Database
+		dbCtx, dbCancel := context.WithTimeout(r.Context(), deps.dbTimeout)
+		dbStart := time.Now()
+		dbErr := deps.pgPool.Ping(dbCtx)
+		dbCancel()
+		stat := deps.pgPool.Pool.Stat()
+		resp.Database = dbStatus{
+			OK:            dbErr == nil,
+			LatencyMillis: time.Since(dbStart).Milliseconds(),
+			MaxConns:      stat.MaxConns(),
+			AcquiredConns: stat.AcquiredConns(),
+			IdleConns:     stat.IdleConns(),
+			TotalConns:    stat.TotalConns(),
+		}
+		if dbErr != nil {
+			resp.Database.Error = dbErr.Error()
+		}
+
+		// Horizon
+		hStart := time.Now()
+		hRes := stellarpkg.PingHorizon(r.Context(), deps.httpClient, deps.horizonURL)
+		resp.Horizon = dependencyStatus{
+			OK:            hRes.OK,
+			Endpoint:      hRes.Endpoint,
+			Error:         hRes.Error,
+			LatencyMillis: time.Since(hStart).Milliseconds(),
+			LatestLedger:  hRes.LatestLedger,
+		}
+
+		// Soroban RPC
+		rStart := time.Now()
+		rRes := stellarpkg.PingSorobanRPC(r.Context(), deps.httpClient, deps.rpcURL)
+		resp.SorobanRPC = dependencyStatus{
+			OK:            rRes.OK,
+			Endpoint:      rRes.Endpoint,
+			Error:         rRes.Error,
+			LatencyMillis: time.Since(rStart).Milliseconds(),
+			LatestLedger:  rRes.LatestLedger,
+		}
+
+		degraded := !resp.Database.OK || !resp.Horizon.OK || !resp.SorobanRPC.OK
+		draining := !deps.ready.Load()
+		switch {
+		case draining:
+			resp.Status = "draining"
+		case degraded:
+			resp.Status = "degraded"
+		}
+
+		status := http.StatusOK
+		if draining || !resp.Database.OK {
+			status = http.StatusServiceUnavailable
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// pingStellarDependencies verifies Horizon and Soroban RPC are reachable
+// before the server starts accepting traffic. Failure here exits the process
+// so orchestrators can restart against a healthy node.
+func pingStellarDependencies(logger *slog.Logger, cfg *config.Config) error {
+	timeout := cfg.Startup().DependencyTimeout()
+	client := &http.Client{Timeout: timeout}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if res := stellarpkg.PingHorizon(ctx, client, cfg.Stellar().HorizonURL()); !res.OK {
+		return fmt.Errorf("horizon unreachable at %s: %s", cfg.Stellar().HorizonURL(), res.Error)
+	} else {
+		logger.Info("horizon reachable", "url", cfg.Stellar().HorizonURL(), "latest_ledger", res.LatestLedger)
+	}
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), timeout)
+	defer rpcCancel()
+	if res := stellarpkg.PingSorobanRPC(rpcCtx, client, cfg.Stellar().RPCURL()); !res.OK {
+		return fmt.Errorf("soroban rpc unreachable at %s: %s", cfg.Stellar().RPCURL(), res.Error)
+	} else {
+		logger.Info("soroban rpc reachable", "url", cfg.Stellar().RPCURL(), "latest_ledger", res.LatestLedger)
+	}
+
+	return nil
 }
 
 func startEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, rpcURL string) {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -25,6 +25,15 @@ type Config struct {
 	log                   LogConfig
 	allowedOrigins        []string
 	performance           PerformanceConfig
+	startup               StartupConfig
+}
+
+// StartupConfig governs one-shot work performed before the server begins
+// accepting traffic (migrations, dependency reachability checks).
+type StartupConfig struct {
+	enableAutoMigrate bool
+	migrationsDir     string
+	dependencyTimeout time.Duration
 }
 
 type PerformanceConfig struct {
@@ -32,11 +41,14 @@ type PerformanceConfig struct {
 }
 
 type ServerConfig struct {
-	host             string
-	port             int
-	readTimeout      time.Duration
-	writeTimeout     time.Duration
-	gracefulShutdown time.Duration
+	host              string
+	port              int
+	readTimeout       time.Duration
+	readHeaderTimeout time.Duration
+	writeTimeout      time.Duration
+	idleTimeout       time.Duration
+	gracefulShutdown  time.Duration
+	maxHeaderBytes    int
 }
 
 type DatabaseConfig struct {
@@ -95,11 +107,14 @@ func Load() (*Config, error) {
 	cfg := &Config{
 		environment: environment,
 		server: ServerConfig{
-			host:             loader.stringDefault("SERVER_HOST", "0.0.0.0"),
-			port:             loader.intDefault("SERVER_PORT", 8080),
-			readTimeout:      loader.durationDefault("SERVER_READ_TIMEOUT", 15*time.Second),
-			writeTimeout:     loader.durationDefault("SERVER_WRITE_TIMEOUT", 15*time.Second),
-			gracefulShutdown: loader.durationDefault("SERVER_SHUTDOWN_TIMEOUT", 20*time.Second),
+			host:              loader.stringDefault("SERVER_HOST", "0.0.0.0"),
+			port:              loader.intDefault("SERVER_PORT", 8080),
+			readTimeout:       loader.durationDefault("SERVER_READ_TIMEOUT", 15*time.Second),
+			readHeaderTimeout: loader.durationDefault("SERVER_READ_HEADER_TIMEOUT", 10*time.Second),
+			writeTimeout:      loader.durationDefault("SERVER_WRITE_TIMEOUT", 15*time.Second),
+			idleTimeout:       loader.durationDefault("SERVER_IDLE_TIMEOUT", 60*time.Second),
+			gracefulShutdown:  loader.durationDefault("SERVER_SHUTDOWN_TIMEOUT", 20*time.Second),
+			maxHeaderBytes:    loader.intDefault("SERVER_MAX_HEADER_BYTES", 1<<20),
 		},
 		database: DatabaseConfig{
 			dsn:               loader.requiredString("DATABASE_DSN"),
@@ -136,6 +151,11 @@ func Load() (*Config, error) {
 		allowedOrigins: loader.stringSliceDefault("ALLOWED_ORIGINS", nil),
 		performance: PerformanceConfig{
 			snapshotInterval: loader.durationDefault("PERFORMANCE_SNAPSHOT_INTERVAL", 1*time.Hour),
+		},
+		startup: StartupConfig{
+			enableAutoMigrate: loader.boolDefault("ENABLE_AUTO_MIGRATE", false),
+			migrationsDir:     loader.stringDefault("MIGRATIONS_DIR", "./migrations"),
+			dependencyTimeout: loader.durationDefault("STARTUP_DEPENDENCY_TIMEOUT", 5*time.Second),
 		},
 	}
 
@@ -188,6 +208,22 @@ func (c Config) Performance() PerformanceConfig {
 	return c.performance
 }
 
+func (c Config) Startup() StartupConfig {
+	return c.startup
+}
+
+func (s StartupConfig) EnableAutoMigrate() bool {
+	return s.enableAutoMigrate
+}
+
+func (s StartupConfig) MigrationsDir() string {
+	return s.migrationsDir
+}
+
+func (s StartupConfig) DependencyTimeout() time.Duration {
+	return s.dependencyTimeout
+}
+
 func (p PerformanceConfig) SnapshotInterval() time.Duration {
 	return p.snapshotInterval
 }
@@ -217,12 +253,32 @@ func (c *Config) validate(loader *envLoader) {
 		loader.addError("SERVER_READ_TIMEOUT must be greater than 0")
 	}
 
+	if c.server.readHeaderTimeout <= 0 {
+		loader.addError("SERVER_READ_HEADER_TIMEOUT must be greater than 0")
+	}
+
 	if c.server.writeTimeout <= 0 {
 		loader.addError("SERVER_WRITE_TIMEOUT must be greater than 0")
 	}
 
+	if c.server.idleTimeout <= 0 {
+		loader.addError("SERVER_IDLE_TIMEOUT must be greater than 0")
+	}
+
 	if c.server.gracefulShutdown <= 0 {
 		loader.addError("SERVER_SHUTDOWN_TIMEOUT must be greater than 0")
+	}
+
+	if c.server.maxHeaderBytes <= 0 {
+		loader.addError("SERVER_MAX_HEADER_BYTES must be greater than 0")
+	}
+
+	if c.startup.dependencyTimeout <= 0 {
+		loader.addError("STARTUP_DEPENDENCY_TIMEOUT must be greater than 0")
+	}
+
+	if strings.TrimSpace(c.startup.migrationsDir) == "" {
+		loader.addError("MIGRATIONS_DIR must not be empty")
 	}
 
 	if c.database.poolSize <= 0 {
@@ -317,12 +373,24 @@ func (s ServerConfig) ReadTimeout() time.Duration {
 	return s.readTimeout
 }
 
+func (s ServerConfig) ReadHeaderTimeout() time.Duration {
+	return s.readHeaderTimeout
+}
+
 func (s ServerConfig) WriteTimeout() time.Duration {
 	return s.writeTimeout
 }
 
+func (s ServerConfig) IdleTimeout() time.Duration {
+	return s.idleTimeout
+}
+
 func (s ServerConfig) GracefulShutdown() time.Duration {
 	return s.gracefulShutdown
+}
+
+func (s ServerConfig) MaxHeaderBytes() int {
+	return s.maxHeaderBytes
 }
 
 func (s ServerConfig) Address() string {
@@ -461,6 +529,19 @@ func (l *envLoader) stringSliceDefault(key string, fallback []string) []string {
 		}
 	}
 	return out
+}
+
+func (l *envLoader) boolDefault(key string, fallback bool) bool {
+	raw, ok := l.lookup(key)
+	if !ok {
+		return fallback
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		l.addError(fmt.Sprintf("%s must be a boolean (true/false), got %q", key, raw))
+		return fallback
+	}
+	return value
 }
 
 func (l *envLoader) durationDefault(key string, fallback time.Duration) time.Duration {

--- a/apps/api/internal/stellar/health.go
+++ b/apps/api/internal/stellar/health.go
@@ -1,0 +1,115 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// HealthResult captures the outcome of a single dependency probe.
+type HealthResult struct {
+	OK            bool   `json:"ok"`
+	Endpoint      string `json:"endpoint,omitempty"`
+	Error         string `json:"error,omitempty"`
+	LatencyMillis int64  `json:"latency_ms,omitempty"`
+	LatestLedger  uint64 `json:"latest_ledger,omitempty"`
+}
+
+// PingHorizon issues a GET against the Horizon root endpoint and reports
+// reachability plus the current ledger sequence. It does not retry; callers
+// supply their own timeout via ctx.
+func PingHorizon(ctx context.Context, client *http.Client, horizonURL string) HealthResult {
+	url := strings.TrimRight(horizonURL, "/") + "/"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return HealthResult{Endpoint: horizonURL, Error: err.Error()}
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return HealthResult{Endpoint: horizonURL, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return HealthResult{
+			Endpoint: horizonURL,
+			Error:    fmt.Sprintf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body))),
+		}
+	}
+
+	var payload struct {
+		HistoryLatestLedger uint64 `json:"history_latest_ledger"`
+		CoreLatestLedger    uint64 `json:"core_latest_ledger"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&payload); err != nil {
+		// Reachability is established by the 2xx response; failure to parse
+		// the body shouldn't fail the health check.
+		return HealthResult{OK: true, Endpoint: horizonURL}
+	}
+
+	ledger := payload.HistoryLatestLedger
+	if ledger == 0 {
+		ledger = payload.CoreLatestLedger
+	}
+	return HealthResult{OK: true, Endpoint: horizonURL, LatestLedger: ledger}
+}
+
+// PingSorobanRPC issues a getHealth JSON-RPC call to a Soroban RPC node and
+// reports reachability.
+func PingSorobanRPC(ctx context.Context, client *http.Client, rpcURL string) HealthResult {
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "nester-health",
+		"method":  "getHealth",
+	})
+	if err != nil {
+		return HealthResult{Endpoint: rpcURL, Error: err.Error()}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rpcURL, strings.NewReader(string(body)))
+	if err != nil {
+		return HealthResult{Endpoint: rpcURL, Error: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return HealthResult{Endpoint: rpcURL, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return HealthResult{
+			Endpoint: rpcURL,
+			Error:    fmt.Sprintf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload))),
+		}
+	}
+
+	var rpcResp struct {
+		Result struct {
+			Status       string `json:"status"`
+			LatestLedger uint64 `json:"latestLedger"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&rpcResp); err != nil {
+		return HealthResult{Endpoint: rpcURL, Error: fmt.Sprintf("decode: %s", err.Error())}
+	}
+	if rpcResp.Error != nil {
+		return HealthResult{Endpoint: rpcURL, Error: rpcResp.Error.Message}
+	}
+	if rpcResp.Result.Status != "" && !strings.EqualFold(rpcResp.Result.Status, "healthy") {
+		return HealthResult{Endpoint: rpcURL, Error: fmt.Sprintf("rpc status %q", rpcResp.Result.Status)}
+	}
+	return HealthResult{OK: true, Endpoint: rpcURL, LatestLedger: rpcResp.Result.LatestLedger}
+}


### PR DESCRIPTION
Done. Here's what I changed:
Closes #169 

Files modified

[apps/api/internal/config/config.go](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/internal/config/config.go) — added StartupConfig (ENABLE_AUTO_MIGRATE, MIGRATIONS_DIR, STARTUP_DEPENDENCY_TIMEOUT); added SERVER_READ_HEADER_TIMEOUT, SERVER_IDLE_TIMEOUT, SERVER_MAX_HEADER_BYTES to ServerConfig; added boolDefault loader helper; validation + getters.
[apps/api/internal/stellar/health.go](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/internal/stellar/health.go) — new file: PingHorizon (GET Horizon root, parses latest ledger) and PingSorobanRPC (getHealth JSON-RPC).
[apps/api/cmd/api/main.go](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/cmd/api/main.go) — wired startup validation:
Auto-migrate via dbpkg.MigrateUp when ENABLE_AUTO_MIGRATE=true.
pingStellarDependencies runs Horizon + Soroban probes; failure exits before serving traffic.
atomic.Bool ready flag — livenessHandler and readinessHandler flip to 503 on shutdown.
New GET /health/detailed returns DB pool stats (max/acquired/idle/total + ping latency), Horizon and Soroban reachability with latencies and latest ledger, uptime, env, version. Returns 503 if DB is down or draining; "degraded" status if any dep is down.
http.Server hardening: IdleTimeout, ReadHeaderTimeout, MaxHeaderBytes set from config.
Shutdown: signal → ready.Store(false) → server.Shutdown(ctx) → log "server stopped" with uptime. Existing defer pgPool.Pool.Close() runs after Shutdown returns, so the pool closes only once in-flight requests are drained.
Startup summary log includes addr, env, version, Horizon/RPC URLs, network passphrase, auto-migrate flag.
[apps/api/.env.example](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/apps/api/.env.example) — documented the new SERVER_*, ENABLE_AUTO_MIGRATE, MIGRATIONS_DIR, STARTUP_DEPENDENCY_TIMEOUT.
Build status: modified packages (internal/config, internal/stellar, internal/db) build clean. The cmd/api build fails only on pre-existing missing go-chi/v5 and gorilla/websocket deps — unchanged from before this task.

Notes / scope decisions

The RunWithGracefulShutdown helper in internal/server/server.go is unused by cmd/api/main.go (which has its own server setup). I left it alone rather than churning unrelated code; the harden-on-the-actual-server path is what matters.
Event-indexer lag and settlement-provider checks were called out in the issue as "when integrated"; current code has the indexer running (no exposed lag metric) and no settlement provider client. I didn't fabricate metrics for these — the detailed health response can be extended once those expose lag/health surfaces.