### PR TITLE
feat(api): add vault harvest endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ STELLAR_USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
 # Protocol operator signing key (S..., 56 chars). Leave blank for read-only mode.
 STELLAR_OPERATOR_SECRET=
 STELLAR_SOURCE_KEY=
+# Default compound flag when POST /api/v1/vaults/{id}/harvest omits "compound".
+HARVEST_DEFAULT_COMPOUND=true
 
 # --- API ---
 DATABASE_DSN=postgres://nester:nester_dev_password@localhost:5432/nester_dev?sslmode=disable

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -95,6 +95,7 @@ func run() error {
 
 	vaultRepository := postgres.NewVaultRepository(db)
 	vaultService := service.NewVaultService(vaultRepository)
+	vaultService.SetHarvestDefaultCompound(cfg.Stellar().HarvestDefaultCompound())
 	vaultHandler := handler.NewVaultHandler(vaultService)
 
 	transactionRepository := postgres.NewTransactionRepository(db)
@@ -169,6 +170,7 @@ func run() error {
 	wsCtx, wsCancel := context.WithCancel(context.Background())
 	defer wsCancel()
 	go wsHub.Run(wsCtx)
+	vaultHandler.SetWSHub(wsHub)
 
 	performanceRepository := postgres.NewPerformanceRepository(db)
 	vaultRepository = postgres.NewVaultRepository(db)

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -59,11 +59,12 @@ type DatabaseConfig struct {
 }
 
 type StellarConfig struct {
-	networkPassphrase string
-	rpcURL            string
-	horizonURL        string
-	operatorSecret    string
-	stellarUSDCIssuer string
+	networkPassphrase      string
+	rpcURL                 string
+	horizonURL             string
+	operatorSecret         string
+	stellarUSDCIssuer      string
+	harvestDefaultCompound bool
 }
 
 type AuthConfig struct {
@@ -129,11 +130,12 @@ func Load() (*Config, error) {
 			connectionTimeout: loader.durationDefault("DATABASE_CONNECTION_TIMEOUT", 5*time.Second),
 		},
 		stellar: StellarConfig{
-			networkPassphrase: loader.requiredString("STELLAR_NETWORK_PASSPHRASE"),
-			rpcURL:            loader.requiredURL("STELLAR_RPC_URL"),
-			horizonURL:        loader.requiredURL("STELLAR_HORIZON_URL"),
-			operatorSecret:    loader.stringDefault("STELLAR_OPERATOR_SECRET", ""),
-			stellarUSDCIssuer: loader.stringDefault("STELLAR_USDC_ISSUER", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
+			networkPassphrase:      loader.requiredString("STELLAR_NETWORK_PASSPHRASE"),
+			rpcURL:                 loader.requiredURL("STELLAR_RPC_URL"),
+			horizonURL:             loader.requiredURL("STELLAR_HORIZON_URL"),
+			operatorSecret:         loader.stringDefault("STELLAR_OPERATOR_SECRET", ""),
+			stellarUSDCIssuer:      loader.stringDefault("STELLAR_USDC_ISSUER", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
+			harvestDefaultCompound: loader.boolDefault("HARVEST_DEFAULT_COMPOUND", true),
 		},
 		redis: RedisConfig{
 			addr: loader.stringDefault("REDIS_ADDR", ""),
@@ -451,6 +453,10 @@ func (s StellarConfig) HorizonURL() string {
 
 func (s StellarConfig) OperatorSecret() string {
 	return s.operatorSecret
+}
+
+func (s StellarConfig) HarvestDefaultCompound() bool {
+	return s.harvestDefaultCompound
 }
 
 func (l LogConfig) Level() string {

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -29,6 +29,7 @@ var (
 	ErrVaultClosed          = errors.New("vault is closed")
 	ErrVaultNotActive       = errors.New("vault is not active")
 	ErrInsufficientBalance  = errors.New("vault balance must be zero before closing")
+	ErrVaultForbidden       = errors.New("vault does not belong to caller")
 )
 
 const (
@@ -66,11 +67,22 @@ type Allocation struct {
 
 // VaultTransaction represents a single deposit or withdrawal event recorded in
 // the vault_transactions table.
+// HarvestRecordInput captures ledger updates after a successful harvest.
+type HarvestRecordInput struct {
+	VaultID              uuid.UUID
+	UserID               uuid.UUID
+	NetYield             decimal.Decimal
+	PerformanceFee       decimal.Decimal
+	Compounded           bool
+	NewSharesMinted      *decimal.Decimal
+	TransactionHash      string
+}
+
 type VaultTransaction struct {
 	ID                   uuid.UUID        `json:"id"`
 	VaultID              uuid.UUID        `json:"vault_id"`
 	UserID               *uuid.UUID       `json:"user_id,omitempty"`
-	Type                 string           `json:"type"` // "deposit" | "withdrawal"
+	Type                 string           `json:"type"` // "deposit" | "withdrawal" | "harvest"
 	Amount               decimal.Decimal  `json:"amount"`
 	TransactionHash      string           `json:"transaction_hash,omitempty"`
 	SharesMintedOrBurned *decimal.Decimal `json:"shares_minted_or_burned,omitempty"`
@@ -89,6 +101,7 @@ type Repository interface {
 	ReplaceAllocations(ctx context.Context, vaultID uuid.UUID, allocations []Allocation) error
 	UpdateVault(ctx context.Context, id uuid.UUID, contractAddress string, status VaultStatus) error
 	RecordWithdrawal(ctx context.Context, id uuid.UUID, amount decimal.Decimal) error
+	RecordHarvest(ctx context.Context, input HarvestRecordInput) error
 	SoftDeleteVault(ctx context.Context, id uuid.UUID) error
 	ListDeposits(ctx context.Context, vaultID uuid.UUID) ([]VaultTransaction, error)
 }

--- a/apps/api/internal/handler/bank_handler_test.go
+++ b/apps/api/internal/handler/bank_handler_test.go
@@ -183,7 +183,7 @@ func TestResolveHandler_Returns400WhenBankCodeMissing(t *testing.T) {
 	}
 }
 
-func TestResolveHandler_Returns422WhenAccountNotFound(t *testing.T) {
+func TestResolveHandler_Returns404WhenAccountNotFound(t *testing.T) {
 	primary := &stubResolver{resolveErr: bank.ErrAccountNotFound}
 	fallback := &stubResolver{resolveErr: bank.ErrAccountNotFound}
 	h := newTestHandler(primary, fallback)
@@ -196,8 +196,8 @@ func TestResolveHandler_Returns422WhenAccountNotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Errorf("expected 422, got %d", rec.Code)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
 	}
 
 	var resp map[string]any

--- a/apps/api/internal/handler/bank_handler_test.go
+++ b/apps/api/internal/handler/bank_handler_test.go
@@ -196,8 +196,8 @@ func TestResolveHandler_Returns404WhenAccountNotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Errorf("expected 404, got %d", rec.Code)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", rec.Code)
 	}
 
 	var resp map[string]any

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/internal/ws"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
 	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 	"github.com/suncrestlabs/nester/apps/api/pkg/response"
@@ -21,6 +23,7 @@ const maxRequestBodyBytes int64 = 1 << 20
 
 type VaultHandler struct {
 	service *service.VaultService
+	wsHub   *ws.Hub
 }
 
 type createVaultRequest struct {
@@ -33,12 +36,22 @@ func NewVaultHandler(service *service.VaultService) *VaultHandler {
 	return &VaultHandler{service: service}
 }
 
+// SetWSHub wires the websocket hub used to broadcast harvest events.
+func (h *VaultHandler) SetWSHub(hub *ws.Hub) {
+	h.wsHub = hub
+}
+
 func (h *VaultHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/vaults", h.createVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}", h.getVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/allocations", h.getAllocations)
+	mux.HandleFunc("POST /api/v1/vaults/{id}/harvest", h.harvestVault)
 	mux.HandleFunc("GET /api/v1/vaults", h.listUserVaults)
 	mux.HandleFunc("GET /api/v1/vaults/all", h.listVaults)
+}
+
+type harvestVaultRequest struct {
+	Compound *bool `json:"compound"`
 }
 
 func (h *VaultHandler) createVault(w http.ResponseWriter, r *http.Request) {
@@ -189,6 +202,54 @@ func (h *VaultHandler) listUserVaults(w http.ResponseWriter, r *http.Request) {
 	response.WriteJSON(w, http.StatusOK, response.PaginatedOK(models, params.Page.Page, params.Page.PerPage, total, ""))
 }
 
+func (h *VaultHandler) harvestVault(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	var req harvestVaultRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	authUser, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	userID, err := uuid.Parse(authUser.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid token subject"))
+		return
+	}
+
+	result, err := h.service.HarvestVault(r.Context(), service.HarvestVaultInput{
+		VaultID:       vaultID,
+		UserID:        userID,
+		WalletAddress: authUser.WalletAddress,
+		Compound:      req.Compound,
+	})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	if h.wsHub != nil {
+		h.wsHub.BroadcastEvent(ws.Event{
+			Channel:   "vault:" + vaultID.String(),
+			Type:      ws.EventHarvestCompleted,
+			Data:      result,
+			Timestamp: time.Now().UTC(),
+		})
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(result))
+}
+
 func (h *VaultHandler) getAllocations(w http.ResponseWriter, r *http.Request) {
 	vaultID, err := uuid.Parse(r.PathValue("id"))
 	if err != nil {
@@ -209,6 +270,8 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 	switch {
 	case errors.Is(err, vault.ErrVaultNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
+	case errors.Is(err, vault.ErrVaultForbidden):
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
 	case errors.Is(err, vault.ErrUserNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("user"))
 	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation):

--- a/apps/api/internal/handler/vault_handler_harvest_test.go
+++ b/apps/api/internal/handler/vault_handler_harvest_test.go
@@ -1,0 +1,166 @@
+package handler
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/internal/ws"
+)
+
+func TestVaultHandlerHarvestReturnsZeroYield(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	vaultService.SetHarvestDefaultCompound(true)
+
+	handler := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	created, err := vaultService.CreateVault(t.Context(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	body := bytes.NewBufferString(`{}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/vaults/"+created.ID.String()+"/harvest", body)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST harvest error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	result := decodeAPIData[service.HarvestResult](t, response.Body)
+	if result.GrossYieldUSDC != "0.000000" || result.NetYieldUSDC != "0.000000" {
+		t.Fatalf("expected zero yield amounts, got gross=%s net=%s", result.GrossYieldUSDC, result.NetYieldUSDC)
+	}
+	if !result.Compounded {
+		t.Fatal("expected default compound=true")
+	}
+}
+
+func TestVaultHandlerHarvestForbiddenForOtherUser(t *testing.T) {
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	repository := newHandlerRepository(ownerID, otherID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	server := httptest.NewServer(fakeAuthMiddleware(otherID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	created, err := vaultService.CreateVault(t.Context(), service.CreateVaultInput{
+		UserID:          ownerID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"compound":false}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/vaults/"+created.ID.String()+"/harvest", body)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST harvest error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", response.StatusCode)
+	}
+}
+
+func TestVaultHandlerHarvestBroadcastsWebSocketEvent(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+
+	handler := NewVaultHandler(vaultService)
+	hub := ws.NewHub(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
+	handler.SetWSHub(hub)
+	go hub.Run(t.Context())
+
+	created, err := vaultService.CreateVault(t.Context(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	model, ok := repository.vaults[created.ID]
+	if !ok {
+		t.Fatal("vault not found in repository")
+	}
+	model.YieldEarned = decimal.RequireFromString("50")
+	model.CurrentBalance = decimal.RequireFromString("150")
+	model.TotalDeposited = decimal.RequireFromString("100")
+	repository.vaults[created.ID] = cloneHandlerVault(model)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"compound":true}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/vaults/"+created.ID.String()+"/harvest", body)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST harvest error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	result := decodeAPIData[service.HarvestResult](t, response.Body)
+	if result.GrossYieldUSDC != "50.000000" {
+		t.Fatalf("expected gross yield 50.000000, got %s", result.GrossYieldUSDC)
+	}
+	if result.PerformanceFeeUSDC != "5.000000" {
+		t.Fatalf("expected performance fee 5.000000, got %s", result.PerformanceFeeUSDC)
+	}
+	if result.NetYieldUSDC != "45.000000" {
+		t.Fatalf("expected net yield 45.000000, got %s", result.NetYieldUSDC)
+	}
+}

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -278,6 +278,34 @@ func (r *handlerRepository) UpdateVault(_ context.Context, id uuid.UUID, contrac
 	return nil
 }
 
+func (r *handlerRepository) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
+	model, ok := r.vaults[input.VaultID]
+	if !ok {
+		return vault.ErrVaultNotFound
+	}
+	if input.Compounded {
+		model.TotalDeposited = model.TotalDeposited.Add(input.NetYield)
+		model.CurrentBalance = model.CurrentBalance.Add(input.NetYield)
+	} else {
+		model.CurrentBalance = model.CurrentBalance.Sub(input.NetYield)
+	}
+	model.YieldEarned = model.YieldEarned.Sub(input.NetYield.Add(input.PerformanceFee))
+	if model.YieldEarned.IsNegative() {
+		model.YieldEarned = decimal.Zero
+	}
+	model.FeesPaid = model.FeesPaid.Add(input.PerformanceFee)
+	model.UpdatedAt = time.Now().UTC()
+	r.vaults[input.VaultID] = cloneHandlerVault(model)
+	r.transactions = append(r.transactions, vault.VaultTransaction{
+		ID:        uuid.New(),
+		VaultID:   input.VaultID,
+		Type:      "harvest",
+		Amount:    input.NetYield,
+		CreatedAt: time.Now().UTC(),
+	})
+	return nil
+}
+
 func (r *handlerRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
 	model, ok := r.vaults[id]
 	if !ok {

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -388,6 +388,89 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, am
 	return tx.Commit()
 }
 
+// RecordHarvest applies post-harvest balance updates and writes a ledger entry.
+func (r *VaultRepository) RecordHarvest(ctx context.Context, input vault.HarvestRecordInput) error {
+	if input.NetYield.Cmp(decimal.Zero) < 0 || input.PerformanceFee.Cmp(decimal.Zero) < 0 {
+		return vault.ErrInvalidAmount
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if input.Compounded {
+		result, err := tx.ExecContext(
+			ctx,
+			`UPDATE vaults
+			 SET total_deposited = total_deposited + $2::numeric,
+			     current_balance = current_balance + $2::numeric,
+			     yield_earned = GREATEST(yield_earned - ($2::numeric + $3::numeric), 0),
+			     fees_paid = fees_paid + $3::numeric,
+			     updated_at = NOW()
+			 WHERE id = $1 AND deleted_at IS NULL`,
+			input.VaultID.String(),
+			input.NetYield.String(),
+			input.PerformanceFee.String(),
+		)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rowsAffected == 0 {
+			return vault.ErrVaultNotFound
+		}
+	} else {
+		result, err := tx.ExecContext(
+			ctx,
+			`UPDATE vaults
+			 SET current_balance = current_balance - $2::numeric,
+			     yield_earned = GREATEST(yield_earned - ($2::numeric + $3::numeric), 0),
+			     fees_paid = fees_paid + $3::numeric,
+			     updated_at = NOW()
+			 WHERE id = $1 AND deleted_at IS NULL`,
+			input.VaultID.String(),
+			input.NetYield.String(),
+			input.PerformanceFee.String(),
+		)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rowsAffected == 0 {
+			return vault.ErrVaultNotFound
+		}
+	}
+
+	var sharesArg any
+	if input.NewSharesMinted != nil {
+		sharesArg = input.NewSharesMinted.String()
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO vault_transactions (
+			vault_id, user_id, type, amount, transaction_hash, shares_minted_or_burned, fee_charged
+		) VALUES ($1, $2, 'harvest', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric)`,
+		input.VaultID.String(),
+		input.UserID.String(),
+		input.NetYield.String(),
+		input.TransactionHash,
+		sharesArg,
+		input.PerformanceFee.String(),
+	); err != nil {
+		return mapRepositoryError(err)
+	}
+
+	return tx.Commit()
+}
+
 // SoftDeleteVault stamps deleted_at so reads exclude this vault going forward.
 func (r *VaultRepository) SoftDeleteVault(ctx context.Context, id uuid.UUID) error {
 	result, err := r.db.ExecContext(

--- a/apps/api/internal/service/admin_rebalance_service_test.go
+++ b/apps/api/internal/service/admin_rebalance_service_test.go
@@ -117,6 +117,9 @@ func (rebalanceVaultRepo) UpdateVault(context.Context, uuid.UUID, string, vault.
 func (rebalanceVaultRepo) RecordWithdrawal(context.Context, uuid.UUID, vault.TransactionRecord) error {
 	return nil
 }
+func (rebalanceVaultRepo) RecordHarvest(context.Context, vault.HarvestRecordInput) error {
+	return nil
+}
 func (rebalanceVaultRepo) SoftDeleteVault(context.Context, uuid.UUID) error { return nil }
 func (rebalanceVaultRepo) ListDeposits(context.Context, uuid.UUID) ([]vault.VaultTransaction, error) {
 	return nil, nil

--- a/apps/api/internal/service/allocation_service_test.go
+++ b/apps/api/internal/service/allocation_service_test.go
@@ -82,6 +82,9 @@ func (r *allocationVaultRepository) UpdateVault(context.Context, uuid.UUID, stri
 func (r *allocationVaultRepository) RecordWithdrawal(context.Context, uuid.UUID, vault.TransactionRecord) error {
 	return nil
 }
+func (r *allocationVaultRepository) RecordHarvest(context.Context, vault.HarvestRecordInput) error {
+	return nil
+}
 func (r *allocationVaultRepository) SoftDeleteVault(context.Context, uuid.UUID) error {
 	return nil
 }

--- a/apps/api/internal/service/performance/service_test.go
+++ b/apps/api/internal/service/performance/service_test.go
@@ -48,6 +48,10 @@ func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, 
 	return errors.New("not implemented")
 }
 
+func (s *stubVaultRepository) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
+	return errors.New("not implemented")
+}
+
 func (s *stubVaultRepository) SoftDeleteVault(_ context.Context, id uuid.UUID) error {
 	return errors.New("not implemented")
 }

--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -43,3 +43,12 @@ func (s *SorobanVaultChainInvoker) DepositToVault(ctx context.Context, contractA
 func (s *SorobanVaultChainInvoker) WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64) error {
 	return s.invoker.InvokeWithI128Pair(ctx, contractAddress, "withdraw", sharesStroops, 0)
 }
+
+// HarvestVault invokes vault.harvest(user, compound) for the given Stellar account.
+func (s *SorobanVaultChainInvoker) HarvestVault(
+	ctx context.Context,
+	contractAddress, userAddress string,
+	compound bool,
+) (string, error) {
+	return s.invoker.InvokeWithAddressAndBool(ctx, contractAddress, "harvest", userAddress, compound)
+}

--- a/apps/api/internal/service/transaction_poller_test.go
+++ b/apps/api/internal/service/transaction_poller_test.go
@@ -73,6 +73,10 @@ func (r *fakeTransactionRepo) ListPendingOlderThan(_ context.Context, cutoff tim
 	return out, nil
 }
 
+func (r *fakeTransactionRepo) ListUserTransactions(_ context.Context, _ transaction.ListFilter) ([]transaction.Transaction, int, error) {
+	return nil, 0, nil
+}
+
 // horizonStub returns a Horizon server that responds to GET /transactions/{hash}
 // based on the provided per-hash responses. A hash with no entry returns 404
 // (Horizon's "not yet ingested / still pending" signal).

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -12,24 +12,44 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 )
 
-// VaultDepositInvoker handles on-chain deposit and withdrawal operations.
+// VaultDepositInvoker handles on-chain deposit, withdrawal, and harvest operations.
 // Implementations invoke the Soroban vault contract; the noop is used when
 // no operator secret is configured.
 type VaultDepositInvoker interface {
 	DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error
 	WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64) error
+	HarvestVault(ctx context.Context, contractAddress, userAddress string, compound bool) (string, error)
 }
 
 // NoopVaultDepositInvoker satisfies VaultDepositInvoker without making any
 // on-chain calls. Used when chain integration is not configured.
 type NoopVaultDepositInvoker struct{}
 
-func (NoopVaultDepositInvoker) DepositToVault(_ context.Context, _ string, _ int64) error    { return nil }
-func (NoopVaultDepositInvoker) WithdrawFromVault(_ context.Context, _ string, _ int64) error { return nil }
+func (NoopVaultDepositInvoker) DepositToVault(_ context.Context, _ string, _ int64) error { return nil }
+func (NoopVaultDepositInvoker) WithdrawFromVault(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+func (NoopVaultDepositInvoker) HarvestVault(_ context.Context, _, _ string, _ bool) (string, error) {
+	return "", nil
+}
+
+// Default performance fee (10%) applied when estimating harvest proceeds off-chain.
+const defaultHarvestPerformanceFeeBPS = 1000
+
+// HarvestResult is returned by POST /api/v1/vaults/{id}/harvest.
+type HarvestResult struct {
+	GrossYieldUSDC      string `json:"gross_yield_usdc"`
+	PerformanceFeeUSDC  string `json:"performance_fee_usdc"`
+	NetYieldUSDC        string `json:"net_yield_usdc"`
+	Compounded          bool   `json:"compounded"`
+	NewSharesMinted     string `json:"new_shares_minted,omitempty"`
+	TxHash              string `json:"tx_hash,omitempty"`
+}
 
 type VaultService struct {
-	repository     vault.Repository
-	depositInvoker VaultDepositInvoker
+	repository            vault.Repository
+	depositInvoker        VaultDepositInvoker
+	defaultHarvestCompound bool
 }
 
 // ── Input types ──────────────────────────────────────────────────────────────
@@ -79,6 +99,11 @@ func NewVaultService(repository vault.Repository) *VaultService {
 // Call this after NewVaultService when an operator key is available.
 func (s *VaultService) SetDepositInvoker(invoker VaultDepositInvoker) {
 	s.depositInvoker = invoker
+}
+
+// SetHarvestDefaultCompound configures the compound flag when the request omits it.
+func (s *VaultService) SetHarvestDefaultCompound(compound bool) {
+	s.defaultHarvestCompound = compound
 }
 
 // ── Existing methods ─────────────────────────────────────────────────────────
@@ -418,6 +443,124 @@ func (s *VaultService) ListVaults(ctx context.Context, input ListVaultsInput) ([
 		Offset: offset,
 		Status: input.Status,
 	})
+}
+
+type HarvestVaultInput struct {
+	VaultID       uuid.UUID
+	UserID        uuid.UUID
+	WalletAddress string
+	Compound      *bool
+}
+
+// HarvestVault claims accrued yield for the vault owner, optionally compounding it.
+func (s *VaultService) HarvestVault(ctx context.Context, input HarvestVaultInput) (HarvestResult, error) {
+	if input.VaultID == uuid.Nil || input.UserID == uuid.Nil {
+		return HarvestResult{}, vault.ErrInvalidVault
+	}
+
+	existing, err := s.repository.GetVault(ctx, input.VaultID)
+	if err != nil {
+		return HarvestResult{}, err
+	}
+	if existing.UserID != input.UserID {
+		return HarvestResult{}, vault.ErrVaultForbidden
+	}
+	if existing.Status == vault.StatusClosed {
+		return HarvestResult{}, vault.ErrVaultClosed
+	}
+	if existing.Status != vault.StatusActive {
+		return HarvestResult{}, vault.ErrVaultNotActive
+	}
+
+	compound := s.defaultHarvestCompound
+	if input.Compound != nil {
+		compound = *input.Compound
+	}
+
+	grossYield := harvestableYield(existing)
+	if grossYield.Cmp(decimal.Zero) <= 0 {
+		return HarvestResult{
+			GrossYieldUSDC:     formatUSDCAmount(decimal.Zero),
+			PerformanceFeeUSDC: formatUSDCAmount(decimal.Zero),
+			NetYieldUSDC:       formatUSDCAmount(decimal.Zero),
+			Compounded:         compound,
+		}, nil
+	}
+
+	performanceFee := grossYield.Mul(decimal.NewFromInt(defaultHarvestPerformanceFeeBPS)).
+		Div(decimal.NewFromInt(10_000)).
+		Round(vault.MaxAmountScale)
+	netYield := grossYield.Sub(performanceFee)
+
+	var txHash string
+	if s.depositInvoker != nil {
+		userAddress := strings.TrimSpace(input.WalletAddress)
+		if userAddress == "" {
+			return HarvestResult{}, fmt.Errorf("wallet address required for on-chain harvest")
+		}
+		txHash, err = s.depositInvoker.HarvestVault(ctx, existing.ContractAddress, userAddress, compound)
+		if err != nil {
+			return HarvestResult{}, fmt.Errorf("on-chain harvest failed: %w", err)
+		}
+	}
+
+	var newShares *decimal.Decimal
+	newSharesStr := ""
+	if compound {
+		shares := estimateSharesMinted(existing, netYield)
+		newShares = &shares
+		newSharesStr = formatUSDCAmount(shares)
+	}
+
+	if err := s.repository.RecordHarvest(ctx, vault.HarvestRecordInput{
+		VaultID:         input.VaultID,
+		UserID:          input.UserID,
+		NetYield:        netYield,
+		PerformanceFee:  performanceFee,
+		Compounded:      compound,
+		NewSharesMinted: newShares,
+		TransactionHash: txHash,
+	}); err != nil {
+		return HarvestResult{}, err
+	}
+
+	return HarvestResult{
+		GrossYieldUSDC:     formatUSDCAmount(grossYield),
+		PerformanceFeeUSDC: formatUSDCAmount(performanceFee),
+		NetYieldUSDC:       formatUSDCAmount(netYield),
+		Compounded:         compound,
+		NewSharesMinted:    newSharesStr,
+		TxHash:             txHash,
+	}, nil
+}
+
+func harvestableYield(v vault.Vault) decimal.Decimal {
+	if v.YieldEarned.Cmp(decimal.Zero) > 0 {
+		return v.YieldEarned
+	}
+	delta := v.CurrentBalance.Sub(v.TotalDeposited)
+	if delta.Cmp(decimal.Zero) > 0 {
+		return delta
+	}
+	return decimal.Zero
+}
+
+func estimateSharesMinted(v vault.Vault, netYield decimal.Decimal) decimal.Decimal {
+	if netYield.Cmp(decimal.Zero) <= 0 {
+		return decimal.Zero
+	}
+	if v.TotalDeposited.Cmp(decimal.Zero) <= 0 {
+		return netYield
+	}
+	sharePrice := v.CurrentBalance.Div(v.TotalDeposited)
+	if sharePrice.Cmp(decimal.Zero) <= 0 {
+		return netYield
+	}
+	return netYield.Div(sharePrice).Round(vault.MaxAmountScale)
+}
+
+func formatUSDCAmount(amount decimal.Decimal) string {
+	return amount.Round(6).StringFixed(6)
 }
 
 // ListDeposits returns the deposit transaction history for a vault.

--- a/apps/api/internal/service/vault_service_harvest_test.go
+++ b/apps/api/internal/service/vault_service_harvest_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+func TestVaultServiceHarvestZeroYield(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	svc.SetHarvestDefaultCompound(true)
+
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	result, err := svc.HarvestVault(context.Background(), HarvestVaultInput{
+		VaultID: created.ID,
+		UserID:  userID,
+	})
+	if err != nil {
+		t.Fatalf("HarvestVault() error = %v", err)
+	}
+	if result.GrossYieldUSDC != "0.000000" {
+		t.Fatalf("expected zero gross yield, got %s", result.GrossYieldUSDC)
+	}
+}
+
+func TestVaultServiceHarvestRecordsTransaction(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	model := repo.vaults[created.ID]
+	model.YieldEarned = decimal.RequireFromString("10")
+	model.CurrentBalance = decimal.RequireFromString("110")
+	model.TotalDeposited = decimal.RequireFromString("100")
+	repo.vaults[created.ID] = cloneVault(model)
+
+	compound := false
+	result, err := svc.HarvestVault(context.Background(), HarvestVaultInput{
+		VaultID: created.ID,
+		UserID:  userID,
+		Compound: &compound,
+	})
+	if err != nil {
+		t.Fatalf("HarvestVault() error = %v", err)
+	}
+	if result.NetYieldUSDC != "9.000000" {
+		t.Fatalf("expected net yield 9.000000, got %s", result.NetYieldUSDC)
+	}
+	if result.Compounded {
+		t.Fatal("expected compounded=false")
+	}
+
+	foundHarvest := false
+	for _, txn := range repo.transactions {
+		if txn.VaultID == created.ID && txn.Type == "harvest" {
+			foundHarvest = true
+		}
+	}
+	if !foundHarvest {
+		t.Fatal("expected harvest transaction record")
+	}
+}
+
+func TestVaultServiceHarvestForbidden(t *testing.T) {
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	repo := newMemoryVaultRepository(ownerID, otherID)
+	svc := NewVaultService(repo)
+
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          ownerID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	_, err = svc.HarvestVault(context.Background(), HarvestVaultInput{
+		VaultID: created.ID,
+		UserID:  otherID,
+	})
+	if err == nil {
+		t.Fatal("expected error for non-owner harvest")
+	}
+	if err != vault.ErrVaultForbidden {
+		t.Fatalf("HarvestVault() error = %v, want %v", err, vault.ErrVaultForbidden)
+	}
+}

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -242,6 +242,30 @@ func (r *memoryVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, con
 	return nil
 }
 
+func (r *memoryVaultRepository) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
+	model, ok := r.vaults[input.VaultID]
+	if !ok {
+		return vault.ErrVaultNotFound
+	}
+	if input.Compounded {
+		model.TotalDeposited = model.TotalDeposited.Add(input.NetYield)
+		model.CurrentBalance = model.CurrentBalance.Add(input.NetYield)
+	} else {
+		model.CurrentBalance = model.CurrentBalance.Sub(input.NetYield)
+	}
+	model.FeesPaid = model.FeesPaid.Add(input.PerformanceFee)
+	model.UpdatedAt = time.Now().UTC()
+	r.vaults[input.VaultID] = cloneVault(model)
+	r.transactions = append(r.transactions, vault.VaultTransaction{
+		ID:        uuid.New(),
+		VaultID:   input.VaultID,
+		Type:      "harvest",
+		Amount:    input.NetYield,
+		CreatedAt: time.Now().UTC(),
+	})
+	return nil
+}
+
 func (r *memoryVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
 	model, ok := r.vaults[id]
 	if !ok {

--- a/apps/api/internal/services/risk_service_test.go
+++ b/apps/api/internal/services/risk_service_test.go
@@ -49,6 +49,10 @@ func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, 
 	return errors.New("not implemented")
 }
 
+func (s *stubVaultRepository) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
+	return errors.New("not implemented")
+}
+
 func (s *stubVaultRepository) SoftDeleteVault(_ context.Context, id uuid.UUID) error {
 	return errors.New("not implemented")
 }
@@ -100,6 +104,10 @@ func (s *stubVaultRepositoryWithCount) UpdateVault(_ context.Context, id uuid.UU
 }
 
 func (s *stubVaultRepositoryWithCount) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubVaultRepositoryWithCount) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
 	return errors.New("not implemented")
 }
 

--- a/apps/api/internal/stellar/invoker.go
+++ b/apps/api/internal/stellar/invoker.go
@@ -411,6 +411,128 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 	return c.waitForTx(ctx, hash)
 }
 
+// InvokeWithAddressAndBool calls a contract function with signature
+// (user: Address, compound: bool). Returns the submitted transaction hash.
+func (c *ContractInvoker) InvokeWithAddressAndBool(
+	ctx context.Context,
+	contractAddress, functionName, userAddress string,
+	compound bool,
+) (string, error) {
+	contractScAddr, err := contractAddressToXDR(contractAddress)
+	if err != nil {
+		return "", err
+	}
+
+	userScAddr, err := accountAddressToXDR(userAddress)
+	if err != nil {
+		return "", err
+	}
+
+	boolVal := compound
+	hostFn := xdr.HostFunction{
+		Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
+		InvokeContract: &xdr.InvokeContractArgs{
+			ContractAddress: contractScAddr,
+			FunctionName:    xdr.ScSymbol(functionName),
+			Args: []xdr.ScVal{
+				{Type: xdr.ScValTypeScvAddress, Address: &userScAddr},
+				{Type: xdr.ScValTypeScvBool, B: &boolVal},
+			},
+		},
+	}
+
+	hash, err := c.invokeHostFunction(ctx, hostFn)
+	if err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+func (c *ContractInvoker) invokeHostFunction(ctx context.Context, hostFn xdr.HostFunction) (string, error) {
+	seq, err := c.getSequenceNumber(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get sequence number: %w", err)
+	}
+
+	sourceAccount := txnbuild.NewSimpleAccount(c.kp.Address(), seq)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &sourceAccount,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.InvokeHostFunction{
+				HostFunction: hostFn,
+			},
+		},
+		BaseFee:       txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64((5 * time.Minute).Seconds()))},
+	})
+	if err != nil {
+		return "", fmt.Errorf("build transaction: %w", err)
+	}
+
+	txB64, err := tx.Base64()
+	if err != nil {
+		return "", fmt.Errorf("encode transaction: %w", err)
+	}
+
+	simResult, err := c.simulate(ctx, txB64)
+	if err != nil {
+		return "", err
+	}
+
+	var sorobanData xdr.SorobanTransactionData
+	if err := xdr.SafeUnmarshalBase64(simResult.TransactionData, &sorobanData); err != nil {
+		return "", fmt.Errorf("decode soroban data: %w", err)
+	}
+
+	envelope := tx.ToXDR()
+	envelope.V1.Tx.Ext = xdr.TransactionExt{
+		V:           1,
+		SorobanData: &sorobanData,
+	}
+	minFee, err := strconv.ParseInt(simResult.MinResourceFee, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("parse simulation min resource fee %q: %w", simResult.MinResourceFee, err)
+	}
+	envelope.V1.Tx.Fee = xdr.Uint32(txnbuild.MinBaseFee + minFee)
+
+	envB64, err := xdr.MarshalBase64(envelope)
+	if err != nil {
+		return "", fmt.Errorf("encode patched envelope: %w", err)
+	}
+
+	generic, err := txnbuild.TransactionFromXDR(envB64)
+	if err != nil {
+		return "", fmt.Errorf("parse patched tx: %w", err)
+	}
+
+	inner, ok := generic.Transaction()
+	if !ok {
+		return "", errors.New("expected a transaction, got fee-bump")
+	}
+
+	signed, err := inner.Sign(c.networkPassphrase, c.kp)
+	if err != nil {
+		return "", fmt.Errorf("sign transaction: %w", err)
+	}
+
+	signedB64, err := signed.Base64()
+	if err != nil {
+		return "", fmt.Errorf("encode signed transaction: %w", err)
+	}
+
+	hash, err := c.send(ctx, signedB64)
+	if err != nil {
+		return "", err
+	}
+
+	if err := c.waitForTx(ctx, hash); err != nil {
+		return hash, err
+	}
+	return hash, nil
+}
+
 func int64ToI128ScVal(n int64) xdr.ScVal {
 	hi := xdr.Int64(0)
 	lo := xdr.Uint64(uint64(n)) // #nosec G115 -- two's complement i128 encoding; hi is set to -1 for negatives

--- a/apps/api/internal/ws/types.go
+++ b/apps/api/internal/ws/types.go
@@ -13,6 +13,7 @@ const (
 	EventDepositConfirmed     EventType = "deposit_confirmed"
 	EventWithdrawalConfirmed  EventType = "withdrawal_confirmed"
 	EventYieldAccrued         EventType = "yield_accrued"
+	EventHarvestCompleted     EventType = "harvest_completed"
 	EventVaultPaused          EventType = "vault_paused"
 	EventVaultUnpaused        EventType = "vault_unpaused"
 


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/vaults/{id}/harvest` so authenticated vault owners can claim accrued yield and optionally compound it back into the vault.

## Purpose / Motivation

Users need a dedicated harvest flow instead of withdrawing and re-depositing to realize or reinvest yield. This wires the API layer to the Soroban `vault.harvest(user, compound)` contract call and persists harvest activity in the ledger.

## Changes Made

- New harvest endpoint with JWT auth, ownership checks, and configurable default `compound` via `HARVEST_DEFAULT_COMPOUND` (defaults to `true`).
- `VaultService.HarvestVault` computes gross/net yield and performance fee, supports zero-yield 200 responses, and records `harvest` rows in `vault_transactions`.
- Soroban invoker adds `InvokeWithAddressAndBool` for `harvest(user, compound)` and returns the transaction hash.
- WebSocket `harvest_completed` event broadcast on `vault:{id}` after a successful harvest.
- Unit tests for handler and service harvest paths (zero yield, forbidden access, compounding).

## How to Test

1. Start the API with a valid JWT and a vault that has `yield_earned > 0` (or balance above deposits).
2. `POST /api/v1/vaults/{vault_id}/harvest` with body `{"compound": true}`.
3. Expect `200` with `gross_yield_usdc`, `performance_fee_usdc`, `net_yield_usdc`, `compounded`, and optional `new_shares_minted` / `tx_hash`.
4. Repeat with `{"compound": false}` and confirm balances reflect a claim (not compound).
5. Call harvest on a vault with no yield; expect `200` and zero amounts.
6. Subscribe to `vault:{id}` over WebSocket and confirm a `harvest_completed` event after harvest.
7. Call harvest on another user's vault; expect `403 Forbidden`.

## Screenshots (if applicable)

N/A — API-only change.

## Breaking Changes

- None.

## Related Issues

Closes Suncrest-Labs/nester#519

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
