### PR TITLE
feat(api): add user vault position endpoint with live PnL

### DIFF
--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -84,13 +84,14 @@ type Repository interface {
 	GetVault(ctx context.Context, id uuid.UUID) (Vault, error)
 	ListUserVaults(ctx context.Context, userID uuid.UUID, filter UserListFilter) ([]Vault, int, error)
 	ListVaults(ctx context.Context, filter ListFilter) ([]Vault, int, error)
-	RecordDeposit(ctx context.Context, id uuid.UUID, amount decimal.Decimal) error
+	RecordDeposit(ctx context.Context, vaultID uuid.UUID, record TransactionRecord) error
 	UpdateVaultBalances(ctx context.Context, id uuid.UUID, totalDeposited decimal.Decimal, currentBalance decimal.Decimal) error
 	ReplaceAllocations(ctx context.Context, vaultID uuid.UUID, allocations []Allocation) error
 	UpdateVault(ctx context.Context, id uuid.UUID, contractAddress string, status VaultStatus) error
-	RecordWithdrawal(ctx context.Context, id uuid.UUID, amount decimal.Decimal) error
+	RecordWithdrawal(ctx context.Context, vaultID uuid.UUID, record TransactionRecord) error
 	SoftDeleteVault(ctx context.Context, id uuid.UUID) error
 	ListDeposits(ctx context.Context, vaultID uuid.UUID) ([]VaultTransaction, error)
+	ListUserVaultTransactions(ctx context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]VaultTransaction, error)
 }
 
 // CanTransitionTo reports whether moving from the receiver status to next is a

--- a/apps/api/internal/domain/vault/position.go
+++ b/apps/api/internal/domain/vault/position.go
@@ -1,0 +1,149 @@
+package vault
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+const positionDecimalPlaces = int32(6)
+
+// UserVaultPosition is the aggregated per-user position in a single vault.
+type UserVaultPosition struct {
+	VaultID            uuid.UUID  `json:"vault_id"`
+	UserID             uuid.UUID  `json:"user_id"`
+	TotalDepositedUSDC string     `json:"total_deposited_usdc"`
+	SharesHeld         string     `json:"shares_held"`
+	CurrentValueUSDC   string     `json:"current_value_usdc"`
+	UnrealizedPnLUSDC  string     `json:"unrealized_pnl_usdc"`
+	UnrealizedPnLPct   string     `json:"unrealized_pnl_pct"`
+	FeesPaidUSDC       string     `json:"fees_paid_usdc"`
+	FirstDepositAt     *time.Time `json:"first_deposit_at"`
+	LastActivityAt     *time.Time `json:"last_activity_at"`
+}
+
+// TransactionRecord captures ledger metadata written alongside a deposit or withdrawal.
+type TransactionRecord struct {
+	UserID               uuid.UUID
+	Amount               decimal.Decimal
+	TransactionHash      string
+	SharesMintedOrBurned decimal.Decimal
+	SharePriceAtTime     decimal.Decimal
+	FeeCharged           decimal.Decimal
+}
+
+// ComputeSharePrice returns the live NAV per share for a vault.
+func ComputeSharePrice(v Vault) decimal.Decimal {
+	if v.TotalDeposited.IsZero() || v.TotalDeposited.Sign() <= 0 {
+		return decimal.NewFromInt(1)
+	}
+	return v.CurrentBalance.Div(v.TotalDeposited).Round(8)
+}
+
+// BuildUserVaultPosition aggregates user transactions and applies live vault pricing.
+func BuildUserVaultPosition(v Vault, userID uuid.UUID, txns []VaultTransaction) UserVaultPosition {
+	if len(txns) == 0 {
+		return EmptyUserVaultPosition(v.ID, userID)
+	}
+
+	totalDeposited := decimal.Zero
+	totalWithdrawn := decimal.Zero
+	sharesHeld := decimal.Zero
+	feesPaid := decimal.Zero
+
+	var firstDepositAt *time.Time
+	var lastActivityAt *time.Time
+
+	for _, txn := range txns {
+		if lastActivityAt == nil || txn.CreatedAt.After(*lastActivityAt) {
+			t := txn.CreatedAt
+			lastActivityAt = &t
+		}
+
+		shares := decimal.Zero
+		if txn.SharesMintedOrBurned != nil {
+			shares = *txn.SharesMintedOrBurned
+		}
+
+		fee := decimal.Zero
+		if txn.FeeCharged != nil {
+			fee = *txn.FeeCharged
+		}
+		feesPaid = feesPaid.Add(fee)
+
+		switch txn.Type {
+		case "deposit":
+			totalDeposited = totalDeposited.Add(txn.Amount)
+			sharesHeld = sharesHeld.Add(shares)
+			if firstDepositAt == nil || txn.CreatedAt.Before(*firstDepositAt) {
+				t := txn.CreatedAt
+				firstDepositAt = &t
+			}
+		case "withdrawal":
+			totalWithdrawn = totalWithdrawn.Add(txn.Amount)
+			sharesHeld = sharesHeld.Sub(shares)
+		}
+	}
+
+	if sharesHeld.Sign() < 0 {
+		sharesHeld = decimal.Zero
+	}
+
+	sharePrice := ComputeSharePrice(v)
+	currentValue := sharesHeld.Mul(sharePrice).Round(positionDecimalPlaces)
+	netInvested := totalDeposited.Sub(totalWithdrawn)
+	unrealizedPnL := currentValue.Sub(netInvested)
+
+	pnlPct := decimal.Zero
+	if netInvested.Sign() > 0 {
+		pnlPct = unrealizedPnL.Div(netInvested).Mul(decimal.NewFromInt(100)).Round(2)
+	}
+
+	return UserVaultPosition{
+		VaultID:            v.ID,
+		UserID:             userID,
+		TotalDepositedUSDC: formatUSDC(totalDeposited),
+		SharesHeld:         formatUSDC(sharesHeld),
+		CurrentValueUSDC:   formatUSDC(currentValue),
+		UnrealizedPnLUSDC:  formatSignedUSDC(unrealizedPnL),
+		UnrealizedPnLPct:   formatSignedPct(pnlPct),
+		FeesPaidUSDC:       formatUSDC(feesPaid),
+		FirstDepositAt:     firstDepositAt,
+		LastActivityAt:     lastActivityAt,
+	}
+}
+
+// EmptyUserVaultPosition returns a zero-valued position for users with no activity.
+func EmptyUserVaultPosition(vaultID, userID uuid.UUID) UserVaultPosition {
+	return UserVaultPosition{
+		VaultID:            vaultID,
+		UserID:             userID,
+		TotalDepositedUSDC: "0.000000",
+		SharesHeld:         "0.000000",
+		CurrentValueUSDC:   "0.000000",
+		UnrealizedPnLUSDC:  "+0.000000",
+		UnrealizedPnLPct:   "+0.00",
+		FeesPaidUSDC:       "0.000000",
+	}
+}
+
+func formatUSDC(value decimal.Decimal) string {
+	return value.Round(positionDecimalPlaces).StringFixed(positionDecimalPlaces)
+}
+
+func formatSignedUSDC(value decimal.Decimal) string {
+	sign := "+"
+	if value.Sign() < 0 {
+		sign = "-"
+	}
+	return sign + value.Abs().Round(positionDecimalPlaces).StringFixed(positionDecimalPlaces)
+}
+
+func formatSignedPct(value decimal.Decimal) string {
+	sign := "+"
+	if value.Sign() < 0 {
+		sign = "-"
+	}
+	return sign + value.Abs().Round(2).StringFixed(2)
+}

