### PR TITLE
feat: transaction list, Prometheus live context, bank name enquiry, provider key validation

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -124,3 +124,12 @@ TX_POLLER_INTERVAL=15s
 # Minimum age a transaction must reach before the poller checks it, giving
 # Horizon time to ingest a freshly submitted transaction.
 TX_POLLER_MIN_AGE=30s
+
+# Payment provider keys for offramp features (bank list, account resolution).
+# At least one must be set in production or staging — the API will refuse to
+# start if both are empty in those environments.
+# In development, empty keys are accepted (offramp features are simply unavailable).
+# Generate at https://dashboard.paystack.com/#/settings/developer
+PAYSTACK_SECRET_KEY=sk_test_your_paystack_key_here
+# Generate at https://developer.flutterwave.com/docs/integration-guides/api-keys
+FLUTTERWAVE_SECRET_KEY=FLWSECK_TEST-your_flutterwave_key_here

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -404,6 +404,14 @@ func (c *Config) validate(loader *envLoader) {
 	if c.transactionPoller.minAge < 0 {
 		loader.addError("TX_POLLER_MIN_AGE must not be negative")
 	}
+
+	// Require at least one payment provider key in production/staging so
+	// offramp features (bank list, account resolution) work at deploy time
+	// rather than failing silently when a user first triggers them.
+	if (c.environment == "production" || c.environment == "staging") &&
+		c.bank.paystackKey == "" && c.bank.flutterwaveKey == "" {
+		loader.addError("at least one of PAYSTACK_SECRET_KEY or FLUTTERWAVE_SECRET_KEY must be set in production")
+	}
 }
 
 func validateAllowedOrigins(environment string, origins []string, loader *envLoader) {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -58,6 +58,7 @@ func TestLoadFromDotEnv(t *testing.T) {
 		"STELLAR_HORIZON_URL=https://horizon.example.com",
 		"AUTH_JWT_SECRET=this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes",
 		"ALLOWED_ORIGINS=https://app.example.com",
+		"PAYSTACK_SECRET_KEY=sk_test_dummy",
 	}, "\n"))
 
 	chdir(t, dir)
@@ -210,6 +211,7 @@ func TestLoadEnvVarsTakePrecedenceOverDotEnv(t *testing.T) {
 	t.Setenv("STELLAR_RPC_URL", "https://envvar-rpc.example.com")
 	t.Setenv("STELLAR_HORIZON_URL", "https://envvar-horizon.example.com")
 	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+	t.Setenv("PAYSTACK_SECRET_KEY", "sk_test_dummy")
 
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".env"), strings.Join([]string{
@@ -254,6 +256,7 @@ func TestLoadConcurrentCalls(t *testing.T) {
 		"STELLAR_HORIZON_URL=https://horizon.example.com",
 		"AUTH_JWT_SECRET=this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes",
 		"ALLOWED_ORIGINS=https://app.example.com",
+		"PAYSTACK_SECRET_KEY=sk_test_dummy",
 	}, "\n"))
 	chdir(t, dir)
 
