### PR TITLE
fix(api): only move vault balance after on-chain confirmation

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -112,3 +112,15 @@ MIGRATIONS_DIR=./migrations
 # Timeout for startup reachability probes against Horizon and Soroban RPC.
 # If a probe fails within this window, the API exits before serving traffic.
 STARTUP_DEPENDENCY_TIMEOUT=5s
+
+# Background poller that reconciles pending transactions against Horizon so
+# their status is confirmed even when the client never polls
+# GET /api/v1/transactions/{hash}. Set to false to disable.
+TX_POLLER_ENABLED=true
+
+# How often the poller checks for pending transactions to reconcile.
+TX_POLLER_INTERVAL=15s
+
+# Minimum age a transaction must reach before the poller checks it, giving
+# Horizon time to ingest a freshly submitted transaction.
+TX_POLLER_MIN_AGE=30s

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -100,6 +100,9 @@ func run() error {
 
 	transactionRepository := postgres.NewTransactionRepository(db)
 	transactionService := service.NewTransactionService(transactionRepository, cfg.Stellar().HorizonURL())
+	// Balance is moved only after a deposit/withdrawal is confirmed on-chain
+	// (issue #496); the vault repository applies it idempotently by tx hash.
+	transactionService.SetBalanceApplier(vaultRepository)
 	transactionHandler := handler.NewTransactionHandler(transactionService)
 
 	settlementRepository := postgres.NewSettlementRepository(db)

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/golang-migrate/migrate/v4"
 	migratedb "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -189,6 +190,25 @@ func run() error {
 		}
 	}()
 
+	// Background reconciliation of pending transactions: polls Horizon so a
+	// transaction's status is confirmed even when the client never calls
+	// GET /api/v1/transactions/{hash}. Broadcasts a WebSocket event on change.
+	txPoller := service.NewTransactionPoller(
+		service.TransactionPollerConfig{
+			Enabled:  cfg.TransactionPoller().Enabled(),
+			Interval: cfg.TransactionPoller().Interval(),
+			MinAge:   cfg.TransactionPoller().MinAge(),
+		},
+		transactionService,
+		func(_ context.Context, tx transaction.Transaction) {
+			wsHub.BroadcastEvent(transactionStatusEvent(tx))
+		},
+		baseLogger.WithGroup("tx-poller"),
+	)
+	pollerCtx, cancelPoller := context.WithCancel(context.Background())
+	defer cancelPoller()
+	go txPoller.Run(pollerCtx)
+
 	var ready atomic.Bool
 	ready.Store(true)
 
@@ -332,6 +352,27 @@ func run() error {
 		"uptime", time.Since(startedAt).String(),
 	)
 	return nil
+}
+
+// transactionStatusEvent maps a reconciled transaction to the WebSocket event
+// the dApp listens for on the "vaults:global" channel. Confirmed deposits and
+// withdrawals get their dedicated event type; everything else (failures, other
+// types) uses the generic status_changed event.
+func transactionStatusEvent(tx transaction.Transaction) ws.Event {
+	eventType := ws.EventStatusChanged
+	if tx.Status == transaction.StatusCompleted {
+		switch tx.Type {
+		case transaction.TypeDeposit:
+			eventType = ws.EventDepositConfirmed
+		case transaction.TypeWithdrawal:
+			eventType = ws.EventWithdrawalConfirmed
+		}
+	}
+	return ws.Event{
+		Channel: "vaults:global",
+		Type:    eventType,
+		Data:    tx,
+	}
 }
 
 func walletKeyFromContext(r *http.Request) string {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -27,6 +27,15 @@ type Config struct {
 	performance           PerformanceConfig
 	startup               StartupConfig
 	bank                  BankConfig
+	transactionPoller     TransactionPollerConfig
+}
+
+// TransactionPollerConfig governs the background loop that reconciles pending
+// transactions against Horizon (see internal/service.TransactionPoller).
+type TransactionPollerConfig struct {
+	enabled  bool
+	interval time.Duration
+	minAge   time.Duration
 }
 
 // StartupConfig governs one-shot work performed before the server begins
@@ -169,6 +178,11 @@ func Load() (*Config, error) {
 			paystackKey:    loader.stringDefault("PAYSTACK_SECRET_KEY", ""),
 			flutterwaveKey: loader.stringDefault("FLUTTERWAVE_SECRET_KEY", ""),
 		},
+		transactionPoller: TransactionPollerConfig{
+			enabled:  loader.boolDefault("TX_POLLER_ENABLED", true),
+			interval: loader.durationDefault("TX_POLLER_INTERVAL", 15*time.Second),
+			minAge:   loader.durationDefault("TX_POLLER_MIN_AGE", 30*time.Second),
+		},
 	}
 
 	cfg.validate(&loader)
