### PR TITLE
chore(api): wire golang-migrate into API startup behind RUN_MIGRATIONS env flag

### DIFF
--- a/OSS_CLEANUP.md
+++ b/OSS_CLEANUP.md
@@ -221,12 +221,10 @@
   This will confuse any migration runner that applies files in lexicographic order. Rename one of
   them and renumber consistently. Needs care — check if the runner is order-sensitive before touching.
 
-- [ ] **No migration runner is wired into the Go API startup.**
-  `scripts/seed.sql` is used as a workaround (it runs via Docker's `initdb`). This means:
-  - New migrations added after the initial seed are NOT applied automatically in the dev environment.
-  - Developers must run `make dev-reset` (wipes data) to pick up new schema changes.
-  Long-term: wire `golang-migrate` or equivalent into the API startup behind a flag
-  (`RUN_MIGRATIONS=true`) so `make dev` applies incremental migrations without data loss.
+- [x] **No migration runner is wired into the Go API startup.**
+  Resolved: `golang-migrate` runs on API startup when `RUN_MIGRATIONS=true` (set in
+  `docker-compose.yml` for local dev). Pending migrations apply incrementally on `make dev`
+  without requiring `make dev-reset`. See `apps/api/migrations/README.md`.
 
 ---
 

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -24,6 +24,7 @@ func baseEnv(t *testing.T) {
 		"RATELIMIT_WALLET_LIMIT", "RATELIMIT_WALLET_WINDOW",
 		"LOG_LEVEL", "LOG_FORMAT",
 		"ALLOWED_ORIGINS",
+		"RUN_MIGRATIONS", "MIGRATIONS_DIR", "STARTUP_DEPENDENCY_TIMEOUT",
 	} {
 		t.Setenv(key, "")
 	}
@@ -897,6 +898,76 @@ func TestLoadAllowedOriginsOptionalInDevelopment(t *testing.T) {
 	if len(cfg.AllowedOrigins()) != 0 {
 		t.Fatalf("expected empty AllowedOrigins() in dev with no env, got %v", cfg.AllowedOrigins())
 	}
+}
+
+// TestLoadRunMigrationsFlag verifies RUN_MIGRATIONS controls startup auto-migrate.
+func TestLoadRunMigrationsFlag(t *testing.T) {
+	cases := []struct {
+		name       string
+		envValue   string
+		wantEnable bool
+	}{
+		{"default false when unset", "", false},
+		{"true when enabled", "true", true},
+		{"false when explicitly disabled", "false", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			if tc.envValue != "" {
+				t.Setenv("RUN_MIGRATIONS", tc.envValue)
+			}
+
+			chdir(t, t.TempDir())
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got := cfg.Startup().EnableAutoMigrate(); got != tc.wantEnable {
+				t.Fatalf("EnableAutoMigrate() = %v, want %v", got, tc.wantEnable)
+			}
+		})
+	}
+}
+
+// TestLoadMigrationsDir verifies MIGRATIONS_DIR defaults and can be overridden.
+func TestLoadMigrationsDir(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "development")
+
+		chdir(t, t.TempDir())
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if got := cfg.Startup().MigrationsDir(); got != "./migrations" {
+			t.Fatalf("MigrationsDir() = %q, want ./migrations", got)
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "development")
+		t.Setenv("MIGRATIONS_DIR", "/custom/migrations")
+
+		chdir(t, t.TempDir())
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if got := cfg.Startup().MigrationsDir(); got != "/custom/migrations" {
+			t.Fatalf("MigrationsDir() = %q, want /custom/migrations", got)
+		}
+	})
 }
 
 func chdir(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary
Wire `golang-migrate` into the API startup path so pending SQL migrations apply automatically when `RUN_MIGRATIONS=true`, and skip safely when the flag is off.

## Purpose / Motivation
The dev environment previously relied on Docker `initdb` running `scripts/seed.sql`, so new migration files were never applied unless developers ran a destructive `make dev-reset`. This blocked incremental schema updates during local development.

## Changes Made
- Run `golang-migrate` in `apps/api/cmd/api/main.go` when `RUN_MIGRATIONS=true`, using the existing DB connection and `MIGRATIONS_DIR` (default `./migrations`).
- Return a startup error if migration initialization or `Up()` fails; treat `migrate.ErrNoChange` as success.
- Set `RUN_MIGRATIONS: "true"` on the `api` service in `docker-compose.yml` so `make dev` applies pending migrations automatically.
- Load `RUN_MIGRATIONS` via `config.Startup().EnableAutoMigrate()` (defaults to `false` outside Docker).
- Add config tests for the `RUN_MIGRATIONS` / `MIGRATIONS_DIR` startup settings.
- Mark the OSS cleanup tracking item as resolved.

## How to Test
1. Start the stack: `make dev` (or `docker compose up --build`).
2. Confirm API logs include `running database migrations` and `database migrations complete`.
3. Connect to Postgres and verify `schema_migrations` reflects the latest version:
   ```bash
   make dev-db
   SELECT version, dirty FROM schema_migrations;
   ```
4. Add a new migration pair under `apps/api/migrations/` (e.g. `023_test_column.up.sql` / `.down.sql`).
5. Restart only the API: `docker compose restart api`.
6. Confirm the new schema change is present and the API starts successfully.
7. Set `RUN_MIGRATIONS=false` on the API service, restart, and confirm logs show `auto-migrate disabled; skipping migrations` with no migration activity.
8. Introduce a broken migration SQL file and restart with `RUN_MIGRATIONS=true`; confirm the API exits with an `auto-migrate: up:` error and does not serve traffic.

## Screenshots (if applicable)
N/A — backend/infrastructure change only.

## Breaking Changes
None. Migration auto-run is opt-in via `RUN_MIGRATIONS`; production can leave it disabled and run migrations out-of-band.

## Related Issues
Closes Suncrest-Labs/nester#522

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)
