### PR TITLE
feat(vault): add preview_withdraw_net for slippage-safe withdrawals (…

### DIFF
--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -96,3 +96,10 @@ func (s *SorobanVaultChainInvoker) HarvestVault(
 ) (string, error) {
 	return s.invoker.InvokeWithAddressAndBool(ctx, contractAddress, "harvest", userAddress, compound)
 }
+
+// PreviewWithdrawNet calls preview_withdraw_net on the vault contract and
+// returns the net amount (in stroops) the user receives after all fees.
+// Use this value as min_assets_out when building a withdraw transaction.
+func (s *SorobanVaultChainInvoker) PreviewWithdrawNet(ctx context.Context, contractAddress string, sharesStroops int64) (int64, error) {
+	return s.invoker.SimulateI128Function(ctx, contractAddress, "preview_withdraw_net", sharesStroops)
+}

--- a/apps/dapp/frontend/components/vault-action-modals.tsx
+++ b/apps/dapp/frontend/components/vault-action-modals.tsx
@@ -688,6 +688,7 @@ export function WithdrawModal({
                 walletAddress: address,
                 contractId,
                 shares: quote.sharesBurned,
+                minAssetsOut: quote.netAmount,
             });
             const signedXdr = await signTransaction(xdr);
 

--- a/apps/dapp/frontend/components/vault/withdrawModal.tsx
+++ b/apps/dapp/frontend/components/vault/withdrawModal.tsx
@@ -196,6 +196,7 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
         contractId: vaultDef?.contractAddress || "",
         asset: position.asset?.toUpperCase() === "XLM" ? "XLM" : "USDC",
         shares: quote.sharesBurned,
+        minAssetsOut: quote.netAmount,
       });
 
       const result = recordWithdrawal({

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -399,14 +399,15 @@ export async function executeVaultWithdraw(params: {
   contractId: string;
   asset: "USDC" | "XLM";
   shares: number;
+  minAssetsOut?: number;
 }): Promise<TransactionReceipt> {
-  const { walletAddress, contractId, shares } = params;
+  const { walletAddress, contractId, shares, minAssetsOut } = params;
 
   if (!isRealContractId(contractId)) {
     throw new Error("Vault is not yet live. Withdrawals are currently disabled.");
   }
 
-  const { xdr } = await buildWithdrawTransaction({ walletAddress, contractId, shares });
+  const { xdr } = await buildWithdrawTransaction({ walletAddress, contractId, shares, minAssetsOut });
   const signedXdr = await signTransaction(xdr);
   return submitTransaction(signedXdr);
 }

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -1371,13 +1371,47 @@ impl VaultContract {
     /// the amount actually transferred is *less* than this gross figure and the
     /// call reverts with `ContractError::SlippageExceeded` (see #448). For a
     /// slippage-safe floor that reflects the fees deducted on withdrawal, use
-    /// [`VaultContract::withdrawal_fee_preview`] and read `net_amount_received`.
+    /// [`VaultContract::preview_withdraw_net`] or
+    /// [`VaultContract::withdrawal_fee_preview`].
     pub fn preview_withdraw(env: Env, shares: i128) -> i128 {
         require_initialized(&env);
         if shares <= 0 {
             panic_with_error!(&env, ContractError::InvalidAmount);
         }
         vault_token_client(&env).amount_for_shares(&shares)
+    }
+
+    /// Returns the amount the caller actually receives after all fees —
+    /// safe to use directly as `min_assets_out` in [`VaultContract::withdraw`].
+    ///
+    /// Worst-case scenario: assumes the entire gross amount is yield (maximum
+    /// performance fee) and that the lock period is still active (early-withdrawal
+    /// fee applies). Callers that know the user's cost basis or lock status can
+    /// use [`VaultContract::withdrawal_fee_preview`] for a tighter estimate.
+    pub fn preview_withdraw_net(env: Env, shares: i128) -> i128 {
+        require_initialized(&env);
+        if shares <= 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+        let gross = vault_token_client(&env).amount_for_shares(&shares);
+        let config = get_fee_config(&env);
+
+        // Worst-case: treat the full gross as yield.
+        let perf_fee = nester_common::fees::calculate_performance_fee(
+            gross,
+            config.performance_fee_bps,
+        )
+        .unwrap_or(0);
+
+        // Worst-case: assume still within lock period.
+        let early_fee = nester_common::fees::calculate_withdrawal_fee(
+            gross,
+            config.early_withdrawal_fee_bps,
+        )
+        .unwrap_or(0);
+
+        let total_fee = perf_fee.saturating_add(early_fee);
+        gross.saturating_sub(total_fee)
     }
 
     pub fn get_shares(env: Env, user: Address) -> i128 {

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -546,6 +546,60 @@ fn gross_preview_as_min_assets_out_trips_slippage_on_fee_bearing_withdrawal() {
     vault.withdraw(&user, &shares, &gross);
 }
 
+// preview_withdraw_net must always be <= preview_withdraw (gross).
+#[test]
+fn preview_withdraw_net_le_preview_withdraw() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    vault.report_yield(&admin, &(200 * XLM));
+    mint(&token, &vault.address, 200 * XLM);
+
+    let shares = vault.get_shares(&user);
+    let gross = vault.preview_withdraw(&shares);
+    let net = vault.preview_withdraw_net(&shares);
+    assert!(net <= gross, "net must be <= gross");
+}
+
+// No early-withdrawal fee when outside the lock period.
+// preview_withdraw_net is worst-case (always deducts both fees), so the
+// result is still <= gross. The user-aware withdrawal_fee_preview is the
+// right tool when the lock period is known to have elapsed.
+#[test]
+fn preview_withdraw_net_no_early_fee_after_lock() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    // Advance past the lock period (DAY seconds).
+    env.ledger().set(LedgerInfo {
+        timestamp: DAY + 1,
+        ..env.ledger().get()
+    });
+
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    vault.report_yield(&admin, &(200 * XLM));
+    mint(&token, &vault.address, 200 * XLM);
+
+    let shares = vault.get_shares(&user);
+    let gross = vault.preview_withdraw(&shares);
+    let net = vault.preview_withdraw_net(&shares);
+
+    // preview_withdraw_net is always worst-case — net <= gross regardless of
+    // lock status. The user-aware withdrawal_fee_preview returns a tighter
+    // estimate once the lock has elapsed.
+    assert!(net <= gross);
+
+    // Confirm withdrawal_fee_preview correctly omits the early fee after lock.
+    let fee_preview = vault.withdrawal_fee_preview(&user, &shares);
+    assert_eq!(fee_preview.early_withdrawal_fee_deducted, 0, "no early fee after lock");
+    assert!(fee_preview.net_amount_received >= net, "user-aware preview >= worst-case net");
+}
+
 #[test]
 #[should_panic]
 fn withdrawal_of_more_than_owned_is_rejected() {


### PR DESCRIPTION
…#448)

Fixes the SlippageExceeded regression described in #448 where callers passing the gross preview_withdraw value as min_assets_out would always revert on fee-bearing withdrawals.

Changes:

- vault contract: add preview_withdraw_net(shares) -> i128 returning gross minus worst-case fees (full perf fee + early-withdrawal fee). Safe to pass directly as min_assets_out.

- vault tests: preview_withdraw_net_le_preview_withdraw asserts net <= gross; preview_withdraw_net_no_early_fee_after_lock verifies withdrawal_fee_preview correctly omits early fee after lock and that user-aware preview >= worst-case net.

- stellar/invoker.go: add SimulateI128Function for read-only i128-in/i128-out contract calls; extend simulateResult to capture results[].xdr.

- soroban_vault_chain_invoker.go: add PreviewWithdrawNet wrapping SimulateI128Function.

- transaction.ts: thread minAssetsOut through executeVaultWithdraw -> buildWithdrawTransaction.

- withdrawModal.tsx, vault-action-modals.tsx: pass quote.netAmount as minAssetsOut so the on-chain slippage guard is set to the actual post-fee floor.

## Summary
What does this PR do? (1-3 sentences)

## Related Issues
Closes #XX

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- 
- 

## Testing Done
How was this tested?

## Screenshots
For UI changes, add before/after screenshots if applicable.

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
- [ ] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications


closes #562