### PR TITLE
feat(mobile): migrate mobile app from Flutter to React Native with Expo

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,22 @@
+import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+
+export default function RootLayout() {
+  return (
+    <>
+      <StatusBar style="light" />
+      <Stack
+        screenOptions={{
+          headerStyle: { backgroundColor: "#0f172a" },
+          headerTintColor: "#ffffff",
+          headerTitleStyle: { fontWeight: "bold" },
+          contentStyle: { backgroundColor: "#0f172a" },
+        }}
+      >
+        <Stack.Screen name="index" options={{ title: "Nester" }} />
+        <Stack.Screen name="dashboard/index" options={{ title: "Dashboard" }} />
+        <Stack.Screen name="vaults/index" options={{ title: "Vaults" }} />
+      </Stack>
+    </>
+  );
+}

--- a/apps/mobile/app/dashboard/index.tsx
+++ b/apps/mobile/app/dashboard/index.tsx
@@ -1,0 +1,34 @@
+import { View, Text, ScrollView, StyleSheet } from "react-native";
+
+const metrics = [
+  { label: "Total Balance", value: "$0.00", sub: "USDC" },
+  { label: "Yield Earned", value: "$0.00", sub: "All time" },
+  { label: "Active Vaults", value: "0", sub: "Positions" },
+];
+
+export default function DashboardScreen() {
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Portfolio Overview</Text>
+      {metrics.map((m) => (
+        <View key={m.label} style={styles.card}>
+          <Text style={styles.cardLabel}>{m.label}</Text>
+          <Text style={styles.cardValue}>{m.value}</Text>
+          <Text style={styles.cardSub}>{m.sub}</Text>
+        </View>
+      ))}
+      <Text style={styles.hint}>Connect a wallet to see live data.</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#0f172a" },
+  content: { padding: 20 },
+  heading: { fontSize: 22, fontWeight: "bold", color: "#ffffff", marginBottom: 20 },
+  card: { backgroundColor: "#1e293b", borderRadius: 12, padding: 20, marginBottom: 12 },
+  cardLabel: { color: "#94a3b8", fontSize: 13, marginBottom: 4 },
+  cardValue: { color: "#ffffff", fontSize: 28, fontWeight: "bold", marginBottom: 2 },
+  cardSub: { color: "#64748b", fontSize: 12 },
+  hint: { color: "#475569", fontSize: 13, textAlign: "center", marginTop: 24 },
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,37 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+
+export default function WelcomeScreen() {
+  const router = useRouter();
+
+  const handleConnect = () => {
+    // TODO: integrate WalletConnect / Freighter deep-link
+    router.push("/dashboard");
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.logo}>☕</Text>
+      <Text style={styles.title}>Nester</Text>
+      <Text style={styles.subtitle}>
+        Decentralized savings &amp; instant fiat settlements
+      </Text>
+      <TouchableOpacity style={styles.button} onPress={handleConnect}>
+        <Text style={styles.buttonText}>Connect Wallet</Text>
+      </TouchableOpacity>
+      <Text style={styles.hint}>
+        Supports Freighter · Lobstr · WalletConnect
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24, backgroundColor: "#0f172a" },
+  logo: { fontSize: 64, marginBottom: 16 },
+  title: { fontSize: 36, fontWeight: "bold", color: "#ffffff", marginBottom: 8 },
+  subtitle: { fontSize: 16, color: "#94a3b8", textAlign: "center", marginBottom: 48, lineHeight: 24 },
+  button: { backgroundColor: "#3b82f6", paddingVertical: 16, paddingHorizontal: 48, borderRadius: 12, marginBottom: 16 },
+  buttonText: { color: "#ffffff", fontSize: 18, fontWeight: "600" },
+  hint: { color: "#475569", fontSize: 13 },
+});

--- a/apps/mobile/app/vaults/index.tsx
+++ b/apps/mobile/app/vaults/index.tsx
@@ -1,0 +1,41 @@
+import { View, Text, FlatList, StyleSheet } from "react-native";
+
+const VAULTS = [
+  { id: "1", name: "Conservative Vault", apy: "6-8%", risk: "Low", lock: "None" },
+  { id: "2", name: "Balanced Vault", apy: "8-12%", risk: "Medium", lock: "7 days" },
+  { id: "3", name: "Growth Vault", apy: "12-18%", risk: "Higher", lock: "30 days" },
+];
+
+export default function VaultsScreen() {
+  return (
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      data={VAULTS}
+      keyExtractor={(item) => item.id}
+      ListHeaderComponent={<Text style={styles.heading}>Available Vaults</Text>}
+      renderItem={({ item }) => (
+        <View style={styles.card}>
+          <Text style={styles.name}>{item.name}</Text>
+          <View style={styles.row}>
+            <Text style={styles.apy}>{item.apy} APY</Text>
+            <Text style={styles.risk}>{item.risk} risk</Text>
+          </View>
+          <Text style={styles.lock}>Lock period: {item.lock}</Text>
+        </View>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#0f172a" },
+  content: { padding: 20 },
+  heading: { fontSize: 22, fontWeight: "bold", color: "#ffffff", marginBottom: 20 },
+  card: { backgroundColor: "#1e293b", borderRadius: 12, padding: 20, marginBottom: 12 },
+  name: { color: "#ffffff", fontSize: 17, fontWeight: "600", marginBottom: 8 },
+  row: { flexDirection: "row", justifyContent: "space-between", marginBottom: 4 },
+  apy: { color: "#22c55e", fontSize: 15, fontWeight: "bold" },
+  risk: { color: "#94a3b8", fontSize: 14 },
+  lock: { color: "#64748b", fontSize: 12 },
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "nester-mobile",
+  "version": "1.0.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "expo-router": "~3.5.0",
+    "expo-secure-store": "~13.0.0",
+    "expo-status-bar": "~1.12.0",
+    "nativewind": "^4.0.1",
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "react-native-safe-area-context": "4.10.0",
+    "react-native-screens": "3.31.0",
+    "zustand": "^4.5.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@types/react": "~18.2.0",
+    "@types/react-native": "~0.73.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #180

Migrates the mobile app from the default Flutter counter template to a React Native Expo project, enabling TypeScript and component sharing with the Next.js frontend.

## New files in `apps/mobile/`n
| File | Purpose |
|---|---|
| `package.json` | Expo + React Native deps: Expo Router, NativeWind, Zustand, expo-secure-store |
| `tsconfig.json` | TypeScript config extending Expo defaults |
| `app/_layout.tsx` | Root Expo Router layout with Stack navigator |
| `app/index.tsx` | Welcome / wallet connection screen |
| `app/dashboard/index.tsx` | Portfolio overview - total balance, yield, active vaults |
| `app/vaults/index.tsx` | Vault list with APY and risk level |

## Acceptance Criteria
- [x] Flutter project replaced with Expo project in `apps/mobile/`  
- [x] Wallet connection screen present
- [x] Dashboard and vault list screens present
- [x] TypeScript configured
- [ ] Add to pnpm workspace (follow-up)
- [ ] CI job (follow-up)