### PR TITLE
feat(backend+frontend): saved bank accounts under user profile for re…

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	cryptopkg "github.com/suncrestlabs/nester/apps/api/internal/crypto"
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
 	dbpkg "github.com/suncrestlabs/nester/apps/api/internal/db"
 	"github.com/suncrestlabs/nester/apps/api/internal/handler"
@@ -89,8 +90,26 @@ func run() error {
 	transactionService := service.NewTransactionService(transactionRepository, cfg.Stellar().HorizonURL())
 	transactionHandler := handler.NewTransactionHandler(transactionService)
 
+	bankAccountRepository := postgres.NewBankAccountRepository(db)
+	var accountCipher *cryptopkg.AccountCipher
+	if key := cfg.BankAccountEncryptionKey(); key != "" {
+		cipher, cipherErr := cryptopkg.NewAccountCipher(key)
+		if cipherErr != nil {
+			return fmt.Errorf("bank account cipher: %w", cipherErr)
+		}
+		accountCipher = cipher
+	}
+
+	paystackResolver := service.NewPaystackResolver(cfg.Bank().PaystackKey())
+	flutterwaveResolver := service.NewFlutterwaveResolver(cfg.Bank().FlutterwaveKey())
+	bankService := service.NewBankService(paystackResolver, flutterwaveResolver)
+	bankHandler := handler.NewBankHandler(bankService)
+
+	bankAccountService := service.NewBankAccountService(bankAccountRepository, accountCipher, bankService)
+	bankAccountHandler := handler.NewBankAccountHandler(bankAccountService)
+
 	settlementRepository := postgres.NewSettlementRepository(db)
-	settlementService := service.NewSettlementService(settlementRepository)
+	settlementService := service.NewSettlementService(settlementRepository, bankAccountService)
 	settlementHandler := handler.NewSettlementHandler(settlementService)
 
 	userRepository := postgres.NewUserRepository(db)
@@ -181,11 +200,6 @@ func run() error {
 
 	depHTTPClient := &http.Client{Timeout: cfg.Startup().DependencyTimeout()}
 
-	paystackResolver := service.NewPaystackResolver(cfg.Bank().PaystackKey())
-	flutterwaveResolver := service.NewFlutterwaveResolver(cfg.Bank().FlutterwaveKey())
-	bankService := service.NewBankService(paystackResolver, flutterwaveResolver)
-	bankHandler := handler.NewBankHandler(bankService)
-
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", livenessHandler(&ready))
 	mux.HandleFunc("GET /healthz", livenessHandler(&ready))
@@ -210,6 +224,7 @@ func run() error {
 	rateHandler.Register(mux)
 	performanceHandler.Register(mux)
 	bankHandler.Register(mux)
+	bankAccountHandler.Register(mux)
 
 	mux.HandleFunc("GET /ws", wsHub.ServeWs)
 

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	performance           PerformanceConfig
 	startup               StartupConfig
 	bank                  BankConfig
+	bankAccountCipherKey  string
 }
 
 // StartupConfig governs one-shot work performed before the server begins
@@ -167,6 +168,11 @@ func Load() (*Config, error) {
 			paystackKey:    loader.stringDefault("PAYSTACK_SECRET_KEY", ""),
 			flutterwaveKey: loader.stringDefault("FLUTTERWAVE_SECRET_KEY", ""),
 		},
+		bankAccountCipherKey: loader.stringDefault("BANK_ACCOUNT_ENCRYPTION_KEY", ""),
+	}
+
+	if cfg.bankAccountCipherKey == "" && environment == "development" {
+		cfg.bankAccountCipherKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 	}
 
 	cfg.validate(&loader)
@@ -252,6 +258,10 @@ func (r RedisConfig) Addr() string {
 
 func (c Config) Bank() BankConfig {
 	return c.bank
+}
+
+func (c Config) BankAccountEncryptionKey() string {
+	return c.bankAccountCipherKey
 }
 
 func (b BankConfig) PaystackKey() string {

--- a/apps/api/internal/crypto/account_cipher.go
+++ b/apps/api/internal/crypto/account_cipher.go
@@ -1,0 +1,81 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+var (
+	ErrInvalidKey       = errors.New("encryption key must be 32 bytes (base64-encoded)")
+	ErrCiphertextTooShort = errors.New("ciphertext is too short")
+)
+
+// AccountCipher encrypts and decrypts sensitive account numbers at rest.
+type AccountCipher struct {
+	aead cipher.AEAD
+	mac  []byte
+}
+
+// NewAccountCipher builds a cipher from a base64-encoded 32-byte key.
+func NewAccountCipher(keyB64 string) (*AccountCipher, error) {
+	keyB64 = strings.TrimSpace(keyB64)
+	if keyB64 == "" {
+		return nil, ErrInvalidKey
+	}
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil || len(key) != 32 {
+		return nil, ErrInvalidKey
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+
+	return &AccountCipher{
+		aead: aead,
+		mac:  key,
+	}, nil
+}
+
+// Encrypt returns nonce || ciphertext for storage.
+func (c *AccountCipher) Encrypt(plaintext string) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return c.aead.Seal(nonce, nonce, []byte(plaintext), nil), nil
+}
+
+// Decrypt reverses Encrypt.
+func (c *AccountCipher) Decrypt(blob []byte) (string, error) {
+	if len(blob) < c.aead.NonceSize() {
+		return "", ErrCiphertextTooShort
+	}
+	nonce := blob[:c.aead.NonceSize()]
+	ciphertext := blob[c.aead.NonceSize():]
+	plain, err := c.aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+// Fingerprint returns a stable HMAC for uniqueness checks without decryption.
+func (c *AccountCipher) Fingerprint(normalizedAccount string) string {
+	mac := hmac.New(sha256.New, c.mac)
+	_, _ = mac.Write([]byte(normalizedAccount))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/apps/api/internal/domain/bankaccount/model.go
+++ b/apps/api/internal/domain/bankaccount/model.go
@@ -1,0 +1,94 @@
+// Package bankaccount defines saved fiat payout accounts for recurring offramps.
+package bankaccount
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrNotFound            = errors.New("bank account not found")
+	ErrForbidden           = errors.New("bank account does not belong to user")
+	ErrDuplicateAccount    = errors.New("bank account already saved for this user")
+	ErrInvalidInput        = errors.New("invalid bank account input")
+	ErrEncryptionUnavailable = errors.New("bank account encryption is not configured")
+)
+
+// BankAccount is the persisted saved account (account number stored encrypted).
+type BankAccount struct {
+	ID            uuid.UUID
+	UserID        uuid.UUID
+	BankName      string
+	BankCode      string
+	AccountNumber string
+	AccountName   string
+	Currency      string
+	Country       string
+	IsDefault     bool
+	VerifiedAt    *time.Time
+	CreatedAt     time.Time
+}
+
+// PublicView is returned by list/get APIs (never includes full account number).
+type PublicView struct {
+	ID           uuid.UUID  `json:"id"`
+	BankName     string     `json:"bank_name"`
+	BankCode     string     `json:"bank_code,omitempty"`
+	AccountLast4 string     `json:"account_last4"`
+	AccountName  string     `json:"account_name"`
+	Currency     string     `json:"currency"`
+	Country      string     `json:"country"`
+	IsDefault    bool       `json:"is_default"`
+	VerifiedAt   *time.Time `json:"verified_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+func ToPublicView(a BankAccount) PublicView {
+	last4 := a.AccountNumber
+	if len(last4) > 4 {
+		last4 = last4[len(last4)-4:]
+	}
+	return PublicView{
+		ID:           a.ID,
+		BankName:     a.BankName,
+		BankCode:     a.BankCode,
+		AccountLast4: last4,
+		AccountName:  a.AccountName,
+		Currency:     a.Currency,
+		Country:      a.Country,
+		IsDefault:    a.IsDefault,
+		VerifiedAt:   a.VerifiedAt,
+		CreatedAt:    a.CreatedAt,
+	}
+}
+
+// AddInput is the data required to save a new bank account.
+type AddInput struct {
+	BankName      string
+	BankCode      string
+	AccountNumber string
+	AccountName   string
+	Currency      string
+	Country       string
+	SetAsDefault  bool
+	VerifiedAt    *time.Time
+}
+
+// UpdateInput supports setting default and optional label (bank name override).
+type UpdateInput struct {
+	SetAsDefault *bool
+	BankName     *string
+}
+
+// Repository persists encrypted bank accounts.
+type Repository interface {
+	Create(ctx context.Context, account BankAccount, encryptedNumber []byte, fingerprint string) (BankAccount, error)
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]BankAccount, error)
+	GetByID(ctx context.Context, id uuid.UUID) (BankAccount, []byte, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	ClearDefaultForCurrency(ctx context.Context, userID uuid.UUID, currency string) error
+	SetDefault(ctx context.Context, id uuid.UUID, userID uuid.UUID) error
+}

--- a/apps/api/internal/handler/bank_account_handler.go
+++ b/apps/api/internal/handler/bank_account_handler.go
@@ -1,0 +1,197 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+type BankAccountHandler struct {
+	service *service.BankAccountService
+}
+
+func NewBankAccountHandler(svc *service.BankAccountService) *BankAccountHandler {
+	return &BankAccountHandler{service: svc}
+}
+
+func (h *BankAccountHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/users/{id}/bank-accounts", h.listAccounts)
+	mux.HandleFunc("POST /api/v1/users/{id}/bank-accounts", h.addAccount)
+	mux.HandleFunc("PATCH /api/v1/users/{id}/bank-accounts/{acctId}", h.patchAccount)
+	mux.HandleFunc("DELETE /api/v1/users/{id}/bank-accounts/{acctId}", h.deleteAccount)
+}
+
+type addBankAccountRequest struct {
+	BankName      string `json:"bank_name"`
+	BankCode      string `json:"bank_code"`
+	AccountNumber string `json:"account_number"`
+	AccountName   string `json:"account_name"`
+	Currency      string `json:"currency"`
+	Country       string `json:"country"`
+	IsDefault     bool   `json:"is_default"`
+}
+
+type patchBankAccountRequest struct {
+	IsDefault *bool   `json:"is_default"`
+	BankName  *string `json:"bank_name"`
+}
+
+func (h *BankAccountHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
+	userID, err := h.authorizeUserPath(r)
+	if err != nil {
+		h.writeAuthError(w, err)
+		return
+	}
+
+	accounts, err := h.service.List(r.Context(), userID)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+	if accounts == nil {
+		accounts = []bankaccount.PublicView{}
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(accounts))
+}
+
+func (h *BankAccountHandler) addAccount(w http.ResponseWriter, r *http.Request) {
+	userID, err := h.authorizeUserPath(r)
+	if err != nil {
+		h.writeAuthError(w, err)
+		return
+	}
+
+	var req addBankAccountRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	view, err := h.service.Add(r.Context(), userID, bankaccount.AddInput{
+		BankName:      req.BankName,
+		BankCode:      req.BankCode,
+		AccountNumber: req.AccountNumber,
+		AccountName:   req.AccountName,
+		Currency:      req.Currency,
+		Country:       req.Country,
+		SetAsDefault:  req.IsDefault,
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusCreated, response.Created(view))
+}
+
+func (h *BankAccountHandler) patchAccount(w http.ResponseWriter, r *http.Request) {
+	userID, err := h.authorizeUserPath(r)
+	if err != nil {
+		h.writeAuthError(w, err)
+		return
+	}
+
+	acctID, err := uuid.Parse(r.PathValue("acctId"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("acctId must be a valid UUID"))
+		return
+	}
+
+	var req patchBankAccountRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	view, err := h.service.Update(r.Context(), userID, acctID, bankaccount.UpdateInput{
+		SetAsDefault: req.IsDefault,
+		BankName:     req.BankName,
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(view))
+}
+
+func (h *BankAccountHandler) deleteAccount(w http.ResponseWriter, r *http.Request) {
+	userID, err := h.authorizeUserPath(r)
+	if err != nil {
+		h.writeAuthError(w, err)
+		return
+	}
+
+	acctID, err := uuid.Parse(r.PathValue("acctId"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("acctId must be a valid UUID"))
+		return
+	}
+
+	if err := h.service.Remove(r.Context(), userID, acctID); err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(map[string]string{"deleted": acctID.String()}))
+}
+
+func (h *BankAccountHandler) authorizeUserPath(r *http.Request) (uuid.UUID, error) {
+	pathID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		return uuid.Nil, errPathUserInvalid
+	}
+	caller, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		return uuid.Nil, errUnauthorized
+	}
+	callerID, err := uuid.Parse(caller.ID)
+	if err != nil {
+		return uuid.Nil, errUnauthorized
+	}
+	if callerID != pathID {
+		return uuid.Nil, errForbidden
+	}
+	return pathID, nil
+}
+
+var (
+	errUnauthorized     = errors.New("unauthorized")
+	errForbidden        = errors.New("forbidden")
+	errPathUserInvalid  = errors.New("invalid user id")
+)
+
+func (h *BankAccountHandler) writeAuthError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errUnauthorized):
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+	case errors.Is(err, errForbidden):
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "you cannot access another user's bank accounts"))
+	case errors.Is(err, errPathUserInvalid):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("user id must be a valid UUID"))
+	default:
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	}
+}
+
+func (h *BankAccountHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, bankaccount.ErrNotFound):
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("bank account"))
+	case errors.Is(err, bankaccount.ErrForbidden):
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", err.Error()))
+	case errors.Is(err, bankaccount.ErrDuplicateAccount):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "DUPLICATE_BANK_ACCOUNT", err.Error()))
+	case errors.Is(err, bankaccount.ErrInvalidInput):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	case errors.Is(err, bankaccount.ErrEncryptionUnavailable):
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "ENCRYPTION_UNAVAILABLE", err.Error()))
+	default:
+		logpkg.FromContext(r.Context()).Error("bank account handler failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+	}
+}

--- a/apps/api/internal/handler/settlement_handler.go
+++ b/apps/api/internal/handler/settlement_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -40,14 +41,15 @@ type destinationRequest struct {
 }
 
 type initiateSettlementRequest struct {
-	UserID       string             `json:"user_id"`
-	VaultID      string             `json:"vault_id"`
-	Amount       string             `json:"amount"`
-	Currency     string             `json:"currency"`
-	FiatCurrency string             `json:"fiat_currency"`
-	FiatAmount   string             `json:"fiat_amount"`
-	ExchangeRate string             `json:"exchange_rate"`
-	Destination  destinationRequest `json:"destination"`
+	UserID        string              `json:"user_id"`
+	VaultID       string              `json:"vault_id"`
+	Amount        string              `json:"amount"`
+	Currency      string              `json:"currency"`
+	FiatCurrency  string              `json:"fiat_currency"`
+	FiatAmount    string              `json:"fiat_amount"`
+	ExchangeRate  string              `json:"exchange_rate"`
+	BankAccountID *string             `json:"bank_account_id,omitempty"`
+	Destination   *destinationRequest `json:"destination,omitempty"`
 }
 
 type updateStatusRequest struct {
@@ -93,7 +95,7 @@ func (h *SettlementHandler) initiateSettlement(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	model, err := h.service.InitiateSettlement(r.Context(), service.InitiateSettlementInput{
+	input := service.InitiateSettlementInput{
 		UserID:       userID,
 		VaultID:      vaultID,
 		Amount:       amount,
@@ -101,14 +103,28 @@ func (h *SettlementHandler) initiateSettlement(w http.ResponseWriter, r *http.Re
 		FiatCurrency: req.FiatCurrency,
 		FiatAmount:   fiatAmount,
 		ExchangeRate: exchangeRate,
-		Destination: offramp.Destination{
+	}
+	if req.BankAccountID != nil && strings.TrimSpace(*req.BankAccountID) != "" {
+		acctID, parseErr := uuid.Parse(strings.TrimSpace(*req.BankAccountID))
+		if parseErr != nil {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("bank_account_id must be a valid UUID"))
+			return
+		}
+		input.BankAccountID = &acctID
+	} else if req.Destination != nil {
+		input.Destination = offramp.Destination{
 			Type:          req.Destination.Type,
 			Provider:      req.Destination.Provider,
 			AccountNumber: req.Destination.AccountNumber,
 			AccountName:   req.Destination.AccountName,
 			BankCode:      req.Destination.BankCode,
-		},
-	})
+		}
+	} else {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("either bank_account_id or destination is required"))
+		return
+	}
+
+	model, err := h.service.InitiateSettlement(r.Context(), input)
 	if err != nil {
 		h.writeDomainError(w, r, err)
 		return

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -96,7 +96,7 @@ func validSettlementJSONBody(userID, vaultID uuid.UUID) string {
 func TestSettlementHandler_PostCreates201(t *testing.T) {
 	userID := uuid.New()
 	vaultID := uuid.New()
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
@@ -122,7 +122,7 @@ func TestSettlementHandler_PostCreates201(t *testing.T) {
 }
 
 func TestSettlementHandler_PostInvalidBody400(t *testing.T) {
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
@@ -142,7 +142,7 @@ func TestSettlementHandler_PostInvalidBody400(t *testing.T) {
 func TestSettlementHandler_PostDomainValidation400(t *testing.T) {
 	userID := uuid.New()
 	vaultID := uuid.New()
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
@@ -174,7 +174,7 @@ func TestSettlementHandler_Get200And404(t *testing.T) {
 	userID := uuid.New()
 	vaultID := uuid.New()
 	repo := newSettlementStubRepo()
-	svc := service.NewSettlementService(repo)
+	svc := service.NewSettlementService(repo, nil)
 	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
 		UserID:       userID,
 		VaultID:      vaultID,
@@ -222,7 +222,7 @@ func TestSettlementHandler_Get200And404(t *testing.T) {
 func TestSettlementHandler_PatchStatus200(t *testing.T) {
 	userID := uuid.New()
 	vaultID := uuid.New()
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
 		UserID:       userID,
 		VaultID:      vaultID,
@@ -273,7 +273,7 @@ func TestSettlementHandler_PatchStatus200(t *testing.T) {
 func TestSettlementHandler_PatchStatus403NonOwner(t *testing.T) {
 	ownerID := uuid.New()
 	vaultID := uuid.New()
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	created, err := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
 		UserID:       ownerID,
 		VaultID:      vaultID,
@@ -319,7 +319,7 @@ func TestSettlementHandler_PatchStatus403NonOwner(t *testing.T) {
 }
 
 func TestSettlementHandler_PatchStatus401NoAuth(t *testing.T) {
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
@@ -347,7 +347,7 @@ func TestSettlementHandler_PatchStatus401NoAuth(t *testing.T) {
 func TestSettlementHandler_ListUserSettlementsWithStatus(t *testing.T) {
 	userID := uuid.New()
 	vaultID := uuid.New()
-	svc := service.NewSettlementService(newSettlementStubRepo())
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)

--- a/apps/api/internal/repository/postgres/bank_account_repository.go
+++ b/apps/api/internal/repository/postgres/bank_account_repository.go
@@ -1,0 +1,208 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
+)
+
+type BankAccountRepository struct {
+	db *sql.DB
+}
+
+func NewBankAccountRepository(db *sql.DB) *BankAccountRepository {
+	return &BankAccountRepository{db: db}
+}
+
+func (r *BankAccountRepository) Create(
+	ctx context.Context,
+	account bankaccount.BankAccount,
+	encryptedNumber []byte,
+	fingerprint string,
+) (bankaccount.BankAccount, error) {
+	last4 := account.AccountNumber
+	if len(last4) > 4 {
+		last4 = last4[len(last4)-4:]
+	}
+
+	query := `
+		INSERT INTO bank_accounts (
+			id, user_id, bank_name, bank_code,
+			account_number_encrypted, account_number_fingerprint, account_last4,
+			account_name, currency, country, is_default, verified_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		RETURNING created_at
+	`
+
+	err := r.db.QueryRowContext(
+		ctx,
+		query,
+		account.ID.String(),
+		account.UserID.String(),
+		account.BankName,
+		nullOptionalString(account.BankCode),
+		encryptedNumber,
+		fingerprint,
+		last4,
+		account.AccountName,
+		strings.ToUpper(account.Currency),
+		strings.ToUpper(account.Country),
+		account.IsDefault,
+		account.VerifiedAt,
+	).Scan(&account.CreatedAt)
+	if err != nil {
+		return bankaccount.BankAccount{}, mapBankAccountError(err)
+	}
+	return account, nil
+}
+
+func (r *BankAccountRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]bankaccount.BankAccount, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, user_id, bank_name, COALESCE(bank_code, ''), account_last4,
+		       account_name, currency, country, is_default, verified_at, created_at
+		FROM bank_accounts
+		WHERE user_id = $1
+		ORDER BY is_default DESC, created_at DESC
+	`, userID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []bankaccount.BankAccount
+	for rows.Next() {
+		var (
+			id, uid, bankName, bankCode, last4 string
+			accountName, currency, country     string
+			isDefault                          bool
+			verifiedAt                         sql.NullTime
+			createdAt                          time.Time
+		)
+		if err := rows.Scan(
+			&id, &uid, &bankName, &bankCode, &last4,
+			&accountName, &currency, &country, &isDefault, &verifiedAt, &createdAt,
+		); err != nil {
+			return nil, err
+		}
+		parsedID, _ := uuid.Parse(id)
+		parsedUser, _ := uuid.Parse(uid)
+		var verified *time.Time
+		if verifiedAt.Valid {
+			verified = &verifiedAt.Time
+		}
+		out = append(out, bankaccount.BankAccount{
+			ID:            parsedID,
+			UserID:        parsedUser,
+			BankName:      bankName,
+			BankCode:      bankCode,
+			AccountNumber: last4,
+			AccountName:   accountName,
+			Currency:      currency,
+			Country:       country,
+			IsDefault:     isDefault,
+			VerifiedAt:    verified,
+			CreatedAt:     createdAt,
+		})
+	}
+	return out, rows.Err()
+}
+
+func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, error) {
+	var (
+		uid, bankName, bankCode string
+		encrypted               []byte
+		accountName, currency, country string
+		isDefault               bool
+		verifiedAt              sql.NullTime
+		createdAt               time.Time
+	)
+	err := r.db.QueryRowContext(ctx, `
+		SELECT user_id, bank_name, COALESCE(bank_code, ''), account_number_encrypted,
+		       account_name, currency, country, is_default, verified_at, created_at
+		FROM bank_accounts WHERE id = $1
+	`, id.String()).Scan(
+		&uid, &bankName, &bankCode, &encrypted,
+		&accountName, &currency, &country, &isDefault, &verifiedAt, &createdAt,
+	)
+	if err != nil {
+		return bankaccount.BankAccount{}, nil, mapBankAccountError(err)
+	}
+	parsedUser, _ := uuid.Parse(uid)
+	var verified *time.Time
+	if verifiedAt.Valid {
+		verified = &verifiedAt.Time
+	}
+	return bankaccount.BankAccount{
+		ID:            id,
+		UserID:        parsedUser,
+		BankName:      bankName,
+		BankCode:      bankCode,
+		AccountName:   accountName,
+		Currency:      currency,
+		Country:       country,
+		IsDefault:     isDefault,
+		VerifiedAt:    verified,
+		CreatedAt:     createdAt,
+	}, encrypted, nil
+}
+
+func (r *BankAccountRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM bank_accounts WHERE id = $1`, id.String())
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return bankaccount.ErrNotFound
+	}
+	return nil
+}
+
+func (r *BankAccountRepository) ClearDefaultForCurrency(ctx context.Context, userID uuid.UUID, currency string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE bank_accounts SET is_default = false
+		WHERE user_id = $1 AND currency = $2 AND is_default = true
+	`, userID.String(), strings.ToUpper(currency))
+	return err
+}
+
+func (r *BankAccountRepository) SetDefault(ctx context.Context, id uuid.UUID, userID uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE bank_accounts SET is_default = true
+		WHERE id = $1 AND user_id = $2
+	`, id.String(), userID.String())
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return bankaccount.ErrNotFound
+	}
+	return nil
+}
+
+func mapBankAccountError(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return bankaccount.ErrNotFound
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return bankaccount.ErrDuplicateAccount
+	}
+	return fmt.Errorf("bank account repository: %w", err)
+}
+
+func nullOptionalString(s string) any {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return s
+}

--- a/apps/api/internal/service/bankaccount_service.go
+++ b/apps/api/internal/service/bankaccount_service.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bank"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
+)
+
+var (
+	supportedCurrencies = map[string]bool{"NGN": true, "GHS": true, "KES": true}
+	supportedCountries  = map[string]bool{"NG": true, "GH": true, "KE": true}
+	reAccountDigits     = regexp.MustCompile(`^\d{10}$`)
+)
+
+// BankAccountService manages saved payout accounts for users.
+type BankAccountService struct {
+	repo      bankaccount.Repository
+	cipher    *crypto.AccountCipher
+	resolver  *BankService
+}
+
+func NewBankAccountService(
+	repo bankaccount.Repository,
+	cipher *crypto.AccountCipher,
+	resolver *BankService,
+) *BankAccountService {
+	return &BankAccountService{repo: repo, cipher: cipher, resolver: resolver}
+}
+
+// Add validates and persists a new saved bank account.
+func (s *BankAccountService) Add(ctx context.Context, userID uuid.UUID, input bankaccount.AddInput) (bankaccount.PublicView, error) {
+	if s.cipher == nil {
+		return bankaccount.PublicView{}, bankaccount.ErrEncryptionUnavailable
+	}
+	if userID == uuid.Nil {
+		return bankaccount.PublicView{}, bankaccount.ErrInvalidInput
+	}
+
+	normalized, err := normalizeAddInput(input)
+	if err != nil {
+		return bankaccount.PublicView{}, err
+	}
+
+	if s.resolver != nil && normalized.Country == "NG" {
+		info, resolveErr := s.resolver.ResolveAccount(ctx, normalized.AccountNumber, normalized.BankCode, normalized.Country)
+		if resolveErr != nil {
+			return bankaccount.PublicView{}, mapResolveError(resolveErr)
+		}
+		if info != nil && strings.TrimSpace(info.AccountName) != "" {
+			normalized.AccountName = strings.TrimSpace(info.AccountName)
+		}
+	}
+
+	encrypted, err := s.cipher.Encrypt(normalized.AccountNumber)
+	if err != nil {
+		return bankaccount.PublicView{}, err
+	}
+	fingerprint := s.cipher.Fingerprint(normalizeAccountKey(normalized.AccountNumber, normalized.BankCode))
+
+	model := bankaccount.BankAccount{
+		ID:            uuid.New(),
+		UserID:        userID,
+		BankName:      normalized.BankName,
+		BankCode:      normalized.BankCode,
+		AccountNumber: normalized.AccountNumber,
+		AccountName:   normalized.AccountName,
+		Currency:      normalized.Currency,
+		Country:       normalized.Country,
+		IsDefault:     normalized.SetAsDefault,
+		VerifiedAt:    normalized.VerifiedAt,
+	}
+
+	if model.IsDefault {
+		if err := s.repo.ClearDefaultForCurrency(ctx, userID, model.Currency); err != nil {
+			return bankaccount.PublicView{}, err
+		}
+	}
+
+	created, err := s.repo.Create(ctx, model, encrypted, fingerprint)
+	if err != nil {
+		return bankaccount.PublicView{}, err
+	}
+	return bankaccount.ToPublicView(created), nil
+}
+
+// List returns all saved accounts for a user (masked account numbers).
+func (s *BankAccountService) List(ctx context.Context, userID uuid.UUID) ([]bankaccount.PublicView, error) {
+	if userID == uuid.Nil {
+		return nil, bankaccount.ErrInvalidInput
+	}
+	accounts, err := s.repo.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]bankaccount.PublicView, 0, len(accounts))
+	for _, a := range accounts {
+		out = append(out, bankaccount.ToPublicView(a))
+	}
+	return out, nil
+}
+
+// SetDefault marks one account as the default for its currency.
+func (s *BankAccountService) SetDefault(ctx context.Context, userID, accountID uuid.UUID) (bankaccount.PublicView, error) {
+	if userID == uuid.Nil || accountID == uuid.Nil {
+		return bankaccount.PublicView{}, bankaccount.ErrInvalidInput
+	}
+	account, _, err := s.repo.GetByID(ctx, accountID)
+	if err != nil {
+		return bankaccount.PublicView{}, err
+	}
+	if account.UserID != userID {
+		return bankaccount.PublicView{}, bankaccount.ErrForbidden
+	}
+	if err := s.repo.ClearDefaultForCurrency(ctx, userID, account.Currency); err != nil {
+		return bankaccount.PublicView{}, err
+	}
+	if err := s.repo.SetDefault(ctx, accountID, userID); err != nil {
+		return bankaccount.PublicView{}, err
+	}
+	account.IsDefault = true
+	return bankaccount.ToPublicView(account), nil
+}
+
+// Update applies partial updates (default flag, optional bank name label).
+func (s *BankAccountService) Update(
+	ctx context.Context,
+	userID, accountID uuid.UUID,
+	input bankaccount.UpdateInput,
+) (bankaccount.PublicView, error) {
+	if input.SetAsDefault != nil && *input.SetAsDefault {
+		return s.SetDefault(ctx, userID, accountID)
+	}
+	return bankaccount.PublicView{}, bankaccount.ErrInvalidInput
+}
+
+// Remove deletes a saved account owned by the user.
+func (s *BankAccountService) Remove(ctx context.Context, userID, accountID uuid.UUID) error {
+	if userID == uuid.Nil || accountID == uuid.Nil {
+		return bankaccount.ErrInvalidInput
+	}
+	account, _, err := s.repo.GetByID(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	if account.UserID != userID {
+		return bankaccount.ErrForbidden
+	}
+	return s.repo.Delete(ctx, accountID)
+}
+
+// ResolveForSettlement loads and decrypts a saved account for settlement initiation.
+func (s *BankAccountService) ResolveForSettlement(
+	ctx context.Context,
+	userID, accountID uuid.UUID,
+) (bankaccount.BankAccount, error) {
+	if s.cipher == nil {
+		return bankaccount.BankAccount{}, bankaccount.ErrEncryptionUnavailable
+	}
+	account, encrypted, err := s.repo.GetByID(ctx, accountID)
+	if err != nil {
+		return bankaccount.BankAccount{}, err
+	}
+	if account.UserID != userID {
+		return bankaccount.BankAccount{}, bankaccount.ErrForbidden
+	}
+	plain, err := s.cipher.Decrypt(encrypted)
+	if err != nil {
+		return bankaccount.BankAccount{}, err
+	}
+	account.AccountNumber = plain
+	return account, nil
+}
+
+func normalizeAddInput(input bankaccount.AddInput) (bankaccount.AddInput, error) {
+	input.BankName = strings.TrimSpace(input.BankName)
+	input.BankCode = strings.TrimSpace(input.BankCode)
+	input.AccountNumber = strings.TrimSpace(input.AccountNumber)
+	input.AccountName = strings.TrimSpace(input.AccountName)
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	input.Country = strings.ToUpper(strings.TrimSpace(input.Country))
+
+	if input.BankName == "" || input.AccountName == "" || input.AccountNumber == "" {
+		return input, bankaccount.ErrInvalidInput
+	}
+	if !supportedCurrencies[input.Currency] {
+		return input, bankaccount.ErrInvalidInput
+	}
+	if !supportedCountries[input.Country] {
+		return input, bankaccount.ErrInvalidInput
+	}
+	if input.Country == "NG" && !reAccountDigits.MatchString(input.AccountNumber) {
+		return input, bankaccount.ErrInvalidInput
+	}
+	if input.Country == "NG" && input.BankCode == "" {
+		return input, bankaccount.ErrInvalidInput
+	}
+	if input.VerifiedAt == nil {
+		now := time.Now().UTC()
+		input.VerifiedAt = &now
+	}
+	return input, nil
+}
+
+func normalizeAccountKey(accountNumber, bankCode string) string {
+	return strings.TrimSpace(accountNumber) + "|" + strings.TrimSpace(bankCode)
+}
+
+func mapResolveError(err error) error {
+	switch err {
+	case bank.ErrAccountNotFound:
+		return bankaccount.ErrInvalidInput
+	case bank.ErrInvalidAccountNumber, bank.ErrInvalidBankCode, bank.ErrInvalidCountry:
+		return bankaccount.ErrInvalidInput
+	default:
+		return err
+	}
+}

--- a/apps/api/internal/service/bankaccount_service_test.go
+++ b/apps/api/internal/service/bankaccount_service_test.go
@@ -1,0 +1,184 @@
+package service_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+type memBankAccountRepo struct {
+	byID map[uuid.UUID]storedAccount
+}
+
+type storedAccount struct {
+	account   bankaccount.BankAccount
+	encrypted []byte
+	print     string
+}
+
+func newMemBankAccountRepo() *memBankAccountRepo {
+	return &memBankAccountRepo{byID: make(map[uuid.UUID]storedAccount)}
+}
+
+func (m *memBankAccountRepo) Create(_ context.Context, account bankaccount.BankAccount, encrypted []byte, fingerprint string) (bankaccount.BankAccount, error) {
+	for _, s := range m.byID {
+		if s.account.UserID == account.UserID && s.print == fingerprint {
+			return bankaccount.BankAccount{}, bankaccount.ErrDuplicateAccount
+		}
+	}
+	account.CreatedAt = time.Now().UTC()
+	m.byID[account.ID] = storedAccount{account: account, encrypted: encrypted, print: fingerprint}
+	return account, nil
+}
+
+func (m *memBankAccountRepo) ListByUser(_ context.Context, userID uuid.UUID) ([]bankaccount.BankAccount, error) {
+	var out []bankaccount.BankAccount
+	for _, s := range m.byID {
+		if s.account.UserID == userID {
+			out = append(out, s.account)
+		}
+	}
+	return out, nil
+}
+
+func (m *memBankAccountRepo) GetByID(_ context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, error) {
+	s, ok := m.byID[id]
+	if !ok {
+		return bankaccount.BankAccount{}, nil, bankaccount.ErrNotFound
+	}
+	return s.account, s.encrypted, nil
+}
+
+func (m *memBankAccountRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if _, ok := m.byID[id]; !ok {
+		return bankaccount.ErrNotFound
+	}
+	delete(m.byID, id)
+	return nil
+}
+
+func (m *memBankAccountRepo) ClearDefaultForCurrency(_ context.Context, userID uuid.UUID, currency string) error {
+	for id, s := range m.byID {
+		if s.account.UserID == userID && s.account.Currency == currency {
+			s.account.IsDefault = false
+			m.byID[id] = s
+		}
+	}
+	return nil
+}
+
+func (m *memBankAccountRepo) SetDefault(_ context.Context, id uuid.UUID, userID uuid.UUID) error {
+	s, ok := m.byID[id]
+	if !ok || s.account.UserID != userID {
+		return bankaccount.ErrNotFound
+	}
+	s.account.IsDefault = true
+	m.byID[id] = s
+	return nil
+}
+
+func testCipher(t *testing.T) *crypto.AccountCipher {
+	t.Helper()
+	c, err := crypto.NewAccountCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	return c
+}
+
+func TestBankAccountService_AddListRemove(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemBankAccountRepo()
+	svc := service.NewBankAccountService(repo, testCipher(t), nil)
+
+	created, err := svc.Add(ctx, userID, bankaccount.AddInput{
+		BankName:      "GTBank",
+		BankCode:      "058",
+		AccountNumber: "0123456789",
+		AccountName:   "JOHN DOE",
+		Currency:      "NGN",
+		Country:       "NG",
+		SetAsDefault:  true,
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if !created.IsDefault {
+		t.Error("expected default account")
+	}
+
+	list, err := svc.List(ctx, userID)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list))
+	}
+
+	if err := svc.Remove(ctx, userID, created.ID); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	list, _ = svc.List(ctx, userID)
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %d", len(list))
+	}
+}
+
+func TestBankAccountService_DefaultToggling(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemBankAccountRepo()
+	svc := service.NewBankAccountService(repo, testCipher(t), nil)
+
+	a1, _ := svc.Add(ctx, userID, bankaccount.AddInput{
+		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
+		AccountName: "A", Currency: "NGN", Country: "NG", SetAsDefault: true,
+	})
+	a2, _ := svc.Add(ctx, userID, bankaccount.AddInput{
+		BankName: "Access", BankCode: "044", AccountNumber: "0987654321",
+		AccountName: "B", Currency: "NGN", Country: "NG",
+	})
+
+	updated, err := svc.SetDefault(ctx, userID, a2.ID)
+	if err != nil {
+		t.Fatalf("set default: %v", err)
+	}
+	if !updated.IsDefault {
+		t.Error("a2 should be default")
+	}
+
+	list, _ := svc.List(ctx, userID)
+	var defaults int
+	for _, item := range list {
+		if item.IsDefault {
+			defaults++
+		}
+	}
+	if defaults != 1 {
+		t.Fatalf("expected exactly one default, got %d", defaults)
+	}
+	_ = a1
+}
+
+func TestBankAccountService_DuplicateRejected(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemBankAccountRepo()
+	svc := service.NewBankAccountService(repo, testCipher(t), nil)
+
+	input := bankaccount.AddInput{
+		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
+		AccountName: "A", Currency: "NGN", Country: "NG",
+	}
+	if _, err := svc.Add(ctx, userID, input); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if _, err := svc.Add(ctx, userID, input); err != bankaccount.ErrDuplicateAccount {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+}

--- a/apps/api/internal/service/settlement_service.go
+++ b/apps/api/internal/service/settlement_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/offramp"
 )
 
@@ -17,24 +19,31 @@ var (
 	rebankCode = regexp.MustCompile(`^\d{3,9}$`)
 )
 
-type SettlementService struct {
-	repository offramp.Repository
+// SavedBankAccountResolver loads decrypted bank details for settlement.
+type SavedBankAccountResolver interface {
+	ResolveForSettlement(ctx context.Context, userID, accountID uuid.UUID) (bankaccount.BankAccount, error)
 }
 
-func NewSettlementService(repository offramp.Repository) *SettlementService {
-	return &SettlementService{repository: repository}
+type SettlementService struct {
+	repository   offramp.Repository
+	bankAccounts SavedBankAccountResolver
+}
+
+func NewSettlementService(repository offramp.Repository, bankAccounts SavedBankAccountResolver) *SettlementService {
+	return &SettlementService{repository: repository, bankAccounts: bankAccounts}
 }
 
 // InitiateSettlementInput carries caller-supplied data for a new settlement.
 type InitiateSettlementInput struct {
-	UserID       uuid.UUID
-	VaultID      uuid.UUID
-	Amount       decimal.Decimal
-	Currency     string
-	FiatCurrency string
-	FiatAmount   decimal.Decimal
-	ExchangeRate decimal.Decimal
-	Destination  offramp.Destination
+	UserID        uuid.UUID
+	VaultID       uuid.UUID
+	Amount        decimal.Decimal
+	Currency      string
+	FiatCurrency  string
+	FiatAmount    decimal.Decimal
+	ExchangeRate  decimal.Decimal
+	BankAccountID *uuid.UUID
+	Destination   offramp.Destination
 }
 
 // UpdateStatusInput carries the target state for a status transition.
@@ -71,6 +80,26 @@ func (s *SettlementService) InitiateSettlement(ctx context.Context, input Initia
 
 	if strings.TrimSpace(input.Currency) == "" || strings.TrimSpace(input.FiatCurrency) == "" {
 		return offramp.Settlement{}, offramp.ErrInvalidSettlement
+	}
+
+	if input.BankAccountID != nil {
+		if s.bankAccounts == nil {
+			return offramp.Settlement{}, offramp.ErrInvalidSettlement
+		}
+		saved, err := s.bankAccounts.ResolveForSettlement(ctx, input.UserID, *input.BankAccountID)
+		if err != nil {
+			return offramp.Settlement{}, mapBankAccountSettlementError(err)
+		}
+		input.Destination = offramp.Destination{
+			Type:          "bank_transfer",
+			Provider:      "bank",
+			AccountNumber: saved.AccountNumber,
+			AccountName:   saved.AccountName,
+			BankCode:      saved.BankCode,
+		}
+		if strings.TrimSpace(input.FiatCurrency) == "" {
+			input.FiatCurrency = saved.Currency
+		}
 	}
 
 	if err := validateDestination(input.Destination); err != nil {
@@ -176,4 +205,15 @@ func validateDestination(d offramp.Destination) error {
 		}
 	}
 	return nil
+}
+
+func mapBankAccountSettlementError(err error) error {
+	switch {
+	case errors.Is(err, bankaccount.ErrNotFound):
+		return offramp.ErrInvalidSettlement
+	case errors.Is(err, bankaccount.ErrForbidden):
+		return offramp.ErrForbidden
+	default:
+		return err
+	}
 }

--- a/apps/api/internal/service/settlement_service_test.go
+++ b/apps/api/internal/service/settlement_service_test.go
@@ -85,7 +85,7 @@ func validInput() service.InitiateSettlementInput {
 // ── Tests: InitiateSettlement ─────────────────────────────────────────────────
 
 func TestInitiateSettlement_CreatesInInitiatedStatus(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 
 	s, err := svc.InitiateSettlement(context.Background(), validInput())
 	if err != nil {
@@ -100,7 +100,7 @@ func TestInitiateSettlement_CreatesInInitiatedStatus(t *testing.T) {
 }
 
 func TestInitiateSettlement_ReturnsIDAndAllFields(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 
 	s, err := svc.InitiateSettlement(context.Background(), in)
@@ -126,7 +126,7 @@ func TestInitiateSettlement_ReturnsIDAndAllFields(t *testing.T) {
 }
 
 func TestInitiateSettlement_NilUserIDReturnsError(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 	in.UserID = uuid.Nil
 
@@ -137,7 +137,7 @@ func TestInitiateSettlement_NilUserIDReturnsError(t *testing.T) {
 }
 
 func TestInitiateSettlement_ZeroAmountReturnsError(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 	in.Amount = decimal.Zero
 
@@ -148,7 +148,7 @@ func TestInitiateSettlement_ZeroAmountReturnsError(t *testing.T) {
 }
 
 func TestInitiateSettlement_EmptyCurrencyReturnsError(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 	in.Currency = "   "
 
@@ -159,7 +159,7 @@ func TestInitiateSettlement_EmptyCurrencyReturnsError(t *testing.T) {
 }
 
 func TestInitiateSettlement_EmptyAccountNumberReturnsError(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 	in.Destination.AccountNumber = ""
 
@@ -170,7 +170,7 @@ func TestInitiateSettlement_EmptyAccountNumberReturnsError(t *testing.T) {
 }
 
 func TestInitiateSettlement_BankTransferRequiresBankCode(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	in := validInput()
 	in.Destination.Type = "bank_transfer"
 	in.Destination.BankCode = "" // missing
@@ -184,7 +184,7 @@ func TestInitiateSettlement_BankTransferRequiresBankCode(t *testing.T) {
 // ── Tests: GetSettlement ──────────────────────────────────────────────────────
 
 func TestGetSettlement_ReturnsExistingRecord(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 
 	created, _ := svc.InitiateSettlement(context.Background(), validInput())
 	fetched, err := svc.GetSettlement(context.Background(), created.ID)
@@ -197,7 +197,7 @@ func TestGetSettlement_ReturnsExistingRecord(t *testing.T) {
 }
 
 func TestGetSettlement_UnknownIDReturnsNotFound(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 
 	_, err := svc.GetSettlement(context.Background(), uuid.New())
 	if !errors.Is(err, offramp.ErrSettlementNotFound) {
@@ -208,7 +208,7 @@ func TestGetSettlement_UnknownIDReturnsNotFound(t *testing.T) {
 // ── Tests: GetUserSettlements ─────────────────────────────────────────────────
 
 func TestGetUserSettlements_ReturnsAllForUser(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 
 	in := validInput()
 	svc.InitiateSettlement(context.Background(), in)
@@ -225,7 +225,7 @@ func TestGetUserSettlements_ReturnsAllForUser(t *testing.T) {
 
 func TestGetUserSettlements_FilterByStatus(t *testing.T) {
 	repo := newStubRepo()
-	svc := service.NewSettlementService(repo)
+	svc := service.NewSettlementService(repo, nil)
 
 	in := validInput()
 	s1, _ := svc.InitiateSettlement(context.Background(), in)
@@ -252,7 +252,7 @@ func TestGetUserSettlements_FilterByStatus(t *testing.T) {
 }
 
 func TestGetUserSettlements_InvalidStatusReturnsError(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 
 	_, err := svc.GetUserSettlements(context.Background(), uuid.New(), "nonsense")
 	if !errors.Is(err, offramp.ErrInvalidStatus) {
@@ -263,7 +263,7 @@ func TestGetUserSettlements_InvalidStatusReturnsError(t *testing.T) {
 // ── Tests: UpdateStatus / state machine ─────────────────────────────────────
 
 func TestUpdateStatus_FullLifecycleToConfirmed(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -295,7 +295,7 @@ func TestUpdateStatus_FullLifecycleToConfirmed(t *testing.T) {
 }
 
 func TestUpdateStatus_FullLifecycleToFailed(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -317,7 +317,7 @@ func TestUpdateStatus_FullLifecycleToFailed(t *testing.T) {
 }
 
 func TestUpdateStatus_FailedAfterLiquidityMatched(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -337,7 +337,7 @@ func TestUpdateStatus_FailedAfterLiquidityMatched(t *testing.T) {
 }
 
 func TestUpdateStatus_InvalidTransitionRejected(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -354,7 +354,7 @@ func TestUpdateStatus_InvalidTransitionRejected(t *testing.T) {
 }
 
 func TestUpdateStatus_CannotLeaveConfirmed(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -373,7 +373,7 @@ func TestUpdateStatus_CannotLeaveConfirmed(t *testing.T) {
 }
 
 func TestUpdateStatus_CannotLeaveFailed(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())
@@ -390,7 +390,7 @@ func TestUpdateStatus_CannotLeaveFailed(t *testing.T) {
 }
 
 func TestUpdateStatus_ForbiddenForNonOwner(t *testing.T) {
-	svc := service.NewSettlementService(newStubRepo())
+	svc := service.NewSettlementService(newStubRepo(), nil)
 	ctx := context.Background()
 
 	s, _ := svc.InitiateSettlement(ctx, validInput())

--- a/apps/api/migrations/017_create_bank_accounts_table.down.sql
+++ b/apps/api/migrations/017_create_bank_accounts_table.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_bank_accounts_user_id;
+DROP INDEX IF EXISTS idx_bank_accounts_one_default_per_currency;
+DROP TABLE IF EXISTS bank_accounts;

--- a/apps/api/migrations/017_create_bank_accounts_table.up.sql
+++ b/apps/api/migrations/017_create_bank_accounts_table.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE bank_accounts (
+    id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    bank_name                  TEXT NOT NULL,
+    bank_code                  TEXT,
+    account_number_encrypted   BYTEA NOT NULL,
+    account_number_fingerprint TEXT NOT NULL,
+    account_last4              TEXT NOT NULL,
+    account_name               TEXT NOT NULL,
+    currency                   TEXT NOT NULL,
+    country                    TEXT NOT NULL,
+    is_default                 BOOLEAN NOT NULL DEFAULT false,
+    verified_at                TIMESTAMPTZ,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, account_number_fingerprint, COALESCE(bank_code, ''))
+);
+
+CREATE UNIQUE INDEX idx_bank_accounts_one_default_per_currency
+    ON bank_accounts (user_id, currency)
+    WHERE is_default = true;
+
+CREATE INDEX idx_bank_accounts_user_id ON bank_accounts(user_id);

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -32,7 +32,13 @@ import { getExplorerTxUrl } from "@/utils/explorer";
 import { BankCombobox } from "@/components/offramp/BankCombobox";
 import { AccountNameField } from "@/components/offramp/AccountNameField";
 import { SuggestedBankChips } from "@/components/offramp/SuggestedBankChips";
+import {
+    SavedBankAccountPicker,
+    type PayoutMode,
+} from "@/components/offramp/SavedBankAccountPicker";
+import { SaveAccountPrompt } from "@/components/offramp/SaveAccountPrompt";
 import { useBankResolver } from "@/hooks/useBankResolver";
+import { fetchBankList } from "@/lib/api/bank";
 
 const SEND_ASSETS = [
     { symbol: "USDC", name: "USD Coin", image: "/usdc.png" },
@@ -141,6 +147,14 @@ export default function OfframpPage() {
     const [sendAsset, setSendAsset] = useState(SEND_ASSETS[0]);
     const [receiveCurrency, setReceiveCurrency] = useState(RECEIVE_CURRENCIES[0]);
     const [manualName, setManualName] = useState("");
+    const [payoutMode, setPayoutMode] = useState<PayoutMode>({ type: "manual" });
+    const [savePromptOpen, setSavePromptOpen] = useState(false);
+    const [lastManualPayout, setLastManualPayout] = useState<{
+        bankName: string;
+        bankCode: string;
+        accountNumber: string;
+        accountName: string;
+    } | null>(null);
 
     const { resolveState, accountInfo } = useBankResolver(accountNumber, selectedBankCode);
     const resolvedName = resolveState === "success" ? (accountInfo?.account_name ?? null) : null;
@@ -162,7 +176,14 @@ export default function OfframpPage() {
     }, [isConnected, router]);
 
     const numericAmount = parseFloat(sendAmount) || 0;
-    const allFieldsFilled = isValid;
+    const effectiveBankCode =
+        payoutMode.type === "saved"
+            ? payoutMode.account.bank_code ?? ""
+            : selectedBankCode;
+    const allFieldsFilled =
+        payoutMode.type === "saved"
+            ? numericAmount > 0 && Boolean(effectiveBankCode)
+            : isValid;
 
     const runQuoteScan = useCallback(
         (amount: number, bankCode: string, currency: typeof RECEIVE_CURRENCIES[0]) => {
@@ -221,10 +242,10 @@ export default function OfframpPage() {
 
         if (debounceRef.current) clearTimeout(debounceRef.current);
         debounceRef.current = setTimeout(() => {
-            runQuoteScan(numericAmount, selectedBankCode, receiveCurrency);
+            runQuoteScan(numericAmount, effectiveBankCode, receiveCurrency);
 
             refreshRef.current = setInterval(() => {
-                silentRefresh(numericAmount, selectedBankCode, receiveCurrency);
+                silentRefresh(numericAmount, effectiveBankCode, receiveCurrency);
             }, 8000);
         }, 500);
 
@@ -232,7 +253,7 @@ export default function OfframpPage() {
             if (debounceRef.current) clearTimeout(debounceRef.current);
             if (refreshRef.current) clearInterval(refreshRef.current);
         };
-    }, [allFieldsFilled, numericAmount, selectedBankCode, receiveCurrency, runQuoteScan, silentRefresh]);
+    }, [allFieldsFilled, numericAmount, effectiveBankCode, receiveCurrency, runQuoteScan, silentRefresh]);
 
     if (!isConnected) return null;
 
@@ -243,7 +264,11 @@ export default function OfframpPage() {
             : 0;
 
     const handleWithdraw = handleSubmit((data) => {
-        if (!isValid || quotePhase !== "done" || !selectedQuote) {
+        const canSubmit =
+            payoutMode.type === "saved"
+                ? numericAmount > 0 && quotePhase === "done" && selectedQuote
+                : isValid && quotePhase === "done" && selectedQuote;
+        if (!canSubmit) {
             return;
         }
 
@@ -253,6 +278,20 @@ export default function OfframpPage() {
         }
 
         setShowLargeWarning(false);
+
+        if (payoutMode.type === "manual" && resolvedName) {
+            void fetchBankList("NG").then((banks) => {
+                const bank = banks.find((b) => b.code === data.bankCode);
+                setLastManualPayout({
+                    bankName: bank?.name ?? data.bankCode,
+                    bankCode: data.bankCode,
+                    accountNumber: data.accountNumber,
+                    accountName: resolvedName,
+                });
+                setSavePromptOpen(true);
+            });
+        }
+
         addNotification(
             {
                 type: "withdrawal_processed",
@@ -468,6 +507,34 @@ export default function OfframpPage() {
 
                     {/* Bank Details Section */}
                     <div className="border-t border-border p-4 sm:p-5 space-y-4">
+                        <SavedBankAccountPicker
+                            currency={receiveCurrency.symbol}
+                            value={payoutMode}
+                            onChange={setPayoutMode}
+                        />
+
+                        {savePromptOpen && lastManualPayout && (
+                            <SaveAccountPrompt
+                                {...lastManualPayout}
+                                currency={receiveCurrency.symbol}
+                                country="NG"
+                                onDismiss={() => setSavePromptOpen(false)}
+                                onSaved={() => setSavePromptOpen(false)}
+                            />
+                        )}
+
+                        {payoutMode.type === "saved" ? (
+                            <div className="rounded-xl border border-border bg-secondary/20 px-4 py-3 text-sm">
+                                <p className="font-medium text-foreground">
+                                    {payoutMode.account.bank_name}
+                                </p>
+                                <p className="text-muted-foreground text-xs mt-1">
+                                    {payoutMode.account.account_name} · ••••
+                                    {payoutMode.account.account_last4}
+                                </p>
+                            </div>
+                        ) : (
+                        <>
                         {/* Step 1 — Account number */}
                         <div>
                             <label className="text-xs text-muted-foreground font-medium mb-2 block">
@@ -569,6 +636,8 @@ export default function OfframpPage() {
                             onManualName={setManualName}
                             manualName={manualName}
                         />
+                        </>
+                        )}
                     </div>
 
                     {/* Rate info */}

--- a/apps/dapp/frontend/app/settings/page.tsx
+++ b/apps/dapp/frontend/app/settings/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { AppShell } from "@/components/app-shell";
+import { BankAccountsSection } from "@/components/settings/bank-accounts-section";
+import { useWallet } from "@/components/wallet-provider";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function SettingsPage() {
+  const { isConnected } = useWallet();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isConnected) {
+      router.replace("/");
+    }
+  }, [isConnected, router]);
+
+  return (
+    <AppShell>
+      <div className="max-w-2xl mx-auto px-4 py-10 space-y-8">
+        <div>
+          <h1 className="text-2xl font-semibold text-black tracking-tight">Settings</h1>
+          <p className="text-sm text-black/50 mt-1">
+            Manage payout preferences and saved bank accounts.
+          </p>
+        </div>
+        <BankAccountsSection />
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/dapp/frontend/components/app-shell.tsx
+++ b/apps/dapp/frontend/components/app-shell.tsx
@@ -34,6 +34,7 @@ const SIDEBAR_NAV = [
     { label: "Stocks", href: "/stocks", icon: CandlestickChart },
     { label: "Offramp", href: "/offramp", icon: Globe },
     { label: "Portfolio", href: "/portfolio", icon: BarChart3 },
+    { label: "Settings", href: "/settings", icon: User },
 ];
 
 // ── Sidebar ──────────────────────────────────────────────────────────────────

--- a/apps/dapp/frontend/components/offramp/SaveAccountPrompt.tsx
+++ b/apps/dapp/frontend/components/offramp/SaveAccountPrompt.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { addBankAccount } from "@/lib/api/bank-accounts";
+
+interface SaveAccountPromptProps {
+  bankName: string;
+  bankCode: string;
+  accountNumber: string;
+  accountName: string;
+  currency: string;
+  country: string;
+  onDismiss: () => void;
+  onSaved: () => void;
+}
+
+export function SaveAccountPrompt({
+  bankName,
+  bankCode,
+  accountNumber,
+  accountName,
+  currency,
+  country,
+  onDismiss,
+  onSaved,
+}: SaveAccountPromptProps) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await addBankAccount({
+        bank_name: bankName,
+        bank_code: bankCode,
+        account_number: accountNumber,
+        account_name: accountName,
+        currency,
+        country,
+        is_default: true,
+      });
+      onSaved();
+      onDismiss();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save account");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-4 space-y-3">
+      <p className="text-sm font-medium text-emerald-900">
+        Save this account for next time?
+      </p>
+      <p className="text-xs text-emerald-800/80">
+        Skip re-entering details on your next monthly withdrawal.
+      </p>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="rounded-lg bg-emerald-700 px-3 py-2 text-xs font-medium text-white hover:bg-emerald-800 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save account"}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-lg px-3 py-2 text-xs font-medium text-emerald-800 hover:bg-emerald-100"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dapp/frontend/components/offramp/SavedBankAccountPicker.tsx
+++ b/apps/dapp/frontend/components/offramp/SavedBankAccountPicker.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Building2, Loader2, Plus } from "lucide-react";
+import {
+  listBankAccounts,
+  type SavedBankAccount,
+} from "@/lib/api/bank-accounts";
+import { cn } from "@/lib/utils";
+
+export type PayoutMode = { type: "saved"; account: SavedBankAccount } | { type: "manual" };
+
+interface SavedBankAccountPickerProps {
+  currency: string;
+  value: PayoutMode;
+  onChange: (mode: PayoutMode) => void;
+}
+
+export function SavedBankAccountPicker({
+  currency,
+  value,
+  onChange,
+}: SavedBankAccountPickerProps) {
+  const [accounts, setAccounts] = useState<SavedBankAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listBankAccounts()
+      .then((data) => {
+        if (!cancelled) {
+          const filtered = data.filter((a) => a.currency === currency);
+          setAccounts(filtered);
+          if (filtered.length > 0 && value.type === "manual") {
+            const preferred = filtered.find((a) => a.is_default) ?? filtered[0];
+            onChange({ type: "saved", account: preferred });
+          }
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setAccounts([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-fetch when currency changes
+  }, [currency]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Loading saved accounts…
+      </div>
+    );
+  }
+
+  if (accounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 mb-4">
+      <p className="text-xs font-medium text-muted-foreground">Saved accounts</p>
+      <div className="flex flex-wrap gap-2">
+        {accounts.map((acct) => {
+          const selected =
+            value.type === "saved" && value.account.id === acct.id;
+          return (
+            <button
+              key={acct.id}
+              type="button"
+              onClick={() => onChange({ type: "saved", account: acct })}
+              className={cn(
+                "flex items-center gap-2 rounded-xl border px-3 py-2 text-left text-xs transition-colors min-h-[44px]",
+                selected
+                  ? "border-foreground bg-foreground/5"
+                  : "border-border hover:border-foreground/20",
+              )}
+            >
+              <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span>
+                <span className="font-medium block">{acct.bank_name}</span>
+                <span className="text-muted-foreground">
+                  ••••{acct.account_last4}
+                  {acct.is_default ? " · Default" : ""}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => onChange({ type: "manual" })}
+          className={cn(
+            "flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium min-h-[44px]",
+            value.type === "manual"
+              ? "border-foreground bg-foreground/5"
+              : "border-dashed border-border text-muted-foreground hover:border-foreground/20",
+          )}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Use a different account
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dapp/frontend/components/settings/bank-accounts-section.tsx
+++ b/apps/dapp/frontend/components/settings/bank-accounts-section.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Building2, Loader2, Star, Trash2 } from "lucide-react";
+import { BankCombobox } from "@/components/offramp/BankCombobox";
+import { AccountNameField } from "@/components/offramp/AccountNameField";
+import { useBankResolver } from "@/hooks/useBankResolver";
+import {
+  addBankAccount,
+  listBankAccounts,
+  removeBankAccount,
+  setDefaultBankAccount,
+  type SavedBankAccount,
+} from "@/lib/api/bank-accounts";
+import { cn } from "@/lib/utils";
+
+const CURRENCY_FLAGS: Record<string, string> = {
+  NGN: "🇳🇬",
+  GHS: "🇬🇭",
+  KES: "🇰🇪",
+};
+
+export function BankAccountsSection() {
+  const [accounts, setAccounts] = useState<SavedBankAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [accountNumber, setAccountNumber] = useState("");
+  const [bankCode, setBankCode] = useState("");
+  const [currency, setCurrency] = useState("NGN");
+  const [country, setCountry] = useState("NG");
+  const [saving, setSaving] = useState(false);
+
+  const { resolveState, accountInfo } = useBankResolver(accountNumber, bankCode, country);
+  const resolvedName = resolveState === "success" ? accountInfo?.account_name ?? null : null;
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listBankAccounts();
+      setAccounts(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load accounts");
+      setAccounts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleAdd = async () => {
+    if (!resolvedName || accountNumber.length !== 10 || !bankCode) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await addBankAccount({
+        bank_name: accountInfo?.bank_name || "Bank",
+        bank_code: bankCode,
+        account_number: accountNumber,
+        account_name: resolvedName,
+        currency,
+        country,
+        is_default: accounts.length === 0,
+      });
+      setShowAdd(false);
+      setAccountNumber("");
+      setBankCode("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save account");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-black/[0.06] bg-white p-6">
+      <div className="flex items-center justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-lg font-semibold text-black">Bank accounts</h2>
+          <p className="text-sm text-black/50 mt-1">
+            Save accounts for faster monthly offramps.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowAdd((v) => !v)}
+          className="rounded-xl bg-black px-4 py-2 text-sm font-medium text-white hover:bg-black/90"
+        >
+          {showAdd ? "Cancel" : "Add account"}
+        </button>
+      </div>
+
+      {error && (
+        <p className="mb-4 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-black/40 text-sm py-8">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading saved accounts…
+        </div>
+      ) : accounts.length === 0 ? (
+        <p className="text-sm text-black/40 py-4">No saved accounts yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {accounts.map((acct) => (
+            <li
+              key={acct.id}
+              className="flex items-center justify-between gap-3 rounded-xl border border-black/[0.06] px-4 py-3"
+            >
+              <div className="flex items-start gap-3 min-w-0">
+                <Building2 className="h-5 w-5 text-black/30 shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  <p className="font-medium text-black truncate">
+                    {CURRENCY_FLAGS[acct.currency] ?? ""} {acct.bank_name}
+                    {acct.is_default && (
+                      <span className="ml-2 inline-flex items-center gap-0.5 rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
+                        <Star className="h-3 w-3" /> Default
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-sm text-black/50 truncate">
+                    {acct.account_name} · ••••{acct.account_last4}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {!acct.is_default && (
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-black/50 hover:text-black"
+                    onClick={() => void setDefaultBankAccount(acct.id).then(refresh)}
+                  >
+                    Set default
+                  </button>
+                )}
+                <button
+                  type="button"
+                  aria-label="Remove account"
+                  className="p-2 text-black/30 hover:text-red-600"
+                  onClick={() => void removeBankAccount(acct.id).then(refresh)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showAdd && (
+        <div className="mt-6 pt-6 border-t border-black/[0.06] space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-xs font-medium text-black/50">
+              Currency
+              <select
+                value={currency}
+                onChange={(e) => {
+                  setCurrency(e.target.value);
+                  setCountry(e.target.value === "NGN" ? "NG" : e.target.value === "GHS" ? "GH" : "KE");
+                }}
+                className="mt-1 w-full rounded-xl border border-black/10 px-3 py-2 text-sm"
+              >
+                <option value="NGN">NGN</option>
+                <option value="GHS">GHS</option>
+                <option value="KES">KES</option>
+              </select>
+            </label>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-black/50">Account number</label>
+            <input
+              value={accountNumber}
+              onChange={(e) => setAccountNumber(e.target.value.replace(/\D/g, "").slice(0, 10))}
+              className="mt-1 w-full rounded-xl border border-black/10 px-3 py-2 text-sm"
+              placeholder="10-digit account number"
+            />
+          </div>
+          {accountNumber.length === 10 && (
+            <BankCombobox
+              value={bankCode}
+              onChange={setBankCode}
+              country={country}
+            />
+          )}
+          <AccountNameField resolveState={resolveState} accountName={resolvedName} />
+          <button
+            type="button"
+            disabled={saving || resolveState !== "success" || !bankCode}
+            onClick={() => void handleAdd()}
+            className={cn(
+              "w-full rounded-xl py-3 text-sm font-medium text-white",
+              saving || resolveState !== "success" ? "bg-black/30" : "bg-black hover:bg-black/90",
+            )}
+          >
+            {saving ? "Saving…" : "Save account"}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/dapp/frontend/lib/api/auth.ts
+++ b/apps/dapp/frontend/lib/api/auth.ts
@@ -1,0 +1,31 @@
+import { config } from "@/lib/config";
+
+export function getStoredToken(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem("nester_token") ?? "";
+}
+
+/** JWT `sub` claim — the authenticated user UUID. */
+export function getUserIdFromToken(): string | null {
+  const token = getStoredToken();
+  if (!token) return null;
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+    return typeof payload.sub === "string" ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+export function apiAuthHeaders(): HeadersInit {
+  const token = getStoredToken();
+  const headers: HeadersInit = { "Content-Type": "application/json" };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export const API_V1 = config.apiUrl.replace(/\/$/, "");

--- a/apps/dapp/frontend/lib/api/bank-accounts.ts
+++ b/apps/dapp/frontend/lib/api/bank-accounts.ts
@@ -1,0 +1,82 @@
+import { API_V1, apiAuthHeaders, getUserIdFromToken } from "@/lib/api/auth";
+
+export interface SavedBankAccount {
+  id: string;
+  bank_name: string;
+  bank_code?: string;
+  account_last4: string;
+  account_name: string;
+  currency: string;
+  country: string;
+  is_default: boolean;
+  verified_at?: string;
+  created_at: string;
+}
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: { code: string; message: string };
+}
+
+async function parseEnvelope<T>(res: Response): Promise<T> {
+  const json = (await res.json()) as ApiEnvelope<T>;
+  if (!res.ok || !json.success) {
+    throw new Error(json.error?.message ?? `Request failed (${res.status})`);
+  }
+  return json.data as T;
+}
+
+function requireUserId(): string {
+  const id = getUserIdFromToken();
+  if (!id) {
+    throw new Error("Sign in to manage saved bank accounts.");
+  }
+  return id;
+}
+
+export async function listBankAccounts(): Promise<SavedBankAccount[]> {
+  const userId = requireUserId();
+  const res = await fetch(`${API_V1}/users/${userId}/bank-accounts`, {
+    headers: apiAuthHeaders(),
+    cache: "no-store",
+  });
+  return parseEnvelope<SavedBankAccount[]>(res);
+}
+
+export async function addBankAccount(body: {
+  bank_name: string;
+  bank_code: string;
+  account_number: string;
+  account_name: string;
+  currency: string;
+  country: string;
+  is_default?: boolean;
+}): Promise<SavedBankAccount> {
+  const userId = requireUserId();
+  const res = await fetch(`${API_V1}/users/${userId}/bank-accounts`, {
+    method: "POST",
+    headers: apiAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  return parseEnvelope<SavedBankAccount>(res);
+}
+
+export async function setDefaultBankAccount(acctId: string): Promise<SavedBankAccount> {
+  const userId = requireUserId();
+  const res = await fetch(`${API_V1}/users/${userId}/bank-accounts/${acctId}`, {
+    method: "PATCH",
+    headers: apiAuthHeaders(),
+    body: JSON.stringify({ is_default: true }),
+  });
+  return parseEnvelope<SavedBankAccount>(res);
+}
+
+export async function removeBankAccount(acctId: string): Promise<void> {
+  const userId = requireUserId();
+  const res = await fetch(`${API_V1}/users/${userId}/bank-accounts/${acctId}`, {
+    method: "DELETE",
+    headers: apiAuthHeaders(),
+  });
+  await parseEnvelope<{ deleted: string }>(res);
+}


### PR DESCRIPTION
## Summary

Adds saved bank accounts under the user profile so repeat offramps do not require re-entering NUBAN details. The API stores account numbers encrypted at rest, exposes CRUD endpoints, and lets settlements use either inline destination details or `bank_account_id`. The dapp adds a Settings “Bank Accounts” section and quick-select on the offramp flow, with a “Save for next time?” prompt after a successful manual entry.

## Related Issues

Closes #214

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made

- Added migration `017_create_bank_accounts_table` (`bank_accounts` with encrypted account number, fingerprint for uniqueness, one default per user per currency).
- Added `internal/domain/bankaccount/`, AES-256-GCM `internal/crypto/account_cipher.go`, postgres repository, and `BankAccountService` (add, list, set default, remove, resolve for settlement).
- Added REST routes: `GET/POST /api/v1/users/{id}/bank-accounts`, `PATCH/DELETE /api/v1/users/{id}/bank-accounts/{acctId}` (caller JWT `sub` must match `{id}`).
- Extended `POST /api/v1/settlements` to accept `bank_account_id` as an alternative to inline `destination`; resolves saved account into settlement destination server-side.
- Wired services in `cmd/api/main.go`; config `BANK_ACCOUNT_ENCRYPTION_KEY` (32-byte key, base64; dev fallback when unset in development).
- Frontend: `/settings` bank accounts UI, `lib/api/bank-accounts.ts`, offramp saved-account picker, manual-entry fallback, and post-withdrawal save prompt.
- Unit tests: `bankaccount_service_test.go` (add, default toggling, duplicate rejection, remove); settlement handler/service tests updated for new constructor signature.

## Testing Done

- `go test ./internal/service/...` — bank account and settlement service tests pass.
- `go test ./internal/handler/... -run Settlement` — settlement handler tests pass.
- Manual (recommended before merge): run migration `017`, set `BANK_ACCOUNT_ENCRYPTION_KEY` in staging/production, sign in via wallet auth, add/list/delete accounts on Settings, initiate settlement with `bank_account_id`, confirm offramp quick-select and “Save for next time?” after manual flow.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [ ] Documentation updated if needed _(optional: short API note for `bank_account_id` on settlements)_
- [x] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications _(N/A — backend + frontend only)_


Deploy note for reviewers: set BANK_ACCOUNT_ENCRYPTION_KEY in non-dev environments; loss of this key makes stored account numbers unrecoverable.