@@ -304,6 +307,7 @@ func TestLoadProcessEnvOverridesDotEnvAndFallsBack(t *testing.T) {
 	t.Setenv("SERVER_PORT", "9091")
 	t.Setenv("DATABASE_DSN", "postgres://env:secret@localhost:5432/nester?sslmode=disable")
 	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+	t.Setenv("PAYSTACK_SECRET_KEY", "sk_test_dummy")
 
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".env"), strings.Join([]string{
@@ -478,6 +482,7 @@ func TestLoadProductionMode(t *testing.T) {
 	requiredEnv(t)
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+	t.Setenv("PAYSTACK_SECRET_KEY", "sk_test_dummy")
 
 	chdir(t, t.TempDir())
 
@@ -880,6 +885,96 @@ func TestLoadAllowedOriginsRejectsMalformed(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLoadPaymentProviderKeysValidation verifies that production/staging requires
+// at least one payment provider key, while development does not.
+func TestLoadPaymentProviderKeysValidation(t *testing.T) {
+	t.Run("production fails when both keys are empty", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+
+		chdir(t, t.TempDir())
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail when both provider keys are empty in production")
+		}
+		if !strings.Contains(err.Error(), "PAYSTACK_SECRET_KEY") {
+			t.Fatalf("expected error to mention PAYSTACK_SECRET_KEY, got %q", err.Error())
+		}
+	})
+
+	t.Run("staging fails when both keys are empty", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "staging")
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+
+		chdir(t, t.TempDir())
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail when both provider keys are empty in staging")
+		}
+		if !strings.Contains(err.Error(), "PAYSTACK_SECRET_KEY") {
+			t.Fatalf("expected error to mention PAYSTACK_SECRET_KEY, got %q", err.Error())
+		}
+	})
+
+	t.Run("production succeeds with paystack key set", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+		t.Setenv("PAYSTACK_SECRET_KEY", "sk_test_dummy")
+
+		chdir(t, t.TempDir())
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+	})
+
+	t.Run("production succeeds with flutterwave key set", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+		t.Setenv("FLUTTERWAVE_SECRET_KEY", "FLWSECK_TEST-dummy")
+
+		chdir(t, t.TempDir())
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+	})
+
+	t.Run("development succeeds without any provider key", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "development")
+
+		chdir(t, t.TempDir())
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load() error = %v (dev should not require provider keys)", err)
+		}
+	})
+
+	t.Run("test env succeeds without any provider key", func(t *testing.T) {
+		baseEnv(t)
+		requiredEnv(t)
+		t.Setenv("APP_ENV", "test")
+
+		chdir(t, t.TempDir())
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load() error = %v (test env should not require provider keys)", err)
+		}
+	})
 }
 
 // TestLoadAllowedOriginsOptionalInDevelopment verifies development loads

--- a/apps/api/internal/domain/transaction/model.go
+++ b/apps/api/internal/domain/transaction/model.go
@@ -46,6 +46,16 @@ type Transaction struct {
 	ConfirmedAt *time.Time        `json:"confirmed_at,omitempty"`
 }
 
