### PR TITLE
feat(api): add vault admin dashboard with aggregated health metrics

### DIFF
--- a/apps/api/internal/domain/admin/model.go
+++ b/apps/api/internal/domain/admin/model.go
@@ -48,12 +48,51 @@ type DashboardSettlementMetrics struct {
 	Volume24h    decimal.Decimal `json:"volume_24h"`
 }
 
-type DashboardMetrics struct {
-	TotalTVL               decimal.Decimal             `json:"total_tvl"`
-	TotalUsers             int64                       `json:"total_users"`
-	ActiveVaults           int64                       `json:"active_vaults"`
-	TotalYieldDistributed  decimal.Decimal             `json:"total_yield_distributed"`
-	Settlements            DashboardSettlementMetrics  `json:"settlements"`
+type VaultAlert struct {
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type SystemAlert struct {
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type VaultHealthEntry struct {
+	ID                  uuid.UUID    `json:"id"`
+	Name                string       `json:"name"`
+	TVLUSDC             string       `json:"tvl_usdc"`
+	APY7d               string       `json:"apy_7d"`
+	Depositors          int64        `json:"depositors"`
+	PendingTransactions int64        `json:"pending_transactions"`
+	LastRebalanceAt     *string      `json:"last_rebalance_at,omitempty"`
+	Status              string       `json:"status"`
+	Alerts              []VaultAlert `json:"alerts"`
+}
+
+type VaultHealthDashboard struct {
+	TotalTVLUSDC    string             `json:"total_tvl_usdc"`
+	TotalDepositors int64              `json:"total_depositors"`
+	Vaults          []VaultHealthEntry `json:"vaults"`
+	SystemAlerts    []SystemAlert      `json:"system_alerts"`
+}
+
+type VaultHealthRow struct {
+	ID                  uuid.UUID
+	Name                string
+	TVL                 decimal.Decimal
+	APY7d               *decimal.Decimal
+	APY7d24hAgo         *decimal.Decimal
+	Depositors          int64
+	PendingTransactions int64
+	LastRebalanceAt     *time.Time
+	Status              vault.VaultStatus
+}
+
+type VaultHealthDashboardData struct {
+	TotalTVL        decimal.Decimal
+	TotalDepositors int64
+	Vaults          []VaultHealthRow
 }
 
 type VaultSummary struct {
@@ -117,7 +156,7 @@ type DashboardSystemHealth struct {
 
 // Repository is the persistence/read model contract required by admin APIs.
 type Repository interface {
-	GetDashboardMetrics(ctx context.Context) (DashboardMetrics, error)
+	GetVaultHealthDashboard(ctx context.Context) (VaultHealthDashboardData, error)
 	ListVaults(ctx context.Context, filter VaultListFilter) ([]VaultSummary, int, error)
 	GetVaultDetail(ctx context.Context, id uuid.UUID) (VaultDetail, error)
 	UpdateVaultStatus(ctx context.Context, id uuid.UUID, status vault.VaultStatus) (VaultDetail, error)

--- a/apps/api/internal/handler/admin_handler.go
+++ b/apps/api/internal/handler/admin_handler.go
@@ -24,7 +24,7 @@ const (
 )
 
 type adminService interface {
-	GetDashboard(ctx context.Context) (service.DashboardResponse, error)
+	GetDashboard(ctx context.Context) (admindomain.VaultHealthDashboard, error)
 	ListVaults(ctx context.Context, filter admindomain.VaultListFilter) ([]admindomain.VaultSummary, int, error)
 	GetVaultDetail(ctx context.Context, id uuid.UUID) (admindomain.VaultDetail, error)
 	PauseVault(ctx context.Context, id uuid.UUID) (admindomain.VaultDetail, error)

--- a/apps/api/internal/handler/admin_handler_test.go
+++ b/apps/api/internal/handler/admin_handler_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type adminHandlerStubService struct {
-	dashboard   service.DashboardResponse
+	dashboard   admindomain.VaultHealthDashboard
 	vaults      map[uuid.UUID]admindomain.VaultDetail
 	settlements []admindomain.SettlementSummary
 	users       []admindomain.UserSummary
@@ -53,24 +53,22 @@ func newAdminHandlerStubService(vaultID uuid.UUID) *adminHandlerStubService {
 	}
 
 	return &adminHandlerStubService{
-		dashboard: service.DashboardResponse{
-			TotalTVL:              "2450000.00",
-			TotalUsers:            342,
-			ActiveVaults:          518,
-			TotalYieldDistributed: "45230.12",
-			Settlements: admindomain.DashboardSettlementMetrics{
-				Total:        1205,
-				Pending:      12,
-				Completed24h: 45,
-				Failed24h:    2,
-				Volume24h:    decimal.RequireFromString("125000.00"),
+		dashboard: admindomain.VaultHealthDashboard{
+			TotalTVLUSDC:    "5234891.00",
+			TotalDepositors: 892,
+			Vaults: []admindomain.VaultHealthEntry{
+				{
+					ID:                  vaultID,
+					Name:                "Conservative",
+					TVLUSDC:             "1234000.00",
+					APY7d:               "8.24",
+					Depositors:          234,
+					PendingTransactions: 3,
+					Status:              "healthy",
+					Alerts:              []admindomain.VaultAlert{},
+				},
 			},
-			SystemHealth: admindomain.DashboardSystemHealth{
-				Database:           "healthy",
-				StellarRPC:         "healthy",
-				SettlementProvider: "healthy",
-				LastEventIndexed:   now.Format(time.RFC3339),
-			},
+			SystemAlerts: []admindomain.SystemAlert{},
 		},
 		vaults: map[uuid.UUID]admindomain.VaultDetail{vaultID: detail},
 		settlements: []admindomain.SettlementSummary{
@@ -114,7 +112,7 @@ func newAdminHandlerStubService(vaultID uuid.UUID) *adminHandlerStubService {
 	}
 }
 
-func (s *adminHandlerStubService) GetDashboard(context.Context) (service.DashboardResponse, error) {
+func (s *adminHandlerStubService) GetDashboard(context.Context) (admindomain.VaultHealthDashboard, error) {
 	return s.dashboard, nil
 }
 
@@ -166,6 +164,80 @@ func (s *adminHandlerStubService) ListUsers(context.Context, admindomain.UserLis
 
 func (s *adminHandlerStubService) GetDetailedHealth(context.Context) (admindomain.DetailedHealth, error) {
 	return s.health, nil
+}
+
+func TestAdminHandlerGetDashboard(t *testing.T) {
+	vaultID := uuid.New()
+	svc := newAdminHandlerStubService(vaultID)
+	h := NewAdminHandler(svc)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/admin/dashboard")
+	if err != nil {
+		t.Fatalf("GET /admin/dashboard error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	dashboard := decodeAPIData[admindomain.VaultHealthDashboard](t, resp.Body)
+	if dashboard.TotalTVLUSDC != "5234891.00" {
+		t.Fatalf("total_tvl_usdc = %q, want 5234891.00", dashboard.TotalTVLUSDC)
+	}
+	if dashboard.TotalDepositors != 892 {
+		t.Fatalf("total_depositors = %d, want 892", dashboard.TotalDepositors)
+	}
+	if len(dashboard.Vaults) != 1 {
+		t.Fatalf("vault count = %d, want 1", len(dashboard.Vaults))
+	}
+	if dashboard.Vaults[0].PendingTransactions != 3 {
+		t.Fatalf("pending_transactions = %d, want 3", dashboard.Vaults[0].PendingTransactions)
+	}
+}
+
+func TestAdminHandlerAuthDashboardRequiresAdmin(t *testing.T) {
+	vaultID := uuid.New()
+	h := NewAdminHandler(newAdminHandlerStubService(vaultID))
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	rules := []middleware.RouteRule{
+		{PathPrefix: "/api/v1/admin/", Role: "admin"},
+	}
+	protected := middleware.Authenticate("admin-test-secret", rules)(mux)
+	server := httptest.NewServer(protected)
+	defer server.Close()
+
+	nonAdminToken := makeAdminToken(t, "admin-test-secret", []string{"operator"})
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v1/admin/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer "+nonAdminToken)
+	nonAdminResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET dashboard as non-admin failed: %v", err)
+	}
+	defer nonAdminResp.Body.Close()
+	if nonAdminResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("non-admin status = %d, want 403", nonAdminResp.StatusCode)
+	}
+
+	adminToken := makeAdminToken(t, "admin-test-secret", []string{"admin"})
+	adminReq, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v1/admin/dashboard", nil)
+	adminReq.Header.Set("Authorization", "Bearer "+adminToken)
+	adminResp, err := http.DefaultClient.Do(adminReq)
+	if err != nil {
+		t.Fatalf("GET dashboard as admin failed: %v", err)
+	}
+	defer adminResp.Body.Close()
+	if adminResp.StatusCode != http.StatusOK {
+		t.Fatalf("admin status = %d, want 200", adminResp.StatusCode)
+	}
 }
 
 func TestAdminHandlerListPauseVerifyFlow(t *testing.T) {
@@ -326,8 +398,8 @@ func makeAdminToken(t *testing.T, secret string, roles []string) string {
 
 type adminErrStub struct{}
 
-func (adminErrStub) GetDashboard(context.Context) (service.DashboardResponse, error) {
-	return service.DashboardResponse{}, errors.New("boom")
+func (adminErrStub) GetDashboard(context.Context) (admindomain.VaultHealthDashboard, error) {
+	return admindomain.VaultHealthDashboard{}, errors.New("boom")
 }
 func (adminErrStub) ListVaults(context.Context, admindomain.VaultListFilter) ([]admindomain.VaultSummary, int, error) {
 	return nil, 0, service.ErrInvalidAdminInput

--- a/apps/api/internal/repository/postgres/admin_repository.go
+++ b/apps/api/internal/repository/postgres/admin_repository.go
@@ -45,71 +45,165 @@ func (r *AdminRepository) GetLastEventIndexedAt(ctx context.Context) (*time.Time
 	return &t, nil
 }
 
-func (r *AdminRepository) GetDashboardMetrics(ctx context.Context) (admindomain.DashboardMetrics, error) {
-	const query = `
+func (r *AdminRepository) GetVaultHealthDashboard(ctx context.Context) (admindomain.VaultHealthDashboardData, error) {
+	const totalsQuery = `
 		SELECT
-			COALESCE((SELECT SUM(current_balance) FROM vaults), 0)::text AS total_tvl,
-			(SELECT COUNT(*) FROM users) AS total_users,
-			(SELECT COUNT(*) FROM vaults WHERE status = 'active') AS active_vaults,
-			COALESCE((SELECT SUM(GREATEST(current_balance - total_deposited, 0)) FROM vaults), 0)::text AS total_yield_distributed,
-			(SELECT COUNT(*) FROM settlements) AS settlements_total,
-			(SELECT COUNT(*) FROM settlements WHERE status IN ('initiated', 'liquidity_matched', 'fiat_dispatched')) AS settlements_pending,
-			(SELECT COUNT(*) FROM settlements WHERE status = 'confirmed' AND completed_at >= NOW() - INTERVAL '24 hours') AS settlements_completed_24h,
-			(SELECT COUNT(*) FROM settlements WHERE status = 'failed' AND completed_at >= NOW() - INTERVAL '24 hours') AS settlements_failed_24h,
-			COALESCE((SELECT SUM(amount) FROM settlements WHERE created_at >= NOW() - INTERVAL '24 hours'), 0)::text AS settlements_volume_24h
+			COALESCE((SELECT SUM(current_balance) FROM vaults), 0)::text,
+			COALESCE((
+				SELECT COUNT(*) FROM (
+					SELECT DISTINCT COALESCE(vt.user_id, v.user_id) AS depositor_id
+					FROM vault_transactions vt
+					JOIN vaults v ON v.id = vt.vault_id
+					WHERE vt.type = 'deposit'
+				) d
+			), 0)
 	`
 
-	var (
-		totalTVL              string
-		totalUsers            int64
-		activeVaults          int64
-		totalYieldDistributed string
-		settlementsTotal      int64
-		settlementsPending    int64
-		settlementsCompleted  int64
-		settlementsFailed     int64
-		settlementsVolume24h  string
-	)
-
-	if err := r.db.QueryRowContext(ctx, query).Scan(
-		&totalTVL,
-		&totalUsers,
-		&activeVaults,
-		&totalYieldDistributed,
-		&settlementsTotal,
-		&settlementsPending,
-		&settlementsCompleted,
-		&settlementsFailed,
-		&settlementsVolume24h,
-	); err != nil {
-		return admindomain.DashboardMetrics{}, err
+	var totalTVLStr string
+	var totalDepositors int64
+	if err := r.db.QueryRowContext(ctx, totalsQuery).Scan(&totalTVLStr, &totalDepositors); err != nil {
+		return admindomain.VaultHealthDashboardData{}, err
 	}
 
-	parsedTVL, err := decimal.NewFromString(totalTVL)
+	totalTVL, err := decimal.NewFromString(totalTVLStr)
 	if err != nil {
-		return admindomain.DashboardMetrics{}, fmt.Errorf("parse total_tvl: %w", err)
-	}
-	parsedYield, err := decimal.NewFromString(totalYieldDistributed)
-	if err != nil {
-		return admindomain.DashboardMetrics{}, fmt.Errorf("parse total_yield_distributed: %w", err)
-	}
-	parsedVolume, err := decimal.NewFromString(settlementsVolume24h)
-	if err != nil {
-		return admindomain.DashboardMetrics{}, fmt.Errorf("parse settlements volume_24h: %w", err)
+		return admindomain.VaultHealthDashboardData{}, fmt.Errorf("parse total_tvl: %w", err)
 	}
 
-	return admindomain.DashboardMetrics{
-		TotalTVL:              parsedTVL,
-		TotalUsers:            totalUsers,
-		ActiveVaults:          activeVaults,
-		TotalYieldDistributed: parsedYield,
-		Settlements: admindomain.DashboardSettlementMetrics{
-			Total:        settlementsTotal,
-			Pending:      settlementsPending,
-			Completed24h: settlementsCompleted,
-			Failed24h:    settlementsFailed,
-			Volume24h:    parsedVolume,
-		},
+	const vaultsQuery = `
+		SELECT
+			v.id,
+			COALESCE(NULLIF(TRIM(u.display_name), ''), SUBSTRING(v.contract_address, 1, 12)) AS name,
+			v.current_balance::text,
+			v.status,
+			COALESCE(dep.depositor_count, 0),
+			COALESCE(pend.pending_count, 0),
+			reb.last_rebalance_at,
+			apy_current.realized_apy,
+			apy_24h.realized_apy
+		FROM vaults v
+		JOIN users u ON u.id = v.user_id
+		LEFT JOIN LATERAL (
+			SELECT COUNT(DISTINCT COALESCE(vt.user_id, v.user_id)) AS depositor_count
+			FROM vault_transactions vt
+			WHERE vt.vault_id = v.id AND vt.type = 'deposit'
+		) dep ON true
+		LEFT JOIN LATERAL (
+			SELECT COUNT(*) AS pending_count
+			FROM transactions t
+			WHERE t.vault_id = v.id AND t.status = 'pending'
+		) pend ON true
+		LEFT JOIN LATERAL (
+			SELECT MAX(a.allocated_at) AS last_rebalance_at
+			FROM allocations a
+			WHERE a.vault_id = v.id
+		) reb ON true
+		LEFT JOIN LATERAL (
+			SELECT ah.realized_apy::text
+			FROM apy_history ah
+			WHERE ah.vault_id = v.id AND ah.period = '7d'
+			ORDER BY ah.calculated_at DESC
+			LIMIT 1
+		) apy_current ON true
+		LEFT JOIN LATERAL (
+			SELECT ah.realized_apy::text
+			FROM apy_history ah
+			WHERE ah.vault_id = v.id AND ah.period = '7d'
+				AND ah.calculated_at <= NOW() - INTERVAL '24 hours'
+			ORDER BY ah.calculated_at DESC
+			LIMIT 1
+		) apy_24h ON true
+		ORDER BY v.created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, vaultsQuery)
+	if err != nil {
+		return admindomain.VaultHealthDashboardData{}, err
+	}
+	defer rows.Close()
+
+	vaultRows := make([]admindomain.VaultHealthRow, 0)
+	for rows.Next() {
+		var (
+			id              string
+			name            string
+			tvlStr          string
+			status          string
+			depositors      int64
+			pendingTx       int64
+			lastRebalance   sql.NullTime
+			apyCurrentStr   sql.NullString
+			apy24hStr       sql.NullString
+		)
+
+		if err := rows.Scan(
+			&id,
+			&name,
+			&tvlStr,
+			&status,
+			&depositors,
+			&pendingTx,
+			&lastRebalance,
+			&apyCurrentStr,
+			&apy24hStr,
+		); err != nil {
+			return admindomain.VaultHealthDashboardData{}, err
+		}
+
+		parsedID, err := uuid.Parse(id)
+		if err != nil {
+			return admindomain.VaultHealthDashboardData{}, err
+		}
+		tvl, err := decimal.NewFromString(tvlStr)
+		if err != nil {
+			return admindomain.VaultHealthDashboardData{}, err
+		}
+
+		var apy7d *decimal.Decimal
+		if apyCurrentStr.Valid {
+			parsed, err := decimal.NewFromString(apyCurrentStr.String)
+			if err != nil {
+				return admindomain.VaultHealthDashboardData{}, err
+			}
+			apy7d = &parsed
+		}
+
+		var apy7d24hAgo *decimal.Decimal
+		if apy24hStr.Valid {
+			parsed, err := decimal.NewFromString(apy24hStr.String)
+			if err != nil {
+				return admindomain.VaultHealthDashboardData{}, err
+			}
+			apy7d24hAgo = &parsed
+		}
+
+		var lastRebalanceAt *time.Time
+		if lastRebalance.Valid {
+			t := lastRebalance.Time.UTC()
+			lastRebalanceAt = &t
+		}
+
+		vaultRows = append(vaultRows, admindomain.VaultHealthRow{
+			ID:                  parsedID,
+			Name:                name,
+			TVL:                 tvl,
+			APY7d:               apy7d,
+			APY7d24hAgo:         apy7d24hAgo,
+			Depositors:          depositors,
+			PendingTransactions: pendingTx,
+			LastRebalanceAt:     lastRebalanceAt,
+			Status:              vault.VaultStatus(status),
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return admindomain.VaultHealthDashboardData{}, err
+	}
+
+	return admindomain.VaultHealthDashboardData{
+		TotalTVL:        totalTVL,
+		TotalDepositors: totalDepositors,
+		Vaults:          vaultRows,
 	}, nil
 }
 

--- a/apps/api/internal/repository/postgres/admin_repository_test.go
+++ b/apps/api/internal/repository/postgres/admin_repository_test.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestAdminRepositoryGetVaultHealthDashboard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewAdminRepository(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT
+			COALESCE((SELECT SUM(current_balance) FROM vaults), 0)::text,
+			COALESCE((
+				SELECT COUNT(*) FROM (
+					SELECT DISTINCT COALESCE(vt.user_id, v.user_id) AS depositor_id
+					FROM vault_transactions vt
+					JOIN vaults v ON v.id = vt.vault_id
+					WHERE vt.type = 'deposit'
+				) d
+			), 0)
+	`)).WillReturnRows(sqlmock.NewRows([]string{"total_tvl", "total_depositors"}).
+		AddRow("5234891.00", int64(892)))
+
+	vaultID := uuid.New()
+	rebalanceAt := time.Date(2026, 5, 26, 8, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("FROM vaults v").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "current_balance", "status",
+			"depositor_count", "pending_count", "last_rebalance_at",
+			"realized_apy", "realized_apy",
+		}).AddRow(
+			vaultID.String(),
+			"Conservative",
+			"1234000.00",
+			"active",
+			int64(234),
+			int64(3),
+			rebalanceAt,
+			"8.2400",
+			"10.0000",
+		))
+
+	result, err := repo.GetVaultHealthDashboard(ctx)
+	if err != nil {
+		t.Fatalf("GetVaultHealthDashboard() error = %v", err)
+	}
+	if !result.TotalTVL.Equal(decimal.RequireFromString("5234891.00")) {
+		t.Fatalf("total_tvl = %s, want 5234891.00", result.TotalTVL)
+	}
+	if result.TotalDepositors != 892 {
+		t.Fatalf("total_depositors = %d, want 892", result.TotalDepositors)
+	}
+	if len(result.Vaults) != 1 {
+		t.Fatalf("vault count = %d, want 1", len(result.Vaults))
+	}
+	if result.Vaults[0].PendingTransactions != 3 {
+		t.Fatalf("pending_transactions = %d, want 3", result.Vaults[0].PendingTransactions)
+	}
+	if result.Vaults[0].APY7d == nil || !result.Vaults[0].APY7d.Equal(decimal.RequireFromString("8.24")) {
+		t.Fatalf("apy_7d = %+v, want 8.24", result.Vaults[0].APY7d)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/apps/api/internal/service/admin_service.go
+++ b/apps/api/internal/service/admin_service.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	admindomain "github.com/suncrestlabs/nester/apps/api/internal/domain/admin"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
@@ -15,6 +17,11 @@ import (
 
 var (
 	ErrInvalidAdminInput = errors.New("invalid admin input")
+)
+
+const (
+	dashboardCacheTTL   = 2 * time.Minute
+	apyDropAlertThreshold = 0.20
 )
 
 type VaultChainInvoker interface {
@@ -30,21 +37,16 @@ func (NoopVaultChainInvoker) PauseVault(_ context.Context, _ string) error   { r
 func (NoopVaultChainInvoker) UnpauseVault(_ context.Context, _ string) error { return nil }
 
 type AdminService struct {
-	repository             admindomain.Repository
-	chainInvoker           VaultChainInvoker
-	httpClient             *http.Client
-	stellarHorizonURL      string
-	settlementProviderURL  string
-	startedAt              time.Time
-}
+	repository            admindomain.Repository
+	chainInvoker          VaultChainInvoker
+	httpClient            *http.Client
+	stellarHorizonURL     string
+	settlementProviderURL string
+	startedAt             time.Time
 
-type DashboardResponse struct {
-	TotalTVL              string                              `json:"total_tvl"`
-	TotalUsers            int64                               `json:"total_users"`
-	ActiveVaults          int64                               `json:"active_vaults"`
-	TotalYieldDistributed string                              `json:"total_yield_distributed"`
-	Settlements           admindomain.DashboardSettlementMetrics `json:"settlements"`
-	SystemHealth          admindomain.DashboardSystemHealth   `json:"system_health"`
+	dashboardCache   *admindomain.VaultHealthDashboard
+	dashboardCacheAt time.Time
+	dashboardCacheMu sync.RWMutex
 }
 
 func NewAdminService(
@@ -67,35 +69,103 @@ func NewAdminService(
 	}
 }
 
-func (s *AdminService) GetDashboard(ctx context.Context) (DashboardResponse, error) {
-	metrics, err := s.repository.GetDashboardMetrics(ctx)
+func (s *AdminService) GetDashboard(ctx context.Context) (admindomain.VaultHealthDashboard, error) {
+	s.dashboardCacheMu.RLock()
+	if s.dashboardCache != nil && time.Since(s.dashboardCacheAt) < dashboardCacheTTL {
+		cached := *s.dashboardCache
+		s.dashboardCacheMu.RUnlock()
+		return cached, nil
+	}
+	s.dashboardCacheMu.RUnlock()
+
+	data, err := s.repository.GetVaultHealthDashboard(ctx)
 	if err != nil {
-		return DashboardResponse{}, err
+		return admindomain.VaultHealthDashboard{}, err
 	}
 
-	health, err := s.GetDetailedHealth(ctx)
-	if err != nil {
-		return DashboardResponse{}, err
+	result := buildVaultHealthDashboard(data)
+
+	s.dashboardCacheMu.Lock()
+	s.dashboardCache = &result
+	s.dashboardCacheAt = time.Now().UTC()
+	s.dashboardCacheMu.Unlock()
+
+	return result, nil
+}
+
+func buildVaultHealthDashboard(data admindomain.VaultHealthDashboardData) admindomain.VaultHealthDashboard {
+	vaults := make([]admindomain.VaultHealthEntry, 0, len(data.Vaults))
+	systemAlerts := make([]admindomain.SystemAlert, 0)
+
+	for _, row := range data.Vaults {
+		entry := admindomain.VaultHealthEntry{
+			ID:                  row.ID,
+			Name:                row.Name,
+			TVLUSDC:             row.TVL.StringFixed(2),
+			APY7d:               formatAPY(row.APY7d),
+			Depositors:          row.Depositors,
+			PendingTransactions: row.PendingTransactions,
+			Status:              mapVaultHealthStatus(row.Status),
+			Alerts:              []admindomain.VaultAlert{},
+		}
+
+		if row.LastRebalanceAt != nil {
+			formatted := row.LastRebalanceAt.UTC().Format(time.RFC3339)
+			entry.LastRebalanceAt = &formatted
+		}
+
+		if alert := apyDropAlert(row.Name, row.APY7d, row.APY7d24hAgo); alert != nil {
+			systemAlerts = append(systemAlerts, *alert)
+		}
+
+		vaults = append(vaults, entry)
 	}
 
-	lastEvent := ""
-	if health.EventIndexer.LastEventAt != nil {
-		lastEvent = health.EventIndexer.LastEventAt.UTC().Format(time.RFC3339)
+	return admindomain.VaultHealthDashboard{
+		TotalTVLUSDC:    data.TotalTVL.StringFixed(2),
+		TotalDepositors: data.TotalDepositors,
+		Vaults:          vaults,
+		SystemAlerts:    systemAlerts,
+	}
+}
+
+func formatAPY(apy *decimal.Decimal) string {
+	if apy == nil {
+		return "0.00"
+	}
+	return apy.StringFixed(2)
+}
+
+func mapVaultHealthStatus(status vault.VaultStatus) string {
+	switch status {
+	case vault.StatusActive:
+		return "healthy"
+	case vault.StatusPaused:
+		return "paused"
+	default:
+		return string(status)
+	}
+}
+
+func apyDropAlert(name string, current, previous *decimal.Decimal) *admindomain.SystemAlert {
+	if current == nil || previous == nil || previous.IsZero() {
+		return nil
 	}
 
-	return DashboardResponse{
-		TotalTVL:              metrics.TotalTVL.StringFixed(2),
-		TotalUsers:            metrics.TotalUsers,
-		ActiveVaults:          metrics.ActiveVaults,
-		TotalYieldDistributed: metrics.TotalYieldDistributed.StringFixed(2),
-		Settlements:           metrics.Settlements,
-		SystemHealth: admindomain.DashboardSystemHealth{
-			Database:           health.Database.Status,
-			StellarRPC:         health.StellarRPC.Status,
-			SettlementProvider: health.SettlementProvider.Status,
-			LastEventIndexed:   lastEvent,
-		},
-	}, nil
+	drop := previous.Sub(*current).Div(*previous)
+	if drop.LessThanOrEqual(decimal.NewFromFloat(apyDropAlertThreshold)) {
+		return nil
+	}
+
+	pctDrop := drop.Mul(decimal.NewFromInt(100)).Round(0)
+	return &admindomain.SystemAlert{
+		Severity: "warning",
+		Message: fmt.Sprintf(
+			"%s vault APY dropped %s%% in 24h",
+			name,
+			pctDrop.StringFixed(0),
+		),
+	}
 }
 
 func (s *AdminService) ListVaults(
@@ -279,4 +349,3 @@ func (s *AdminService) checkEventIndexer(ctx context.Context) admindomain.Health
 	}
 
 }
-

--- a/apps/api/internal/service/admin_service_test.go
+++ b/apps/api/internal/service/admin_service_test.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	admindomain "github.com/suncrestlabs/nester/apps/api/internal/domain/admin"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+func TestBuildVaultHealthDashboard_AggregatesMultipleVaults(t *testing.T) {
+	vaultA := uuid.New()
+	vaultB := uuid.New()
+	rebalanceAt := mustParseTime(t, "2026-05-26T08:00:00Z")
+	apyA := decimal.RequireFromString("8.24")
+	apyB := decimal.RequireFromString("12.50")
+
+	data := admindomain.VaultHealthDashboardData{
+		TotalTVL:        decimal.RequireFromString("5234891.00"),
+		TotalDepositors: 892,
+		Vaults: []admindomain.VaultHealthRow{
+			{
+				ID:                  vaultA,
+				Name:                "Conservative",
+				TVL:                 decimal.RequireFromString("1234000.00"),
+				APY7d:               &apyA,
+				Depositors:          234,
+				PendingTransactions: 3,
+				LastRebalanceAt:     &rebalanceAt,
+				Status:              vault.StatusActive,
+			},
+			{
+				ID:                  vaultB,
+				Name:                "Growth",
+				TVL:                 decimal.RequireFromString("4000891.00"),
+				APY7d:               &apyB,
+				Depositors:          658,
+				PendingTransactions: 0,
+				Status:              vault.StatusPaused,
+			},
+		},
+	}
+
+	result := buildVaultHealthDashboard(data)
+
+	if result.TotalTVLUSDC != "5234891.00" {
+		t.Fatalf("total_tvl_usdc = %q, want 5234891.00", result.TotalTVLUSDC)
+	}
+	if result.TotalDepositors != 892 {
+		t.Fatalf("total_depositors = %d, want 892", result.TotalDepositors)
+	}
+	if len(result.Vaults) != 2 {
+		t.Fatalf("vault count = %d, want 2", len(result.Vaults))
+	}
+	if result.Vaults[0].Status != "healthy" {
+		t.Fatalf("vault[0].status = %q, want healthy", result.Vaults[0].Status)
+	}
+	if result.Vaults[1].Status != "paused" {
+		t.Fatalf("vault[1].status = %q, want paused", result.Vaults[1].Status)
+	}
+	if result.Vaults[0].PendingTransactions != 3 {
+		t.Fatalf("vault[0].pending_transactions = %d, want 3", result.Vaults[0].PendingTransactions)
+	}
+	if result.Vaults[0].LastRebalanceAt == nil || *result.Vaults[0].LastRebalanceAt != "2026-05-26T08:00:00Z" {
+		t.Fatalf("vault[0].last_rebalance_at = %+v, want 2026-05-26T08:00:00Z", result.Vaults[0].LastRebalanceAt)
+	}
+	if len(result.SystemAlerts) != 0 {
+		t.Fatalf("system_alerts = %+v, want none", result.SystemAlerts)
+	}
+}
+
+func TestAPYDropAlert_FlagsWarningAboveThreshold(t *testing.T) {
+	current := decimal.RequireFromString("6.00")
+	previous := decimal.RequireFromString("10.00")
+
+	alert := apyDropAlert("Conservative", &current, &previous)
+	if alert == nil {
+		t.Fatal("expected APY drop alert, got nil")
+	}
+	if alert.Severity != "warning" {
+		t.Fatalf("severity = %q, want warning", alert.Severity)
+	}
+	if alert.Message != "Conservative vault APY dropped 40% in 24h" {
+		t.Fatalf("message = %q", alert.Message)
+	}
+}
+
+func TestAPYDropAlert_NoAlertBelowThreshold(t *testing.T) {
+	current := decimal.RequireFromString("9.00")
+	previous := decimal.RequireFromString("10.00")
+
+	if alert := apyDropAlert("Conservative", &current, &previous); alert != nil {
+		t.Fatalf("expected no alert for 10%% drop, got %+v", alert)
+	}
+}
+
+func TestAPYDropAlert_NoAlertWithoutHistoricalAPY(t *testing.T) {
+	current := decimal.RequireFromString("5.00")
+	if alert := apyDropAlert("Conservative", &current, nil); alert != nil {
+		t.Fatalf("expected no alert without historical APY, got %+v", alert)
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+	return parsed.UTC()
+}


### PR DESCRIPTION
## Summary
Adds a vault health admin dashboard at `GET /api/v1/admin/dashboard` that aggregates per-vault TVL, APY, depositor counts, pending transactions, and rebalance timestamps, with system-wide APY drop alerts.

## Purpose / Motivation
Admins had no single endpoint to assess vault health across the platform. This consolidates the key operational metrics needed for an admin dashboard into one cached response.

## Changes Made
- Replaced the platform ops summary dashboard payload with the issue #521 vault health schema (`total_tvl_usdc`, `total_depositors`, `vaults[]`, `system_alerts[]`).
- Added `GetVaultHealthDashboard` repository query aggregating TVL, depositors, pending transactions, 7d APY, and last rebalance time per vault.
- Added in-memory dashboard cache (2-minute TTL) to keep response time under 1s.
- Added APY drop detection: vaults with >20% 7d APY decline in 24h produce warning alerts in `system_alerts`.
- Added service, handler, and repository tests for aggregation, auth, and alert logic.

## How to Test
1. Bootstrap an admin user and obtain an admin JWT.
2. `GET /api/v1/admin/dashboard` with `Authorization: Bearer <admin-jwt>`.
   - Expect 200 with aggregated `total_tvl_usdc`, `total_depositors`, and per-vault metrics.
3. Repeat the request with a non-admin JWT.
   - Expect 403 Forbidden.
4. Seed multiple vaults with deposits, pending transactions, and APY history (including a >20% 24h drop for one vault).
   - Expect correct per-vault counts and a warning in `system_alerts`.
5. Run `go test ./internal/service/... ./internal/handler/... ./internal/repository/postgres/... -run Admin`.

## Breaking Changes
- **Dashboard response shape changed.** Clients using the old `total_tvl` / `system_health` fields must migrate to the new vault health schema.

## Related Issues
Closes Suncrest-Labs/nester#521

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
