### PR TITLE
fix(vault,api): document gross preview_withdraw + lock health dual-path (#445, #448)

### DIFF
--- a/apps/api/cmd/api/health_test.go
+++ b/apps/api/cmd/api/health_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthEndpoints_BothPathsReturnOKWhenReady(t *testing.T) {
+	var ready atomic.Bool
+	ready.Store(true)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", livenessHandler(&ready))
+	mux.HandleFunc("GET /healthz", livenessHandler(&ready))
+
+	for _, path := range []string{"/health", "/healthz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		assert.Equalf(t, http.StatusOK, rec.Code, "GET %s should return 200 when ready", path)
+		assert.Equalf(t, "ok", rec.Body.String(), "GET %s body", path)
+	}
+}
+
+func TestLivenessHandler_ReportsDrainingWhenNotReady(t *testing.T) {
+	var ready atomic.Bool
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	livenessHandler(&ready)(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "draining", rec.Body.String())
+}

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -1333,6 +1333,17 @@ impl VaultContract {
         vault_token_client(&env).shares_for_deposit(&amount)
     }
 
+    /// Returns the **gross**, pre-fee asset value of `shares` (the raw
+    /// share-price conversion, like an EIP-4626 `previewRedeem` of the
+    /// underlying price).
+    ///
+    /// ⚠️ Do **not** pass this value straight through as `min_assets_out` to
+    /// [`VaultContract::withdraw`]. A fee-bearing withdrawal deducts a
+    /// performance fee (on realized yield) and/or an early-withdrawal fee, so
+    /// the amount actually transferred is *less* than this gross figure and the
+    /// call reverts with `ContractError::SlippageExceeded` (see #448). For a
+    /// slippage-safe floor that reflects the fees deducted on withdrawal, use
+    /// [`VaultContract::withdrawal_fee_preview`] and read `net_amount_received`.
     pub fn preview_withdraw(env: Env, shares: i128) -> i128 {
         require_initialized(&env);
         if shares <= 0 {

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -428,6 +428,73 @@ fn withdraw_reverts_when_min_assets_out_is_not_met() {
     vault.withdraw(&user, &(500 * XLM), &(500 * XLM + STROOP));
 }
 
+// Regression for #448: `withdrawal_fee_preview().net_amount_received` is the
+// post-fee amount actually transferred, so a caller can use it directly as
+// `min_assets_out` for a fee-bearing withdrawal without tripping slippage.
+//
+// No time is advanced, so no management fee accrues (elapsed = 0) and the
+// preview models every fee the withdrawal applies exactly: the reported yield
+// triggers a performance fee, and remaining inside the MinLockPeriod triggers
+// the early-withdrawal fee.
+#[test]
+fn withdrawal_fee_preview_net_is_slippage_safe_as_min_assets_out() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    let deposit = 1_000 * XLM;
+    mint(&token, &user, deposit);
+    vault.deposit(&user, &deposit, &0);
+
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    vault.report_yield(&admin, &(500 * XLM));
+    // Back the reported yield with real tokens so the vault can pay it out
+    // (report_yield only updates share-price accounting).
+    mint(&token, &vault.address, 500 * XLM);
+
+    let shares = vault.get_shares(&user);
+    let preview = vault.withdrawal_fee_preview(&user, &shares);
+    assert!(
+        preview.performance_fee_deducted > 0,
+        "expected a performance fee on realized yield"
+    );
+    assert!(
+        preview.early_withdrawal_fee_deducted > 0,
+        "expected an early-withdrawal fee inside the lock period"
+    );
+    assert!(preview.net_amount_received < preview.gross_asset_value);
+
+    let before = token::Client::new(&env, &token.address).balance(&user);
+
+    // Using the NET preview as the slippage floor must succeed.
+    vault.withdraw(&user, &shares, &preview.net_amount_received);
+
+    let after = token::Client::new(&env, &token.address).balance(&user);
+    // The user receives exactly the previewed net amount — the preview is an
+    // exact (not merely conservative) floor.
+    assert_eq!(after - before, preview.net_amount_received);
+}
+
+// Regression for #448: the GROSS preview (`preview_withdraw` /
+// `gross_asset_value`) must NOT be used as `min_assets_out` — on a fee-bearing
+// withdrawal the transfer is below gross, so it reverts with SlippageExceeded
+// (#17). This is exactly the failure mode the issue describes.
+#[test]
+#[should_panic(expected = "Error(Contract, #17)")]
+fn gross_preview_as_min_assets_out_trips_slippage_on_fee_bearing_withdrawal() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    let deposit = 1_000 * XLM;
+    mint(&token, &user, deposit);
+    vault.deposit(&user, &deposit, &0);
+
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    vault.report_yield(&admin, &(500 * XLM));
+
+    let shares = vault.get_shares(&user);
+    let gross = vault.preview_withdraw(&shares);
+    // gross > net (fees apply) => SlippageExceeded.
+    vault.withdraw(&user, &shares, &gross);
+}
+
 #[test]
 #[should_panic]
 fn withdrawal_of_more_than_owned_is_rejected() {


### PR DESCRIPTION
## Summary

Resolves two backlog items in `nester`. Both turned out to have their core fix already present on `main`; the genuine, missing gap in each was guard rails — a documentation warning and regression-test coverage — which this PR adds rather than fabricating a no-op change.

closes #445
closes #448

## #448 — `preview_withdraw` returns gross pre-fee amount

`preview_withdraw(shares)` returns the **gross** share value. Passing it directly as `min_assets_out` reverts with `SlippageExceeded` on any fee-bearing withdrawal. The on-chain **net** preview already exists — `withdrawal_fee_preview(...).net_amount_received` — and it mirrors `withdraw`'s fee math exactly (performance fee on realized yield + conditional early-withdrawal fee). The missing pieces were discoverability and proof:

- **Doc comment** on `preview_withdraw` (`packages/contracts/contracts/vault/src/lib.rs`): warns it is gross, must not be used as `min_assets_out`, and points to `withdrawal_fee_preview` for a slippage-safe floor.
- **Regression tests** (`vault/src/test.rs`):
  - `withdrawal_fee_preview_net_is_slippage_safe_as_min_assets_out` — a fee-bearing withdrawal using `net_amount_received` as `min_assets_out` **succeeds** and transfers **exactly** the previewed net (an exact, not merely conservative, floor).
  - `gross_preview_as_min_assets_out_trips_slippage_on_fee_bearing_withdrawal` — using the gross value as `min_assets_out` reverts with `SlippageExceeded` (#17), reproducing the exact failure the issue describes.

## #445 — healthcheck path mismatch (`/healthz` vs `/health`)

Verified the three sources the issue calls out are **already consistent on `main`**:
- `apps/api/cmd/api/main.go` registers liveness on **both** `GET /health` and `GET /healthz` (plus `/readyz`).
- `docker-compose.yml` probes the API on `/health` — a served route.
- `README.md` documents `/health`.

So the historical mismatch is already fixed; what was missing was test coverage. Added (`apps/api/cmd/api/main_test.go`):
- `TestHealthEndpoints_BothPathsReturnOKWhenReady` — both `/health` and `/healthz` return `200` `ok` when ready (locks the dual-path contract so the compose/k8s probe mismatch can't recur).
- `TestLivenessHandler_ReportsDrainingWhenNotReady` — returns `503 draining` while not ready.

## Test plan
- Contracts: built `vault_token.wasm`, then `cargo test --lib -p vault-contract` → **45 passing** (43 existing + 2 new). This mirrors the contracts CI job (build WASM deps → `cargo test --lib`).
- API: `go test -race ./cmd/api` → passing (incl. the 2 new health tests); `gofmt -s` and `go vet` clean.

## Caveats
- No production behavior changed — `preview_withdraw` still returns gross (intentional, EIP-4626-style), now documented; the health routes were already correct. The value here is the doc warning + regression coverage that lock both contracts.
- I did not run repo-wide `cargo fmt`/`clippy`: the workspace is not rustfmt-clean on `main` (pre-existing diffs across several contracts), and nester CI enforces neither for Rust — it runs `cargo test --lib`. My additions are individually fmt-compliant.
