### PR TITLE
Fix vulnerability on settlement endpoints — user_id accepted from req…

### DIFF
--- a/apps/api/internal/handler/settlement_handler.go
+++ b/apps/api/internal/handler/settlement_handler.go
@@ -63,9 +63,15 @@ func (h *SettlementHandler) initiateSettlement(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	userID, err := uuid.Parse(req.UserID)
+	caller, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	userID, err := uuid.Parse(caller.ID)
 	if err != nil {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("user_id must be a valid UUID"))
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid caller identity"))
 		return
 	}
 
@@ -131,6 +137,12 @@ func (h *SettlementHandler) getSettlement(w http.ResponseWriter, r *http.Request
 	model, err := h.service.GetSettlement(r.Context(), id)
 	if err != nil {
 		h.writeDomainError(w, r, err)
+		return
+	}
+
+	caller, ok := auth.GetUserFromContext(r.Context())
+	if !ok || model.UserID.String() != caller.ID {
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("settlement"))
 		return
 	}
 

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -100,7 +100,9 @@ func TestSettlementHandler_PostCreates201(t *testing.T) {
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
-	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	// Inject auth user middleware
+	handler := injectAuthUser(auth.User{ID: userID.String()}, mux)
+	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(handler))
 	defer server.Close()
 
 	resp, err := http.Post(
@@ -146,7 +148,7 @@ func TestSettlementHandler_PostDomainValidation400(t *testing.T) {
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
-	server := httptest.NewServer(mux)
+	server := httptest.NewServer(injectAuthUser(auth.User{ID: userID.String()}, mux))
 	defer server.Close()
 
 	// bank_transfer without bank_code
@@ -197,7 +199,7 @@ func TestSettlementHandler_Get200And404(t *testing.T) {
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
-	server := httptest.NewServer(mux)
+	server := httptest.NewServer(injectAuthUser(auth.User{ID: userID.String()}, mux))
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + "/api/v1/settlements/" + created.ID.String())
@@ -216,6 +218,32 @@ func TestSettlementHandler_Get200And404(t *testing.T) {
 	defer resp404.Body.Close()
 	if resp404.StatusCode != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", resp404.StatusCode)
+	}
+
+	attacker := uuid.New()
+	created2, _ := svc.InitiateSettlement(context.Background(), service.InitiateSettlementInput{
+		UserID:       attacker,
+		VaultID:      vaultID,
+		Amount:       decimal.RequireFromString("10"),
+		Currency:     "USDC",
+		FiatCurrency: "NGN",
+		FiatAmount:   decimal.RequireFromString("100"),
+		ExchangeRate: decimal.RequireFromString("10"),
+		Destination: offramp.Destination{
+			Type:          "mobile_money",
+			Provider:      "mpesa",
+			AccountNumber: "0712345678",
+			AccountName:   "Jane",
+		},
+	})
+	
+	respNonOwner, err := http.Get(server.URL + "/api/v1/settlements/" + created2.ID.String())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer respNonOwner.Body.Close()
+	if respNonOwner.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 for non-owner, got %d", respNonOwner.StatusCode)
 	}
 }
 
@@ -270,7 +298,7 @@ func TestSettlementHandler_PatchStatus200(t *testing.T) {
 	}
 }
 
-func TestSettlementHandler_PatchStatus403NonOwner(t *testing.T) {
+func TestSettlementHandler_PatchStatus404NonOwner(t *testing.T) {
 	ownerID := uuid.New()
 	vaultID := uuid.New()
 	svc := service.NewSettlementService(newSettlementStubRepo())
@@ -313,8 +341,8 @@ func TestSettlementHandler_PatchStatus403NonOwner(t *testing.T) {
 		t.Fatalf("PATCH: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("want 403 for non-owner, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 for non-owner, got %d", resp.StatusCode)
 	}
 }
 
@@ -351,7 +379,7 @@ func TestSettlementHandler_ListUserSettlementsWithStatus(t *testing.T) {
 	h := NewSettlementHandler(svc)
 	mux := http.NewServeMux()
 	h.Register(mux)
-	server := httptest.NewServer(mux)
+	server := httptest.NewServer(injectAuthUser(auth.User{ID: userID.String()}, mux))
 	defer server.Close()
 
 	_, err := http.Post(server.URL+"/api/v1/settlements", "application/json", bytes.NewBufferString(validSettlementJSONBody(userID, vaultID)))

--- a/apps/api/internal/service/settlement_service.go
+++ b/apps/api/internal/service/settlement_service.go
@@ -137,7 +137,7 @@ func (s *SettlementService) UpdateStatus(ctx context.Context, input UpdateStatus
 	}
 
 	if current.UserID != input.CallerID {
-		return offramp.Settlement{}, offramp.ErrForbidden
+		return offramp.Settlement{}, offramp.ErrSettlementNotFound
 	}
 
 	if !current.CanTransitionTo(input.NewStatus) {

--- a/apps/api/internal/service/settlement_service_test.go
+++ b/apps/api/internal/service/settlement_service_test.go
@@ -389,7 +389,7 @@ func TestUpdateStatus_CannotLeaveFailed(t *testing.T) {
 	}
 }
 
-func TestUpdateStatus_ForbiddenForNonOwner(t *testing.T) {
+func TestUpdateStatus_NotFoundForNonOwner(t *testing.T) {
 	svc := service.NewSettlementService(newStubRepo())
 	ctx := context.Background()
 
@@ -401,7 +401,7 @@ func TestUpdateStatus_ForbiddenForNonOwner(t *testing.T) {
 		CallerID:     attacker,
 		NewStatus:    offramp.StatusLiquidityMatched,
 	})
-	if !errors.Is(err, offramp.ErrForbidden) {
-		t.Errorf("expected ErrForbidden for non-owner, got %v", err)
+	if !errors.Is(err, offramp.ErrSettlementNotFound) {
+		t.Errorf("expected ErrSettlementNotFound for non-owner, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #442 

## Fix BOLA vulnerabilities in settlement endpoints

### PR Summary
This PR remediates high-severity Broken Object Level Authorization (BOLA) vulnerabilities across the settlement endpoints, ensuring strict ownership validation and preventing resource enumeration.

### Key Changes
- **Initiate Settlement (`POST`)**: Ignores `user_id` in the request payload and strictly extracts the caller's identity from the authenticated JWT context.
- **Read Settlement (`GET`)**: Validates caller ownership against the retrieved settlement. Returns `404 Not Found` for unauthorized access to prevent existence leaks.
- **Update Settlement (`PATCH`)**: Modified service validation to return `404 Not Found` (via `ErrSettlementNotFound`) instead of `403 Forbidden` for non-owners, closing the existence oracle.
- **Testing**: Updated handler and service tests to inject auth context and verify the new `404` constraints for unauthorized ownership access.

### Security Impact
Resolves OWASP API1:2023 (Broken Object Level Authorization) issues without altering the existing database schema or routing structure or core routing logic.