### PR TITLE
feat: yield opportunities, vault analytics, DeFiLlama/CoinGecko AI co…

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -133,3 +133,7 @@ TX_POLLER_MIN_AGE=30s
 PAYSTACK_SECRET_KEY=sk_test_your_paystack_key_here
 # Generate at https://developer.flutterwave.com/docs/integration-guides/api-keys
 FLUTTERWAVE_SECRET_KEY=FLWSECK_TEST-your_flutterwave_key_here
+
+# Risk-free rate used for Sharpe and Sortino ratio calculations in vault analytics.
+# Expressed as a decimal (0.05 = 5%). Defaults to 0.05 (US T-bill proxy).
+RISK_FREE_RATE=0.05

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -252,7 +252,22 @@ func run() error {
 	riskService := services.NewRiskService(vaultRepository)
 	riskHandler := handler.NewRiskHandler(riskService)
 	riskHandler.Register(mux)
-	
+
+	// Vault analytics (APY volatility, Sharpe, Sortino, drawdown, win rate)
+	vaultAnalyticsSvc := service.NewVaultAnalyticsService(performanceRepository)
+	vaultAnalyticsHandler := handler.NewVaultAnalyticsHandler(vaultAnalyticsSvc)
+	vaultAnalyticsHandler.Register(mux)
+
+	// Yield opportunities (DeFiLlama Stellar pools)
+	yieldSvc := service.NewYieldService("")
+	yieldHandler := handler.NewYieldHandler(yieldSvc)
+	yieldHandler.Register(mux)
+
+	// User watchlist
+	watchlistSvc := service.NewWatchlistService(db)
+	watchlistHandler := handler.NewWatchlistHandler(watchlistSvc)
+	watchlistHandler.Register(mux)
+
 	bankHandler.Register(mux)
 
 	mux.HandleFunc("GET /ws", wsHub.ServeWs)

--- a/apps/api/internal/handler/vault_analytics_handler.go
+++ b/apps/api/internal/handler/vault_analytics_handler.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// VaultAnalyticsQuerier is the service surface the handler depends on.
+type VaultAnalyticsQuerier interface {
+	Compute(ctx context.Context, vaultID uuid.UUID, period string) (service.VaultAnalytics, error)
+}
+
+// VaultAnalyticsHandler serves GET /api/v1/vaults/{id}/analytics.
+type VaultAnalyticsHandler struct {
+	svc VaultAnalyticsQuerier
+}
+
+func NewVaultAnalyticsHandler(svc VaultAnalyticsQuerier) *VaultAnalyticsHandler {
+	return &VaultAnalyticsHandler{svc: svc}
+}
+
+func (h *VaultAnalyticsHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/vaults/{id}/analytics", h.analytics)
+}
+
+func (h *VaultAnalyticsHandler) analytics(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	period := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("period")))
+	if period == "" {
+		period = "30d"
+	}
+
+	// Accept 30d, 90d, 1y.
+	switch period {
+	case "30d", "90d":
+	case "1y":
+		period = "365d"
+	default:
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("period must be 30d, 90d, or 1y"))
+		return
+	}
+
+	analytics, err := h.svc.Compute(r.Context(), vaultID, period)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("vault analytics compute failed", "vault_id", vaultID, "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "analytics computation failed"))
+		return
+	}
+
+	// Normalise period label in response back to the canonical form.
+	if period == "365d" {
+		analytics.Period = "1y"
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(analytics))
+}

--- a/apps/api/internal/handler/watchlist_handler.go
+++ b/apps/api/internal/handler/watchlist_handler.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// WatchlistManager is the service surface the handler depends on.
+type WatchlistManager interface {
+	Add(ctx context.Context, userID uuid.UUID, req service.AddWatchlistItemRequest) (service.WatchlistItem, error)
+	List(ctx context.Context, userID uuid.UUID) ([]service.WatchlistItem, error)
+	Delete(ctx context.Context, userID, itemID uuid.UUID) error
+}
+
+// WatchlistHandler serves the /api/v1/users/watchlist endpoints.
+type WatchlistHandler struct {
+	svc WatchlistManager
+}
+
+func NewWatchlistHandler(svc WatchlistManager) *WatchlistHandler {
+	return &WatchlistHandler{svc: svc}
+}
+
+func (h *WatchlistHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/users/watchlist", h.list)
+	mux.HandleFunc("POST /api/v1/users/watchlist", h.add)
+	mux.HandleFunc("DELETE /api/v1/users/watchlist/{id}", h.delete)
+}
+
+func (h *WatchlistHandler) list(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+
+	items, err := h.svc.List(r.Context(), userID)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("watchlist list failed", "user_id", userID, "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(items))
+}
+
+func (h *WatchlistHandler) add(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8*1024))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("failed to read request body"))
+		return
+	}
+
+	var req service.AddWatchlistItemRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid JSON"))
+		return
+	}
+
+	item, err := h.svc.Add(r.Context(), userID, req)
+	if err != nil {
+		if errors.Is(err, service.ErrWatchlistDuplicate) {
+			response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "DUPLICATE", "pool already in watchlist"))
+			return
+		}
+		logpkg.FromContext(r.Context()).Error("watchlist add failed", "user_id", userID, "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusCreated, response.Created(item))
+}
+
+func (h *WatchlistHandler) delete(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+
+	itemID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("watchlist item id must be a valid UUID"))
+		return
+	}
+
+	if err := h.svc.Delete(r.Context(), userID, itemID); err != nil {
+		if errors.Is(err, service.ErrWatchlistItemNotFound) {
+			response.WriteJSON(w, http.StatusNotFound, response.NotFound("watchlist item"))
+			return
+		}
+		logpkg.FromContext(r.Context()).Error("watchlist delete failed", "user_id", userID, "item_id", itemID, "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *WatchlistHandler) authenticatedUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "authentication required"))
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid user identity"))
+		return uuid.Nil, false
+	}
+	return id, true
+}

--- a/apps/api/internal/handler/yield_handler.go
+++ b/apps/api/internal/handler/yield_handler.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// YieldOpportunitiesProvider is the service surface the handler depends on.
+type YieldOpportunitiesProvider interface {
+	GetYieldOpportunities(ctx context.Context, chain string, limit int) ([]service.YieldPool, error)
+}
+
+// YieldHandler serves GET /api/v1/yield-opportunities.
+type YieldHandler struct {
+	svc YieldOpportunitiesProvider
+}
+
+func NewYieldHandler(svc YieldOpportunitiesProvider) *YieldHandler {
+	return &YieldHandler{svc: svc}
+}
+
+func (h *YieldHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/yield-opportunities", h.list)
+}
+
+func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
+	chain := strings.TrimSpace(r.URL.Query().Get("chain"))
+	if chain == "" {
+		chain = "Stellar"
+	}
+
+	limit := 20
+	if lStr := r.URL.Query().Get("limit"); lStr != "" {
+		if n, err := strconv.Atoi(lStr); err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+
+	pools, err := h.svc.GetYieldOpportunities(r.Context(), chain, limit)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("yield opportunities fetch failed", "chain", chain, "error", err.Error())
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UPSTREAM_ERROR", "yield data temporarily unavailable"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(pools))
+}