--- a/apps/api/internal/domain/vault/position_test.go
+++ b/apps/api/internal/domain/vault/position_test.go
@@ -1,0 +1,102 @@
+package vault
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestBuildUserVaultPositionEmpty(t *testing.T) {
+	vaultID := uuid.New()
+	userID := uuid.New()
+
+	position := EmptyUserVaultPosition(vaultID, userID)
+
+	if position.TotalDepositedUSDC != "0.000000" {
+		t.Fatalf("expected zero deposited, got %s", position.TotalDepositedUSDC)
+	}
+	if position.UnrealizedPnLUSDC != "+0.000000" {
+		t.Fatalf("expected zero pnl, got %s", position.UnrealizedPnLUSDC)
+	}
+}
+
+func TestBuildUserVaultPositionWithYield(t *testing.T) {
+	vaultID := uuid.New()
+	userID := uuid.New()
+	depositTime := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+
+	shares := decimal.RequireFromString("1000")
+	v := Vault{
+		ID:             vaultID,
+		TotalDeposited: decimal.RequireFromString("1000"),
+		CurrentBalance: decimal.RequireFromString("1100"),
+	}
+
+	txns := []VaultTransaction{
+		{
+			VaultID:              vaultID,
+			UserID:               &userID,
+			Type:                 "deposit",
+			Amount:               decimal.RequireFromString("1000"),
+			SharesMintedOrBurned: &shares,
+			CreatedAt:            depositTime,
+		},
+	}
+
+	position := BuildUserVaultPosition(v, userID, txns)
+
+	if position.CurrentValueUSDC != "1100.000000" {
+		t.Fatalf("expected current value 1100, got %s", position.CurrentValueUSDC)
+	}
+	if position.UnrealizedPnLUSDC != "+100.000000" {
+		t.Fatalf("expected pnl +100, got %s", position.UnrealizedPnLUSDC)
+	}
+	if position.UnrealizedPnLPct != "+10.00" {
+		t.Fatalf("expected pnl pct +10.00, got %s", position.UnrealizedPnLPct)
+	}
+}
+
+func TestBuildUserVaultPositionAccountsForWithdrawals(t *testing.T) {
+	vaultID := uuid.New()
+	userID := uuid.New()
+
+	depositShares := decimal.RequireFromString("1000")
+	withdrawShares := decimal.RequireFromString("200")
+
+	v := Vault{
+		ID:             vaultID,
+		TotalDeposited: decimal.RequireFromString("1000"),
+		CurrentBalance: decimal.RequireFromString("800"),
+	}
+
+	txns := []VaultTransaction{
+		{
+			VaultID:              vaultID,
+			UserID:               &userID,
+			Type:                 "deposit",
+			Amount:               decimal.RequireFromString("1000"),
+			SharesMintedOrBurned: &depositShares,
+			CreatedAt:            time.Now().Add(-48 * time.Hour),
+		},
+		{
+			VaultID:              vaultID,
+			UserID:               &userID,
+			Type:                 "withdrawal",
+			Amount:               decimal.RequireFromString("200"),
+			SharesMintedOrBurned: &withdrawShares,
+			CreatedAt:            time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	position := BuildUserVaultPosition(v, userID, txns)
+
+	if position.SharesHeld != "800.000000" {
+		t.Fatalf("expected 800 shares held, got %s", position.SharesHeld)
+	}
+	// current_value = 800 shares * 0.8 price = 640; net invested = 800; pnl = -160
+	if position.UnrealizedPnLUSDC != "-160.000000" {
+		t.Fatalf("expected pnl -160 after withdrawal, got %s", position.UnrealizedPnLUSDC)
+	}
+}

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -37,6 +37,7 @@ func (h *VaultHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/vaults", h.createVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}", h.getVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/allocations", h.getAllocations)
+	mux.HandleFunc("GET /api/v1/vaults/{id}/my-position", h.getMyPosition)
 	mux.HandleFunc("GET /api/v1/vaults", h.listUserVaults)
 	mux.HandleFunc("GET /api/v1/vaults/all", h.listVaults)
 }
@@ -203,6 +204,34 @@ func (h *VaultHandler) getAllocations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.WriteJSON(w, http.StatusOK, response.OK(v.Allocations))
+}
+
+func (h *VaultHandler) getMyPosition(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid token subject"))
+		return
+	}
+
+	position, err := h.service.GetMyPosition(r.Context(), userID, vaultID)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(position))
 }
 
 func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {

--- a/apps/api/internal/handler/vault_handler_my_position_test.go
+++ b/apps/api/internal/handler/vault_handler_my_position_test.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+func TestVaultHandlerGetMyPositionEmpty(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	response, err := http.Get(server.URL + "/api/v1/vaults/" + created.ID.String() + "/my-position")
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	position := decodeAPIData[vault.UserVaultPosition](t, response.Body)
+	if position.TotalDepositedUSDC != "0.000000" {
+		t.Fatalf("expected zero deposited, got %s", position.TotalDepositedUSDC)
+	}
+}
+
+func TestVaultHandlerGetMyPositionWithYield(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	if _, err := vaultService.RecordDeposit(context.Background(), service.RecordDepositInput{
+		VaultID: created.ID,
+		UserID:  userID,
+		Amount:  decimal.RequireFromString("1000"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit() error = %v", err)
+	}
+
+	if err := repository.UpdateVaultBalances(context.Background(), created.ID,
+		decimal.RequireFromString("1000"),
+		decimal.RequireFromString("1089.45"),
+	); err != nil {
+		t.Fatalf("UpdateVaultBalances() error = %v", err)
+	}
+
+	response, err := http.Get(server.URL + "/api/v1/vaults/" + created.ID.String() + "/my-position")
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+
+	position := decodeAPIData[vault.UserVaultPosition](t, response.Body)
+	if !strings.HasPrefix(position.UnrealizedPnLUSDC, "+") {
+		t.Fatalf("expected positive pnl, got %s", position.UnrealizedPnLUSDC)
+	}
+}
+
+func TestVaultHandlerGetMyPositionUnauthorized(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	handler := NewVaultHandler(service.NewVaultService(repository))
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+	defer server.Close()
+
+	created, err := service.NewVaultService(repository).CreateVault(context.Background(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	response, err := http.Get(server.URL + "/api/v1/vaults/" + created.ID.String() + "/my-position")
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", response.StatusCode)
+	}
+}
+
+func TestVaultHandlerGetMyPositionInvalidVaultID(t *testing.T) {
+	userID := uuid.New()
+	handler := NewVaultHandler(service.NewVaultService(newHandlerRepository(userID)))
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/vaults/not-a-uuid/my-position")
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", response.StatusCode)
+	}
+}
+
+func TestVaultHandlerGetMyPositionVaultNotFound(t *testing.T) {
+	userID := uuid.New()
+	handler := NewVaultHandler(service.NewVaultService(newHandlerRepository(userID)))
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/vaults/" + uuid.New().String() + "/my-position")
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", response.StatusCode)
+	}
+}
+
+func TestVaultHandlerGetMyPositionNoAuthBodyRequired(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)))
+	defer server.Close()
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/vaults/"+created.ID.String()+"/my-position", bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET my-position error = %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.StatusCode)
+	}
+}

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -232,25 +232,32 @@ func (r *handlerRepository) UpdateVaultBalances(_ context.Context, id uuid.UUID,
 	return nil
 }
 