@@ -258,6 +272,22 @@ func (r RedisConfig) Addr() string {
 
 func (c Config) Bank() BankConfig {
 	return c.bank
+}
+
+func (c Config) TransactionPoller() TransactionPollerConfig {
+	return c.transactionPoller
+}
+
+func (t TransactionPollerConfig) Enabled() bool {
+	return t.enabled
+}
+
+func (t TransactionPollerConfig) Interval() time.Duration {
+	return t.interval
+}
+
+func (t TransactionPollerConfig) MinAge() time.Duration {
+	return t.minAge
 }
 
 func (b BankConfig) PaystackKey() string {
@@ -365,6 +395,14 @@ func (c *Config) validate(loader *envLoader) {
 
 	if c.performance.snapshotInterval <= 0 {
 		loader.addError("PERFORMANCE_SNAPSHOT_INTERVAL must be greater than 0")
+	}
+
+	if c.transactionPoller.interval <= 0 {
+		loader.addError("TX_POLLER_INTERVAL must be greater than 0")
+	}
+
+	if c.transactionPoller.minAge < 0 {
+		loader.addError("TX_POLLER_MIN_AGE must not be negative")
 	}
 }
 

--- a/apps/api/internal/domain/transaction/model.go
+++ b/apps/api/internal/domain/transaction/model.go
@@ -50,4 +50,9 @@ type Repository interface {
 	Upsert(ctx context.Context, model Transaction) (Transaction, error)
 	GetByHash(ctx context.Context, hash string) (Transaction, error)
 	UpdateStatus(ctx context.Context, hash string, status TransactionStatus, confirmedAt *time.Time, errorReason string) (Transaction, error)
+	// ListPendingOlderThan returns every transaction still in StatusPending
+	// whose created_at is at or before cutoff. The background poller uses it
+	// to find transactions that have had time to settle on-chain but were
+	// never reconciled (e.g. the client never polled GET /transactions/{hash}).
+	ListPendingOlderThan(ctx context.Context, cutoff time.Time) ([]Transaction, error)
 }

--- a/apps/api/internal/repository/postgres/transaction_repository.go
+++ b/apps/api/internal/repository/postgres/transaction_repository.go
@@ -75,6 +75,37 @@ func (r *TransactionRepository) GetByHash(ctx context.Context, hash string) (tra
 	return model, nil
 }
 
+func (r *TransactionRepository) ListPendingOlderThan(ctx context.Context, cutoff time.Time) ([]transaction.Transaction, error) {
+	query := `
+		SELECT id, vault_id, type, amount, currency, tx_hash, status, error_reason, created_at, updated_at, confirmed_at
+		FROM transactions
+		WHERE status = $1
+		  AND tx_hash IS NOT NULL
+		  AND created_at <= $2
+		ORDER BY created_at ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, string(transaction.StatusPending), cutoff)
+	if err != nil {
+		return nil, mapTransactionError(err)
+	}
+	defer rows.Close()
+
+	var transactions []transaction.Transaction
+	for rows.Next() {
+		model, err := scanTransaction(rows)
+		if err != nil {
+			return nil, mapTransactionError(err)
+		}
+		transactions = append(transactions, model)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, mapTransactionError(err)
+	}
+
+	return transactions, nil
+}
+
 func (r *TransactionRepository) UpdateStatus(ctx context.Context, hash string, status transaction.TransactionStatus, confirmedAt *time.Time, errorReason string) (transaction.Transaction, error) {
 	result, err := r.db.ExecContext(
 		ctx,

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -388,6 +388,92 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, am
 	return tx.Commit()
 }
 
+// ApplyConfirmedDeposit credits a vault's balance for a deposit that has been
+// confirmed on-chain. It is keyed by the Stellar transaction hash and is
+// idempotent: a second call with the same hash is a no-op (no balance change,
+// no duplicate ledger row), so the auto-confirmation worker can safely retry.
+// This is the only path that credits balance from a confirmed deposit —
+// balance is never moved at submission time.
+func (r *VaultRepository) ApplyConfirmedDeposit(ctx context.Context, id uuid.UUID, amount decimal.Decimal, txHash string) error {
+	return r.applyConfirmedBalanceChange(ctx, id, amount, txHash, "deposit")
+}
+
+// ApplyConfirmedWithdrawal debits a vault's balance for a withdrawal confirmed
+// on-chain. Idempotent on txHash, mirroring ApplyConfirmedDeposit.
+func (r *VaultRepository) ApplyConfirmedWithdrawal(ctx context.Context, id uuid.UUID, amount decimal.Decimal, txHash string) error {
+	return r.applyConfirmedBalanceChange(ctx, id, amount, txHash, "withdrawal")
+}
+
+func (r *VaultRepository) applyConfirmedBalanceChange(ctx context.Context, id uuid.UUID, amount decimal.Decimal, txHash, txType string) error {
+	if amount.Cmp(decimal.Zero) <= 0 {
+		return vault.ErrInvalidAmount
+	}
+	if strings.TrimSpace(txHash) == "" {
+		// Without a hash we cannot dedupe, and a confirmed on-chain change
+		// always has one. Refuse rather than risk a double credit.
+		return vault.ErrInvalidVault
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Claim the hash first. If another worker (or an earlier retry) already
+	// applied this transaction, the insert affects zero rows and we leave the
+	// balance untouched.
+	ledger, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO vault_transactions (vault_id, type, amount, transaction_hash)
+		 VALUES ($1, $2, $3::numeric, $4)
+		 ON CONFLICT (transaction_hash) DO NOTHING`,
+		id.String(),
+		txType,
+		amount.String(),
+		txHash,
+	)
+	if err != nil {
+		return mapRepositoryError(err)
+	}
+	inserted, err := ledger.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 0 {
+		// Already applied for this hash — idempotent no-op.
+		return tx.Commit()
+	}
+
+	var balanceSQL string
+	if txType == "deposit" {
+		balanceSQL = `UPDATE vaults
+			 SET total_deposited = total_deposited + $2::numeric,
+			     current_balance = current_balance + $2::numeric,
+			     updated_at = NOW()
+			 WHERE id = $1 AND deleted_at IS NULL`
+	} else {
+		balanceSQL = `UPDATE vaults
+			 SET current_balance = current_balance - $2::numeric,
+			     updated_at = NOW()
+			 WHERE id = $1 AND deleted_at IS NULL`
+	}
+
+	result, err := tx.ExecContext(ctx, balanceSQL, id.String(), amount.String())
+	if err != nil {
+		return mapRepositoryError(err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return vault.ErrVaultNotFound
+	}
+
+	return tx.Commit()
+}
+
 // SoftDeleteVault stamps deleted_at so reads exclude this vault going forward.
 func (r *VaultRepository) SoftDeleteVault(ctx context.Context, id uuid.UUID) error {
 	result, err := r.db.ExecContext(

--- a/apps/api/internal/service/transaction_balance_test.go
+++ b/apps/api/internal/service/transaction_balance_test.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+// fakeBalanceApplier records confirmed balance applications and can be made to
+// fail to exercise the retry/no-double-apply path.
+type fakeBalanceApplier struct {
+	mu          sync.Mutex
+	deposits    []balanceCall
+	withdrawals []balanceCall
+	err         error
+}
+
+type balanceCall struct {
+	vaultID uuid.UUID
+	amount  decimal.Decimal
+	hash    string
+}
+
+func (f *fakeBalanceApplier) ApplyConfirmedDeposit(_ context.Context, vaultID uuid.UUID, amount decimal.Decimal, hash string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.deposits = append(f.deposits, balanceCall{vaultID, amount, hash})
+	return nil
+}
+
+func (f *fakeBalanceApplier) ApplyConfirmedWithdrawal(_ context.Context, vaultID uuid.UUID, amount decimal.Decimal, hash string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.withdrawals = append(f.withdrawals, balanceCall{vaultID, amount, hash})
+	return nil
+}
+
+func (f *fakeBalanceApplier) depositCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.deposits)
+}
+
+func (f *fakeBalanceApplier) withdrawalCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.withdrawals)
+}
+
+func newConfirmedHorizon(t *testing.T, hash string, successful bool) string {
+	t.Helper()
+	resp := horizonTransactionResponse{CreatedAt: time.Now().UTC().Format(time.RFC3339), Successful: successful}
+	if !successful {
+		resp.ResultXdr = "AAAAreverted"
+	}
+	srv := horizonStub(t, map[string]horizonTransactionResponse{hash: resp})
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestConfirmedDeposit_CreditsBalanceThenMarksCompleted(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "dep-confirm", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+	svc := NewTransactionService(repo, newConfirmedHorizon(t, "dep-confirm", true))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "dep-confirm")
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("status = %q, want completed", stored.Status)
+	}
+	if applier.depositCount() != 1 {
+		t.Fatalf("expected 1 deposit credit, got %d", applier.depositCount())
+	}
+	if applier.deposits[0].vaultID != tx.VaultID || !applier.deposits[0].amount.Equal(tx.Amount) || applier.deposits[0].hash != "dep-confirm" {
+		t.Errorf("unexpected deposit credit: %+v", applier.deposits[0])
+	}
+}
+
+func TestConfirmedWithdrawal_DebitsBalance(t *testing.T) {
+	tx := newPendingTx(transaction.TypeWithdrawal, "wd-confirm", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+	svc := NewTransactionService(repo, newConfirmedHorizon(t, "wd-confirm", true))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "wd-confirm")
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("status = %q, want completed", stored.Status)
+	}
+	if applier.withdrawalCount() != 1 || applier.depositCount() != 0 {
+		t.Fatalf("expected 1 withdrawal debit and 0 deposits, got %d / %d", applier.withdrawalCount(), applier.depositCount())
+	}
+}
+
+// Criterion 5: Soroban returned a successful submission (the tx exists on
+// Horizon) but the ledger result is a failure. The DB must show failed, and
+// the balance must never be touched.
+func TestSuccessfulSubmitButFailedLedger_MarksFailedAndLeavesBalanceUntouched(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "dep-revert", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+	svc := NewTransactionService(repo, newConfirmedHorizon(t, "dep-revert", false))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "dep-revert")
+	if stored.Status != transaction.StatusFailed {
+		t.Fatalf("status = %q, want failed", stored.Status)
+	}
+	if stored.Status == transaction.StatusCompleted {
+		t.Fatal("a failed ledger result must never be recorded as completed")
+	}
+	if stored.ErrorReason == "" {
+		t.Error("expected a failure reason to be recorded")
+	}
+	if applier.depositCount() != 0 || applier.withdrawalCount() != 0 {
+		t.Fatalf("balance must not move for a failed transaction; deposits=%d withdrawals=%d",
+			applier.depositCount(), applier.withdrawalCount())
+	}
+}
+
+// If the balance application fails, the transaction must stay pending so the
+// next poll retries — it must NOT be marked completed (which would strand the
+// balance forever). The idempotent applier makes the retry safe.
+func TestBalanceApplyFailure_LeavesTransactionPendingForRetry(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "dep-retry", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+	svc := NewTransactionService(repo, newConfirmedHorizon(t, "dep-retry", true))
+	applier := &fakeBalanceApplier{err: errors.New("vault db unavailable")}
+	svc.SetBalanceApplier(applier)
+
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+
+	poller.Tick(context.Background())
+	stored, _ := repo.GetByHash(context.Background(), "dep-retry")
+	if stored.Status != transaction.StatusPending {
+		t.Fatalf("after a failed balance apply, status = %q, want pending", stored.Status)
+	}
+
+	// Recover and retry — now it should confirm and credit.
+	applier.mu.Lock()
+	applier.err = nil
+	applier.mu.Unlock()
+
+	poller.Tick(context.Background())
+	stored, _ = repo.GetByHash(context.Background(), "dep-retry")
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("after recovery, status = %q, want completed", stored.Status)
+	}
+	if applier.depositCount() != 1 {
+		t.Fatalf("expected exactly 1 successful credit after retry, got %d", applier.depositCount())
+	}
+}
+
+// Initial registration must always be pending and must never move balance.
+func TestRegisterTransaction_AlwaysPendingNoBalance(t *testing.T) {
+	repo := newFakeTransactionRepo()
+	svc := NewTransactionService(repo, "")
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+
+	tx, err := svc.RegisterTransaction(context.Background(), RegisterTransactionInput{
+		VaultID:  uuid.New(),
+		Type:     transaction.TypeDeposit,
+		Amount:   decimal.NewFromInt(100),
+		Currency: "USDC",
+		TxHash:   "reg-1",
+	})
+	if err != nil {
+		t.Fatalf("RegisterTransaction: %v", err)
+	}
+	if tx.Status != transaction.StatusPending {
+		t.Fatalf("status = %q, want pending", tx.Status)
+	}
+	if applier.depositCount() != 0 || applier.withdrawalCount() != 0 {
+		t.Fatal("registration must not move balance")
+	}
+}