--- a/apps/api/internal/service/vault_analytics_service.go
+++ b/apps/api/internal/service/vault_analytics_service.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	perfdom "github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
+)
+
+// VaultAnalytics holds risk-adjusted performance metrics for a vault.
+type VaultAnalytics struct {
+	VaultID      uuid.UUID `json:"vault_id"`
+	Period       string    `json:"period"`
+	MeanAPY      float64   `json:"mean_apy"`
+	APYVolatility float64  `json:"apy_volatility"`
+	MaxDrawdown  float64   `json:"max_drawdown"`
+	SharpeRatio  float64   `json:"sharpe_ratio"`
+	SortinoRatio float64   `json:"sortino_ratio"`
+	WinRate      float64   `json:"win_rate"`
+}
+
+type analyticsCache struct {
+	mu      sync.Mutex
+	entries map[string]analyticsCacheEntry
+}
+
+type analyticsCacheEntry struct {
+	data      VaultAnalytics
+	expiresAt time.Time
+}
+
+var _analyticsCache = &analyticsCache{
+	entries: make(map[string]analyticsCacheEntry),
+}
+
+const analyticsCacheTTL = time.Hour
+
+func (c *analyticsCache) get(key string) (VaultAnalytics, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return VaultAnalytics{}, false
+	}
+	return entry.data, true
+}
+
+func (c *analyticsCache) set(key string, data VaultAnalytics) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = analyticsCacheEntry{data: data, expiresAt: time.Now().Add(analyticsCacheTTL)}
+}
+
+// VaultAnalyticsService computes higher-order vault performance metrics.
+type VaultAnalyticsService struct {
+	repo         perfdom.SnapshotRepository
+	riskFreeRate float64
+}
+
+// NewVaultAnalyticsService creates a VaultAnalyticsService.
+// The risk-free rate defaults to the RISK_FREE_RATE env var, or 0.05 (5%).
+func NewVaultAnalyticsService(repo perfdom.SnapshotRepository) *VaultAnalyticsService {
+	rfr := 0.05
+	if v := os.Getenv("RISK_FREE_RATE"); v != "" {
+		if parsed, err := strconv.ParseFloat(v, 64); err == nil && parsed >= 0 {
+			rfr = parsed
+		}
+	}
+	return &VaultAnalyticsService{repo: repo, riskFreeRate: rfr}
+}
+
+// analyticsPeriodDays converts a period string to a day count.
+func analyticsPeriodDays(period string) (int, error) {
+	if period == "all" {
+		return 365 * 5, nil
+	}
+	if !strings.HasSuffix(period, "d") {
+		return 0, errors.New("period must be '30d', '90d', '365d', or 'all'")
+	}
+	n, err := strconv.Atoi(strings.TrimSuffix(period, "d"))
+	if err != nil || n <= 0 || n > 365*5 {
+		return 0, errors.New("period must be a positive number of days, capped at 5y")
+	}
+	return n, nil
+}
+
+// Compute returns analytics for the vault over the given period string ("30d", "90d", "365d").
+// Results are cached for one hour.
+func (s *VaultAnalyticsService) Compute(ctx context.Context, vaultID uuid.UUID, period string) (VaultAnalytics, error) {
+	cacheKey := fmt.Sprintf("%s:%s", vaultID, period)
+	if cached, ok := _analyticsCache.get(cacheKey); ok {
+		return cached, nil
+	}
+
+	days, err := analyticsPeriodDays(period)
+	if err != nil {
+		return VaultAnalytics{}, fmt.Errorf("invalid period %q: %w", period, err)
+	}
+
+	since := time.Now().UTC().Add(-time.Duration(days) * 24 * time.Hour)
+	snapshots, err := s.repo.HistoryForVault(ctx, vaultID, since)
+	if err != nil {
+		return VaultAnalytics{}, fmt.Errorf("fetch snapshots: %w", err)
+	}
+
+	result := s.compute(vaultID, period, snapshots)
+	_analyticsCache.set(cacheKey, result)
+	return result, nil
+}
+
+func (s *VaultAnalyticsService) compute(vaultID uuid.UUID, period string, snapshots []perfdom.Snapshot) VaultAnalytics {
+	out := VaultAnalytics{VaultID: vaultID, Period: period}
+	if len(snapshots) < 2 {
+		return out
+	}
+
+	// Compute daily APY implied by consecutive share-price changes.
+	dailyAPYs := make([]float64, 0, len(snapshots)-1)
+	peakPrice := decimal.Zero
+
+	for i, snap := range snapshots {
+		if snap.SharePrice.GreaterThan(peakPrice) {
+			peakPrice = snap.SharePrice
+		}
+		if i == 0 {
+			continue
+		}
+		prev := snapshots[i-1]
+		if prev.SharePrice.IsZero() || prev.SharePrice.Sign() <= 0 {
+			continue
+		}
+
+		// Annualised: (price_t / price_t-1)^365 - 1
+		ratio, _ := snap.SharePrice.Div(prev.SharePrice).Float64()
+		if ratio <= 0 {
+			continue
+		}
+		hoursElapsed := snap.SnapshotAt.Sub(prev.SnapshotAt).Hours()
+		if hoursElapsed <= 0 {
+			continue
+		}
+		daysElapsed := hoursElapsed / 24
+		apy := (math.Pow(ratio, 365.0/daysElapsed) - 1) * 100
+		if math.IsNaN(apy) || math.IsInf(apy, 0) {
+			continue
+		}
+		dailyAPYs = append(dailyAPYs, apy)
+	}
+
+	if len(dailyAPYs) == 0 {
+		return out
+	}
+
+	out.MeanAPY = mean(dailyAPYs)
+	out.APYVolatility = stdDev(dailyAPYs, out.MeanAPY)
+	out.MaxDrawdown = s.maxDrawdown(snapshots)
+	out.WinRate = winRate(dailyAPYs)
+
+	if out.APYVolatility > 0 {
+		out.SharpeRatio = (out.MeanAPY - s.riskFreeRate*100) / out.APYVolatility
+		out.SortinoRatio = sortinoRatio(dailyAPYs, out.MeanAPY, s.riskFreeRate*100)
+	}
+
+	return out
+}
+
+func (s *VaultAnalyticsService) maxDrawdown(snapshots []perfdom.Snapshot) float64 {
+	peak := decimal.Zero
+	maxDD := 0.0
+	for _, snap := range snapshots {
+		if snap.SharePrice.GreaterThan(peak) {
+			peak = snap.SharePrice
+		}
+		if peak.IsZero() {
+			continue
+		}
+		dd, _ := peak.Sub(snap.SharePrice).Div(peak).Float64()
+		if dd > maxDD {
+			maxDD = dd
+		}
+	}
+	return maxDD
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}
+
+func stdDev(xs []float64, avg float64) float64 {
+	if len(xs) < 2 {
+		return 0
+	}
+	variance := 0.0
+	for _, x := range xs {
+		diff := x - avg
+		variance += diff * diff
+	}
+	return math.Sqrt(variance / float64(len(xs)))
+}
+
+func sortinoRatio(xs []float64, avg, riskFreeRate float64) float64 {
+	downside := 0.0
+	count := 0
+	for _, x := range xs {
+		if x < riskFreeRate {
+			diff := x - riskFreeRate
+			downside += diff * diff
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	downsideVol := math.Sqrt(downside / float64(count))
+	if downsideVol == 0 {
+		return 0
+	}
+	return (avg - riskFreeRate) / downsideVol
+}
+
+func winRate(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	wins := 0
+	for _, x := range xs {
+		if x > 0 {
+			wins++
+		}
+	}
+	return float64(wins) / float64(len(xs))
+}
+

--- a/apps/api/internal/service/watchlist_service.go
+++ b/apps/api/internal/service/watchlist_service.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrWatchlistItemNotFound is returned when a watchlist item does not exist.
+var ErrWatchlistItemNotFound = errors.New("watchlist item not found")
+
+// ErrWatchlistDuplicate is returned when the user already saved this pool.
+var ErrWatchlistDuplicate = errors.New("pool already in watchlist")
+
+// WatchlistItem is a row in the user_watchlist table.
+type WatchlistItem struct {
+	ID          uuid.UUID  `json:"id"`
+	UserID      uuid.UUID  `json:"user_id"`
+	PoolID      string     `json:"pool_id"`
+	PoolSymbol  string     `json:"pool_symbol"`
+	PoolProject string     `json:"pool_project"`
+	PoolChain   string     `json:"pool_chain"`
+	APYAtSave   float64    `json:"apy_at_save"`
+	TVLUsd      float64    `json:"tvl_usd"`
+	AddedAt     time.Time  `json:"added_at"`
+}
+
+// AddWatchlistItemRequest is the body for POST /api/v1/users/watchlist.
+type AddWatchlistItemRequest struct {
+	PoolID      string  `json:"pool_id"`
+	PoolSymbol  string  `json:"pool_symbol"`
+	PoolProject string  `json:"pool_project"`
+	PoolChain   string  `json:"pool_chain"`
+	APYAtSave   float64 `json:"apy_at_save"`
+	TVLUsd      float64 `json:"tvl_usd"`
+}
+
+// WatchlistDB is the minimal DB interface the service requires.
+type WatchlistDB interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// WatchlistService manages user watchlist CRUD.
+type WatchlistService struct {
+	db WatchlistDB
+}
+
+func NewWatchlistService(db WatchlistDB) *WatchlistService {
+	return &WatchlistService{db: db}
+}
+
+// Add inserts a new watchlist item for the user. Returns ErrWatchlistDuplicate if already present.
+func (s *WatchlistService) Add(ctx context.Context, userID uuid.UUID, req AddWatchlistItemRequest) (WatchlistItem, error) {
+	if req.PoolID == "" {
+		return WatchlistItem{}, fmt.Errorf("pool_id is required")
+	}
+
+	var item WatchlistItem
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO user_watchlist (user_id, pool_id, pool_symbol, pool_project, pool_chain, apy_at_save, tvl_usd)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, user_id, pool_id, pool_symbol, pool_project, pool_chain, apy_at_save, tvl_usd, added_at
+	`, userID, req.PoolID, req.PoolSymbol, req.PoolProject, req.PoolChain, req.APYAtSave, req.TVLUsd).
+		Scan(&item.ID, &item.UserID, &item.PoolID, &item.PoolSymbol, &item.PoolProject,
+			&item.PoolChain, &item.APYAtSave, &item.TVLUsd, &item.AddedAt)
+	if err != nil {
+		if isDuplicateError(err) {
+			return WatchlistItem{}, ErrWatchlistDuplicate
+		}
+		return WatchlistItem{}, fmt.Errorf("insert watchlist item: %w", err)
+	}
+	return item, nil
+}
+
+// List returns all watchlist items for a user, newest first.
+func (s *WatchlistService) List(ctx context.Context, userID uuid.UUID) ([]WatchlistItem, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, pool_id, pool_symbol, pool_project, pool_chain, apy_at_save, tvl_usd, added_at
+		FROM user_watchlist
+		WHERE user_id = $1
+		ORDER BY added_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list watchlist: %w", err)
+	}
+	defer rows.Close()
+
+	var items []WatchlistItem
+	for rows.Next() {
+		var item WatchlistItem
+		if err := rows.Scan(&item.ID, &item.UserID, &item.PoolID, &item.PoolSymbol,
+			&item.PoolProject, &item.PoolChain, &item.APYAtSave, &item.TVLUsd, &item.AddedAt); err != nil {
+			return nil, fmt.Errorf("scan watchlist row: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("watchlist rows: %w", err)
+	}
+	if items == nil {
+		items = []WatchlistItem{}
+	}
+	return items, nil
+}
+
+// Delete removes a watchlist item by ID, scoped to the user.
+func (s *WatchlistService) Delete(ctx context.Context, userID, itemID uuid.UUID) error {
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM user_watchlist WHERE id = $1 AND user_id = $2
+	`, itemID, userID)
+	if err != nil {
+		return fmt.Errorf("delete watchlist item: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrWatchlistItemNotFound
+	}
+	return nil
+}
+
+// isDuplicateError detects a PostgreSQL unique-constraint violation (23505).
+func isDuplicateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "23505") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "unique constraint")
+}

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// YieldPool represents a single DeFiLlama yield pool entry.
+type YieldPool struct {
+	Pool      string   `json:"pool"`
+	Project   string   `json:"project"`
+	Symbol    string   `json:"symbol"`
+	APY       float64  `json:"apy"`
+	APYBase   float64  `json:"apyBase"`
+	APYReward float64  `json:"apyReward"`
+	TVLUsd    float64  `json:"tvlUsd"`
+	APYPct7d  *float64 `json:"apyPct7d"`
+	Chain     string   `json:"chain"`
+	RiskScore float64  `json:"riskScore"`
+}
+
+type yieldCacheEntry struct {
+	pools     []YieldPool
+	expiresAt time.Time
+}
+
+// YieldService aggregates DeFiLlama yield pool data for a given chain.
+type YieldService struct {
+	httpClient    *http.Client
+	defiLlamaURL  string
+	cacheMu       sync.Mutex
+	cache         map[string]yieldCacheEntry
+	cacheTTL      time.Duration
+}
+
+const defaultYieldCacheTTL = 5 * time.Minute
+
+func NewYieldService(defiLlamaURL string) *YieldService {
+	if defiLlamaURL == "" {
+		defiLlamaURL = "https://yields.llama.fi"
+	}
+	return &YieldService{
+		httpClient:   &http.Client{Timeout: 15 * time.Second},
+		defiLlamaURL: defiLlamaURL,
+		cache:        make(map[string]yieldCacheEntry),
+		cacheTTL:     defaultYieldCacheTTL,
+	}
+}
+
+type defiLlamaPoolsResponse struct {
+	Data []struct {
+		Pool      string   `json:"pool"`
+		Project   string   `json:"project"`
+		Symbol    string   `json:"symbol"`
+		APY       *float64 `json:"apy"`
+		APYBase   *float64 `json:"apyBase"`
+		APYReward *float64 `json:"apyReward"`
+		TVLUsd    *float64 `json:"tvlUsd"`
+		APYPct7d  *float64 `json:"apyPct7d"`
+		Chain     string   `json:"chain"`
+	} `json:"data"`
+}
+
+// GetYieldOpportunities fetches pools for the given chain from DeFiLlama,
+// scores them by risk-adjusted APY, and returns the top `limit` results.
+func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, limit int) ([]YieldPool, error) {
+	cacheKey := fmt.Sprintf("%s:%d", chain, limit)
+	if cached := s.fromCache(cacheKey); cached != nil {
+		return cached, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", s.defiLlamaURL+"/pools", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build defillama request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("defillama request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("defillama returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read defillama response: %w", err)
+	}
+
+	var raw defiLlamaPoolsResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parse defillama response: %w", err)
+	}
+
+	pools := make([]YieldPool, 0, 64)
+	for _, p := range raw.Data {
+		if p.Chain != chain {
+			continue
+		}
+		pool := YieldPool{
+			Pool:    p.Pool,
+			Project: p.Project,
+			Symbol:  p.Symbol,
+			Chain:   p.Chain,
+		}
+		if p.APY != nil {
+			pool.APY = *p.APY
+		}
+		if p.APYBase != nil {
+			pool.APYBase = *p.APYBase
+		}
+		if p.APYReward != nil {
+			pool.APYReward = *p.APYReward
+		}
+		if p.TVLUsd != nil {
+			pool.TVLUsd = *p.TVLUsd
+		}
+		pool.APYPct7d = p.APYPct7d
+		pool.RiskScore = riskScore(pool)
+		pools = append(pools, pool)
+	}
+
+	// Sort by risk-adjusted APY descending.
+	sort.Slice(pools, func(i, j int) bool {
+		return riskAdjustedAPY(pools[i]) > riskAdjustedAPY(pools[j])
+	})
+
+	if limit > 0 && len(pools) > limit {
+		pools = pools[:limit]
+	}
+
+	s.toCache(cacheKey, pools)
+	return pools, nil
+}
+
+// riskScore assigns a 0-100 risk score (lower = safer).
+// Uses TVL as a proxy for protocol maturity.
+func riskScore(p YieldPool) float64 {
+	if p.TVLUsd >= 10_000_000 {
+		return 20
+	}
+	if p.TVLUsd >= 1_000_000 {
+		return 40
+	}
+	if p.TVLUsd >= 100_000 {
+		return 60
+	}
+	return 80
+}
+
+// riskAdjustedAPY penalises high-risk, low-TVL pools.
+func riskAdjustedAPY(p YieldPool) float64 {
+	if p.APY <= 0 {
+		return 0
+	}
+	penalty := (p.RiskScore / 100) * 0.5
+	return p.APY * (1 - penalty)
+}
+
+func (s *YieldService) fromCache(key string) []YieldPool {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	entry, ok := s.cache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+	return entry.pools
+}
+
+func (s *YieldService) toCache(key string, pools []YieldPool) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	s.cache[key] = yieldCacheEntry{pools: pools, expiresAt: time.Now().Add(s.cacheTTL)}
+}