-func (r *handlerRepository) RecordDeposit(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (r *handlerRepository) RecordDeposit(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	model, ok := r.vaults[id]
 	if !ok {
 		return vault.ErrVaultNotFound
 	}
-	if amount.Cmp(decimal.Zero) <= 0 {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
-	model.TotalDeposited = model.TotalDeposited.Add(amount)
-	model.CurrentBalance = model.CurrentBalance.Add(amount)
+	model.TotalDeposited = model.TotalDeposited.Add(record.Amount)
+	model.CurrentBalance = model.CurrentBalance.Add(record.Amount)
 	model.UpdatedAt = time.Now().UTC()
 	r.vaults[id] = cloneHandlerVault(model)
+
+	userID := record.UserID
 	r.transactions = append(r.transactions, vault.VaultTransaction{
-		ID:        uuid.New(),
-		VaultID:   id,
-		Type:      "deposit",
-		Amount:    amount,
-		CreatedAt: time.Now().UTC(),
+		ID:                   uuid.New(),
+		VaultID:              id,
+		UserID:               &userID,
+		Type:                 "deposit",
+		Amount:               record.Amount,
+		TransactionHash:      record.TransactionHash,
+		SharesMintedOrBurned: &record.SharesMintedOrBurned,
+		SharePriceAtTime:     &record.SharePriceAtTime,
+		FeeCharged:           feePtr(record.FeeCharged),
+		CreatedAt:            time.Now().UTC(),
 	})
 	return nil
 }
@@ -278,24 +285,31 @@ func (r *handlerRepository) UpdateVault(_ context.Context, id uuid.UUID, contrac
 	return nil
 }
 
-func (r *handlerRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (r *handlerRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	model, ok := r.vaults[id]
 	if !ok {
 		return vault.ErrVaultNotFound
 	}
-	if amount.Cmp(decimal.Zero) <= 0 {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
-	model.CurrentBalance = model.CurrentBalance.Sub(amount)
+	model.CurrentBalance = model.CurrentBalance.Sub(record.Amount)
 	model.UpdatedAt = time.Now().UTC()
 	r.vaults[id] = cloneHandlerVault(model)
+
+	userID := record.UserID
 	r.transactions = append(r.transactions, vault.VaultTransaction{
-		ID:        uuid.New(),
-		VaultID:   id,
-		Type:      "withdrawal",
-		Amount:    amount,
-		CreatedAt: time.Now().UTC(),
+		ID:                   uuid.New(),
+		VaultID:              id,
+		UserID:               &userID,
+		Type:                 "withdrawal",
+		Amount:               record.Amount,
+		TransactionHash:      record.TransactionHash,
+		SharesMintedOrBurned: &record.SharesMintedOrBurned,
+		SharePriceAtTime:     &record.SharePriceAtTime,
+		FeeCharged:           feePtr(record.FeeCharged),
+		CreatedAt:            time.Now().UTC(),
 	})
 	return nil
 }
@@ -336,6 +350,23 @@ func (r *handlerRepository) ListVaults(_ context.Context, filter vault.ListFilte
 		out = out[:filter.Limit]
 	}
 	return out, total, nil
+}
+
+func (r *handlerRepository) ListUserVaultTransactions(_ context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	result := make([]vault.VaultTransaction, 0)
+	for _, txn := range r.transactions {
+		if txn.VaultID == vaultID && txn.UserID != nil && *txn.UserID == userID {
+			result = append(result, txn)
+		}
+	}
+	return result, nil
+}
+
+func feePtr(fee decimal.Decimal) *decimal.Decimal {
+	if fee.IsZero() {
+		return nil
+	}
+	return &fee
 }
 
 func cloneHandlerVault(model vault.Vault) vault.Vault {

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -226,8 +226,8 @@ func (r *VaultRepository) UpdateVaultBalances(ctx context.Context, id uuid.UUID,
 	return nil
 }
 
-func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, amount decimal.Decimal) error {
-	if amount.Cmp(decimal.Zero) <= 0 {
+func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, record vault.TransactionRecord) error {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
@@ -245,7 +245,7 @@ func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, amoun
 		     updated_at = NOW()
 		 WHERE id = $1 AND deleted_at IS NULL`,
 		id.String(),
-		amount.String(),
+		record.Amount.String(),
 	)
 	if err != nil {
 		return mapRepositoryError(err)
@@ -261,9 +261,17 @@ func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, amoun
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO vault_transactions (vault_id, type, amount) VALUES ($1, 'deposit', $2::numeric)`,
+		`INSERT INTO vault_transactions (
+			vault_id, user_id, type, amount, transaction_hash,
+			shares_minted_or_burned, share_price_at_time, fee_charged
+		) VALUES ($1, $2, 'deposit', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric, $7::numeric)`,
 		id.String(),
-		amount.String(),
+		record.UserID.String(),
+		record.Amount.String(),
+		record.TransactionHash,
+		record.SharesMintedOrBurned.String(),
+		record.SharePriceAtTime.String(),
+		record.FeeCharged.String(),
 	); err != nil {
 		return mapRepositoryError(err)
 	}
@@ -344,8 +352,8 @@ func (r *VaultRepository) UpdateVault(ctx context.Context, id uuid.UUID, contrac
 
 // RecordWithdrawal decrements current_balance atomically and writes a ledger
 // entry. It does NOT touch total_deposited (deposits are never reversed).
-func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, amount decimal.Decimal) error {
-	if amount.Cmp(decimal.Zero) <= 0 {
+func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, record vault.TransactionRecord) error {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
@@ -362,7 +370,7 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, am
 		     updated_at = NOW()
 		 WHERE id = $1 AND deleted_at IS NULL`,
 		id.String(),
-		amount.String(),
+		record.Amount.String(),
 	)
 	if err != nil {
 		return mapRepositoryError(err)
@@ -378,9 +386,17 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, am
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO vault_transactions (vault_id, type, amount) VALUES ($1, 'withdrawal', $2::numeric)`,
+		`INSERT INTO vault_transactions (
+			vault_id, user_id, type, amount, transaction_hash,
+			shares_minted_or_burned, share_price_at_time, fee_charged
+		) VALUES ($1, $2, 'withdrawal', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric, $7::numeric)`,
 		id.String(),
-		amount.String(),
+		record.UserID.String(),
+		record.Amount.String(),
+		record.TransactionHash,
+		record.SharesMintedOrBurned.String(),
+		record.SharePriceAtTime.String(),
+		record.FeeCharged.String(),
 	); err != nil {
 		return mapRepositoryError(err)
 	}
@@ -420,6 +436,38 @@ func (r *VaultRepository) ListDeposits(ctx context.Context, vaultID uuid.UUID) (
 		 WHERE vault_id = $1 AND type = 'deposit'
 		 ORDER BY created_at DESC`,
 		vaultID.String(),
+	)
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+	defer rows.Close()
+
+	txns := make([]vault.VaultTransaction, 0)
+	for rows.Next() {
+		txn, err := scanVaultTransaction(rows)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, txn)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return txns, nil
+}
+
+// ListUserVaultTransactions returns all deposit and withdrawal rows for a user in a vault.
+func (r *VaultRepository) ListUserVaultTransactions(ctx context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	rows, err := r.db.QueryContext(
+		ctx,
+		`SELECT id, vault_id, user_id, type, amount, COALESCE(transaction_hash, ''), shares_minted_or_burned, share_price_at_time, fee_charged, created_at
+		 FROM vault_transactions
+		 WHERE vault_id = $1 AND user_id = $2
+		 ORDER BY created_at ASC`,
+		vaultID.String(),
+		userID.String(),
 	)
 	if err != nil {
 		return nil, mapRepositoryError(err)

--- a/apps/api/internal/repository/postgres/vault_repository_extended_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_extended_integration_test.go
@@ -442,12 +442,22 @@ func TestVaultRepositoryIntegrationRecordDeposit(t *testing.T) {
 	}
 
 	// Record deposits
-	err = repository.RecordDeposit(ctx, created.ID, decimal.RequireFromString("100.50"))
+	err = repository.RecordDeposit(ctx, created.ID, vault.TransactionRecord{
+		UserID:               userID,
+		Amount:               decimal.RequireFromString("100.50"),
+		SharesMintedOrBurned: decimal.RequireFromString("100.50"),
+		SharePriceAtTime:     decimal.NewFromInt(1),
+	})
 	if err != nil {
 		t.Fatalf("RecordDeposit() error = %v", err)
 	}
 
-	err = repository.RecordDeposit(ctx, created.ID, decimal.RequireFromString("50.25"))
+	err = repository.RecordDeposit(ctx, created.ID, vault.TransactionRecord{
+		UserID:               userID,
+		Amount:               decimal.RequireFromString("50.25"),
+		SharesMintedOrBurned: decimal.RequireFromString("50.25"),
+		SharePriceAtTime:     decimal.NewFromInt(1),
+	})
 	if err != nil {
 		t.Fatalf("RecordDeposit() error = %v", err)
 	}

--- a/apps/api/internal/repository/postgres/vault_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_integration_test.go
@@ -179,7 +179,12 @@ func TestVaultRepositoryIntegrationRecordDepositConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	deposit := func() {
 		defer wg.Done()
-		if err := repository.RecordDeposit(ctx, created.ID, decimal.RequireFromString("10")); err != nil {
+		if err := repository.RecordDeposit(ctx, created.ID, vault.TransactionRecord{
+			UserID:               userID,
+			Amount:               decimal.RequireFromString("10"),
+			SharesMintedOrBurned: decimal.RequireFromString("10"),
+			SharePriceAtTime:     decimal.NewFromInt(1),
+		}); err != nil {
 			t.Errorf("RecordDeposit() error = %v", err)
 		}
 	}

--- a/apps/api/internal/repository/postgres/vault_repository_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_test.go
@@ -56,6 +56,7 @@ func TestRecordDepositUpdatesBalancesAtomically(t *testing.T) {
 
 	repository := NewVaultRepository(db)
 	vaultID := uuid.New()
+	userID := uuid.New()
 
 	// RecordDeposit now runs inside a transaction and also inserts a ledger entry.
 	mock.ExpectBegin()
@@ -66,12 +67,21 @@ func TestRecordDepositUpdatesBalancesAtomically(t *testing.T) {
 		 WHERE id = $1 AND deleted_at IS NULL`)).
 		WithArgs(vaultID.String(), "25.5").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO vault_transactions (vault_id, type, amount) VALUES ($1, 'deposit', $2::numeric)`)).
-		WithArgs(vaultID.String(), "25.5").
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO vault_transactions (
+			vault_id, user_id, type, amount, transaction_hash,
+			shares_minted_or_burned, share_price_at_time, fee_charged
+		) VALUES ($1, $2, 'deposit', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric, $7::numeric)`)).
+		WithArgs(vaultID.String(), userID.String(), "25.5", "", "25.5", "1", "0").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	if err := repository.RecordDeposit(context.Background(), vaultID, decimal.RequireFromString("25.5")); err != nil {
+	record := vault.TransactionRecord{
+		UserID:               userID,
+		Amount:               decimal.RequireFromString("25.5"),
+		SharesMintedOrBurned: decimal.RequireFromString("25.5"),
+		SharePriceAtTime:     decimal.NewFromInt(1),
+	}
+	if err := repository.RecordDeposit(context.Background(), vaultID, record); err != nil {
 		t.Fatalf("RecordDeposit() error = %v", err)
 	}
 }

--- a/apps/api/internal/service/performance/service_test.go
+++ b/apps/api/internal/service/performance/service_test.go
@@ -28,7 +28,7 @@ func (s *stubVaultRepository) GetUserVaults(_ context.Context, userID uuid.UUID)
 	return s.vaults, s.err
 }
 
-func (s *stubVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -44,7 +44,7 @@ func (s *stubVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, contr
 	return errors.New("not implemented")
 }
 
-func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -53,6 +53,10 @@ func (s *stubVaultRepository) SoftDeleteVault(_ context.Context, id uuid.UUID) e
 }
 
 func (s *stubVaultRepository) ListDeposits(_ context.Context, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubVaultRepository) ListUserVaultTransactions(_ context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -43,8 +43,10 @@ type CreateVaultInput struct {
 
 type RecordDepositInput struct {
 	VaultID uuid.UUID
+	UserID  uuid.UUID
 	Amount  decimal.Decimal
 	TxHash  string
+	Fee     decimal.Decimal
 }
 
 type UpdateAllocationsInput struct {
@@ -65,8 +67,10 @@ type CloseVaultInput struct {
 
 type RecordWithdrawalInput struct {
 	VaultID uuid.UUID
+	UserID  uuid.UUID
 	Amount  decimal.Decimal
 	TxHash  string
+	Fee     decimal.Decimal
 }
 
 // ── Constructor ──────────────────────────────────────────────────────────────
@@ -162,18 +166,35 @@ func (s *VaultService) RecordDeposit(ctx context.Context, input RecordDepositInp
 		return vault.Vault{}, vault.ErrInvalidPrecision
 	}
 
+	existing, err := s.repository.GetVault(ctx, input.VaultID)
+	if err != nil {
+		return vault.Vault{}, err
+	}
+
+	userID := input.UserID
+	if userID == uuid.Nil {
+		userID = existing.UserID
+	}
+
+	sharePrice := vault.ComputeSharePrice(existing)
+	shares := input.Amount.Div(sharePrice).Round(6)
+
 	if s.depositInvoker != nil {
-		existing, err := s.repository.GetVault(ctx, input.VaultID)
-		if err != nil {
-			return vault.Vault{}, err
-		}
 		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
 		if err := s.depositInvoker.DepositToVault(ctx, existing.ContractAddress, stroops); err != nil {
 			return vault.Vault{}, fmt.Errorf("on-chain deposit failed: %w", err)
 		}
 	}
 
-	if err := s.repository.RecordDeposit(ctx, input.VaultID, input.Amount); err != nil {
+	record := vault.TransactionRecord{
+		UserID:               userID,
+		Amount:               input.Amount,
+		TransactionHash:      input.TxHash,
+		SharesMintedOrBurned: shares,
+		SharePriceAtTime:     sharePrice,
+		FeeCharged:           input.Fee,
+	}
+	if err := s.repository.RecordDeposit(ctx, input.VaultID, record); err != nil {
 		return vault.Vault{}, err
 	}
 
@@ -361,6 +382,14 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 		return vault.Vault{}, vault.ErrInsufficientBalance
 	}
 
+	userID := input.UserID
+	if userID == uuid.Nil {
+		userID = existing.UserID
+	}
+
+	sharePrice := vault.ComputeSharePrice(existing)
+	shares := input.Amount.Div(sharePrice).Round(6)
+
 	if s.depositInvoker != nil {
 		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
 		if err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, stroops); err != nil {
@@ -368,7 +397,15 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 		}
 	}
 
-	if err := s.repository.RecordWithdrawal(ctx, input.VaultID, input.Amount); err != nil {
+	record := vault.TransactionRecord{
+		UserID:               userID,
+		Amount:               input.Amount,
+		TransactionHash:      input.TxHash,
+		SharesMintedOrBurned: shares,
+		SharePriceAtTime:     sharePrice,
+		FeeCharged:           input.Fee,
+	}
+	if err := s.repository.RecordWithdrawal(ctx, input.VaultID, record); err != nil {
 		return vault.Vault{}, err
 	}
 
@@ -431,6 +468,25 @@ func (s *VaultService) ListDeposits(ctx context.Context, vaultID uuid.UUID) ([]v
 	}
 
 	return s.repository.ListDeposits(ctx, vaultID)
+}
+
+// GetMyPosition returns the authenticated user's aggregated position in a vault.
+func (s *VaultService) GetMyPosition(ctx context.Context, userID uuid.UUID, vaultID uuid.UUID) (vault.UserVaultPosition, error) {
+	if userID == uuid.Nil || vaultID == uuid.Nil {
+		return vault.UserVaultPosition{}, vault.ErrInvalidVault
+	}
+
+	v, err := s.repository.GetVault(ctx, vaultID)
+	if err != nil {
+		return vault.UserVaultPosition{}, err
+	}
+
+	txns, err := s.repository.ListUserVaultTransactions(ctx, userID, vaultID)
+	if err != nil {
+		return vault.UserVaultPosition{}, err
+	}
+
+	return vault.BuildUserVaultPosition(v, userID, txns), nil
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -110,6 +110,69 @@ func TestVaultServiceRejectsExcessiveDecimalScale(t *testing.T) {
 	}
 }
 
+func TestVaultServiceGetMyPositionWithYield(t *testing.T) {
+	userID := uuid.New()
+	repository := newMemoryVaultRepository(userID)
+	service := NewVaultService(repository)
+
+	created, err := service.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CA123",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	if _, err := service.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID,
+		UserID:  userID,
+		Amount:  decimal.RequireFromString("1000"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit() error = %v", err)
+	}
+
+	if err := repository.UpdateVaultBalances(context.Background(), created.ID,
+		decimal.RequireFromString("1000"),
+		decimal.RequireFromString("1050"),
+	); err != nil {
+		t.Fatalf("UpdateVaultBalances() error = %v", err)
+	}
+
+	position, err := service.GetMyPosition(context.Background(), userID, created.ID)
+	if err != nil {
+		t.Fatalf("GetMyPosition() error = %v", err)
+	}
+
+	if position.UnrealizedPnLUSDC != "+50.000000" {
+		t.Fatalf("expected pnl +50, got %s", position.UnrealizedPnLUSDC)
+	}
+}
+
+func TestVaultServiceGetMyPositionEmpty(t *testing.T) {
+	userID := uuid.New()
+	repository := newMemoryVaultRepository(userID)
+	service := NewVaultService(repository)
+
+	created, err := service.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CA123",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	position, err := service.GetMyPosition(context.Background(), userID, created.ID)
+	if err != nil {
+		t.Fatalf("GetMyPosition() error = %v", err)
+	}
+
+	if position.SharesHeld != "0.000000" {
+		t.Fatalf("expected zero shares, got %s", position.SharesHeld)
+	}
+}
+
 type memoryVaultRepository struct {
 	users        map[uuid.UUID]struct{}
 	vaults       map[uuid.UUID]vault.Vault
@@ -195,25 +258,31 @@ func (r *memoryVaultRepository) UpdateVaultBalances(_ context.Context, id uuid.U
 	return nil
 }
 
-func (r *memoryVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (r *memoryVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	model, ok := r.vaults[id]
 	if !ok {
 		return vault.ErrVaultNotFound
 	}
-	if amount.Cmp(decimal.Zero) <= 0 {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
-	model.TotalDeposited = model.TotalDeposited.Add(amount)
-	model.CurrentBalance = model.CurrentBalance.Add(amount)
+	model.TotalDeposited = model.TotalDeposited.Add(record.Amount)
+	model.CurrentBalance = model.CurrentBalance.Add(record.Amount)
 	model.UpdatedAt = time.Now().UTC()
 	r.vaults[id] = cloneVault(model)
+
+	userID := record.UserID
 	r.transactions = append(r.transactions, vault.VaultTransaction{
-		ID:        uuid.New(),
-		VaultID:   id,
-		Type:      "deposit",
-		Amount:    amount,
-		CreatedAt: time.Now().UTC(),
+		ID:                   uuid.New(),
+		VaultID:              id,
+		UserID:               &userID,
+		Type:                 "deposit",
+		Amount:               record.Amount,
+		TransactionHash:      record.TransactionHash,
+		SharesMintedOrBurned: &record.SharesMintedOrBurned,
+		SharePriceAtTime:     &record.SharePriceAtTime,
+		CreatedAt:            time.Now().UTC(),
 	})
 	return nil
 }
@@ -242,24 +311,30 @@ func (r *memoryVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, con
 	return nil
 }
 
-func (r *memoryVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (r *memoryVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	model, ok := r.vaults[id]
 	if !ok {
 		return vault.ErrVaultNotFound
 	}
-	if amount.Cmp(decimal.Zero) <= 0 {
+	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
 
-	model.CurrentBalance = model.CurrentBalance.Sub(amount)
+	model.CurrentBalance = model.CurrentBalance.Sub(record.Amount)
 	model.UpdatedAt = time.Now().UTC()
 	r.vaults[id] = cloneVault(model)
+
+	userID := record.UserID
 	r.transactions = append(r.transactions, vault.VaultTransaction{
-		ID:        uuid.New(),
-		VaultID:   id,
-		Type:      "withdrawal",
-		Amount:    amount,
-		CreatedAt: time.Now().UTC(),
+		ID:                   uuid.New(),
+		VaultID:              id,
+		UserID:               &userID,
+		Type:                 "withdrawal",
+		Amount:               record.Amount,
+		TransactionHash:      record.TransactionHash,
+		SharesMintedOrBurned: &record.SharesMintedOrBurned,
+		SharePriceAtTime:     &record.SharePriceAtTime,
+		CreatedAt:            time.Now().UTC(),
 	})
 	return nil
 }
@@ -300,6 +375,16 @@ func (r *memoryVaultRepository) ListVaults(_ context.Context, filter vault.ListF
 		out = out[:filter.Limit]
 	}
 	return out, total, nil
+}
+
+func (r *memoryVaultRepository) ListUserVaultTransactions(_ context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	result := make([]vault.VaultTransaction, 0)
+	for _, txn := range r.transactions {
+		if txn.VaultID == vaultID && txn.UserID != nil && *txn.UserID == userID {
+			result = append(result, txn)
+		}
+	}
+	return result, nil
 }
 
 func cloneVault(model vault.Vault) vault.Vault {

--- a/apps/api/internal/services/risk_service_test.go
+++ b/apps/api/internal/services/risk_service_test.go
@@ -29,7 +29,7 @@ func (s *stubVaultRepository) ListUserVaults(_ context.Context, userID uuid.UUID
 	return nil, 0, errors.New("not implemented")
 }
 
-func (s *stubVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepository) RecordDeposit(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -45,7 +45,7 @@ func (s *stubVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, contr
 	return errors.New("not implemented")
 }
 
-func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -54,6 +54,10 @@ func (s *stubVaultRepository) SoftDeleteVault(_ context.Context, id uuid.UUID) e
 }
 
 func (s *stubVaultRepository) ListDeposits(_ context.Context, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubVaultRepository) ListUserVaultTransactions(_ context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -83,7 +87,7 @@ func (s *stubVaultRepositoryWithCount) ListUserVaults(_ context.Context, userID 
 	return nil, 0, errors.New("not implemented")
 }
 
-func (s *stubVaultRepositoryWithCount) RecordDeposit(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepositoryWithCount) RecordDeposit(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -99,7 +103,7 @@ func (s *stubVaultRepositoryWithCount) UpdateVault(_ context.Context, id uuid.UU
 	return errors.New("not implemented")
 }
 
-func (s *stubVaultRepositoryWithCount) RecordWithdrawal(_ context.Context, id uuid.UUID, amount decimal.Decimal) error {
+func (s *stubVaultRepositoryWithCount) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
 
@@ -108,6 +112,10 @@ func (s *stubVaultRepositoryWithCount) SoftDeleteVault(_ context.Context, id uui
 }
 
 func (s *stubVaultRepositoryWithCount) ListDeposits(_ context.Context, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubVaultRepositoryWithCount) ListUserVaultTransactions(_ context.Context, userID uuid.UUID, vaultID uuid.UUID) ([]vault.VaultTransaction, error) {
 	return nil, errors.New("not implemented")
 }
 


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/vaults/{id}/my-position`, an authenticated endpoint that returns the calling user's aggregated deposit position in a vault, including live current value and unrealized profit/loss.

## Purpose / Motivation

Users need a per-vault view of their deposit activity — how much they deposited, current share balance, live value, and P&L — distinct from raw transaction events. Closes Suncrest-Labs/nester#517.

## Changes Made

- **New endpoint:** `GET /api/v1/vaults/{id}/my-position` (JWT required; scoped to the authenticated user)
- **Domain:** `UserVaultPosition` model and `BuildUserVaultPosition` aggregation with live share-price calculation (`current_balance / total_deposited`)
- **Repository:** Extended `RecordDeposit` / `RecordWithdrawal` to persist `user_id`, shares, share price, and fees in `vault_transactions`; added `ListUserVaultTransactions`
- **Service:** `GetMyPosition` aggregates user ledger rows and computes P&L as `current_value - (deposits - withdrawals)`
- **Tests:** Unit tests for position math, service, and handler (empty position, yield PnL > 0, auth, validation)

## How to Test

1. Start the API with a valid JWT for a test user.
2. Create or pick a vault UUID.
3. Record a deposit for that user (e.g. 1000 USDC via `RecordDeposit` or on-chain flow).
4. Simulate yield by increasing the vault's `current_balance` above `total_deposited` (or wait for yield accrual).
5. `GET /api/v1/vaults/{vault_id}/my-position` with `Authorization: Bearer <token>`.
6. **Expected:** `200` with non-zero `total_deposited_usdc`, `shares_held`, `current_value_usdc`, and positive `unrealized_pnl_usdc`.
7. Call the same endpoint for a vault with no user deposits.
8. **Expected:** `200` with zero-valued fields (not `404`).
9. Call without a JWT.
10. **Expected:** `401 Unauthorized`.

Run tests:

```bash
cd apps/api
go test ./internal/domain/vault/... ./internal/handler/... ./internal/service/... ./internal/repository/postgres/... -short
```

## Breaking Changes

None for API consumers. The `vault.Repository` interface signature for `RecordDeposit` and `RecordWithdrawal` now accepts a `TransactionRecord` struct instead of a bare amount (internal change only).

## Related Issues

Closes Suncrest-Labs/nester#517

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