+// ListFilter drives paginated, filtered transaction listing for a user.
+type ListFilter struct {
+	UserID  uuid.UUID
+	VaultID uuid.UUID // zero value means all vaults
+	Type    string    // "deposit" | "withdrawal" | "" for all
+	Status  string    // "pending" | "completed" | "failed" | "" for all
+	Limit   int
+	Offset  int
+}
+
 type Repository interface {
 	Upsert(ctx context.Context, model Transaction) (Transaction, error)
 	GetByHash(ctx context.Context, hash string) (Transaction, error)
@@ -55,4 +65,7 @@ type Repository interface {
 	// to find transactions that have had time to settle on-chain but were
 	// never reconciled (e.g. the client never polled GET /transactions/{hash}).
 	ListPendingOlderThan(ctx context.Context, cutoff time.Time) ([]Transaction, error)
+	// ListUserTransactions returns paginated transactions scoped to the user,
+	// with optional filtering by vault, type, and status.
+	ListUserTransactions(ctx context.Context, filter ListFilter) ([]Transaction, int, error)
 }

--- a/apps/api/internal/handler/bank_handler.go
+++ b/apps/api/internal/handler/bank_handler.go
@@ -79,7 +79,9 @@ func (h *BankHandler) resolveAccount(w http.ResponseWriter, r *http.Request) {
 func (h *BankHandler) writeDomainError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, bank.ErrAccountNotFound):
-		response.WriteJSON(w, http.StatusNotFound, response.Response{
+		// 422 Unprocessable Entity: the request was valid but Paystack could not
+		// resolve the account — invalid account/bank combination.
+		response.WriteJSON(w, http.StatusUnprocessableEntity, response.Response{
 			Success: false,
 			Error: &response.ErrorBody{
 				Code:    "ACCOUNT_NOT_FOUND",

--- a/apps/api/internal/handler/transaction_handler.go
+++ b/apps/api/internal/handler/transaction_handler.go
@@ -3,10 +3,13 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
@@ -22,8 +25,138 @@ func NewTransactionHandler(service *service.TransactionService) *TransactionHand
 }
 
 func (h *TransactionHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/transactions", h.listTransactions)
 	mux.HandleFunc("POST /api/v1/transactions", h.createTransaction)
 	mux.HandleFunc("GET /api/v1/transactions/{hash}", h.getTransactionByHash)
+}
+
+// transactionView is the public representation of a transaction.
+// "completed" status is surfaced as "confirmed", and "currency" as "asset".
+type transactionView struct {
+	ID          string  `json:"id"`
+	VaultID     string  `json:"vault_id"`
+	Type        string  `json:"type"`
+	Amount      string  `json:"amount"`
+	Asset       string  `json:"asset"`
+	Status      string  `json:"status"`
+	TxHash      string  `json:"tx_hash,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	ConfirmedAt *string `json:"confirmed_at,omitempty"`
+}
+
+type listTransactionsData struct {
+	Data       []transactionView    `json:"data"`
+	Pagination transactionPagination `json:"pagination"`
+}
+
+type transactionPagination struct {
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func toTransactionView(t transaction.Transaction) transactionView {
+	status := string(t.Status)
+	if status == string(transaction.StatusCompleted) {
+		status = "confirmed"
+	}
+	v := transactionView{
+		ID:        t.ID.String(),
+		VaultID:   t.VaultID.String(),
+		Type:      string(t.Type),
+		Amount:    t.Amount.StringFixed(6),
+		Asset:     t.Currency,
+		Status:    status,
+		TxHash:    t.TxHash,
+		CreatedAt: t.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if t.ConfirmedAt != nil {
+		s := t.ConfirmedAt.UTC().Format(time.RFC3339)
+		v.ConfirmedAt = &s
+	}
+	return v
+}
+
+func (h *TransactionHandler) listTransactions(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid token subject"))
+		return
+	}
+
+	q := r.URL.Query()
+
+	var vaultID uuid.UUID
+	if raw := q.Get("vault_id"); raw != "" {
+		vaultID, err = uuid.Parse(raw)
+		if err != nil {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault_id must be a valid UUID"))
+			return
+		}
+	}
+
+	txType := q.Get("type")
+	if txType != "" && txType != "deposit" && txType != "withdrawal" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("type must be deposit or withdrawal"))
+		return
+	}
+
+	txStatus := q.Get("status")
+	if txStatus != "" && txStatus != "pending" && txStatus != "confirmed" && txStatus != "failed" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("status must be pending, confirmed, or failed"))
+		return
+	}
+
+	limit := 20
+	if raw := q.Get("limit"); raw != "" {
+		limit, err = strconv.Atoi(raw)
+		if err != nil || limit <= 0 {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("limit must be a positive integer"))
+			return
+		}
+	}
+
+	offset := 0
+	if raw := q.Get("offset"); raw != "" {
+		offset, err = strconv.Atoi(raw)
+		if err != nil || offset < 0 {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("offset must be a non-negative integer"))
+			return
+		}
+	}
+
+	txns, total, err := h.service.ListUserTransactions(r.Context(), service.ListUserTransactionsInput{
+		UserID:  userID,
+		VaultID: vaultID,
+		Type:    txType,
+		Status:  txStatus,
+		Limit:   limit,
+		Offset:  offset,
+	})
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("list transactions failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	views := make([]transactionView, len(txns))
+	for i, t := range txns {
+		views[i] = toTransactionView(t)
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(listTransactionsData{
+		Data: views,
+		Pagination: transactionPagination{
+			Total:  total,
+			Limit:  limit,
+			Offset: offset,
+		},
+	}))
 }
 
 type createTransactionRequest struct {

--- a/apps/api/internal/repository/postgres/transaction_repository.go
+++ b/apps/api/internal/repository/postgres/transaction_repository.go
@@ -203,6 +203,72 @@ func nullString(value string) any {
 	return strings.TrimSpace(value)
 }
 
+// ListUserTransactions returns paginated transactions scoped to the given user
+// via a JOIN with the vaults table. Optional filters narrow by vault, type,
+// and status. Results are ordered by created_at DESC.
+func (r *TransactionRepository) ListUserTransactions(ctx context.Context, filter transaction.ListFilter) ([]transaction.Transaction, int, error) {
+	args := []any{filter.UserID.String()}
+	argIdx := 2
+
+	where := "v.user_id = $1 AND v.deleted_at IS NULL"
+
+	if filter.VaultID != (uuid.UUID{}) {
+		where += fmt.Sprintf(" AND t.vault_id = $%d", argIdx)
+		args = append(args, filter.VaultID.String())
+		argIdx++
+	}
+	if filter.Type != "" {
+		where += fmt.Sprintf(" AND t.type = $%d", argIdx)
+		args = append(args, filter.Type)
+		argIdx++
+	}
+	if filter.Status != "" {
+		where += fmt.Sprintf(" AND t.status = $%d", argIdx)
+		args = append(args, filter.Status)
+		argIdx++
+	}
+
+	countQuery := `SELECT COUNT(*) FROM transactions t JOIN vaults v ON t.vault_id = v.id WHERE ` + where
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, mapTransactionError(err)
+	}
+
+	listQuery := fmt.Sprintf(
+		`SELECT t.id, t.vault_id, t.type, t.amount, t.currency, t.tx_hash, t.status, t.error_reason, t.created_at, t.updated_at, t.confirmed_at
+		 FROM transactions t
+		 JOIN vaults v ON t.vault_id = v.id
+		 WHERE %s
+		 ORDER BY t.created_at DESC
+		 LIMIT $%d OFFSET $%d`,
+		where, argIdx, argIdx+1,
+	) // #nosec G201 -- where clause built from parameterised fragments only
+	args = append(args, filter.Limit, filter.Offset)
+
+	rows, err := r.db.QueryContext(ctx, listQuery, args...)
+	if err != nil {
+		return nil, 0, mapTransactionError(err)
+	}
+	defer rows.Close()
+
+	var txns []transaction.Transaction
+	for rows.Next() {
+		model, err := scanTransaction(rows)
+		if err != nil {
+			return nil, 0, mapTransactionError(err)
+		}
+		txns = append(txns, model)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, mapTransactionError(err)
+	}
+	if txns == nil {
+		txns = []transaction.Transaction{}
+	}
+
+	return txns, total, nil
+}
+
 func mapTransactionError(err error) error {
 	if err == nil {
 		return nil

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -224,6 +224,59 @@ func (s *TransactionService) lookupHorizonTransaction(ctx context.Context, hash 
 	return transaction.StatusFailed, &confirmedAt, strings.TrimSpace(payload.ResultXdr), nil
 }
 
+const (
+	defaultTransactionListLimit = 20
+	maxTransactionListLimit     = 100
+)
+
+// ListUserTransactionsInput carries validated query params for the list endpoint.
+type ListUserTransactionsInput struct {
+	UserID  uuid.UUID
+	VaultID uuid.UUID // optional
+	Type    string    // "deposit" | "withdrawal" | ""
+	Status  string    // "pending" | "confirmed" | "failed" | "" — "confirmed" maps to "completed"
+	Limit   int
+	Offset  int
+}
+
+// ListUserTransactions returns paginated transactions for the authenticated user.
+// The "confirmed" status value accepted from callers is mapped to the internal
+// "completed" value before querying.
+func (s *TransactionService) ListUserTransactions(ctx context.Context, input ListUserTransactionsInput) ([]transaction.Transaction, int, error) {
+	if input.UserID == uuid.Nil {
+		return nil, 0, transaction.ErrInvalidTransaction
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultTransactionListLimit
+	}
+	if limit > maxTransactionListLimit {
+		limit = maxTransactionListLimit
+	}
+	offset := input.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Map external "confirmed" status to internal "completed".
+	dbStatus := input.Status
+	if dbStatus == "confirmed" {
+		dbStatus = string(transaction.StatusCompleted)
+	}
+
+	filter := transaction.ListFilter{
+		UserID:  input.UserID,
+		VaultID: input.VaultID,
+		Type:    input.Type,
+		Status:  dbStatus,
+		Limit:   limit,
+		Offset:  offset,
+	}
+
+	return s.repository.ListUserTransactions(ctx, filter)
+}
+
 func isSupportedTransactionType(value transaction.TransactionType) bool {
 	switch value {
 	case transaction.TypeDeposit, transaction.TypeWithdrawal, transaction.TypeSettlement:

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -626,7 +626,14 @@ export default function OfframpPage() {
                     {/* CTA Button */}
                     <div className="p-4 sm:p-5 pt-0">
                         <button
-                            disabled={!isValid || quotePhase !== "done" || resolveState === "loading" || resolveState === "not_found"}
+                            disabled={
+                                !isValid ||
+                                quotePhase !== "done" ||
+                                resolveState === "loading" ||
+                                resolveState === "not_found" ||
+                                resolveState === "idle" ||
+                                (resolveState === "provider_error" && !manualName.trim())
+                            }
                             onClick={handleWithdraw}
                             className="w-full rounded-xl bg-foreground text-background py-4 text-sm font-medium transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
                         >
@@ -640,11 +647,13 @@ export default function OfframpPage() {
                                             ? "Verifying account..."
                                             : resolveState === "not_found"
                                                 ? "Account not found"
-                                                : quotePhase !== "done"
-                                                    ? "Finding best rate..."
-                                                    : showLargeWarning
-                                                        ? "Yes, confirm withdrawal"
-                                                : `Withdraw ${displayReceive.toLocaleString("en-US", { minimumFractionDigits: 2 })} ${receiveCurrency.symbol}`}
+                                                : resolveState === "idle"
+                                                    ? "Waiting for account verification..."
+                                                    : quotePhase !== "done"
+                                                        ? "Finding best rate..."
+                                                        : showLargeWarning
+                                                            ? "Yes, confirm withdrawal"
+                                                            : `Withdraw ${displayReceive.toLocaleString("en-US", { minimumFractionDigits: 2 })} ${receiveCurrency.symbol}`}
                         </button>
                     </div>
                 </motion.div>

--- a/apps/dapp/frontend/hooks/useBankResolver.ts
+++ b/apps/dapp/frontend/hooks/useBankResolver.ts
@@ -20,7 +20,7 @@ export interface UseBankResolverResult {
   accountInfo: AccountInfo | null;
 }
 
-const DEBOUNCE_MS = 400;
+const DEBOUNCE_MS = 500;
 
 export function useBankResolver(
   accountNumber: string,

--- a/apps/dapp/frontend/lib/api/bank.ts
+++ b/apps/dapp/frontend/lib/api/bank.ts
@@ -115,7 +115,9 @@ export async function resolveAccountName(
       }
     );
 
-    if (res.status === 404) return { status: "not_found" };
+    // 422: Paystack resolved but found no matching account (valid format, wrong combo).
+    // 404: legacy fallback for older API versions.
+    if (res.status === 422 || res.status === 404) return { status: "not_found" };
     if (res.status === 429) return { status: "provider_error" }; // rate limited
     if (res.status === 503) return { status: "provider_error" }; // both providers down
     if (!res.ok) return { status: "provider_error" };

--- a/apps/intelligence/.env.example
+++ b/apps/intelligence/.env.example
@@ -15,3 +15,14 @@ INTELLIGENCE_PORT=8000
 # JWT secret — must match AUTH_JWT_SECRET from the Go API (apps/api)
 # Used to verify Bearer tokens on all protected endpoints
 INTELLIGENCE_JWT_SECRET=your-shared-jwt-secret-here
+
+# Redis URL for conversation history and portfolio context caching (60s TTL).
+# Falls back to in-process memory when not set (single-instance only).
+INTELLIGENCE_REDIS_URL=redis://localhost:6379/0
+
+# Base URL of the Nester Go API — used to fetch live user portfolio data.
+INTELLIGENCE_NESTER_API_BASE_URL=http://api:8080
+
+# Service-to-service API key issued by the Go API for internal requests.
+# Must match the value configured in the Go API (apps/api).
+INTELLIGENCE_NESTER_SERVICE_API_KEY=your-service-api-key-here

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -2,10 +2,13 @@
 
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
+from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 import anthropic
+import aiohttp
 
 from app.config import settings
 from app.services.conversation_store import store as conversation_store
@@ -16,8 +19,16 @@ logger = logging.getLogger(__name__)
 CHAT_MAX_TOKENS = 1024
 ANALYZE_MAX_TOKENS = 800
 
+_CONTEXT_CACHE_TTL = 60  # seconds
+_CONTEXT_KEY_PREFIX = "prometheus:ctx:"
+
 _client: anthropic.AsyncAnthropic | None = None
 _vault_context_fetcher: VaultContextFetcher | None = None
+_redis_client: Any = None
+_redis_available: bool = False
+
+# In-process fallback cache: {user_id: (context_dict, expires_at)}
+_mem_context_cache: dict[str, tuple[dict[str, Any], float]] = {}
 
 
 def get_client() -> anthropic.AsyncAnthropic:
@@ -35,6 +46,107 @@ def get_vault_context_fetcher() -> VaultContextFetcher:
             service_api_key=settings.nester_service_api_key
         )
     return _vault_context_fetcher
+
+
+def _get_redis() -> Any:
+    """Return a shared Redis client, or None if unavailable."""
+    global _redis_client, _redis_available
+    if _redis_client is not None:
+        return _redis_client if _redis_available else None
+    try:
+        import redis as _redis
+        _redis_client = _redis.from_url(settings.redis_url, decode_responses=True)
+        _redis_client.ping()
+        _redis_available = True
+        logger.info("prometheus context cache: redis connected")
+    except Exception as exc:
+        logger.warning("prometheus context cache: redis unavailable (%s), using in-memory", exc)
+        _redis_available = False
+    return _redis_client if _redis_available else None
+
+
+def _cache_get(user_id: str) -> dict[str, Any] | None:
+    key = _CONTEXT_KEY_PREFIX + user_id
+    r = _get_redis()
+    if r is not None:
+        try:
+            raw = r.get(key)
+            if raw:
+                return dict(json.loads(raw))
+        except Exception as exc:
+            logger.warning("context cache redis get failed: %s", exc)
+    # In-process fallback
+    entry = _mem_context_cache.get(user_id)
+    if entry and time.monotonic() < entry[1]:
+        return entry[0]
+    return None
+
+
+def _cache_set(user_id: str, context: dict[str, Any]) -> None:
+    key = _CONTEXT_KEY_PREFIX + user_id
+    r = _get_redis()
+    if r is not None:
+        try:
+            r.setex(key, _CONTEXT_CACHE_TTL, json.dumps(context))
+            return
+        except Exception as exc:
+            logger.warning("context cache redis set failed: %s", exc)
+    # In-process fallback
+    _mem_context_cache[user_id] = (context, time.monotonic() + _CONTEXT_CACHE_TTL)
+
+
+async def fetch_user_context(user_id: str, api_base_url: str, service_api_key: str) -> dict[str, Any]:
+    """Fetch user vaults, balances, allocations, and recent APY snapshots.
+
+    Returns a dict with 'vaults', 'performance', and 'fetched_at'.
+    Raises on network or auth errors so the caller can fall back gracefully.
+    """
+    headers = {
+        "Authorization": f"Bearer {service_api_key}",
+        "Content-Type": "application/json",
+    }
+    base = api_base_url.rstrip("/")
+
+    async with aiohttp.ClientSession() as session:
+        # Fetch vaults scoped to this user
+        async with session.get(
+            f"{base}/api/v1/users/{user_id}/vaults",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as resp:
+            vaults_data = await resp.json() if resp.status == 200 else {}
+
+        # Fetch recent performance snapshots (best-effort)
+        async with session.get(
+            f"{base}/api/v1/performance/snapshots",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as resp:
+            performance_data = await resp.json() if resp.status == 200 else {}
+
+    return {
+        "vaults": vaults_data,
+        "performance": performance_data,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def _get_cached_user_context(user_id: str) -> dict[str, Any] | None:
+    """Return cached user context, or fetch and cache it. Returns None on failure."""
+    cached = _cache_get(user_id)
+    if cached is not None:
+        return cached
+    try:
+        ctx = await fetch_user_context(
+            user_id,
+            settings.nester_api_base_url,
+            settings.nester_service_api_key,
+        )
+        _cache_set(user_id, ctx)
+        return ctx
+    except Exception as exc:
+        logger.warning("fetch_user_context failed for user %s: %s", user_id, exc)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +263,24 @@ Provide personalized, data-driven advice based on user positions
 and current market conditions. Always cite specific numbers from their
 portfolio."""
 
-    messages = _to_anthropic_messages(history) + [
+    # Fetch live portfolio context (60s Redis-backed cache).
+    # Injected as a prepended user message so Claude can personalise responses
+    # without the instruction appearing in the visible conversation history.
+    # If the fetch fails, continue with static knowledge — no error surfaced.
+    user_context = await _get_cached_user_context(user_id)
+    context_injection: list[dict[str, str]] = []
+    if user_context:
+        context_injection = [
+            {
+                "role": "user",
+                "content": (
+                    "[PORTFOLIO CONTEXT — do not quote this back, use it to personalise your response]\n"
+                    + json.dumps(user_context, indent=2)
+                ),
+            }
+        ]
+
+    messages = context_injection + _to_anthropic_messages(history) + [
         {"role": "user", "content": message}
     ]
 


### PR DESCRIPTION
## Summary

- **feat(api):** Add `GET /api/v1/transactions` endpoint with filters (`vault_id`, `type`, `status`, `limit`, `offset`). Results are always scoped to the authenticated user via a JOIN with the vaults table. Pagination uses limit/offset (default 20, max 100), sorted by `created_at DESC`. The public `"confirmed"` status maps to the internal `"completed"` value.

- **feat(intelligence):** Inject live user portfolio into every Prometheus chat call. A new `fetch_user_context()` function fetches the user's vaults and performance snapshots from the Go API and caches the result per-user in Redis with a 60-second TTL (in-process dict fallback when Redis is unavailable). The context is prepended as a `[PORTFOLIO CONTEXT]` user message so Claude can personalise responses without echoing raw JSON back to users. Falls back gracefully to static knowledge on any fetch failure.

- **feat(api,dapp):** Resolve bank account holder name before offramp submission. Backend now returns `422 Unprocessable Entity` (was `404`) when Paystack cannot resolve an account. Frontend updated to handle 422 as `not_found`, debounce increased to 500 ms per spec, and the submit button is now blocked until `resolveState === "success"` (or `provider_error` with a manual name entered) — previously `"idle"` could bypass the guard.

- **bug(api):** Payment provider keys (`PAYSTACK_SECRET_KEY`, `FLUTTERWAVE_SECRET_KEY`) were silently accepted as empty strings. The API now exits at startup with a clear error message if both keys are missing in `production` or `staging`. Development and test environments are unaffected. Existing config tests updated with dummy key values; new `TestLoadPaymentProviderKeysValidation` test covers all cases. Both keys documented in `.env.example`.

## Related Issues
Closes #457
Closes #458 
Closes #461 
Closes #491 