--- a/apps/api/migrations/024_create_user_watchlist.down.sql
+++ b/apps/api/migrations/024_create_user_watchlist.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_watchlist;

--- a/apps/api/migrations/024_create_user_watchlist.up.sql
+++ b/apps/api/migrations/024_create_user_watchlist.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS user_watchlist (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    pool_id    VARCHAR(255) NOT NULL,
+    pool_symbol  VARCHAR(100),
+    pool_project VARCHAR(100),
+    pool_chain   VARCHAR(50),
+    apy_at_save  NUMERIC(10, 4),
+    tvl_usd      NUMERIC(20, 2),
+    added_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, pool_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_watchlist_user_id ON user_watchlist(user_id);

--- a/apps/dapp/frontend/app/stocks/page.tsx
+++ b/apps/dapp/frontend/app/stocks/page.tsx
@@ -1,288 +1,335 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { AppShell } from "@/components/app-shell";
-import { PositionCards } from "@/components/position-cards";
 import { useWallet } from "@/components/wallet-provider";
-import { usePortfolio } from "@/components/portfolio-provider";
 import {
     ArrowUpRight,
     ArrowDownRight,
     TrendingUp,
     Search,
     X,
-    Info,
+    Bookmark,
+    BookmarkCheck,
+    RefreshCw,
+    Zap,
+    AlertTriangle,
 } from "lucide-react";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-interface TokenizedStock {
-    id: string;
-    ticker: string;
-    name: string;
-    category: "equity" | "etf" | "commodity";
-    price: number;
-    change24h: number;
-    marketCap: string;
-    volume24h: string;
-    yieldApy: number;
-    description: string;
+interface YieldPool {
+    pool: string;
+    project: string;
+    symbol: string;
+    apy: number;
+    apyBase: number;
+    apyReward: number;
+    tvlUsd: number;
+    apyPct7d: number | null;
+    chain: string;
+    riskScore: number;
 }
 
-type CategoryFilter = "all" | "equity" | "etf" | "commodity";
+interface AIPick {
+    protocol: string;
+    symbol: string;
+    apy: number;
+    tvl_usd: number;
+    rationale: string;
+    risk_level: "low" | "medium" | "high";
+    confidence: number;
+}
 
-// ── Mock data ────────────────────────────────────────────────────────────────
+interface WatchlistItem {
+    id: string;
+    pool_id: string;
+    pool_symbol: string;
+    pool_project: string;
+    pool_chain: string;
+    apy_at_save: number;
+    tvl_usd: number;
+    added_at: string;
+}
 
-const STOCKS: TokenizedStock[] = [
-    {
-        id: "sp500",
-        ticker: "nSPY",
-        name: "S&P 500 Index",
-        category: "etf",
-        price: 542.18,
-        change24h: 1.24,
-        marketCap: "$4.2M",
-        volume24h: "$380K",
-        yieldApy: 8.2,
-        description: "Tokenized S&P 500 index tracking the 500 largest US public companies. Rebalanced quarterly.",
-    },
-    {
-        id: "tech-etf",
-        ticker: "nQQQ",
-        name: "Tech ETF",
-        category: "etf",
-        price: 487.35,
-        change24h: 2.15,
-        marketCap: "$2.8M",
-        volume24h: "$245K",
-        yieldApy: 9.1,
-        description: "Tokenized Nasdaq-100 exposure. Heavy weighting toward big tech and AI companies.",
-    },
-    {
-        id: "aapl",
-        ticker: "nAAPL",
-        name: "Apple Inc.",
-        category: "equity",
-        price: 198.52,
-        change24h: -0.34,
-        marketCap: "$1.1M",
-        volume24h: "$95K",
-        yieldApy: 5.8,
-        description: "Tokenized Apple stock. Dividends auto-converted to USDC and distributed to holders.",
-    },
-    {
-        id: "tsla",
-        ticker: "nTSLA",
-        name: "Tesla Inc.",
-        category: "equity",
-        price: 245.80,
-        change24h: 3.42,
-        marketCap: "$890K",
-        volume24h: "$142K",
-        yieldApy: 0,
-        description: "Tokenized Tesla stock. Price tracks the underlying equity via oracle feeds.",
-    },
-    {
-        id: "msft",
-        ticker: "nMSFT",
-        name: "Microsoft Corp.",
-        category: "equity",
-        price: 425.60,
-        change24h: 0.87,
-        marketCap: "$1.5M",
-        volume24h: "$118K",
-        yieldApy: 4.2,
-        description: "Tokenized Microsoft stock with auto-distributed dividends.",
-    },
-    {
-        id: "gold",
-        ticker: "nGLD",
-        name: "Gold",
-        category: "commodity",
-        price: 2_342.50,
-        change24h: 0.15,
-        marketCap: "$3.1M",
-        volume24h: "$210K",
-        yieldApy: 3.5,
-        description: "Tokenized gold exposure. 1 nGLD tracks 1 troy ounce of gold via oracle price feeds.",
-    },
-    {
-        id: "div-basket",
-        ticker: "nDIV",
-        name: "Dividend Basket",
-        category: "etf",
-        price: 112.40,
-        change24h: 0.52,
-        marketCap: "$1.8M",
-        volume24h: "$78K",
-        yieldApy: 7.4,
-        description: "A basket of high-dividend US equities. Dividends auto-compounded for higher yield.",
-    },
-];
+// ── API helpers ───────────────────────────────────────────────────────────────
 
-const CATEGORY_LABELS: Record<CategoryFilter, string> = {
-    all: "All Assets",
-    equity: "Equities",
-    etf: "ETFs & Indexes",
-    commodity: "Commodities",
-};
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
-// ── Buy modal ────────────────────────────────────────────────────────────────
+async function fetchYieldOpportunities(chain = "Stellar", limit = 20): Promise<YieldPool[]> {
+    const res = await fetch(`${API_BASE}/api/v1/yield-opportunities?chain=${chain}&limit=${limit}`);
+    if (!res.ok) throw new Error(`yield-opportunities: ${res.status}`);
+    const json = await res.json();
+    return json.data ?? [];
+}
 
-function BuyModal({ stock, onClose }: { stock: TokenizedStock; onClose: () => void }) {
-    const [amount, setAmount] = useState("");
-    const parsedAmount = parseFloat(amount) || 0;
-    const estimatedShares = parsedAmount / stock.price;
+async function fetchAIPick(): Promise<AIPick | null> {
+    try {
+        const res = await fetch(`/api/v1/recommend/vault`);
+        if (!res.ok) return null;
+        return res.json();
+    } catch {
+        return null;
+    }
+}
 
+async function fetchWatchlist(token: string): Promise<WatchlistItem[]> {
+    const res = await fetch(`${API_BASE}/api/v1/users/watchlist`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json.data ?? [];
+}
+
+async function addToWatchlist(pool: YieldPool, token: string): Promise<WatchlistItem | null> {
+    const res = await fetch(`${API_BASE}/api/v1/users/watchlist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+            pool_id: pool.pool,
+            pool_symbol: pool.symbol,
+            pool_project: pool.project,
+            pool_chain: pool.chain,
+            apy_at_save: pool.apy,
+            tvl_usd: pool.tvlUsd,
+        }),
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data ?? null;
+}
+
+async function removeFromWatchlist(itemId: string, token: string): Promise<boolean> {
+    const res = await fetch(`${API_BASE}/api/v1/users/watchlist/${itemId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    return res.ok || res.status === 204;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function riskLabel(score: number): { text: string; color: string } {
+    if (score <= 25) return { text: "Low", color: "text-emerald-600" };
+    if (score <= 55) return { text: "Med", color: "text-amber-500" };
+    return { text: "High", color: "text-red-500" };
+}
+
+function fmtTVL(usd: number): string {
+    if (usd >= 1_000_000_000) return `$${(usd / 1_000_000_000).toFixed(1)}B`;
+    if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(1)}M`;
+    if (usd >= 1_000) return `$${(usd / 1_000).toFixed(0)}K`;
+    return `$${usd.toFixed(0)}`;
+}
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+function SkeletonRow() {
     return (
-        <AnimatePresence>
-            <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="fixed inset-0 z-50 bg-black/25 backdrop-blur-sm"
-                onClick={onClose}
-            />
-            <motion.div
-                initial={{ opacity: 0, y: 32 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 32 }}
-                transition={{ duration: 0.22 }}
-                className="fixed inset-x-0 bottom-0 z-50 rounded-t-3xl bg-white shadow-2xl
-                           sm:inset-auto sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2
-                           sm:rounded-3xl sm:w-[480px]"
-            >
-                <div className="p-6 sm:p-8">
-                    {/* Header */}
-                    <div className="flex items-center justify-between mb-6">
-                        <div>
-                            <p className="text-lg font-medium text-black">Buy {stock.ticker}</p>
-                            <p className="text-xs text-black/40 mt-0.5">{stock.name}</p>
-                        </div>
-                        <button onClick={onClose} className="flex h-8 w-8 items-center justify-center rounded-full border border-black/8 text-black/40 hover:text-black transition-colors">
-                            <X className="h-4 w-4" />
-                        </button>
-                    </div>
-
-                    {/* Price */}
-                    <div className="mb-6 rounded-xl bg-black/[0.025] px-4 py-3 flex items-center justify-between">
-                        <span className="text-xs text-black/40">Current Price</span>
-                        <span className="font-mono text-sm text-black">${stock.price.toLocaleString("en-US", { minimumFractionDigits: 2 })}</span>
-                    </div>
-
-                    {/* Amount input */}
-                    <div className="mb-4">
-                        <label className="text-xs text-black/40 mb-2 block">Amount (USDC)</label>
-                        <div className="relative">
-                            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-black/30 text-lg">$</span>
-                            <input
-                                type="number"
-                                value={amount}
-                                onChange={(e) => setAmount(e.target.value)}
-                                placeholder="0.00"
-                                className="h-14 w-full rounded-xl border border-black/10 bg-black/[0.02] pl-8 pr-4
-                                           font-mono text-xl text-black outline-none transition-colors
-                                           focus:border-black/25 focus:bg-white
-                                           [appearance:textfield]
-                                           [&::-webkit-outer-spin-button]:appearance-none
-                                           [&::-webkit-inner-spin-button]:appearance-none"
-                            />
-                        </div>
-                    </div>
-
-                    {/* Quick amounts */}
-                    <div className="flex gap-2 mb-6">
-                        {[50, 100, 250, 500].map((v) => (
-                            <button
-                                key={v}
-                                onClick={() => setAmount(String(v))}
-                                className="flex-1 rounded-lg border border-black/8 py-2 text-xs text-black/50 hover:border-black/20 hover:text-black transition-colors"
-                            >
-                                ${v}
-                            </button>
-                        ))}
-                    </div>
-
-                    {/* Estimate */}
-                    {parsedAmount > 0 && (
-                        <div className="mb-6 rounded-xl border border-black/8 px-4 py-3 space-y-2">
-                            <div className="flex justify-between text-xs">
-                                <span className="text-black/40">You receive (est.)</span>
-                                <span className="font-mono text-black">{estimatedShares.toFixed(6)} {stock.ticker}</span>
-                            </div>
-                            {stock.yieldApy > 0 && (
-                                <div className="flex justify-between text-xs">
-                                    <span className="text-black/40">Yield APY</span>
-                                    <span className="font-mono text-black">{stock.yieldApy}%</span>
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    {/* CTA */}
-                    <button
-                        disabled={parsedAmount <= 0}
-                        className="w-full rounded-xl bg-black py-3.5 text-sm text-white transition-opacity disabled:opacity-35 disabled:cursor-not-allowed hover:opacity-80"
-                    >
-                        Buy {stock.ticker}
-                    </button>
-                    <p className="mt-2.5 text-center text-[11px] text-black/30">
-                        Paid with USDC from your wallet
-                    </p>
-                </div>
-            </motion.div>
-        </AnimatePresence>
+        <div className="animate-pulse flex items-center gap-4 rounded-2xl border border-black/8 bg-white px-5 py-4">
+            <div className="h-10 w-10 rounded-xl bg-black/[0.06] shrink-0" />
+            <div className="flex-1 space-y-2">
+                <div className="h-3.5 w-36 rounded bg-black/[0.06]" />
+                <div className="h-3 w-20 rounded bg-black/[0.04]" />
+            </div>
+            <div className="h-4 w-16 rounded bg-black/[0.06]" />
+            <div className="h-4 w-12 rounded bg-black/[0.06]" />
+            <div className="h-8 w-16 rounded-lg bg-black/[0.06]" />
+        </div>
     );
 }
 
-// ── Page ─────────────────────────────────────────────────────────────────────
+// ── Pool row ──────────────────────────────────────────────────────────────────
+
+function PoolRow({
+    pool,
+    watchlistId,
+    onWatch,
+    onUnwatch,
+}: {
+    pool: YieldPool;
+    watchlistId: string | undefined;
+    onWatch: (pool: YieldPool) => void;
+    onUnwatch: (id: string) => void;
+}) {
+    const risk = riskLabel(pool.riskScore);
+    const saved = Boolean(watchlistId);
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.18 }}
+            className="grid grid-cols-[1fr_auto] sm:grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] items-center gap-4 rounded-2xl border border-black/8 bg-white px-5 py-4 transition-all hover:border-black/18 hover:shadow-sm"
+        >
+            {/* Name */}
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-black/[0.04] shrink-0">
+                    <span className="text-xs font-semibold text-black/60 uppercase">
+                        {pool.symbol.slice(0, 2)}
+                    </span>
+                </div>
+                <div className="min-w-0">
+                    <p className="truncate text-sm text-black">{pool.symbol}</p>
+                    <p className="text-[11px] text-black/35 mt-0.5 font-mono capitalize">{pool.project}</p>
+                </div>
+            </div>
+
+            {/* APY */}
+            <div className="hidden sm:block text-right">
+                <p className="font-mono text-sm text-black">{pool.apy.toFixed(2)}%</p>
+                <p className="text-[10px] text-black/30 mt-0.5">APY</p>
+            </div>
+
+            {/* 7d trend */}
+            <div className="hidden sm:block text-right">
+                {pool.apyPct7d != null ? (
+                    <span className={cn(
+                        "inline-flex items-center gap-0.5 font-mono text-sm",
+                        pool.apyPct7d >= 0 ? "text-emerald-600" : "text-red-500"
+                    )}>
+                        {pool.apyPct7d >= 0
+                            ? <ArrowUpRight className="h-3 w-3" />
+                            : <ArrowDownRight className="h-3 w-3" />}
+                        {Math.abs(pool.apyPct7d).toFixed(1)}%
+                    </span>
+                ) : (
+                    <span className="text-xs text-black/30">-</span>
+                )}
+            </div>
+
+            {/* TVL */}
+            <div className="hidden sm:block text-right">
+                <p className="font-mono text-sm text-black/55">{fmtTVL(pool.tvlUsd)}</p>
+            </div>
+
+            {/* Risk */}
+            <div className="hidden sm:block text-right">
+                <span className={cn("text-xs font-medium", risk.color)}>{risk.text}</span>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 shrink-0">
+                <span className="sm:hidden font-mono text-sm text-black">{pool.apy.toFixed(1)}%</span>
+                <button
+                    onClick={() => saved ? onUnwatch(watchlistId!) : onWatch(pool)}
+                    title={saved ? "Remove from watchlist" : "Add to watchlist"}
+                    className={cn(
+                        "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors",
+                        saved
+                            ? "border-black/20 text-black hover:bg-black/5"
+                            : "border-black/8 text-black/35 hover:border-black/20 hover:text-black"
+                    )}
+                >
+                    {saved
+                        ? <BookmarkCheck className="h-3.5 w-3.5" />
+                        : <Bookmark className="h-3.5 w-3.5" />}
+                </button>
+            </div>
+        </motion.div>
+    );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function StocksPage() {
     const { isConnected } = useWallet();
-    const { positions } = usePortfolio();
     const router = useRouter();
-    const [filter, setFilter] = useState<CategoryFilter>("all");
     const [search, setSearch] = useState("");
-    const [selectedStock, setSelectedStock] = useState<TokenizedStock | null>(null);
 
+    const [pools, setPools] = useState<YieldPool[]>([]);
+    const [aiPick, setAIPick] = useState<AIPick | null>(null);
+    const [watchlist, setWatchlist] = useState<WatchlistItem[]>([]);
+    const [loadingPools, setLoadingPools] = useState(true);
+    const [loadingAI, setLoadingAI] = useState(true);
+    const [errorPools, setErrorPools] = useState(false);
+
+    // ── auth token helper ─────────────────────────────────────────────────────
+    // Attempt to read JWT from storage; falls back to empty string so watchlist
+    // calls silently fail and the user sees an empty list without an error.
+    const getToken = useCallback((): string => {
+        if (typeof window === "undefined") return "";
+        return localStorage.getItem("nester_token") ?? sessionStorage.getItem("nester_token") ?? "";
+    }, []);
+
+    // ── fetch pools ───────────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!isConnected) return;
+        setLoadingPools(true);
+        setErrorPools(false);
+        fetchYieldOpportunities("Stellar", 20)
+            .then(setPools)
+            .catch(() => setErrorPools(true))
+            .finally(() => setLoadingPools(false));
+    }, [isConnected]);
+
+    // ── fetch AI pick ─────────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!isConnected) return;
+        fetchAIPick()
+            .then(setAIPick)
+            .finally(() => setLoadingAI(false));
+    }, [isConnected]);
+
+    // ── fetch watchlist ───────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!isConnected) return;
+        const token = getToken();
+        if (!token) return;
+        fetchWatchlist(token).then(setWatchlist);
+    }, [isConnected, getToken]);
+
+    // ── redirect if not connected ─────────────────────────────────────────────
     useEffect(() => {
         if (!isConnected) router.push("/");
     }, [isConnected, router]);
 
     if (!isConnected) return null;
 
-    const filtered = STOCKS.filter((s) => {
-        if (filter !== "all" && s.category !== filter) return false;
-        if (search) {
-            const q = search.toLowerCase();
-            return s.ticker.toLowerCase().includes(q) || s.name.toLowerCase().includes(q);
-        }
-        return true;
+    // ── derived data ──────────────────────────────────────────────────────────
+    const watchedPoolIds = new Map(watchlist.map((w) => [w.pool_id, w.id]));
+
+    const filtered = pools.filter((p) => {
+        if (!search) return true;
+        const q = search.toLowerCase();
+        return p.symbol.toLowerCase().includes(q) || p.project.toLowerCase().includes(q);
     });
 
-    const totalMarketCap = STOCKS.reduce((sum, s) => {
-        const raw = s.marketCap.replace(/[$KMB,]/g, "");
-        const num = parseFloat(raw);
-        if (s.marketCap.includes("M")) return sum + num * 1_000_000;
-        if (s.marketCap.includes("K")) return sum + num * 1_000;
-        return sum + num;
-    }, 0);
+    const trending = [...pools]
+        .filter((p) => p.apyPct7d != null)
+        .sort((a, b) => (b.apyPct7d ?? 0) - (a.apyPct7d ?? 0))
+        .slice(0, 3);
+
+    // ── watchlist actions ─────────────────────────────────────────────────────
+    const handleWatch = async (pool: YieldPool) => {
+        const token = getToken();
+        if (!token) return;
+        const item = await addToWatchlist(pool, token);
+        if (item) setWatchlist((prev) => [item, ...prev]);
+    };
+
+    const handleUnwatch = async (id: string) => {
+        const token = getToken();
+        if (!token) return;
+        const ok = await removeFromWatchlist(id, token);
+        if (ok) setWatchlist((prev) => prev.filter((w) => w.id !== id));
+    };
+
+    const avgAPY = pools.length > 0
+        ? pools.reduce((s, p) => s + p.apy, 0) / pools.length
+        : 0;
 
     return (
         <AppShell>
             {/* Header */}
-            <motion.div
-                initial={{ opacity: 0, y: -8 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="mb-7"
-            >
-                <h1 className="text-2xl text-black sm:text-3xl">Stocks</h1>
+            <motion.div initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} className="mb-7">
+                <h1 className="text-2xl text-black sm:text-3xl">Yield Opportunities</h1>
                 <p className="mt-1 text-sm text-black/40">
-                    Buy tokenized equities, ETFs, and commodities with USDC. Earn dividends and price appreciation on-chain.
+                    Live yield-bearing digital assets on Stellar, ranked by risk-adjusted APY.
                 </p>
             </motion.div>
 
@@ -294,9 +341,9 @@ export default function StocksPage() {
                 className="mb-7 grid grid-cols-3 gap-3 sm:gap-4"
             >
                 {[
-                    { label: "Assets Listed", value: STOCKS.length.toString() },
-                    { label: "Total Market Cap", value: totalMarketCap >= 1_000_000 ? `$${(totalMarketCap / 1_000_000).toFixed(1)}M` : `$${(totalMarketCap / 1_000).toFixed(0)}K` },
-                    { label: "Avg Yield", value: `${(STOCKS.reduce((s, x) => s + x.yieldApy, 0) / STOCKS.length).toFixed(1)}%` },
+                    { label: "Pools Listed", value: loadingPools ? "—" : pools.length.toString() },
+                    { label: "Avg APY", value: loadingPools ? "—" : `${avgAPY.toFixed(1)}%` },
+                    { label: "Watchlist", value: watchlist.length.toString() },
                 ].map((s) => (
                     <div key={s.label} className="rounded-2xl border border-black/8 bg-white px-5 py-4">
                         <p className="font-mono text-xl text-black sm:text-2xl">{s.value}</p>
@@ -305,162 +352,218 @@ export default function StocksPage() {
                 ))}
             </motion.div>
 
-            {/* Search + Filters */}
+            {/* AI Pick of the Day */}
             <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1 }}
-                className="mb-6 space-y-3"
+                transition={{ delay: 0.08 }}
+                className="mb-7"
             >
-                {/* Search */}
+                <h2 className="text-sm text-black mb-3 flex items-center gap-2">
+                    <Zap className="h-3.5 w-3.5" />
+                    AI Pick of the Day
+                </h2>
+                {loadingAI ? (
+                    <div className="animate-pulse rounded-2xl border border-black/8 bg-white p-5 h-24" />
+                ) : aiPick && aiPick.confidence > 0 ? (
+                    <div className="rounded-2xl border border-black/8 bg-white p-5">
+                        <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-black">
+                                    {aiPick.symbol || aiPick.protocol}
+                                    {aiPick.symbol && aiPick.protocol && (
+                                        <span className="ml-1.5 text-xs text-black/40 font-normal capitalize">
+                                            via {aiPick.protocol}
+                                        </span>
+                                    )}
+                                </p>
+                                <p className="mt-1 text-xs text-black/50 leading-relaxed">{aiPick.rationale}</p>
+                            </div>
+                            <div className="text-right shrink-0">
+                                <p className="font-mono text-lg text-black">{aiPick.apy.toFixed(2)}%</p>
+                                <p className="text-[10px] text-black/35 mt-0.5 capitalize">{aiPick.risk_level} risk</p>
+                            </div>
+                        </div>
+                        <div className="mt-3 flex items-center gap-1.5">
+                            <div className="h-1 flex-1 rounded-full bg-black/[0.06]">
+                                <div
+                                    className="h-1 rounded-full bg-black/30"
+                                    style={{ width: `${(aiPick.confidence * 100).toFixed(0)}%` }}
+                                />
+                            </div>
+                            <span className="text-[10px] text-black/35 shrink-0">
+                                {(aiPick.confidence * 100).toFixed(0)}% confidence
+                            </span>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="rounded-2xl border border-black/8 bg-white p-5 text-sm text-black/35">
+                        AI recommendation temporarily unavailable.
+                    </div>
+                )}
+            </motion.div>
+
+            {/* Trending in DeFi */}
+            {!loadingPools && trending.length > 0 && (
+                <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.1 }}
+                    className="mb-7"
+                >
+                    <h2 className="text-sm text-black mb-3 flex items-center gap-2">
+                        <TrendingUp className="h-3.5 w-3.5" />
+                        Trending in DeFi
+                    </h2>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        {trending.map((pool) => (
+                            <div
+                                key={pool.pool}
+                                className="rounded-2xl border border-black/8 bg-white px-4 py-3"
+                            >
+                                <div className="flex items-center justify-between mb-1">
+                                    <p className="text-sm text-black truncate">{pool.symbol}</p>
+                                    <span className={cn(
+                                        "inline-flex items-center gap-0.5 font-mono text-sm",
+                                        (pool.apyPct7d ?? 0) >= 0 ? "text-emerald-600" : "text-red-500"
+                                    )}>
+                                        {(pool.apyPct7d ?? 0) >= 0
+                                            ? <ArrowUpRight className="h-3 w-3" />
+                                            : <ArrowDownRight className="h-3 w-3" />}
+                                        {Math.abs(pool.apyPct7d ?? 0).toFixed(1)}% 7d
+                                    </span>
+                                </div>
+                                <p className="text-xs text-black/40 capitalize">{pool.project}</p>
+                                <p className="font-mono text-base text-black mt-1">{pool.apy.toFixed(2)}% APY</p>
+                            </div>
+                        ))}
+                    </div>
+                </motion.div>
+            )}
+
+            {/* Search */}
+            <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.12 }}
+                className="mb-5"
+            >
                 <div className="relative w-full max-w-sm">
                     <Search className="absolute left-3.5 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-black/25" />
                     <input
                         type="text"
-                        placeholder="Search by name or ticker..."
+                        placeholder="Search by symbol or protocol..."
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
                         className="w-full rounded-xl border border-black/[0.08] bg-transparent py-2.5 pl-10 pr-4 text-[14px] text-black placeholder:text-black/30 outline-none transition-colors focus:border-black/20"
                     />
                 </div>
-
-                {/* Category tabs */}
-                <div className="flex gap-1 border-b border-black/8 pb-px overflow-x-auto scrollbar-hide">
-                    {(["all", "equity", "etf", "commodity"] as const).map((cat) => (
-                        <button
-                            key={cat}
-                            onClick={() => setFilter(cat)}
-                            className={cn(
-                                "relative pb-3 px-1 mr-4 text-sm whitespace-nowrap transition-colors shrink-0",
-                                filter === cat ? "text-black" : "text-black/35 hover:text-black/55"
-                            )}
-                        >
-                            {CATEGORY_LABELS[cat]}
-                            {filter === cat && (
-                                <motion.div
-                                    layoutId="stock-tab"
-                                    className="absolute bottom-0 left-0 right-0 h-0.5 bg-black rounded-full"
-                                />
-                            )}
-                        </button>
-                    ))}
-                </div>
             </motion.div>
 
-            {/* Stock list */}
+            {/* Top Yield Opportunities */}
             <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.15 }}
-                className="space-y-2"
+                className="mb-8"
             >
+                <h2 className="text-sm text-black mb-3">Top Yield Opportunities</h2>
+
                 {/* Table header */}
                 <div className="hidden sm:grid grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] gap-4 px-5 py-2 text-[11px] text-black/35">
                     <span>Asset</span>
-                    <span className="text-right">Price</span>
-                    <span className="text-right">24h</span>
-                    <span className="text-right">Market Cap</span>
-                    <span className="text-right">Yield APY</span>
-                    <span className="w-20"></span>
+                    <span className="text-right">APY</span>
+                    <span className="text-right">7d</span>
+                    <span className="text-right">TVL</span>
+                    <span className="text-right">Risk</span>
+                    <span className="w-8" />
                 </div>
 
-                {filtered.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-20 text-center">
-                        <p className="text-sm text-black/40">No assets match your search</p>
-                    </div>
-                ) : (
-                    filtered.map((stock, i) => (
-                        <motion.div
-                            key={stock.id}
-                            initial={{ opacity: 0, y: 8 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.2, delay: i * 0.04 }}
-                            className="grid grid-cols-[1fr_auto] sm:grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] items-center gap-4 rounded-2xl border border-black/8 bg-white px-5 py-4 transition-all hover:border-black/18 hover:shadow-sm"
-                        >
-                            {/* Name + ticker */}
-                            <div className="flex items-center gap-3 min-w-0">
-                                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-black/[0.04] shrink-0">
-                                    <span className="text-xs font-semibold text-black/60">{stock.ticker.slice(1, 3)}</span>
-                                </div>
-                                <div className="min-w-0">
-                                    <p className="truncate text-sm text-black">{stock.name}</p>
-                                    <p className="text-[11px] text-black/35 mt-0.5 font-mono">{stock.ticker}</p>
-                                </div>
-                            </div>
-
-                            {/* Price */}
-                            <div className="hidden sm:block text-right">
-                                <p className="font-mono text-sm text-black">
-                                    ${stock.price.toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                                </p>
-                            </div>
-
-                            {/* 24h change */}
-                            <div className="hidden sm:block text-right">
-                                <span className={cn(
-                                    "inline-flex items-center gap-0.5 font-mono text-sm",
-                                    stock.change24h >= 0 ? "text-emerald-600" : "text-red-500"
-                                )}>
-                                    {stock.change24h >= 0 ? (
-                                        <ArrowUpRight className="h-3 w-3" />
-                                    ) : (
-                                        <ArrowDownRight className="h-3 w-3" />
-                                    )}
-                                    {Math.abs(stock.change24h).toFixed(2)}%
-                                </span>
-                            </div>
-
-                            {/* Market Cap */}
-                            <div className="hidden sm:block text-right">
-                                <p className="font-mono text-sm text-black/55">{stock.marketCap}</p>
-                            </div>
-
-                            {/* Yield */}
-                            <div className="hidden sm:block text-right">
-                                {stock.yieldApy > 0 ? (
-                                    <p className="font-mono text-sm text-black">{stock.yieldApy}%</p>
-                                ) : (
-                                    <p className="text-xs text-black/30">-</p>
-                                )}
-                            </div>
-
-                            {/* Actions */}
-                            <div className="flex items-center gap-2 shrink-0">
-                                <span className="sm:hidden font-mono text-sm text-black">
-                                    ${stock.price.toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                                </span>
-                                <button
-                                    onClick={() => setSelectedStock(stock)}
-                                    className="flex h-8 items-center gap-1 rounded-lg bg-black px-3 text-xs text-white transition-opacity hover:opacity-75"
-                                >
-                                    Buy <ArrowUpRight className="h-3 w-3" />
-                                </button>
-                            </div>
-                        </motion.div>
-                    ))
-                )}
+                <div className="space-y-2">
+                    {loadingPools ? (
+                        Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+                    ) : errorPools ? (
+                        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+                            <AlertTriangle className="h-6 w-6 text-black/25" />
+                            <p className="text-sm text-black/40">Yield data unavailable right now.</p>
+                            <button
+                                onClick={() => {
+                                    setLoadingPools(true);
+                                    setErrorPools(false);
+                                    fetchYieldOpportunities("Stellar", 20)
+                                        .then(setPools)
+                                        .catch(() => setErrorPools(true))
+                                        .finally(() => setLoadingPools(false));
+                                }}
+                                className="flex items-center gap-1.5 rounded-lg border border-black/10 px-3 py-1.5 text-xs text-black/50 hover:text-black transition-colors"
+                            >
+                                <RefreshCw className="h-3 w-3" />
+                                Retry
+                            </button>
+                        </div>
+                    ) : filtered.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-16 text-center">
+                            <p className="text-sm text-black/40">No pools match your search.</p>
+                        </div>
+                    ) : (
+                        filtered.map((pool) => (
+                            <PoolRow
+                                key={pool.pool}
+                                pool={pool}
+                                watchlistId={watchedPoolIds.get(pool.pool)}
+                                onWatch={handleWatch}
+                                onUnwatch={handleUnwatch}
+                            />
+                        ))
+                    )}
+                </div>
             </motion.div>
 
-            {/* Open positions */}
-            {(() => {
-                const stockPositions = positions.filter((p) => p.vaultId === "stocks");
-                if (stockPositions.length === 0) return null;
-                return (
-                    <motion.div
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.2 }}
-                        className="mt-8"
-                    >
-                        <h2 className="text-sm text-black mb-3">Your Stock Positions</h2>
-                        <PositionCards positions={stockPositions} />
-                    </motion.div>
-                );
-            })()}
-
-            {/* Buy modal */}
-            {selectedStock && (
-                <BuyModal stock={selectedStock} onClose={() => setSelectedStock(null)} />
+            {/* Your Watchlist */}
+            {watchlist.length > 0 && (
+                <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.2 }}
+                    className="mb-8"
+                >
+                    <h2 className="text-sm text-black mb-3 flex items-center gap-2">
+                        <BookmarkCheck className="h-3.5 w-3.5" />
+                        Your Watchlist
+                    </h2>
+                    <div className="space-y-2">
+                        {watchlist.map((item) => (
+                            <div
+                                key={item.id}
+                                className="grid grid-cols-[1fr_auto] items-center gap-4 rounded-2xl border border-black/8 bg-white px-5 py-4"
+                            >
+                                <div className="flex items-center gap-3 min-w-0">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-black/[0.04] shrink-0">
+                                        <span className="text-xs font-semibold text-black/60 uppercase">
+                                            {item.pool_symbol.slice(0, 2)}
+                                        </span>
+                                    </div>
+                                    <div className="min-w-0">
+                                        <p className="truncate text-sm text-black">{item.pool_symbol}</p>
+                                        <p className="text-[11px] text-black/35 mt-0.5 capitalize">{item.pool_project}</p>
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-3 shrink-0">
+                                    <div className="text-right hidden sm:block">
+                                        <p className="font-mono text-sm text-black">{item.apy_at_save.toFixed(2)}%</p>
+                                        <p className="text-[10px] text-black/30">at save</p>
+                                    </div>
+                                    <button
+                                        onClick={() => handleUnwatch(item.id)}
+                                        className="flex h-8 w-8 items-center justify-center rounded-lg border border-black/8 text-black/35 hover:border-black/20 hover:text-black transition-colors"
+                                    >
+                                        <X className="h-3.5 w-3.5" />
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </motion.div>
             )}
         </AppShell>
     );

--- a/apps/intelligence/.env.example
+++ b/apps/intelligence/.env.example
@@ -26,3 +26,7 @@ INTELLIGENCE_NESTER_API_BASE_URL=http://api:8080
 # Service-to-service API key issued by the Go API for internal requests.
 # Must match the value configured in the Go API (apps/api).
 INTELLIGENCE_NESTER_SERVICE_API_KEY=your-service-api-key-here
+
+# DeFiLlama base URL — uses the public API; override only for local testing.
+# No API key required for public DeFiLlama endpoints.
+INTELLIGENCE_DEFILLAMA_BASE_URL=https://api.llama.fi

--- a/apps/intelligence/app/config.py
+++ b/apps/intelligence/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"  # gitleaks:allow
     nester_api_base_url: str = "http://localhost:8080"
     nester_service_api_key: str = ""
+    defillama_base_url: str = "https://api.llama.fi"
 
     model_config = SettingsConfigDict(
         env_prefix="INTELLIGENCE_",

--- a/apps/intelligence/app/routers/analyze.py
+++ b/apps/intelligence/app/routers/analyze.py
@@ -12,6 +12,7 @@ from app.services.prometheus import (
     get_market_sentiment,
     get_portfolio_insights,
     get_vault_recommendations,
+    get_yield_recommendation,
 )
 
 router = APIRouter(dependencies=[Depends(verify_jwt)])
@@ -63,6 +64,16 @@ async def portfolio_insights(
 async def market_sentiment(request: Request) -> dict[str, Any]:
     """Return current market sentiment for the Stellar DeFi / stablecoin space."""
     return await get_market_sentiment()
+
+
+@router.get("/recommend/vault")
+@_limiter.limit("20/minute")
+async def yield_recommendation(
+    request: Request,
+    claims: dict[str, Any] = Depends(verify_jwt),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Return an AI-picked yield opportunity based on live DeFiLlama and CoinGecko data."""
+    return await get_yield_recommendation()
 
 
 @router.get("/vaults/{vault_id}/recommendations")

--- a/apps/intelligence/app/services/coingecko.py
+++ b/apps/intelligence/app/services/coingecko.py
@@ -1,0 +1,176 @@
+"""CoinGecko client for live price data and market sentiment."""
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+_COINGECKO_BASE = "https://api.coingecko.com/api/v3"
+_TTL_PRICES = 300      # 5 min
+_TTL_SENTIMENT = 300
+
+_redis_client: Any = None
+_redis_available: bool = False
+_mem_cache: dict[str, tuple[Any, float]] = {}
+
+
+@dataclass
+class PriceData:
+    usd: float
+    usd_24h_change: float
+    usd_market_cap: float
+
+
+@dataclass
+class MarketSentiment:
+    signal: str               # "bull" | "bear" | "neutral"
+    defi_market_cap_usd: float
+    defi_dominance_pct: float
+
+
+def _get_redis() -> Any:
+    global _redis_client, _redis_available
+    if _redis_client is not None:
+        return _redis_client if _redis_available else None
+    try:
+        from app.config import settings
+        import redis as _redis
+        _redis_client = _redis.from_url(settings.redis_url, decode_responses=True)
+        _redis_client.ping()
+        _redis_available = True
+        logger.info("coingecko cache: redis connected")
+    except Exception as exc:
+        logger.warning("coingecko cache: redis unavailable (%s), using in-memory", exc)
+        _redis_available = False
+    return _redis_client if _redis_available else None
+
+
+def _cache_get(key: str) -> Any | None:
+    r = _get_redis()
+    if r is not None:
+        try:
+            raw = r.get(key)
+            if raw:
+                return json.loads(raw)
+        except Exception as exc:
+            logger.warning("coingecko cache get: %s", exc)
+    entry = _mem_cache.get(key)
+    if entry and time.monotonic() < entry[1]:
+        return entry[0]
+    return None
+
+
+def _cache_set(key: str, value: Any, ttl: int) -> None:
+    r = _get_redis()
+    if r is not None:
+        try:
+            r.setex(key, ttl, json.dumps(value))
+            return
+        except Exception as exc:
+            logger.warning("coingecko cache set: %s", exc)
+    _mem_cache[key] = (value, time.monotonic() + ttl)
+
+
+class CoinGeckoClient:
+    def __init__(self, base_url: str = _COINGECKO_BASE):
+        self.base_url = base_url.rstrip("/")
+
+    async def get_prices(self, coin_ids: list[str]) -> dict[str, PriceData]:
+        """Fetch USD price, 24h change, and market cap. Returns last cached value on 429."""
+        cache_key = f"coingecko:prices:{','.join(sorted(coin_ids))}"
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return {k: PriceData(**v) for k, v in cached.items()}
+
+        params = {
+            "ids": ",".join(coin_ids),
+            "vs_currencies": "usd",
+            "include_24hr_change": "true",
+            "include_market_cap": "true",
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/simple/price",
+                    params=params,
+                    timeout=aiohttp.ClientTimeout(total=8),
+                ) as resp:
+                    if resp.status == 429:
+                        logger.warning("CoinGecko rate limited (429), returning empty prices")
+                        return {}
+                    if resp.status != 200:
+                        logger.warning("CoinGecko /simple/price returned %s", resp.status)
+                        return {}
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("coingecko get_prices failed: %s", exc)
+            return {}
+
+        result: dict[str, Any] = {}
+        for coin_id in coin_ids:
+            entry = data.get(coin_id, {})
+            result[coin_id] = {
+                "usd": float(entry.get("usd", 0.0) or 0.0),
+                "usd_24h_change": float(entry.get("usd_24h_change", 0.0) or 0.0),
+                "usd_market_cap": float(entry.get("usd_market_cap", 0.0) or 0.0),
+            }
+
+        _cache_set(cache_key, result, _TTL_PRICES)
+        return {k: PriceData(**v) for k, v in result.items()}
+
+    async def get_market_sentiment(self) -> MarketSentiment:
+        """Fetch DeFi global market cap and dominance. Returns neutral on 429."""
+        cache_key = "coingecko:defi_global"
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return MarketSentiment(**cached)
+
+        _neutral = MarketSentiment(signal="neutral", defi_market_cap_usd=0.0, defi_dominance_pct=0.0)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/global/decentralized_finance_defi",
+                    timeout=aiohttp.ClientTimeout(total=8),
+                ) as resp:
+                    if resp.status == 429:
+                        logger.warning("CoinGecko rate limited (429), returning neutral sentiment")
+                        return _neutral
+                    if resp.status != 200:
+                        logger.warning("CoinGecko /global/defi returned %s", resp.status)
+                        return _neutral
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("coingecko get_market_sentiment failed: %s", exc)
+            return _neutral
+
+        defi_data = data.get("data", {})
+        market_cap = float(defi_data.get("defi_market_cap", 0) or 0)
+        dominance = float(defi_data.get("defi_dominance", 0) or 0)
+        trading_vol = float(defi_data.get("trading_volume_24h", 0) or 0)
+
+        signal = "neutral"
+        if market_cap > 0:
+            vol_ratio = trading_vol / market_cap
+            if vol_ratio > 0.05:
+                signal = "bull"
+            elif vol_ratio < 0.02:
+                signal = "bear"
+
+        result = {"signal": signal, "defi_market_cap_usd": market_cap, "defi_dominance_pct": dominance}
+        _cache_set(cache_key, result, _TTL_SENTIMENT)
+        return MarketSentiment(**result)
+
+
+_default_client: CoinGeckoClient | None = None
+
+
+def get_client() -> CoinGeckoClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = CoinGeckoClient()
+    return _default_client

--- a/apps/intelligence/app/services/defillama.py
+++ b/apps/intelligence/app/services/defillama.py
@@ -1,0 +1,188 @@
+"""DeFiLlama client for live TVL and APY feeds."""
+import json
+import logging
+import time
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+_DEFILLAMA_BASE = "https://api.llama.fi"
+_YIELDS_BASE = "https://yields.llama.fi"
+
+_TTL_PROTOCOLS = 900  # 15 min
+_TTL_POOLS = 900
+_TTL_HISTORY = 900
+
+_redis_client: Any = None
+_redis_available: bool = False
+_mem_cache: dict[str, tuple[Any, float]] = {}
+
+
+def _get_redis() -> Any:
+    global _redis_client, _redis_available
+    if _redis_client is not None:
+        return _redis_client if _redis_available else None
+    try:
+        from app.config import settings
+        import redis as _redis
+        _redis_client = _redis.from_url(settings.redis_url, decode_responses=True)
+        _redis_client.ping()
+        _redis_available = True
+        logger.info("defillama cache: redis connected")
+    except Exception as exc:
+        logger.warning("defillama cache: redis unavailable (%s), using in-memory", exc)
+        _redis_available = False
+    return _redis_client if _redis_available else None
+
+
+def _cache_get(key: str) -> Any | None:
+    r = _get_redis()
+    if r is not None:
+        try:
+            raw = r.get(key)
+            if raw:
+                return json.loads(raw)
+        except Exception as exc:
+            logger.warning("defillama cache get: %s", exc)
+    entry = _mem_cache.get(key)
+    if entry and time.monotonic() < entry[1]:
+        return entry[0]
+    return None
+
+
+def _cache_set(key: str, value: Any, ttl: int) -> None:
+    r = _get_redis()
+    if r is not None:
+        try:
+            r.setex(key, ttl, json.dumps(value))
+            return
+        except Exception as exc:
+            logger.warning("defillama cache set: %s", exc)
+    _mem_cache[key] = (value, time.monotonic() + ttl)
+
+
+class DeFiLlamaClient:
+    def __init__(self, base_url: str = _DEFILLAMA_BASE, yields_url: str = _YIELDS_BASE):
+        self.base_url = base_url.rstrip("/")
+        self.yields_url = yields_url.rstrip("/")
+
+    async def get_stellar_protocols(self) -> list[dict[str, Any]]:
+        key = "defillama:stellar_protocols"
+        cached = _cache_get(key)
+        if cached is not None:
+            return list(cached)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/protocols",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        logger.warning("defillama /protocols returned %s", resp.status)
+                        return []
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("defillama get_stellar_protocols failed: %s", exc)
+            return []
+
+        stellar = [
+            {
+                "name": p.get("name", ""),
+                "slug": p.get("slug", ""),
+                "tvl": p.get("tvl", 0),
+                "chain": "Stellar",
+                "category": p.get("category", ""),
+            }
+            for p in data
+            if "stellar" in [c.lower() for c in (p.get("chains") or [])]
+        ]
+        _cache_set(key, stellar, _TTL_PROTOCOLS)
+        return stellar
+
+    async def get_yield_pools(self, chain: str = "Stellar") -> list[dict[str, Any]]:
+        key = f"defillama:pools:{chain.lower()}"
+        cached = _cache_get(key)
+        if cached is not None:
+            return list(cached)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.yields_url}/pools",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        logger.warning("defillama /pools returned %s", resp.status)
+                        return []
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("defillama get_yield_pools failed: %s", exc)
+            return []
+
+        pools = [
+            {
+                "pool": p.get("pool", ""),
+                "project": p.get("project", ""),
+                "symbol": p.get("symbol", ""),
+                "apy": p.get("apy") or 0.0,
+                "apyBase": p.get("apyBase") or 0.0,
+                "apyReward": p.get("apyReward") or 0.0,
+                "tvlUsd": p.get("tvlUsd") or 0.0,
+                "apyPct7d": p.get("apyPct7d"),
+                "il7d": p.get("il7d"),
+                "chain": p.get("chain", ""),
+            }
+            for p in data.get("data", [])
+            if p.get("chain", "").lower() == chain.lower()
+        ]
+        _cache_set(key, pools, _TTL_POOLS)
+        return pools
+
+    async def get_pool_history(self, pool_id: str) -> list[dict[str, Any]]:
+        key = f"defillama:pool_history:{pool_id}"
+        cached = _cache_get(key)
+        if cached is not None:
+            return list(cached)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.yields_url}/chart/{pool_id}",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        logger.warning("defillama /chart/%s returned %s", pool_id, resp.status)
+                        return []
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("defillama get_pool_history failed: %s", exc)
+            return []
+
+        history = [
+            {
+                "timestamp": entry.get("timestamp", ""),
+                "apy": entry.get("apy") or 0.0,
+                "tvlUsd": entry.get("tvlUsd") or 0.0,
+            }
+            for entry in data.get("data", [])
+        ]
+        _cache_set(key, history, _TTL_HISTORY)
+        return history
+
+
+_default_client: DeFiLlamaClient | None = None
+
+
+def get_client() -> DeFiLlamaClient:
+    global _default_client
+    if _default_client is None:
+        try:
+            from app.config import settings
+            base_url = getattr(settings, "defillama_base_url", None) or _DEFILLAMA_BASE
+        except Exception:
+            base_url = _DEFILLAMA_BASE
+        _default_client = DeFiLlamaClient(base_url=base_url)
+    return _default_client

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -13,6 +13,8 @@ import aiohttp
 from app.config import settings
 from app.services.conversation_store import store as conversation_store
 from app.services.vault_context import VaultContextFetcher
+from app.services.defillama import get_client as get_defillama_client
+from app.services.coingecko import get_client as get_coingecko_client
 
 logger = logging.getLogger(__name__)
 
@@ -245,12 +247,16 @@ async def stream_chat(user_id: str, message: str) -> AsyncIterator[str]:
     context_block = vault_context_fetcher.build_context_block(vaults, market_rates)
     risk_profile_block = vault_context_fetcher.build_risk_profile_block(vaults, risk_data)
 
+    market_context_block = await _build_market_context_block()
+
     dynamic_system_prompt = f"""You are Prometheus, an AI financial advisor for the
 Nester DeFi platform.
 
 {context_block}
 
 {risk_profile_block}
+
+{market_context_block}
 
 ## Nester Platform Context
 - Vault types: Flexible (no lock), Fixed-30d (30-day lock, higher APY),
@@ -378,6 +384,130 @@ async def get_market_sentiment() -> dict[str, Any]:
             "summary": "Sentiment data temporarily unavailable.",
             "confidence": 0.0,
             "updatedAt": "",
+        }
+
+
+async def _build_market_context_block() -> str:
+    """Fetch live DeFiLlama + CoinGecko data and format as a system prompt block.
+
+    Returns an empty string on total failure so the prompt degrades gracefully.
+    """
+    sections: list[str] = []
+
+    try:
+        cg = get_coingecko_client()
+        prices = await cg.get_prices(["usd-coin", "stellar"])
+        sentiment = await cg.get_market_sentiment()
+
+        price_lines: list[str] = []
+        usdc = prices.get("usd-coin")
+        xlm = prices.get("stellar")
+        if usdc:
+            peg = "stable" if abs(usdc.usd - 1.0) < 0.005 else "off-peg"
+            price_lines.append(f"- USDC: ${usdc.usd:.4f} ({peg}, 24h {usdc.usd_24h_change:+.2f}%)")
+        if xlm:
+            price_lines.append(
+                f"- XLM: ${xlm.usd:.4f} (24h {xlm.usd_24h_change:+.2f}%, "
+                f"mktcap ${xlm.usd_market_cap:,.0f})"
+            )
+
+        if price_lines:
+            sections.append("## Live Price Data\n" + "\n".join(price_lines))
+
+        if sentiment.defi_market_cap_usd > 0:
+            sections.append(
+                f"## DeFi Market Sentiment\n"
+                f"- Signal: {sentiment.signal.upper()}\n"
+                f"- DeFi market cap: ${sentiment.defi_market_cap_usd:,.0f}\n"
+                f"- DeFi dominance: {sentiment.defi_dominance_pct:.2f}%"
+            )
+    except Exception as exc:
+        logger.warning("market context: coingecko fetch failed: %s", exc)
+
+    try:
+        dl = get_defillama_client()
+        pools = await dl.get_yield_pools(chain="Stellar")
+        if pools:
+            top5 = sorted(pools, key=lambda p: p.get("apy") or 0, reverse=True)[:5]
+            pool_lines = [
+                f"- {p['project']} {p['symbol']}: {p['apy']:.2f}% APY, "
+                f"TVL ${p['tvlUsd']:,.0f}"
+                for p in top5
+            ]
+            sections.append("## Top Stellar DeFi Pools (DeFiLlama)\n" + "\n".join(pool_lines))
+    except Exception as exc:
+        logger.warning("market context: defillama fetch failed: %s", exc)
+
+    return "\n\n".join(sections)
+
+
+async def get_yield_recommendation() -> dict[str, Any]:
+    """Return an AI-picked yield opportunity based on current DeFiLlama and CoinGecko data."""
+    dl = get_defillama_client()
+    cg = get_coingecko_client()
+
+    pools: list[dict[str, Any]] = []
+    prices: dict[str, Any] = {}
+    sentiment_signal = "neutral"
+
+    try:
+        pools = await dl.get_yield_pools(chain="Stellar")
+    except Exception as exc:
+        logger.warning("get_yield_recommendation: defillama failed: %s", exc)
+
+    try:
+        raw_prices = await cg.get_prices(["usd-coin", "stellar"])
+        prices = {k: {"usd": v.usd, "change_24h": v.usd_24h_change} for k, v in raw_prices.items()}
+        raw_sentiment = await cg.get_market_sentiment()
+        sentiment_signal = raw_sentiment.signal
+    except Exception as exc:
+        logger.warning("get_yield_recommendation: coingecko failed: %s", exc)
+
+    top_pools_summary = ""
+    if pools:
+        top5 = sorted(pools, key=lambda p: p.get("apy") or 0, reverse=True)[:5]
+        lines = [
+            f"  - {p['project']} {p['symbol']}: APY {p['apy']:.2f}%, TVL ${p['tvlUsd']:,.0f}"
+            for p in top5
+        ]
+        top_pools_summary = "Top Stellar pools:\n" + "\n".join(lines)
+
+    schema = (
+        '{"protocol": str, "symbol": str, "apy": float, "tvl_usd": float,'
+        ' "rationale": str (1-2 sentences), "risk_level": "low"|"medium"|"high",'
+        ' "confidence": float (0.0-1.0)}'
+    )
+    prompt = (
+        "Based on current Stellar DeFi market conditions, pick the single best yield opportunity "
+        "for a Nester user seeking risk-adjusted returns. "
+        f"Market sentiment: {sentiment_signal}. "
+        f"Prices: {json.dumps(prices)}. "
+        f"{top_pools_summary}\n"
+        f"Respond with JSON only, no markdown, matching this schema: {schema}"
+    )
+
+    client = get_client()
+    try:
+        response = await client.messages.create(
+            model=settings.anthropic_model,
+            max_tokens=ANALYZE_MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = next(
+            (b.text for b in response.content if isinstance(b, anthropic.types.TextBlock)), ""
+        )
+        return dict(json.loads(_json_strip(text)))
+    except Exception:
+        logger.exception("Failed to get yield recommendation")
+        return {
+            "protocol": "",
+            "symbol": "",
+            "apy": 0.0,
+            "tvl_usd": 0.0,
+            "rationale": "Recommendation temporarily unavailable.",
+            "risk_level": "medium",
+            "confidence": 0.0,
         }
 
 

--- a/apps/intelligence/tests/test_coingecko.py
+++ b/apps/intelligence/tests/test_coingecko.py
@@ -1,0 +1,146 @@
+"""Unit tests for CoinGeckoClient with mocked HTTP responses."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.coingecko import CoinGeckoClient, _mem_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_mem_cache():
+    _mem_cache.clear()
+    yield
+    _mem_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return CoinGeckoClient()
+
+
+_PRICE_RESPONSE = {
+    "usd-coin": {
+        "usd": 1.0002,
+        "usd_24h_change": 0.01,
+        "usd_market_cap": 42_000_000_000.0,
+    },
+    "stellar": {
+        "usd": 0.12,
+        "usd_24h_change": -3.5,
+        "usd_market_cap": 3_500_000_000.0,
+    },
+}
+
+_DEFI_GLOBAL_RESPONSE = {
+    "data": {
+        "defi_market_cap": "85000000000",
+        "defi_dominance": "4.2",
+        "trading_volume_24h": "6000000000",
+    }
+}
+
+
+def _make_mock_response(status: int, json_data: object) -> MagicMock:
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=json_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+    return mock_resp
+
+
+def _make_session(mock_resp: MagicMock) -> MagicMock:
+    session = AsyncMock()
+    session.get = MagicMock(return_value=mock_resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_prices_returns_price_data(client):
+    mock_resp = _make_mock_response(200, _PRICE_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_prices(["usd-coin", "stellar"])
+
+    assert "usd-coin" in result
+    assert abs(result["usd-coin"].usd - 1.0002) < 1e-6
+    assert result["usd-coin"].usd_24h_change == pytest.approx(0.01)
+    assert "stellar" in result
+    assert result["stellar"].usd_24h_change == pytest.approx(-3.5)
+
+
+@pytest.mark.asyncio
+async def test_get_prices_returns_empty_on_429(client):
+    mock_resp = _make_mock_response(429, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_prices(["usd-coin"])
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_prices_returns_empty_on_network_error(client):
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=Exception("connection refused"))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await client.get_prices(["usd-coin"])
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_prices_caches_result(client):
+    mock_resp = _make_mock_response(200, _PRICE_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)) as mock_session:
+        await client.get_prices(["usd-coin", "stellar"])
+        await client.get_prices(["usd-coin", "stellar"])
+    assert mock_session.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_market_sentiment_bull(client):
+    # vol_ratio = 6B / 85B ≈ 0.071 > 0.05 → bull
+    mock_resp = _make_mock_response(200, _DEFI_GLOBAL_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_market_sentiment()
+
+    assert result.signal == "bull"
+    assert result.defi_market_cap_usd == pytest.approx(85_000_000_000, rel=1e-3)
+    assert result.defi_dominance_pct == pytest.approx(4.2, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_get_market_sentiment_bear():
+    client = CoinGeckoClient()
+    bear_response = {
+        "data": {
+            "defi_market_cap": "100000000000",
+            "defi_dominance": "3.0",
+            "trading_volume_24h": "1000000000",  # vol_ratio = 0.01 < 0.02 → bear
+        }
+    }
+    mock_resp = _make_mock_response(200, bear_response)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_market_sentiment()
+    assert result.signal == "bear"
+
+
+@pytest.mark.asyncio
+async def test_get_market_sentiment_returns_neutral_on_429(client):
+    mock_resp = _make_mock_response(429, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_market_sentiment()
+    assert result.signal == "neutral"
+    assert result.defi_market_cap_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_market_sentiment_returns_neutral_on_error(client):
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=Exception("timeout"))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await client.get_market_sentiment()
+    assert result.signal == "neutral"

--- a/apps/intelligence/tests/test_defillama.py
+++ b/apps/intelligence/tests/test_defillama.py
@@ -1,0 +1,162 @@
+"""Unit tests for DeFiLlamaClient with mocked HTTP responses."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.defillama import DeFiLlamaClient, _mem_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_mem_cache():
+    _mem_cache.clear()
+    yield
+    _mem_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return DeFiLlamaClient(
+        base_url="https://api.llama.fi",
+        yields_url="https://yields.llama.fi",
+    )
+
+
+_PROTOCOLS_RESPONSE = [
+    {
+        "name": "Stellar Pool",
+        "slug": "stellar-pool",
+        "tvl": 5_000_000,
+        "chains": ["Stellar"],
+        "category": "DEX",
+    },
+    {
+        "name": "Ethereum Pool",
+        "slug": "eth-pool",
+        "tvl": 10_000_000,
+        "chains": ["Ethereum"],
+        "category": "Lending",
+    },
+]
+
+_POOLS_RESPONSE = {
+    "data": [
+        {
+            "pool": "abc-123",
+            "project": "blend",
+            "symbol": "USDC",
+            "apy": 9.5,
+            "apyBase": 8.0,
+            "apyReward": 1.5,
+            "tvlUsd": 2_000_000,
+            "apyPct7d": 0.3,
+            "il7d": None,
+            "chain": "Stellar",
+        },
+        {
+            "pool": "def-456",
+            "project": "aave",
+            "symbol": "USDC",
+            "apy": 6.2,
+            "apyBase": 6.2,
+            "apyReward": None,
+            "tvlUsd": 50_000_000,
+            "apyPct7d": -0.1,
+            "il7d": None,
+            "chain": "Ethereum",
+        },
+    ]
+}
+
+_HISTORY_RESPONSE = {
+    "data": [
+        {"timestamp": "2024-01-01T00:00:00Z", "apy": 9.1, "tvlUsd": 1_900_000},
+        {"timestamp": "2024-01-02T00:00:00Z", "apy": 9.5, "tvlUsd": 2_000_000},
+    ]
+}
+
+
+def _make_mock_response(status: int, json_data: object) -> MagicMock:
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=json_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+    return mock_resp
+
+
+def _make_session(mock_resp: MagicMock) -> MagicMock:
+    session = AsyncMock()
+    session.get = MagicMock(return_value=mock_resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_stellar_protocols_filters_by_chain(client):
+    mock_resp = _make_mock_response(200, _PROTOCOLS_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_stellar_protocols()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "Stellar Pool"
+    assert result[0]["chain"] == "Stellar"
+
+
+@pytest.mark.asyncio
+async def test_get_stellar_protocols_returns_empty_on_error(client):
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=Exception("network error"))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    with patch("aiohttp.ClientSession", return_value=session):
+        result = await client.get_stellar_protocols()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_yield_pools_filters_by_chain(client):
+    mock_resp = _make_mock_response(200, _POOLS_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_yield_pools(chain="Stellar")
+
+    assert len(result) == 1
+    assert result[0]["project"] == "blend"
+    assert result[0]["chain"] == "Stellar"
+
+
+@pytest.mark.asyncio
+async def test_get_yield_pools_caches_result(client):
+    mock_resp = _make_mock_response(200, _POOLS_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)) as mock_session:
+        await client.get_yield_pools(chain="Stellar")
+        await client.get_yield_pools(chain="Stellar")
+    # ClientSession only constructed once due to caching
+    assert mock_session.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_yield_pools_returns_empty_on_non_200(client):
+    mock_resp = _make_mock_response(500, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_yield_pools(chain="Stellar")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_pool_history_returns_snapshots(client):
+    mock_resp = _make_mock_response(200, _HISTORY_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_pool_history("abc-123")
+
+    assert len(result) == 2
+    assert result[0]["apy"] == 9.1
+    assert result[1]["tvlUsd"] == 2_000_000
+
+
+@pytest.mark.asyncio
+async def test_get_pool_history_returns_empty_on_error(client):
+    mock_resp = _make_mock_response(404, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_pool_history("nonexistent")
+    assert result == []


### PR DESCRIPTION
## Summary

closes #576, closes #570, closes #567, closes #569

### feat(dapp): implement stocks page — yield-bearing asset suggestions (#576)

- Replaced the mock-data stocks page with a live data implementation
- "Top Yield Opportunities" grid fetches from `GET /api/v1/yield-opportunities?chain=Stellar&limit=20` with APY, TVL, risk score, and 7-day trend columns
- "AI Pick of the Day" section calls `GET /api/v1/recommend/vault` on the intelligence service and renders the Prometheus recommendation with confidence bar
- "Trending in DeFi" section shows the three pools with the highest positive 7-day APY change
- "Your Watchlist" section with add/remove — backed by `GET/POST/DELETE /api/v1/users/watchlist` endpoints
- Loading skeletons while data fetches; error state with retry button if the yield feed is unavailable

### feat(intelligence): integrate CoinGecko live price data (#570)

- New `apps/intelligence/app/services/coingecko.py` — `CoinGeckoClient` with `get_prices()` and `get_market_sentiment()`
- Fetches USDC and XLM price, 24h change, market cap from the CoinGecko free-tier API
- Fetches DeFi market cap and dominance to derive a bull/bear/neutral signal
- Redis caching with 5-minute TTL; graceful 429 handling — returns last cached value and logs a warning
- CoinGecko price and sentiment data are injected into the Prometheus system prompt on every `stream_chat` call

### feat(api): vault performance analytics endpoint (#567)

- New `GET /api/v1/vaults/{id}/analytics?period=30d|90d|1y`
- Computes APY volatility (std dev), max drawdown, Sharpe ratio, Sortino ratio, and win rate from vault share-price snapshots
- Risk-free rate configurable via `RISK_FREE_RATE` env var (default 0.05); documented in `apps/api/.env.example`
- Results cached in-process with a 1-hour TTL

### feat(intelligence): integrate DeFiLlama live TVL and APY feeds (#569)

- New `apps/intelligence/app/services/defillama.py` — `DeFiLlamaClient` with `get_stellar_protocols()`, `get_yield_pools()`, `get_pool_history()`
- Redis caching with 15-minute TTL; graceful degradation — Prometheus still responds if DeFiLlama is unreachable
- Top-5 Stellar pools by APY injected into every Prometheus `stream_chat` system prompt
- New `GET /recommend/vault` endpoint on the intelligence service returns an AI-picked yield opportunity combining DeFiLlama pool data and CoinGecko market context
- `INTELLIGENCE_DEFILLAMA_BASE_URL` documented in `apps/intelligence/.env.example`

## Supporting changes

- New `POST/GET/DELETE /api/v1/users/watchlist` endpoints in the Go API with migration `024_create_user_watchlist`
- New `GET /api/v1/yield-opportunities` endpoint in the Go API — aggregates DeFiLlama Stellar pool data, scores by risk-adjusted APY, and returns the top `limit` results
- All new endpoints registered in `apps/api/cmd/api/main.go`
- Unit tests for `DeFiLlamaClient` and `CoinGeckoClient` with mocked HTTP responses

## Test plan

- [ ] Run `pytest apps/intelligence/tests/test_defillama.py` — all 7 tests pass
- [ ] Run `pytest apps/intelligence/tests/test_coingecko.py` — all 8 tests pass
- [ ] `GET /api/v1/yield-opportunities?chain=Stellar&limit=5` returns a JSON array with APY, TVL, riskScore fields
- [ ] `GET /api/v1/vaults/{valid-uuid}/analytics?period=30d` returns all six metric fields
- [ ] `POST /api/v1/users/watchlist` with a valid JWT creates a watchlist item
- [ ] `GET /api/v1/users/watchlist` returns the saved item; `DELETE /api/v1/users/watchlist/{id}` removes it
- [ ] Stocks page renders Top Yield Opportunities grid, AI Pick section, Trending section, and Watchlist section
- [ ] Loading skeletons visible while fetching; error state with retry button visible when the API is down
