### PR TITLE
Implement idempotent event processing

### DIFF
--- a/apps/api/internal/stellar/indexer.go
+++ b/apps/api/internal/stellar/indexer.go
@@ -359,12 +359,10 @@ func setLastIndexedLedger(ctx context.Context, sysRepo systemstate.Repository, l
 
 func markEventProcessed(ctx context.Context, tx *sql.Tx, event indexedEvent) (bool, error) {
 	result, err := tx.ExecContext(ctx, `
-INSERT INTO processed_chain_events (event_id, contract_id, event_type, ledger)
-VALUES ($1, $2, $3, $4)
+INSERT INTO processed_events (event_id, ledger_sequence)
+VALUES ($1, $2)
 ON CONFLICT (event_id) DO NOTHING`,
 		event.ID,
-		event.ContractID,
-		event.EventType,
 		event.Ledger,
 	)
 	if err != nil {

--- a/apps/api/internal/stellar/indexer_test.go
+++ b/apps/api/internal/stellar/indexer_test.go
@@ -26,8 +26,8 @@ func TestApplyIndexedEvent_Deposit_ProcessesOnce(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectExec("INSERT INTO processed_chain_events").
-		WithArgs(event.ID, event.ContractID, event.EventType, event.Ledger).
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE vaults").
 		WithArgs("10.25", event.ContractID).
@@ -56,8 +56,8 @@ func TestApplyIndexedEvent_DuplicateEvent_IsSkipped(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectExec("INSERT INTO processed_chain_events").
-		WithArgs(event.ID, event.ContractID, event.EventType, event.Ledger).
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
 		WillReturnResult(sqlmock.NewResult(1, 0))
 	mock.ExpectCommit()
 

--- a/apps/api/migrations/028_create_processed_events_table.down.sql
+++ b/apps/api/migrations/028_create_processed_events_table.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_processed_events_ledger_sequence;
+DROP TABLE IF EXISTS processed_events;

--- a/apps/api/migrations/028_create_processed_events_table.up.sql
+++ b/apps/api/migrations/028_create_processed_events_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS processed_events (
+    event_id         TEXT PRIMARY KEY,
+    ledger_sequence  BIGINT NOT NULL,
+    processed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_processed_events_ledger_sequence ON processed_events (ledger_sequence);


### PR DESCRIPTION
## Summary
Implements idempotent event processing for the Soroban event indexer by tracking processed event IDs inside an atomic, transactional database query. This guarantees that all balance mutations (deposits and withdrawals) are applied exactly once across restarts, network lag, and RPC replays.

## Related Issues
Closes #557

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- Created migrations `025_create_processed_events_table.up.sql` and `025_create_processed_events_table.down.sql` to manage the `processed_events` table and ledger sequence index.
- Updated database bootstrapping (`ensureIndexerTables`) and recording logic (`markEventProcessed`) in `apps/api/internal/stellar/indexer.go` to use the `processed_events` table.
- Adjusted query expectations and mock argument checks in `apps/api/internal/stellar/indexer_test.go` to match the new idempotency schema.

## Testing Done
- Executed and validated unit tests (`TestApplyIndexedEvent_Deposit_ProcessesOnce` and `TestApplyIndexedEvent_DuplicateEvent_IsSkipped`) verifying that replayed events are safely ignored and balance mutations are correctly committed exactly once.

## Screenshots
N/A (Backend logic enhancement)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [x] No secrets or credentials in the code
- [x] Smart contract changes reviewed for security implications
