### PR TITLE
chore(dev): document AUTH_JWT_SECRET in .env.example and flag the docker dev value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional: Stellar testnet signing key (leave blank to use read-only mode)
 STELLAR_SOURCE_KEY=S...
+
+# Required by the API service for signing/verifying auth JWTs.
+# The value below mirrors the dev placeholder in docker-compose.yml.
+# DO NOT use this value in staging or production — generate a strong, unique
+# secret (>= 32 chars) before deploying anywhere user-reachable.
+AUTH_JWT_SECRET=dev-nester-jwt-secret-change-in-production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
       STELLAR_RPC_URL: https://soroban-testnet.stellar.org
       STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      # DO NOT use in production — this is a development-only placeholder
       AUTH_JWT_SECRET: dev-nester-jwt-secret-change-in-production
       LOG_LEVEL: info
       LOG_FORMAT: text


### PR DESCRIPTION
## Summary

Finishes the parts of #453 that were still outstanding on \`main\`. The API service in \`docker-compose.yml\` already had a development-only \`AUTH_JWT_SECRET\` value, but two acceptance-criteria items were missing: the docker entry carried no inline comment marking the value as dev-only, and \`.env.example\` did not list \`AUTH_JWT_SECRET\` at all (so anyone running the API outside docker-compose had no way to discover that the variable is required).

closes #453

## Changes

- **#453 — \`docker-compose.yml\`**: adds a \`# DO NOT use in production — this is a development-only placeholder\` comment immediately above the existing \`AUTH_JWT_SECRET\` line in the \`api\` service \`environment\` block. The value itself is unchanged.
- **#453 — \`.env.example\`**: appends an \`AUTH_JWT_SECRET\` entry (same placeholder as docker-compose) with a multi-line comment explaining it is required by the API and must be rotated to a strong unique secret before staging/production. Sits alongside the existing \`ANTHROPIC_API_KEY\` / \`STELLAR_SOURCE_KEY\` entries.

No code paths change; this is purely a developer-onboarding/documentation fix.

## Test plan

- \`docker compose config\` parses (yaml shape unchanged — only an added comment line).
- A contributor who copies \`.env.example\` to \`.env\` now has \`AUTH_JWT_SECRET\` set, matching the docker placeholder, and JWT verification continues to use the same key across both run modes.
