### PR TITLE
test(contracts): cover APY deviation guard in yield_registry

### DIFF
--- a/packages/contracts/contracts/yield_registry/src/lib.rs
+++ b/packages/contracts/contracts/yield_registry/src/lib.rs
@@ -43,9 +43,12 @@ pub const MAX_APY_HISTORY: u32 = 16;
 
 // Hard cap for APY stored on-chain (basis points). 10000 == 100% APY.
 const MAX_APY_BPS: u32 = 10_000;
-// Maximum single-update deviation (bps) allowed relative to last stored APY.
-// For example, 2000 == 20% absolute bps change allowed in a single update.
-const MAX_APY_SINGLE_UPDATE_DEVIATION_BPS: u32 = 5_000; // 50% absolute bps
+// Default maximum single-update deviation (bps) allowed relative to the last
+// stored APY. Used to seed the configurable threshold at `initialize`; the live
+// value is read from storage (see `apy_deviation_threshold`) so an admin can
+// tune it without a contract upgrade. 5000 == a 5000-bps (50 percentage-point)
+// absolute change allowed in a single update.
+pub const DEFAULT_APY_DEVIATION_THRESHOLD_BPS: u32 = 5_000;
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -153,6 +156,8 @@ enum DataKey {
     Source(Symbol),
     /// Ordered list of all registered source IDs.
     SourceList,
+    /// Configurable APY single-update deviation threshold, in basis points.
+    ApyDeviationThresholdBps,
 }
 
 // ---------------------------------------------------------------------------
