### PR TITLE
fix(contracts): enforce rebalance delta conservation and add e2e lifecycle tests

### DIFF
--- a/packages/contracts/contracts/allocation_strategy/src/lib.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/lib.rs
@@ -381,6 +381,19 @@ impl AllocationStrategyContract {
             }
         }
 
+        // Enforce delta conservation: the sum of all deltas must equal zero.
+        // A non-zero sum means `total` does not match the sum of
+        // `current_allocations`, which would create or destroy funds.
+        let mut delta_sum: i128 = 0;
+        for d in deltas.iter() {
+            delta_sum = delta_sum
+                .checked_add(d.delta)
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::ArithmeticOverflow));
+        }
+        if delta_sum != 0 {
+            panic_with_error!(&env, ContractError::AllocationError);
+        }
+
         deltas
     }
 

--- a/packages/contracts/contracts/allocation_strategy/src/test.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/test.rs
@@ -741,6 +741,162 @@ fn suggest_weights_uses_apy_and_risk_scores() {
     assert_eq!(weight_for(&suggested, symbol_short!("comp")), 3_030);
 }
 
+// ---------------------------------------------------------------------------
+// Issue #507 — rebalance delta conservation
+// ---------------------------------------------------------------------------
+
+fn delta_sum(deltas: &soroban_sdk::Vec<AllocationDelta>) -> i128 {
+    let mut sum = 0_i128;
+    for d in deltas.iter() {
+        sum += d.delta;
+    }
+    sum
+}
+
+fn delta_for(deltas: &soroban_sdk::Vec<AllocationDelta>, id: soroban_sdk::Symbol) -> i128 {
+    for d in deltas.iter() {
+        if d.source_id == id {
+            return d.delta;
+        }
+    }
+    0
+}
+
+/// Balanced rebalance: total == sum(current_allocations).
+/// With weights 50%/30%/20% and current [700,150,150] (sum=1000),
+/// deltas are [-200, +150, +50] — exactly zero sum.
+#[test]
+fn rebalance_deltas_sum_to_zero_for_balanced_rebalance() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    client.set_weights(
+        &admin,
+        &vec![
+            &env,
+            AllocationWeight {
+                source_id: symbol_short!("aave"),
+                weight_bps: 5_000,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("blend"),
+                weight_bps: 3_000,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("comp"),
+                weight_bps: 2_000,
+            },
+        ],
+    );
+
+    let current = vec![
+        &env,
+        CurrentAllocation {
+            source_id: symbol_short!("aave"),
+            amount: 700,
+        },
+        CurrentAllocation {
+            source_id: symbol_short!("blend"),
+            amount: 150,
+        },
+        CurrentAllocation {
+            source_id: symbol_short!("comp"),
+            amount: 150,
+        },
+    ];
+    let deltas = client.calculate_rebalance_deltas(&current, &1_000_i128);
+
+    assert_eq!(delta_sum(&deltas), 0);
+    assert_eq!(delta_for(&deltas, symbol_short!("aave")), -200);
+    assert_eq!(delta_for(&deltas, symbol_short!("blend")), 150);
+    assert_eq!(delta_for(&deltas, symbol_short!("comp")), 50);
+}
+
+/// Unbalanced: total (300) != sum(current_allocations) (400).
+/// Delta sum = 300 - 400 = -100 ≠ 0 → must panic.
+#[test]
+#[should_panic]
+fn rebalance_deltas_panics_when_total_mismatches_current_sum() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    client.set_weights(
+        &admin,
+        &vec![
+            &env,
+            AllocationWeight {
+                source_id: symbol_short!("aave"),
+                weight_bps: 5_000,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("blend"),
+                weight_bps: 5_000,
+            },
+        ],
+    );
+
+    // sum(current) = 400, but total = 300 → delta sum = -100 ≠ 0
+    let current = vec![
+        &env,
+        CurrentAllocation {
+            source_id: symbol_short!("aave"),
+            amount: 300,
+        },
+        CurrentAllocation {
+            source_id: symbol_short!("blend"),
+            amount: 100,
+        },
+    ];
+    client.calculate_rebalance_deltas(&current, &300_i128);
+}
+
+/// Empty current allocations with total=0 → all deltas are zero → succeeds.
+#[test]
+fn rebalance_deltas_empty_allocations_and_zero_total_succeeds() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    client.set_weights(
+        &admin,
+        &vec![
+            &env,
+            AllocationWeight {
+                source_id: symbol_short!("aave"),
+                weight_bps: 5_000,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("blend"),
+                weight_bps: 5_000,
+            },
+        ],
+    );
+
+    let empty: soroban_sdk::Vec<CurrentAllocation> = soroban_sdk::Vec::new(&env);
+    let deltas = client.calculate_rebalance_deltas(&empty, &0_i128);
+
+    assert_eq!(delta_sum(&deltas), 0);
+}
+
+/// Stored allocation weights must always sum to exactly 10_000 bps.
+#[test]
+fn allocation_weights_always_sum_to_ten_thousand_bps() {
+    for vault_type in [
+        VaultType::Conservative,
+        VaultType::Balanced,
+        VaultType::Growth,
+        VaultType::DeFi500,
+    ] {
+        let (env, _, _, strategy_id) = setup_with_type(vault_type);
+        let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+        let weights = client.get_weights();
+        assert_eq!(
+            weight_sum(&weights),
+            10_000,
+            "weights must sum to 10_000 bps"
+        );
+    }
+}
+
 // AllocationStrategy.set_allocations requires operator role — unauthorized callers are rejected.
 #[test]
 #[should_panic]

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -831,11 +831,24 @@ impl VaultContract {
         let strategy = get_allocation_strategy(&env);
         let current = current_allocations_vec(&env);
 
+        // Rebalance only redistributes capital already deployed to sources.
+        // Passing the deployed sum ensures delta conservation (sum == 0) in
+        // the allocation strategy; undeployed vault buffer is not touched.
+        let mut deployed_total: i128 = 0;
+        for a in current.iter() {
+            deployed_total = deployed_total
+                .checked_add(a.amount)
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::ArithmeticOverflow));
+        }
+        if deployed_total <= 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+
         // Fetch deltas from the allocation strategy.
         let deltas: Vec<AllocationDeltaView> = env.invoke_contract(
             &strategy,
             &Symbol::new(&env, "calculate_rebalance_deltas"),
-            (current, total_assets).into_val(&env),
+            (current, deployed_total).into_val(&env),
         );
 
         // Apply each delta to source-allocation bookkeeping. Min-rebalance

