### PR TITLE
fix(api): pass uuid.UUID to queries in user repository (GetRoles, Get…

### DIFF
--- a/OSS_CLEANUP.md
+++ b/OSS_CLEANUP.md
@@ -72,16 +72,10 @@
 
 ### 🟠 Fix Soon After Merge
 
-- [ ] **`GetRoles` passes `id.String()` instead of the raw `uuid.UUID` to pgx.**
+ - [x] **`GetRoles` passes `id.String()` instead of the raw `uuid.UUID` to pgx.** (resolved in commit `e8072f4`)
   File: `apps/api/internal/repository/postgres/user_repository.go`
-  pgx v5 handles `uuid.UUID` natively. Passing `.String()` forces string serialisation and an
-  implicit server-side cast. The rest of the repo passes UUID values directly. Change to:
-  ```go
-  rows, err := r.db.QueryContext(ctx,
-      `SELECT role FROM user_roles WHERE user_id = $1 ORDER BY role`,
-      id,   // not id.String()
-  )
-  ```
+  pgx v5 handles `uuid.UUID` natively. Passing `.String()` forced string serialisation and an
+  implicit server-side cast. This PR now passes `uuid.UUID` values directly.
 
 - [ ] **`bootstrap-admin` does not call `db.Ping()` after `sql.Open()`.**
   File: `apps/api/cmd/bootstrap-admin/main.go`

--- a/apps/api/internal/repository/postgres/user_repository.go
+++ b/apps/api/internal/repository/postgres/user_repository.go
@@ -32,7 +32,7 @@ func (r *UserRepository) Create(ctx context.Context, model *user.User) error {
 	if err := r.db.QueryRowContext(
 		ctx,
 		query,
-		model.ID.String(),
+		model.ID,
 		model.WalletAddress,
 		model.DisplayName,
 		string(model.KYCStatus),
@@ -49,7 +49,7 @@ func (r *UserRepository) GetByID(ctx context.Context, id uuid.UUID) (*user.User,
 		FROM users
 		WHERE id = $1
 	`
-	return scanUser(r.db.QueryRowContext(ctx, query, id.String()))
+	return scanUser(r.db.QueryRowContext(ctx, query, id))
 }
 
 func (r *UserRepository) GetByWalletAddress(ctx context.Context, addr string) (*user.User, error) {
@@ -119,7 +119,7 @@ func scanUser(row userScanner) (*user.User, error) {
 func (r *UserRepository) GetRoles(ctx context.Context, id uuid.UUID) ([]string, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT role FROM user_roles WHERE user_id = $1 ORDER BY role`,
-		id.String(),
+		id,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# fix(api): pass uuid.UUID to queries in user repository (GetRoles, GetByID, Create) — fixes #446

## Summary
This PR fixes a bug in the user repository where UUID values were passed as strings to SQL queries (via `.String()`), forcing implicit text→uuid casts. It now passes the raw `uuid.UUID` values so the pgx v5 uuid codec is used and driver-level type safety is preserved.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- Pass `uuid.UUID` (not `.String()`) to DB queries in `GetRoles`, `GetByID`, and `Create` in `apps/api/internal/repository/postgres/user_repository.go`.
- Update `OSS_CLEANUP.md` to mark the GetRoles cleanup item resolved.

## Testing Done
- Verified changes and committed on branch `fix/446-getroles-uuid-pgx`.
- Recommend running the package tests and CI to validate integration with the DB driver:

```bash
cd C:\Users\official-ability\dev\nester
go test ./apps/api/internal/repository/postgres -v
```

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Tests added/updated for changes
- [x] Documentation updated if needed
- [x] No secrets or credentials in the code
- [x] Smart contract changes reviewed for security implications

## Notes
This change restores consistent UUID handling across repository code and avoids implicit server-side casts which can fail under stricter DB settings.

## Related Issues

Closes  #446

