### PR TITLE
ci(contracts): build vault_token.wasm and enforce non-empty vault tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,33 @@ jobs:
       - name: Build allocation_strategy WASM
         run: cargo build --release --target wasm32-unknown-unknown -p allocation-strategy-contract
 
-      - name: Build vault_token WASM
+      - name: Build vault_token WASM (required for vault-contract tests)
         run: cargo build --release --target wasm32-unknown-unknown -p vault-token-contract
+
+      - name: Ensure vault_token.wasm is available for vault-contract tests
+        run: test -f target/wasm32-unknown-unknown/release/vault_token.wasm
 
       - name: Test contracts
         run: cargo test --lib
+
+      # The vault contract's integration tests link against the pre-compiled
+      # vault_token.wasm artifact built above. Run them explicitly and fail the
+      # job if zero tests execute — a green run with no tests would otherwise
+      # give false confidence that the contract logic was verified.
+      - name: Run vault-contract tests
+        run: |
+          # Capture output but still fail the job if the build/test command
+          # itself errors (e.g. a missing WASM artifact aborts compilation).
+          if ! output=$(cargo test -p vault-contract 2>&1); then
+            echo "$output"
+            echo "ERROR: vault-contract tests failed to build or run"
+            exit 1
+          fi
+          echo "$output"
+          # \b0 only matches a standalone zero, so "10 tests" / "40 passed"
+          # never trip this guard — only a genuinely empty run does.
+          if echo "$output" | grep -qE '\b0 tests'; then
+            echo "ERROR: No vault-contract tests ran — possible missing WASM artifact"
+            exit 1
+          fi
 

--- a/OSS_CLEANUP.md
+++ b/OSS_CLEANUP.md
@@ -140,11 +140,12 @@
 
 ### 🟠 Fix Soon After Merge
 
-- [ ] **Add impairment regression test to vault contract.**
+- [x] **Add impairment regression test to vault contract.**
   File: `packages/contracts/contracts/vault/src/test.rs`
   The issue explicitly required: "User deposits at rate 1.0, rate halves (impairment) → zero performance fee."
   The code handles it correctly (`yield_part < 0` → fee skipped) but the test proving it is missing.
-  Add a test that simulates a loss scenario and asserts no performance fee is charged.
+  Added `impairment_charges_zero_performance_fee`: deposits at rate 1.0, halves the share price via a
+  negative `report_yield`, and asserts both the preview and the actual withdrawal charge no performance fee.
 
 ---
 
@@ -164,9 +165,11 @@
 
 ### 🟡 Polish
 
-- [ ] **Verify `cargo test -p vault-contract` passes in CI with vault_token.wasm artifact.**
+- [x] **Verify `cargo test -p vault-contract` passes in CI with vault_token.wasm artifact.**
   The contributor left this box unchecked in the PR test plan. Confirm integration tests
   are not silently passing vacuously due to missing WASM artifact.
+  CI now builds `vault_token.wasm`, asserts the artifact exists, runs the tests explicitly,
+  and fails the job if zero vault-contract tests execute (see `.github/workflows/ci.yml`).
 
 ---
 

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -417,6 +417,57 @@ fn performance_fee_charges_only_realized_yield_not_principal() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Impairment regression test (issue #451 / PR #275)
+//
+// The original performance-fee issue explicitly required:
+//   "User deposits at rate 1.0, rate halves (impairment) → zero performance fee."
+//
+// The withdraw path skips the performance fee whenever `yield_part =
+// assets_to_withdraw - principal` is not strictly positive. This test proves
+// that zero-performance-fee invariant holds after a loss halves the share
+// price, so an impaired position is never charged a fee on a gain it never had.
+// ---------------------------------------------------------------------------
+#[test]
+fn impairment_charges_zero_performance_fee() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    let deposit = 1_000 * XLM;
+    mint(&token, &user, deposit);
+
+    // Disable the early-withdrawal fee so the assertion isolates performance-fee
+    // behaviour and the withdrawn amount is unambiguous.
+    let mut fee_config: FeeConfig = vault.get_fee_config();
+    fee_config.early_withdrawal_fee_bps = 0;
+    vault.set_fee_config(&admin, &fee_config);
+
+    // Deposit at the initial share price of 1.0.
+    vault.deposit(&user, &deposit, &0);
+    assert_eq!(vault.share_price(), 10_000_000, "deposit should occur at rate 1.0");
+
+    // Impairment: report a loss that halves the share price (1.0 -> 0.5).
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    vault.report_yield(&admin, &(-(500 * XLM)));
+    assert_eq!(vault.share_price(), 5_000_000, "rate should halve after impairment");
+
+    // The preview must show no performance fee owed on an impaired position.
+    let shares = vault.get_shares(&user);
+    let preview = vault.withdrawal_fee_preview(&user, &shares);
+    assert_eq!(
+        preview.performance_fee_deducted, 0,
+        "no performance fee may be charged when the position has lost value"
+    );
+
+    // The actual withdrawal returns the impaired value (500 XLM) with no fees
+    // siphoned off: 1000 shares now worth 0.5 each.
+    vault.withdraw(&user, &shares, &0);
+    assert_eq!(
+        token::Client::new(&env, &token.address).balance(&user),
+        500 * XLM,
+        "user receives the full impaired value with zero performance fee"
+    );
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #17)")]
 fn withdraw_reverts_when_min_assets_out_is_not_met() {


### PR DESCRIPTION
## Summary

Closes #466.

Hardens CI so the vault contract's tests can never pass vacuously, and adds the missing impairment regression test. Addresses the unchecked test-plan item from PR #277 (Slippage Protection) and the missing test from #451.

## Background

The vault contract's tests link against a pre-compiled `vault_token.wasm` artifact via `contractimport!`. If that artifact isn't built before tests run, the suite could be silently skipped — a green CI run reporting zero tests is worse than a red one, since it gives false confidence that contract logic was verified.

## Changes

### CI (`.github/workflows/ci.yml`) — Refs #277
- Assert `vault_token.wasm` exists before running tests.
- Run `cargo test -p vault-contract` explicitly.
- **Fail the job if zero vault-contract tests execute**, and propagate a build/compile failure (which capturing command output would otherwise swallow).

Two intentional deviations from the issue's literal snippets:
- The Cargo package is `vault-token-contract` (lib name `vault_token`), not `vault-token` — used the correct name so the build actually runs.
- Replaced `grep -q "0 tests"` with a word-boundary regex `\b0 tests`. The literal substring would false-positive on `"10 tests"` / `"40 passed"`; the word-boundary version matches only a genuinely empty run.

### Test (`packages/contracts/contracts/vault/src/test.rs`) — Refs #451
Added `impairment_charges_zero_performance_fee`, implementing the scenario the original issue required: *"User deposits at rate 1.0, rate halves (impairment) → zero performance fee."* It deposits at share price 1.0, halves the price via a negative `report_yield`, and asserts that **both** the `withdrawal_fee_preview` and the actual `withdraw` charge no performance fee on the impaired position.

## Verification

```
cargo build --target wasm32-unknown-unknown --release -p vault-token-contract
cargo test -p vault-contract
# test result: ok. 44 passed; 0 failed
```

Locally: 44 tests pass including the new one. YAML validated, and the zero-test guard was checked against `44 / 10 / 0 tests` and `40 passed` inputs.

## Acceptance criteria
- [x] `vault_token.wasm` is built before `cargo test -p vault-contract` runs in CI
- [x] CI job fails if zero vault-contract tests are executed
- [x] All vault-contract tests pass in CI
- [x] The impairment regression test from #451 is included in the passing suite