--- a/packages/contracts/tests/integration/src/integration/lifecycle_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/lifecycle_tests.rs
@@ -1,0 +1,208 @@
+//! End-to-end integration tests covering the full savings lifecycle.
+//!
+//! Scenarios:
+//!   1. Happy path — deposit → record allocation → rebalance → yield → withdraw
+//!   2. Early-withdrawal penalty — fee charged within min_lock_period
+//!   3. Loss / impairment — no performance fee when vault reports a loss
+//!
+//! Addresses issue #506.
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{symbol_short, testutils::Ledger as _, token, vec};
+
+use allocation_strategy_contract::AllocationWeight;
+use nester_access_control::Role;
+use nester_common::ProtocolType;
+use nester_test_utils::NesterHarness;
+use vault_contract::{CircuitBreakerConfig, FeeConfig};
+
+/// 1 USDC at 7 decimals (MIN_DEPOSIT_AMOUNT).
+const DEPOSIT: i128 = 10_000_000;
+/// 10% simulated yield.
+const YIELD_AMOUNT: i128 = 1_000_000;
+
+/// Configure the vault's fee settings for deterministic test assertions:
+/// - management_fee = 0 (eliminates time-dependent accrual that varies with
+///   ledger timestamps, keeping expected amounts predictable)
+/// - performance_fee = 10 % (1000 bps)
+/// - early_withdrawal_fee = 0.1 % (10 bps)
+fn configure_fees(h: &NesterHarness) {
+    h.vault().set_fee_config(
+        &h.admin,
+        &FeeConfig {
+            performance_fee_bps: 1_000,
+            management_fee_bps: 0,
+            early_withdrawal_fee_bps: 10,
+            treasury_address: h.treasury_id.clone(),
+        },
+    );
+}
+
+/// Disable the circuit breaker so lifecycle tests can withdraw large amounts
+/// without hitting the 20% rolling-window limit.
+fn disable_circuit_breaker(h: &NesterHarness) {
+    h.vault().set_circuit_breaker_config(
+        &h.admin,
+        &CircuitBreakerConfig {
+            threshold_bps: 10_000, // 100 % — effectively off
+            window_seconds: 7_200,
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Happy path — full lifecycle deposit → rebalance → yield → withdraw
+// ---------------------------------------------------------------------------
+
+/// Exercises every cross-contract boundary in the happy path:
+///   vault ↔ vault_token ↔ allocation_strategy ↔ yield_registry
+///
+/// Asserts:
+/// - Shares minted 1:1 on first deposit
+/// - Rebalance applies zero-sum deltas (conservation enforced)
+/// - Yield accrues correctly to share price
+/// - Withdrawal returns deposit + yield - performance fee
+/// - All shares burned after full withdrawal
+#[test]
+fn test_full_lifecycle_deposit_to_withdraw() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    let aave = symbol_short!("aave");
+
+    configure_fees(&h);
+    disable_circuit_breaker(&h);
+
+    // 1. Register yield source, configure strategy weights, wire to vault
+    h.registry()
+        .register_source(&h.admin, &aave, &h.create_user(), &ProtocolType::Lending);
+    h.strategy().set_weights(
+        &h.admin,
+        &vec![
+            &h.env,
+            AllocationWeight {
+                source_id: aave.clone(),
+                weight_bps: 10_000,
+            },
+        ],
+    );
+    h.vault().set_allocation_strategy(&h.admin, &h.strategy_id);
+
+    // 2. User deposits DEPOSIT USDC → shares minted 1:1 on first deposit
+    h.mint_deposit_tokens(&user, DEPOSIT);
+    let shares = h.vault().deposit(&user, &DEPOSIT, &0);
+    assert_eq!(shares, DEPOSIT, "first deposit should mint shares 1:1");
+    assert_eq!(h.token().total_supply(), DEPOSIT);
+    assert_eq!(h.token().total_assets(), DEPOSIT);
+
+    // 3. Admin records that all funds are deployed to aave (bookkeeping)
+    h.vault()
+        .record_source_allocation(&h.admin, &aave, &DEPOSIT);
+
+    // 4. Rebalance — already 100% in aave, delta = 0, no change applied
+    let applied = h.vault().rebalance(&h.admin);
+    assert!(
+        applied.is_empty(),
+        "no rebalance needed when already at target"
+    );
+
+    // 5. Simulate yield returned from aave: mint USDC to vault, then report
+    h.mint_deposit_tokens(&h.vault_id, YIELD_AMOUNT);
+    h.vault().grant_role(&h.admin, &h.admin, &Role::Manager);
+    h.vault().report_yield(&h.admin, &YIELD_AMOUNT);
+    // Update bookkeeping to reflect yield earned in aave
+    h.vault()
+        .record_source_allocation(&h.admin, &aave, &(DEPOSIT + YIELD_AMOUNT));
+
+    assert_eq!(h.token().total_assets(), DEPOSIT + YIELD_AMOUNT);
+
+    // 6. Advance ledger past min_lock_period (86 400 s) → no early-withdrawal fee
+    h.env.ledger().with_mut(|l| l.timestamp = 86_401);
+
+    // 7. User withdraws all shares
+    // Performance fee = 10 % of YIELD_AMOUNT = 100_000
+    let shares_held = h.token().balance(&user);
+    let remaining = h.vault().withdraw(&user, &shares_held, &0);
+    assert_eq!(remaining, 0, "all shares should be burned after full withdrawal");
+    assert_eq!(h.token().total_supply(), 0);
+
+    let perf_fee = YIELD_AMOUNT * 1_000 / 10_000;
+    let expected = DEPOSIT + YIELD_AMOUNT - perf_fee;
+    let user_usdc = token::Client::new(&h.env, &h.deposit_token_id).balance(&user);
+    assert_eq!(
+        user_usdc, expected,
+        "user should receive deposit + yield net of performance fee"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Early-withdrawal penalty
+// ---------------------------------------------------------------------------
+
+/// Withdrawing within the 86 400-second lock period triggers the early-
+/// withdrawal fee (0.1 % by default).
+#[test]
+fn test_early_withdrawal_fee_charged() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    configure_fees(&h);
+    disable_circuit_breaker(&h);
+
+    // Deposit at ledger timestamp 0; no yield; withdraw immediately (t=0 < 86400)
+    h.mint_deposit_tokens(&user, DEPOSIT);
+    h.vault().deposit(&user, &DEPOSIT, &0);
+
+    let shares = h.token().balance(&user);
+    let remaining = h.vault().withdraw(&user, &shares, &0);
+    assert_eq!(remaining, 0, "all shares burned");
+
+    // early_withdrawal_fee_bps = 10 (0.1 %)
+    let early_fee = DEPOSIT * 10 / 10_000;
+    let expected = DEPOSIT - early_fee;
+    let user_usdc = token::Client::new(&h.env, &h.deposit_token_id).balance(&user);
+    assert_eq!(
+        user_usdc, expected,
+        "early withdrawal fee should be deducted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Impairment — no performance fee on a loss
+// ---------------------------------------------------------------------------
+
+/// When the vault reports a loss (negative yield), `assets_for_shares` falls
+/// below the user's cost basis.  `yield_part` is negative, so no performance
+/// fee is charged and the user receives the impaired amount.
+#[test]
+fn test_no_performance_fee_on_loss() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    configure_fees(&h);
+    disable_circuit_breaker(&h);
+
+    h.mint_deposit_tokens(&user, DEPOSIT);
+    h.vault().deposit(&user, &DEPOSIT, &0);
+
+    // Simulate 5 % impairment via Manager role
+    let loss = DEPOSIT / 20; // 500_000
+    h.vault().grant_role(&h.admin, &h.admin, &Role::Manager);
+    h.vault().report_yield(&h.admin, &-loss);
+    assert_eq!(h.token().total_assets(), DEPOSIT - loss);
+
+    // Advance past lock period — no early-withdrawal fee
+    h.env.ledger().with_mut(|l| l.timestamp = 86_401);
+
+    let shares = h.token().balance(&user);
+    let remaining = h.vault().withdraw(&user, &shares, &0);
+    assert_eq!(remaining, 0, "all shares burned");
+    assert_eq!(h.token().total_supply(), 0);
+
+    // yield_part = (DEPOSIT - loss) - DEPOSIT = -loss < 0 → no performance fee
+    let user_usdc = token::Client::new(&h.env, &h.deposit_token_id).balance(&user);
+    assert_eq!(
+        user_usdc,
+        DEPOSIT - loss,
+        "user receives impaired amount with no performance fee on loss"
+    );
+}

--- a/packages/contracts/tests/integration/src/integration/mod.rs
+++ b/packages/contracts/tests/integration/src/integration/mod.rs
@@ -14,6 +14,8 @@
 
 #![cfg(test)]
 
+pub mod lifecycle_tests;
+
 extern crate std;
 
 use soroban_sdk::{symbol_short, vec, Vec};


### PR DESCRIPTION
## Summary

- Closes #507
- Closes #506
- Closes #503 
- Closes #505


## Changes

### Delta conservation

**`allocation_strategy/src/lib.rs`**
- After computing all deltas in `calculate_rebalance_deltas`, sum them. Panic with `ContractError::AllocationError` if the sum ≠ 0.

**`vault/src/lib.rs`**
- In `rebalance()`, compute `deployed_total = sum(current_allocations)` and pass that to `calculate_rebalance_deltas` instead of `total_assets - accrued_fees`. This ensures delta conservation by construction (rebalance redistributes already-deployed capital; undeployed vault buffer is not touched).

**`allocation_strategy/src/test.rs`** — 4 new unit tests:
| Test | Scenario |
|------|----------|
| `rebalance_deltas_sum_to_zero_for_balanced_rebalance` | Balanced [-200,+150,+50] — succeeds |
| `rebalance_deltas_panics_when_total_mismatches_current_sum` | Unbalanced total ≠ sum(current) — panics |
| `rebalance_deltas_empty_allocations_and_zero_total_succeeds` | Empty deltas — succeeds |
| `allocation_weights_always_sum_to_ten_thousand_bps` | Weight invariant across all vault types |

###  End-to-end integration tests

**`tests/integration/src/integration/lifecycle_tests.rs`** (new file):

| Test | Scenario |
|------|----------|
| `test_full_lifecycle_deposit_to_withdraw` | deposit → record allocation → rebalance (delta=0) → yield accrual → withdraw with performance fee |
| `test_early_withdrawal_fee_charged` | early withdrawal within lock period deducts 0.1% fee |
| `test_no_performance_fee_on_loss` | 5% impairment → no performance fee charged |

All tests use `soroban_sdk::testutils` (no live network required) and exercise vault ↔ vault_token ↔ allocation_strategy cross-contract calls.

## Test plan

```
cargo test -p allocation-strategy-contract   # 30 tests — 4 new ones pass
cargo test -p nester-integration-tests       # 18 tests — 3 new lifecycle tests pass
make test                                    # all unit tests pass ✓
make integration-test                        # all integration tests pass ✓
```