@@ -174,6 +179,10 @@ impl YieldRegistryContract {
         env.storage()
             .instance()
             .set(&DataKey::SourceList, &Vec::<Symbol>::new(&env));
+        env.storage().instance().set(
+            &DataKey::ApyDeviationThresholdBps,
+            &DEFAULT_APY_DEVIATION_THRESHOLD_BPS,
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -310,6 +319,16 @@ impl YieldRegistryContract {
 
     /// Update APY in basis points and append a snapshot to the rolling history.
     /// Callable by Admin or Operator.
+    ///
+    /// A deviation guard rejects single-update jumps whose absolute change from
+    /// the last stored APY exceeds the configured threshold (see
+    /// [`Self::set_apy_deviation_threshold`]). The guard is **skipped for the
+    /// first update** (when there is no prior non-zero APY to compare against),
+    /// and the boundary is **inclusive**: a change exactly equal to the
+    /// threshold is accepted; only a strictly larger change is rejected.
+    ///
+    /// To intentionally apply a change beyond the threshold (e.g. to correct a
+    /// stuck APY), an Admin must use [`Self::update_apy_override`].
     pub fn update_apy(env: Env, caller: Address, id: Symbol, new_apy_bps: u32) {
         caller.require_auth();
         require_admin_or_operator(&env, &caller);
@@ -321,31 +340,57 @@ impl YieldRegistryContract {
 
         let mut source = get_source_or_panic(&env, &id);
 
-        // Deviation guard: reject single-update jumps that are implausible
+        // Deviation guard: reject single-update jumps that are implausible.
+        // Threshold is read from storage so it can be tuned by an admin.
         let last_apy = source.current_apy_bps;
         if last_apy != 0 {
-            let deviation = if new_apy_bps > last_apy {
-                new_apy_bps - last_apy
-            } else {
-                last_apy - new_apy_bps
-            };
-            if deviation > MAX_APY_SINGLE_UPDATE_DEVIATION_BPS {
+            let deviation = new_apy_bps.abs_diff(last_apy);
+            if deviation > apy_deviation_threshold(&env) {
                 panic_with_error!(env, ContractError::InvalidOperation);
             }
         }
 
-        source.current_apy_bps = new_apy_bps;
-        append_apy_snapshot(&env, &mut source, new_apy_bps);
-        touch_source(&env, &mut source);
-        save_source(&env, &id, &source);
+        commit_apy_update(&env, &id, &mut source, new_apy_bps);
+    }
 
-        emit_event_with_sym(
-            &env,
-            REGISTRY,
-            SOURCE_PERF,
-            id,
-            performance_event_data(&source),
-        );
+    /// Emergency override: set a source's APY, **bypassing the deviation
+    /// guard**. Admin only — Operators cannot override. The absolute
+    /// [`MAX_APY_BPS`] ceiling is still enforced.
+    ///
+    /// This exists so an operator team can correct a stuck or stale APY when a
+    /// legitimate market move is larger than the configured deviation
+    /// threshold. Because it skips the guard, it is gated on the Admin role.
+    pub fn update_apy_override(env: Env, caller: Address, id: Symbol, new_apy_bps: u32) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        if new_apy_bps > MAX_APY_BPS {
+            panic_with_error!(env, ContractError::InvalidAmount);
+        }
+
+        let mut source = get_source_or_panic(&env, &id);
+        commit_apy_update(&env, &id, &mut source, new_apy_bps);
+    }
+
+    /// Set the APY single-update deviation threshold, in basis points. Admin
+    /// only. Must not exceed [`MAX_APY_BPS`]. A threshold of 0 means any change
+    /// to a non-zero APY is rejected (only the override path can move it).
+    pub fn set_apy_deviation_threshold(env: Env, caller: Address, threshold_bps: u32) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        if threshold_bps > MAX_APY_BPS {
+            panic_with_error!(&env, ContractError::ConfigOutOfRange);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ApyDeviationThresholdBps, &threshold_bps);
+    }
+
+    /// Return the configured APY single-update deviation threshold (bps).
+    pub fn get_apy_deviation_threshold(env: Env) -> u32 {
+        apy_deviation_threshold(&env)
     }
 
     /// Update total value locked for a source.
@@ -654,6 +699,33 @@ fn save_source(env: &Env, id: &Symbol, source: &YieldSource) {
 
 fn touch_source(env: &Env, source: &mut YieldSource) {
     source.last_updated = env.ledger().timestamp();
+}
+
+/// Read the configured APY deviation threshold, falling back to the default if
+/// (for a registry initialised before this field existed) it is unset.
+fn apy_deviation_threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ApyDeviationThresholdBps)
+        .unwrap_or(DEFAULT_APY_DEVIATION_THRESHOLD_BPS)
+}
+
+/// Apply a validated APY value: persist it, append a history snapshot, bump the
+/// last-updated timestamp, and emit the performance event. Shared by the
+/// guarded (`update_apy`) and override (`update_apy_override`) paths.
+fn commit_apy_update(env: &Env, id: &Symbol, source: &mut YieldSource, new_apy_bps: u32) {
+    source.current_apy_bps = new_apy_bps;
+    append_apy_snapshot(env, source, new_apy_bps);
+    touch_source(env, source);
+    save_source(env, id, source);
+
+    emit_event_with_sym(
+        env,
+        REGISTRY,
+        SOURCE_PERF,
+        id.clone(),
+        performance_event_data(source),
+    );
 }
 
 fn append_apy_snapshot(env: &Env, source: &mut YieldSource, apy_bps: u32) {

--- a/packages/contracts/contracts/yield_registry/src/test.rs
+++ b/packages/contracts/contracts/yield_registry/src/test.rs
@@ -10,7 +10,8 @@ use soroban_sdk::{
 use nester_access_control::Role;
 
 use crate::{
-    ProtocolType, SourceStatus, YieldRegistryContract, YieldRegistryContractClient, MAX_APY_HISTORY,
+    ProtocolType, SourceStatus, YieldRegistryContract, YieldRegistryContractClient,
+    DEFAULT_APY_DEVIATION_THRESHOLD_BPS, MAX_APY_HISTORY,
 };
 
 // ---------------------------------------------------------------------------
@@ -347,6 +348,207 @@ fn has_source_returns_false_for_unregistered() {
     let env = Env::default();
     let (client, _) = setup(&env);
     assert!(!client.has_source(&Symbol::new(&env, "ghost")));
+}
+
+// ---------------------------------------------------------------------------
+// APY deviation guard (issue #509)
+//
+// The guard rejects a single APY update whose ABSOLUTE change (in bps) from the
+// last stored APY exceeds the configured threshold (default
+// DEFAULT_APY_DEVIATION_THRESHOLD_BPS = 5000). Boundary is INCLUSIVE: a change
+// exactly equal to the threshold is accepted; only a strictly larger change is
+// rejected. The first update (no prior non-zero APY) is always accepted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_apy_update_within_threshold_succeeds() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    // First update establishes a non-zero baseline (bypasses the guard).
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+    // +1000 bps is well within the default 5000-bps threshold.
+    client.update_apy(&admin, &aave_id(&env), &2_000);
+
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        2_000
+    );
+}
+
+#[test]
+fn test_apy_update_exceeds_threshold_rejected() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+
+    // +6000 bps exceeds the 5000-bps threshold and must be rejected.
+    assert!(client
+        .try_update_apy(&admin, &aave_id(&env), &7_000)
+        .is_err());
+
+    // The rejected update must not have mutated stored state.
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        1_000
+    );
+}
+
+#[test]
+fn test_first_apy_update_always_accepted() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    // No previous (non-zero) APY to compare against, so even a jump far beyond
+    // the threshold is accepted on the first update.
+    let first = DEFAULT_APY_DEVIATION_THRESHOLD_BPS + 4_000; // 9000 bps
+    client.update_apy(&admin, &aave_id(&env), &first);
+
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        first
+    );
+}
+
+#[test]
+fn test_admin_can_override_deviation_guard() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+
+    // Sanity: the guarded path rejects this jump (dev 7000 > 5000).
+    assert!(client
+        .try_update_apy(&admin, &aave_id(&env), &8_000)
+        .is_err());
+
+    // The admin emergency override bypasses the guard.
+    client.update_apy_override(&admin, &aave_id(&env), &8_000);
+
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        8_000
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_operator_cannot_override_deviation_guard() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let operator = Address::generate(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+    client.grant_role(&admin, &operator, &Role::Operator);
+
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+
+    // Operators may update within the threshold but must NOT be able to
+    // override it — the override is gated on the Admin role.
+    client.update_apy_override(&operator, &aave_id(&env), &8_000);
+}
+
+#[test]
+fn test_apy_update_at_exact_threshold_boundary() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+
+    // One bps PAST the threshold (dev 5001) is rejected — leaves state at 1000.
+    assert!(client
+        .try_update_apy(&admin, &aave_id(&env), &6_001)
+        .is_err());
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        1_000
+    );
+
+    // EXACTLY at the threshold (dev 5000) is accepted — boundary is inclusive.
+    client.update_apy(&admin, &aave_id(&env), &6_000);
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        6_000
+    );
+}
+
+#[test]
+fn test_threshold_is_configurable_from_storage() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    // Default is seeded at initialize.
+    assert_eq!(
+        client.get_apy_deviation_threshold(),
+        DEFAULT_APY_DEVIATION_THRESHOLD_BPS
+    );
+
+    client.update_apy(&admin, &aave_id(&env), &1_000);
+
+    // Tighten the threshold to 1000 bps.
+    client.set_apy_deviation_threshold(&admin, &1_000);
+    assert_eq!(client.get_apy_deviation_threshold(), 1_000);
+
+    // A +1500 jump passed under the default 5000 but now exceeds the new 1000.
+    assert!(client
+        .try_update_apy(&admin, &aave_id(&env), &2_500)
+        .is_err());
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        1_000
+    );
+
+    // Within the new threshold still works.
+    client.update_apy(&admin, &aave_id(&env), &1_800);
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        1_800
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_set_threshold() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let operator = Address::generate(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+    client.grant_role(&admin, &operator, &Role::Operator);
+
+    client.set_apy_deviation_threshold(&operator, &1_000);
+}
+
+#[test]
+#[should_panic]
+fn test_set_threshold_above_max_apy_rejected() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    register_default(&client, &env, &admin, &aave_id(&env));
+
+    // Threshold cannot exceed the absolute APY ceiling (MAX_APY_BPS = 10000).
+    client.set_apy_deviation_threshold(&admin, &10_001);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #509.