--- a/apps/api/internal/service/transaction_poller.go
+++ b/apps/api/internal/service/transaction_poller.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+// TransactionStatusNotifier is invoked once per transaction whose status
+// transitions to a terminal state during a poll. The production wiring in
+// main.go broadcasts a WebSocket event; tests pass a recorder. Implementations
+// must not block — the poller calls it inline on the tick goroutine.
+type TransactionStatusNotifier func(ctx context.Context, tx transaction.Transaction)
+
+// TransactionPollerConfig controls the background reconciliation loop. Fields
+// are read once at construction; changes require a restart. Sourced from env in
+// main.go (TX_POLLER_ENABLED, TX_POLLER_INTERVAL, TX_POLLER_MIN_AGE).
+type TransactionPollerConfig struct {
+	Enabled bool
+	// Interval between poll ticks. Defaults to 15s when non-positive.
+	Interval time.Duration
+	// MinAge is the minimum age a transaction must reach before it is polled,
+	// giving Horizon time to ingest a freshly submitted transaction. Defaults
+	// to 30s when non-positive.
+	MinAge time.Duration
+}
+
+const (
+	defaultPollerInterval = 15 * time.Second
+	defaultPollerMinAge   = 30 * time.Second
+)
+
+// TransactionPoller periodically reconciles pending transactions against
+// Horizon so their status is updated even when the client never polls
+// GET /api/v1/transactions/{hash}. Construct with NewTransactionPoller, then
+// call Run from a goroutine alongside the API server; Run returns when the
+// context is cancelled.
+type TransactionPoller struct {
+	cfg         TransactionPollerConfig
+	service     *TransactionService
+	notify      TransactionStatusNotifier
+	logger      *slog.Logger
+	lastTickEnd atomic.Int64 // unix nanos; observability hook
+}
+
+// NewTransactionPoller builds a poller. logger may be nil (a discarding logger
+// is used). notify may be nil (status changes are persisted but not broadcast).
+func NewTransactionPoller(cfg TransactionPollerConfig, svc *TransactionService, notify TransactionStatusNotifier, logger *slog.Logger) *TransactionPoller {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(pollerDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	if notify == nil {
+		notify = func(context.Context, transaction.Transaction) {}
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultPollerInterval
+	}
+	if cfg.MinAge <= 0 {
+		cfg.MinAge = defaultPollerMinAge
+	}
+	return &TransactionPoller{
+		cfg:     cfg,
+		service: svc,
+		notify:  notify,
+		logger:  logger,
+	}
+}
+
+// Run drives the loop until ctx is cancelled. When Config.Enabled is false, Run
+// returns immediately so main.go can call it unconditionally.
+func (p *TransactionPoller) Run(ctx context.Context) {
+	if !p.cfg.Enabled {
+		p.logger.Info("transaction poller disabled; not starting")
+		return
+	}
+	p.logger.Info("transaction poller starting", "interval", p.cfg.Interval, "min_age", p.cfg.MinAge)
+
+	// Run once immediately so a restart picks up any backlog without waiting
+	// for the first tick.
+	p.Tick(ctx)
+
+	ticker := time.NewTicker(p.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("transaction poller stopping")
+			return
+		case <-ticker.C:
+			p.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single reconciliation pass: it lists pending transactions older
+// than MinAge, checks each against Horizon, and notifies for any that reached a
+// terminal state. A failure on one transaction is logged and skipped so the
+// rest of the batch still makes progress. Exported for tests.
+func (p *TransactionPoller) Tick(ctx context.Context) {
+	defer p.lastTickEnd.Store(time.Now().UnixNano())
+
+	pending, err := p.service.ListPendingOlderThan(ctx, p.cfg.MinAge)
+	if err != nil {
+		p.logger.Error("transaction poller: list pending failed", "error", err)
+		return
+	}
+
+	for _, tx := range pending {
+		updated, changed, err := p.service.ReconcileTransaction(ctx, tx)
+		if err != nil {
+			p.logger.Warn("transaction poller: reconcile failed",
+				"tx_hash", tx.TxHash,
+				"error", err,
+			)
+			continue
+		}
+		if !changed {
+			continue
+		}
+		p.logger.Info("transaction poller: status reconciled",
+			"tx_hash", updated.TxHash,
+			"vault_id", updated.VaultID,
+			"type", updated.Type,
+			"status", updated.Status,
+		)
+		p.notify(ctx, updated)
+	}
+}
+
+// LastTickEnd returns the wall-clock time of the last completed tick, or zero
+// if the loop has not ticked yet.
+func (p *TransactionPoller) LastTickEnd() time.Time {
+	v := p.lastTickEnd.Load()
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v)
+}
+
+// pollerDiscardWriter is the io.Writer slog fallback when NewTransactionPoller
+// is called with a nil logger.
+type pollerDiscardWriter struct{}
+
+func (pollerDiscardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/apps/api/internal/service/transaction_poller_test.go
+++ b/apps/api/internal/service/transaction_poller_test.go
@@ -1,0 +1,287 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+// fakeTransactionRepo is an in-memory transaction.Repository for poller tests.
+type fakeTransactionRepo struct {
+	mu  sync.Mutex
+	txs map[string]transaction.Transaction // keyed by tx hash
+}
+
+func newFakeTransactionRepo(seed ...transaction.Transaction) *fakeTransactionRepo {
+	r := &fakeTransactionRepo{txs: make(map[string]transaction.Transaction)}
+	for _, tx := range seed {
+		r.txs[tx.TxHash] = tx
+	}
+	return r
+}
+
+func (r *fakeTransactionRepo) Upsert(_ context.Context, model transaction.Transaction) (transaction.Transaction, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.txs[model.TxHash] = model
+	return model, nil
+}
+
+func (r *fakeTransactionRepo) GetByHash(_ context.Context, hash string) (transaction.Transaction, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tx, ok := r.txs[hash]
+	if !ok {
+		return transaction.Transaction{}, transaction.ErrTransactionNotFound
+	}
+	return tx, nil
+}
+
+func (r *fakeTransactionRepo) UpdateStatus(_ context.Context, hash string, status transaction.TransactionStatus, confirmedAt *time.Time, errorReason string) (transaction.Transaction, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tx, ok := r.txs[hash]
+	if !ok {
+		return transaction.Transaction{}, transaction.ErrTransactionNotFound
+	}
+	tx.Status = status
+	tx.ConfirmedAt = confirmedAt
+	tx.ErrorReason = errorReason
+	tx.UpdatedAt = time.Now().UTC()
+	r.txs[hash] = tx
+	return tx, nil
+}
+
+func (r *fakeTransactionRepo) ListPendingOlderThan(_ context.Context, cutoff time.Time) ([]transaction.Transaction, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []transaction.Transaction
+	for _, tx := range r.txs {
+		if tx.Status == transaction.StatusPending && tx.TxHash != "" && !tx.CreatedAt.After(cutoff) {
+			out = append(out, tx)
+		}
+	}
+	return out, nil
+}
+
+// horizonStub returns a Horizon server that responds to GET /transactions/{hash}
+// based on the provided per-hash responses. A hash with no entry returns 404
+// (Horizon's "not yet ingested / still pending" signal).
+func horizonStub(t *testing.T, successByHash map[string]horizonTransactionResponse) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hash := strings.TrimPrefix(r.URL.Path, "/transactions/")
+		resp, ok := successByHash[hash]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"successful":` + boolStr(resp.Successful) +
+			`,"created_at":"` + resp.CreatedAt + `","result_xdr":"` + resp.ResultXdr + `"}`))
+	}))
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+type recordingNotifier struct {
+	mu    sync.Mutex
+	calls []transaction.Transaction
+}
+
+func (n *recordingNotifier) notify(_ context.Context, tx transaction.Transaction) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, tx)
+}
+
+func newPendingTx(txType transaction.TransactionType, hash string, age time.Duration) transaction.Transaction {
+	now := time.Now().UTC()
+	return transaction.Transaction{
+		ID:        uuid.New(),
+		VaultID:   uuid.New(),
+		Type:      txType,
+		Amount:    decimal.NewFromInt(100),
+		Currency:  "USDC",
+		TxHash:    hash,
+		Status:    transaction.StatusPending,
+		CreatedAt: now.Add(-age),
+		UpdatedAt: now.Add(-age),
+	}
+}
+
+func TestTransactionPoller_Tick_ConfirmsPendingTransaction(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "abc123", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, map[string]horizonTransactionResponse{
+		"abc123": {Successful: true, CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+	})
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	notifier := &recordingNotifier{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc,
+		notifier.notify,
+		nil,
+	)
+
+	poller.Tick(context.Background())
+
+	stored, err := repo.GetByHash(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("GetByHash: %v", err)
+	}
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("expected status completed, got %q", stored.Status)
+	}
+	if stored.ConfirmedAt == nil {
+		t.Fatal("expected confirmed_at to be set")
+	}
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 broadcast, got %d", len(notifier.calls))
+	}
+	if notifier.calls[0].Status != transaction.StatusCompleted || notifier.calls[0].TxHash != "abc123" {
+		t.Errorf("unexpected broadcast payload: %+v", notifier.calls[0])
+	}
+}
+
+func TestTransactionPoller_Tick_MarksFailedTransaction(t *testing.T) {
+	tx := newPendingTx(transaction.TypeWithdrawal, "fail99", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, map[string]horizonTransactionResponse{
+		"fail99": {Successful: false, CreatedAt: time.Now().UTC().Format(time.RFC3339), ResultXdr: "AAAA"},
+	})
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	notifier := &recordingNotifier{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, notifier.notify, nil,
+	)
+
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "fail99")
+	if stored.Status != transaction.StatusFailed {
+		t.Fatalf("expected status failed, got %q", stored.Status)
+	}
+	if len(notifier.calls) != 1 || notifier.calls[0].Status != transaction.StatusFailed {
+		t.Fatalf("expected a single failed broadcast, got %+v", notifier.calls)
+	}
+}
+
+func TestTransactionPoller_Tick_SkipsTransactionsYoungerThanMinAge(t *testing.T) {
+	// 5s old, MinAge 30s — must not even be listed, so Horizon is never hit.
+	tx := newPendingTx(transaction.TypeDeposit, "fresh1", 5*time.Second)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, map[string]horizonTransactionResponse{
+		"fresh1": {Successful: true, CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+	})
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	notifier := &recordingNotifier{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, notifier.notify, nil,
+	)
+
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "fresh1")
+	if stored.Status != transaction.StatusPending {
+		t.Errorf("young tx should remain pending, got %q", stored.Status)
+	}
+	if len(notifier.calls) != 0 {
+		t.Errorf("no broadcast expected for young tx, got %d", len(notifier.calls))
+	}
+}
+
+func TestTransactionPoller_Tick_LeavesStillPendingOnChainUntouched(t *testing.T) {
+	// Old enough to poll, but Horizon returns 404 (not yet ingested).
+	tx := newPendingTx(transaction.TypeDeposit, "pend42", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, nil) // every hash 404s
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	notifier := &recordingNotifier{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, notifier.notify, nil,
+	)
+
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "pend42")
+	if stored.Status != transaction.StatusPending {
+		t.Errorf("expected still pending, got %q", stored.Status)
+	}
+	if len(notifier.calls) != 0 {
+		t.Errorf("no broadcast expected, got %d", len(notifier.calls))
+	}
+}
+
+func TestTransactionPoller_Run_StopsOnContextCancel(t *testing.T) {
+	repo := newFakeTransactionRepo()
+	svc := NewTransactionService(repo, "")
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: 10 * time.Millisecond, MinAge: 0},
+		svc, nil, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		poller.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+		// Run returned promptly on cancellation — clean shutdown.
+	case <-time.After(time.Second):
+		t.Fatal("poller did not stop within 1s of context cancellation")
+	}
+}
+
+func TestTransactionPoller_Run_NoOpWhenDisabled(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "off001", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+	svc := NewTransactionService(repo, "")
+	notifier := &recordingNotifier{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: false},
+		svc, notifier.notify, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // disabled Run must return immediately regardless
+	poller.Run(ctx)
+
+	if len(notifier.calls) != 0 {
+		t.Errorf("disabled poller must never broadcast, got %d", len(notifier.calls))
+	}
+}

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -15,10 +15,25 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 )
 
+// VaultBalanceApplier credits or debits a vault's balance for a transaction
+// that has been confirmed on-chain. Implementations MUST be idempotent on
+// txHash so a retried confirmation never double-applies. The production
+// implementation is the Postgres vault repository; tests pass a fake.
+//
+// This is the single boundary through which a vault balance ever moves as a
+// result of a deposit/withdrawal: balance is applied only after Horizon
+// reports the transaction in a closed, successful ledger — never at submission
+// time (issue #496).
+type VaultBalanceApplier interface {
+	ApplyConfirmedDeposit(ctx context.Context, vaultID uuid.UUID, amount decimal.Decimal, txHash string) error
+	ApplyConfirmedWithdrawal(ctx context.Context, vaultID uuid.UUID, amount decimal.Decimal, txHash string) error
+}
+
 type TransactionService struct {
 	repository transaction.Repository
 	horizonURL  string
 	client      *http.Client
+	balance     VaultBalanceApplier
 }
 
 type RegisterTransactionInput struct {
@@ -37,6 +52,14 @@ func NewTransactionService(repository transaction.Repository, horizonURL string)
 			Timeout: 10 * time.Second,
 		},
 	}
+}
+
+// SetBalanceApplier wires the vault balance applier used to credit/debit a
+// vault once a deposit/withdrawal is confirmed on-chain. Optional: when unset,
+// status is still reconciled but no balance is moved (used by tests that only
+// exercise status transitions).
+func (s *TransactionService) SetBalanceApplier(applier VaultBalanceApplier) {
+	s.balance = applier
 }
 
 func (s *TransactionService) RegisterTransaction(ctx context.Context, input RegisterTransactionInput) (transaction.Transaction, error) {
@@ -110,7 +133,22 @@ func (s *TransactionService) ReconcileTransaction(ctx context.Context, model tra
 	}
 
 	switch horizonStatus {
-	case transaction.StatusCompleted, transaction.StatusFailed:
+	case transaction.StatusCompleted:
+		// Credit/debit the vault BEFORE marking the transaction completed.
+		// If the balance change fails, we return the error and leave the
+		// transaction pending so the next poll retries; the applier is
+		// idempotent, so a retry after a partial failure cannot double-apply.
+		if err := s.applyConfirmedBalance(ctx, model); err != nil {
+			return model, false, err
+		}
+		updated, updateErr := s.repository.UpdateStatus(ctx, model.TxHash, horizonStatus, confirmedAt, errorReason)
+		if updateErr != nil {
+			return model, false, updateErr
+		}
+		return updated, true, nil
+	case transaction.StatusFailed:
+		// Failed/reverted on-chain: record the failure reason and never touch
+		// the balance.
 		updated, updateErr := s.repository.UpdateStatus(ctx, model.TxHash, horizonStatus, confirmedAt, errorReason)
 		if updateErr != nil {
 			return model, false, updateErr
@@ -118,6 +156,23 @@ func (s *TransactionService) ReconcileTransaction(ctx context.Context, model tra
 		return updated, true, nil
 	default:
 		return model, false, nil
+	}
+}
+
+// applyConfirmedBalance moves the vault balance for a confirmed deposit or
+// withdrawal. It is a no-op for other transaction types (e.g. settlement) and
+// when no applier is configured.
+func (s *TransactionService) applyConfirmedBalance(ctx context.Context, model transaction.Transaction) error {
+	if s.balance == nil {
+		return nil
+	}
+	switch model.Type {
+	case transaction.TypeDeposit:
+		return s.balance.ApplyConfirmedDeposit(ctx, model.VaultID, model.Amount, model.TxHash)
+	case transaction.TypeWithdrawal:
+		return s.balance.ApplyConfirmedWithdrawal(ctx, model.VaultID, model.Amount, model.TxHash)
+	default:
+		return nil
 	}
 }
 

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -73,28 +73,51 @@ func (s *TransactionService) GetTransaction(ctx context.Context, hash string) (t
 		return transaction.Transaction{}, err
 	}
 
+	updated, _, err := s.ReconcileTransaction(ctx, model)
+	if err != nil {
+		return transaction.Transaction{}, err
+	}
+	return updated, nil
+}
+
+// ListPendingOlderThan returns transactions still pending whose age exceeds
+// minAge. The background poller calls this each tick; minAge keeps freshly
+// submitted transactions (which Horizon hasn't ingested yet) out of the batch.
+func (s *TransactionService) ListPendingOlderThan(ctx context.Context, minAge time.Duration) ([]transaction.Transaction, error) {
+	cutoff := time.Now().UTC().Add(-minAge)
+	return s.repository.ListPendingOlderThan(ctx, cutoff)
+}
+
+// ReconcileTransaction checks the on-chain status of a single transaction
+// against Horizon and persists a terminal status (completed/failed) if one has
+// been reached. It returns the latest transaction view and whether the status
+// actually changed. Transactions already in a terminal state, and those still
+// pending on-chain, are returned unchanged with changed=false. This is the
+// single source of truth for status reconciliation, shared by GetTransaction
+// (on-demand) and the background poller.
+func (s *TransactionService) ReconcileTransaction(ctx context.Context, model transaction.Transaction) (transaction.Transaction, bool, error) {
 	switch model.Status {
 	case transaction.StatusCompleted, transaction.StatusFailed:
-		return model, nil
+		return model, false, nil
 	}
 
-	horizonStatus, confirmedAt, errorReason, err := s.lookupHorizonTransaction(ctx, hash)
+	horizonStatus, confirmedAt, errorReason, err := s.lookupHorizonTransaction(ctx, model.TxHash)
 	if err != nil {
 		if errors.Is(err, errTransactionPending) {
-			return model, nil
+			return model, false, nil
 		}
-		return transaction.Transaction{}, err
+		return model, false, err
 	}
 
 	switch horizonStatus {
 	case transaction.StatusCompleted, transaction.StatusFailed:
-		updated, updateErr := s.repository.UpdateStatus(ctx, hash, horizonStatus, confirmedAt, errorReason)
+		updated, updateErr := s.repository.UpdateStatus(ctx, model.TxHash, horizonStatus, confirmedAt, errorReason)
 		if updateErr != nil {
-			return transaction.Transaction{}, updateErr
+			return model, false, updateErr
 		}
-		return updated, nil
+		return updated, true, nil
 	default:
-		return model, nil
+		return model, false, nil
 	}
 }
 

--- a/apps/api/migrations/023_vault_transactions_hash_unique.down.sql
+++ b/apps/api/migrations/023_vault_transactions_hash_unique.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_vault_transactions_transaction_hash_unique;

--- a/apps/api/migrations/023_vault_transactions_hash_unique.up.sql
+++ b/apps/api/migrations/023_vault_transactions_hash_unique.up.sql
@@ -1,0 +1,7 @@
+-- Enforce a single ledger row per on-chain transaction hash so that confirmed
+-- deposit/withdrawal balance changes can be applied idempotently (ON CONFLICT)
+-- by the auto-confirmation worker. NULL hashes remain allowed and distinct
+-- (Postgres treats NULLs as distinct in a unique index), so legacy rows without
+-- a hash are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vault_transactions_transaction_hash_unique
+    ON vault_transactions (transaction_hash);


### PR DESCRIPTION
## Summary

Closes #496.

> **Depends on / stacked on #545 (issue #492).** This branch builds on the auto-confirmation poller from #545, so until that merges this PR's diff includes its commit (`feat(api): auto-confirm pending transactions via background poller`) in addition to the #496 change. Once #545 merges into `main`, only the #496 commit will remain. Reviewers may prefer to merge #545 first.

Vault balances were at risk of being credited/debited on the strength of a Soroban *submission* alone. A submitted transaction can still fail on-chain (fee spike, sequence error, contract revert), which would let the database diverge from chain state — a user could see a credited balance while no USDC actually moved (double-spend risk).

This change makes on-chain confirmation a hard precondition for any balance movement.

## Flow

`submit → save status=pending → auto-confirmation worker polls Horizon → verify closed/successful ledger → THEN credit/debit balance + mark completed` (failed ledger → `failed` + reason, balance untouched).

## Changes (the #496 commit)

- **`TransactionService`** gains an optional `VaultBalanceApplier`. In `ReconcileTransaction`, a confirmed (`completed`) deposit/withdrawal credits/debits the vault **before** the transaction is marked completed; if the balance change fails, the transaction stays `pending` and is retried on the next poll. A failed ledger result records the failure reason and never touches the balance.
- **`VaultRepository.ApplyConfirmedDeposit` / `ApplyConfirmedWithdrawal`** apply the change **idempotently**, keyed by the Stellar tx hash via `ON CONFLICT`, so a retried confirmation cannot double-apply.
- **Migration 023** adds the unique index on `vault_transactions.transaction_hash` backing that idempotency. NULL hashes remain allowed/distinct, so legacy rows are unaffected.
- **`main.go`** wires the vault repository as the applier.

## Acceptance criteria

- [x] Initial transaction save always uses `status = pending` (unchanged; covered by a regression test)
- [x] Balance is only credited/debited after on-chain confirmation
- [x] Failed transactions update to `status = failed` with a failure reason; balance untouched
- [x] Confirmation polling handled by the auto-confirmation worker (#492 / #545)
- [x] Test: mock a successful submission but a **failed ledger result** → DB shows `failed`, not `completed`, and balance never moves

## Testing

`go build ./...`, `go vet`, and the `service` + `postgres` unit tests pass. New tests: confirmed deposit credits / withdrawal debits; **successful submit but failed ledger → failed + balance untouched** (acceptance criterion); balance-apply failure leaves the tx pending for a safe idempotent retry; registration is always pending and never moves balance.

## Notes

The idempotency index assumes no pre-existing duplicate non-NULL `transaction_hash` rows in `vault_transactions`; on a fresh schema this is a no-op concern. The legacy `VaultService.RecordDeposit/RecordWithdrawal` immediate-credit helpers are currently unwired to any HTTP endpoint and are left untouched here; the live deposit/withdraw lifecycle now flows through the confirmation-gated path above.