### PR TITLE
fix(api): make Stellar USDC issuer configurable via STELLAR_USDC_ISSU…

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -47,6 +47,11 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Horizon API endpoint.
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# Stellar USDC issuer address used by the oracle order book query.
+# Defaults to Circle's mainnet USDC issuer when not set.
+# Override this value for testnet or other Stellar networks.
+STELLAR_USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+
 # Stellar account secret used to sign on-chain operations from the API
 # (e.g. vault deposits). Leave empty to disable on-chain invocation.
 STELLAR_OPERATOR_SECRET=

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -140,7 +140,7 @@ func run() error {
 	authService := service.NewAuthService(challengeStore, userService, cfg.Auth())
 	authHandler := handler.NewAuthHandler(authService)
 
-	oracleService := oracle.NewRateService(cfg.Stellar().HorizonURL())
+	oracleService := oracle.NewRateService(cfg.Stellar().HorizonURL(), cfg.Stellar().USDCIssuer())
 	rateHandler := handler.NewRateHandler(oracleService)
 
 	wsHub := ws.NewHub(baseLogger.WithGroup("websocket"), func(token string) (string, error) {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -63,6 +63,7 @@ type StellarConfig struct {
 	rpcURL            string
 	horizonURL        string
 	operatorSecret    string
+	stellarUSDCIssuer string
 }
 
 type AuthConfig struct {
@@ -132,6 +133,7 @@ func Load() (*Config, error) {
 			rpcURL:            loader.requiredURL("STELLAR_RPC_URL"),
 			horizonURL:        loader.requiredURL("STELLAR_HORIZON_URL"),
 			operatorSecret:    loader.stringDefault("STELLAR_OPERATOR_SECRET", ""),
+			stellarUSDCIssuer: loader.stringDefault("STELLAR_USDC_ISSUER", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
 		},
 		redis: RedisConfig{
 			addr: loader.stringDefault("REDIS_ADDR", ""),
@@ -192,6 +194,10 @@ func (c Config) Database() DatabaseConfig {
 
 func (c Config) Stellar() StellarConfig {
 	return c.stellar
+}
+
+func (s StellarConfig) USDCIssuer() string {
+	return s.stellarUSDCIssuer
 }
 
 func (c Config) SettlementProviderURL() string {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -18,7 +18,7 @@ func baseEnv(t *testing.T) {
 		"SERVER_HOST", "SERVER_PORT",
 		"SERVER_READ_TIMEOUT", "SERVER_WRITE_TIMEOUT", "SERVER_SHUTDOWN_TIMEOUT",
 		"DATABASE_DSN", "DATABASE_POOL_SIZE", "DATABASE_CONNECTION_TIMEOUT",
-		"STELLAR_NETWORK_PASSPHRASE", "STELLAR_RPC_URL", "STELLAR_HORIZON_URL",
+		"STELLAR_NETWORK_PASSPHRASE", "STELLAR_RPC_URL", "STELLAR_HORIZON_URL", "STELLAR_USDC_ISSUER",
 		"AUTH_JWT_SECRET", "AUTH_TOKEN_EXPIRY", "AUTH_CHALLENGE_EXPIRY",
 		"RATELIMIT_GLOBAL_LIMIT", "RATELIMIT_GLOBAL_WINDOW", "RATELIMIT_WRITE_LIMIT", "RATELIMIT_WRITE_WINDOW",
 		"RATELIMIT_WALLET_LIMIT", "RATELIMIT_WALLET_WINDOW",
@@ -161,6 +161,40 @@ func TestLoadFromEnvVars(t *testing.T) {
 	wantDSN := "postgres://postgres:postgres@localhost:5432/nester?sslmode=disable"
 	if cfg.Database().DSN() != wantDSN {
 		t.Fatalf("unexpected DSN: %q", cfg.Database().DSN())
+	}
+}
+
+func TestLoadStellarUSDCIssuerDefault(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	const expected = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+	if cfg.Stellar().USDCIssuer() != expected {
+		t.Fatalf("expected default USDC issuer %q, got %q", expected, cfg.Stellar().USDCIssuer())
+	}
+}
+
+func TestLoadStellarUSDCIssuerFromEnv(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("STELLAR_USDC_ISSUER", "GTESTUSDCISSUERADDRESSEXAMPLE12345")
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Stellar().USDCIssuer() != "GTESTUSDCISSUERADDRESSEXAMPLE12345" {
+		t.Fatalf("expected USDC issuer from env, got %q", cfg.Stellar().USDCIssuer())
 	}
 }
 

--- a/apps/api/internal/oracle/service.go
+++ b/apps/api/internal/oracle/service.go
@@ -22,9 +22,9 @@ type RateService struct {
 
 // NewRateService constructs a RateService with Horizon (primary) and DeFiLlama
 // (fallback) for crypto rates and the open.er-api.com feed for fiat rates.
-func NewRateService(horizonURL string) *RateService {
+func NewRateService(horizonURL, usdcIssuer string) *RateService {
 	return NewRateServiceWithFetchers(
-		[]Provider{NewStellarProvider(horizonURL), NewDefiLlamaProvider()},
+		[]Provider{NewStellarProvider(horizonURL, usdcIssuer), NewDefiLlamaProvider()},
 		NewFiatProvider(),
 	)
 }

--- a/apps/api/internal/oracle/stellar.go
+++ b/apps/api/internal/oracle/stellar.go
@@ -9,19 +9,18 @@ import (
 	"time"
 )
 
-// usdcIssuer is Circle's USDC issuer on the Stellar network.
-const usdcIssuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
-
 // StellarProvider fetches the XLM/USDC mid-market rate from Horizon's order book.
 type StellarProvider struct {
 	horizonURL string
+	usdcIssuer string
 	client     *http.Client
 }
 
-// NewStellarProvider returns a StellarProvider using the given Horizon base URL.
-func NewStellarProvider(horizonURL string) *StellarProvider {
+// NewStellarProvider returns a StellarProvider using the given Horizon base URL and USDC issuer.
+func NewStellarProvider(horizonURL, usdcIssuer string) *StellarProvider {
 	return &StellarProvider{
 		horizonURL: horizonURL,
+		usdcIssuer: usdcIssuer,
 		client:     &http.Client{Timeout: 10 * time.Second},
 	}
 }
@@ -39,7 +38,7 @@ func (p *StellarProvider) Fetch(ctx context.Context, base, quote string) (float6
 			"&buying_asset_code=USDC"+
 			"&buying_asset_issuer=%s"+
 			"&limit=1",
-		p.horizonURL, usdcIssuer,
+		p.horizonURL, p.usdcIssuer,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)


### PR DESCRIPTION
## Summary

This PR fixes issue #455 by making the Stellar USDC issuer configurable via a new `STELLAR_USDC_ISSUER` environment variable.

## What changed

- Added `STELLAR_USDC_ISSUER` to API config with the existing mainnet Circle USDC issuer as the default
- Removed the hardcoded issuer constant from `apps/api/internal/oracle/stellar.go`
- Updated the Stellar oracle provider to accept the issuer from config
- Updated API bootstrap code to pass the configured issuer
- Documented `STELLAR_USDC_ISSUER` in `apps/api/.env.example`
- Added tests to verify default behavior and env override behavior

## Why

The previous implementation always used the mainnet Circle USDC issuer, which breaks testnet and multi-network Stellar support because the Horizon order book query never matches a non-mainnet issuer.

## Testing

- Verified modified files have no editor diagnostics
- `go` toolchain was unavailable in this environment, so tests were not executed here

## Closes

- closes #455