The `yield_registry` APY deviation guard — which rejects a single APY update whose absolute change from the last stored value exceeds a threshold — had **no test coverage**. The threshold was also a hardcoded constant with no admin escape hatch, so a stuck APY couldn't be corrected and an oracle-controlling attacker reporting an extreme APY could manipulate rebalancing if the guard ever regressed.

This PR adds the missing coverage and closes the two gaps the issue's acceptance criteria require (configurable threshold + admin override).

## Guard hardening (to satisfy the acceptance criteria)

- **Configurable threshold (read from storage, not hardcoded):** the deviation threshold now lives in contract storage, seeded to the former constant (`DEFAULT_APY_DEVIATION_THRESHOLD_BPS = 5000`) at `initialize`, and is tunable by an Admin via `set_apy_deviation_threshold` / `get_apy_deviation_threshold`. `update_apy` reads it on each call.
- **Admin emergency override:** new Admin-only `update_apy_override` bypasses the deviation guard (still enforcing the absolute `MAX_APY_BPS` ceiling) so operators can correct a stuck/stale APY. Operators cannot override — it's gated on the Admin role.

## Boundary behavior (documented by the tests)

The guard is `deviation > threshold`, so the boundary is **inclusive**: a change exactly equal to the threshold is **accepted**; only a strictly larger change is rejected. The **first** update (no prior non-zero APY) always bypasses the guard.

## Tests — `cargo test -p yield-registry-contract`

All 5 required scenarios plus extras (30 tests pass, 9 new):

- [x] `test_apy_update_within_threshold_succeeds`
- [x] `test_apy_update_exceeds_threshold_rejected` (asserts state unchanged)
- [x] `test_first_apy_update_always_accepted`
- [x] `test_admin_can_override_deviation_guard` (+ `test_operator_cannot_override_deviation_guard`)
- [x] `test_apy_update_at_exact_threshold_boundary` (documents inclusive boundary: `==` accepted, `+1` rejected)
- [x] `test_threshold_is_configurable_from_storage` (+ `test_non_admin_cannot_set_threshold`, `test_set_threshold_above_max_apy_rejected`)

## Notes

- The crate's package name is `yield-registry-contract`, so the command is `cargo test -p yield-registry-contract` (the issue wrote `yield-registry`).
- Running the suite requires the WASM artifacts to be built first (`make build`) because a transitive dev-dependency (`nester-test-utils` → `vault-contract`) `contractimport!`s `vault_token.wasm` — this is the repo's existing test bootstrap, unchanged here.
- `cargo fmt` + `clippy` clean on the touched code.