### PR TITLE
Evict expired auth challenges from memory

### DIFF
--- a/apps/api/internal/service/challenge_store.go
+++ b/apps/api/internal/service/challenge_store.go
@@ -12,6 +12,8 @@ import (
 
 var ErrChallengeNotFound = errors.New("challenge not found or expired")
 
+const defaultChallengeCleanupInterval = 30 * time.Second
+
 // ChallengeStore persists single-use auth challenges.
 // Implementations must be safe for concurrent use.
 type ChallengeStore interface {
@@ -66,10 +68,14 @@ type InMemoryChallengeStore struct {
 }
 
 func NewInMemoryChallengeStore(ttl time.Duration) *InMemoryChallengeStore {
-	return &InMemoryChallengeStore{
+	store := &InMemoryChallengeStore{
 		m:   make(map[string]inMemoryEntry),
 		ttl: ttl,
 	}
+
+	go store.cleanupExpiredLoop(challengeCleanupInterval(ttl))
+
+	return store
 }
 
 func (s *InMemoryChallengeStore) Set(_ context.Context, walletAddress, challenge string) error {
@@ -90,4 +96,32 @@ func (s *InMemoryChallengeStore) GetAndDelete(_ context.Context, walletAddress s
 	}
 	delete(s.m, walletAddress)
 	return entry.value, nil
+}
+
+func (s *InMemoryChallengeStore) cleanupExpiredLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.evictExpired(time.Now())
+	}
+}
+
+func (s *InMemoryChallengeStore) evictExpired(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for walletAddress, entry := range s.m {
+		if now.After(entry.expiresAt) {
+			delete(s.m, walletAddress)
+		}
+	}
+}
+
+func challengeCleanupInterval(ttl time.Duration) time.Duration {
+	if ttl <= 0 || ttl > defaultChallengeCleanupInterval {
+		return defaultChallengeCleanupInterval
+	}
+
+	return ttl
 }

--- a/apps/api/internal/service/challenge_store_test.go
+++ b/apps/api/internal/service/challenge_store_test.go
@@ -51,6 +51,28 @@ func TestInMemoryChallengeStore_ExpiredEntryReturnsNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrChallengeNotFound)
 }
 
+func TestInMemoryChallengeStore_BackgroundCleanupEvictsExpiredEntries(t *testing.T) {
+	store := NewInMemoryChallengeStore(10 * time.Millisecond)
+	ctx := context.Background()
+
+	for i := 0; i < 100; i++ {
+		require.NoError(t, store.Set(
+			ctx,
+			fmt.Sprintf("WALLET_%d", i),
+			fmt.Sprintf("hex%d", i),
+		))
+	}
+
+	require.Eventually(t, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		return len(store.m) == 0
+	}, 250*time.Millisecond, 10*time.Millisecond)
+
+	_, err := store.GetAndDelete(ctx, "WALLET_0")
+	assert.ErrorIs(t, err, ErrChallengeNotFound)
+}
+
 func TestInMemoryChallengeStore_SetOverwritesPreviousChallenge(t *testing.T) {
 	store := NewInMemoryChallengeStore(5 * time.Minute)
 	ctx := context.Background()


### PR DESCRIPTION
Summary
- Added a background cleanup loop for the in-memory auth challenge store so expired challenges are evicted from memory even when no later read touches the same wallet key. The cleanup runs from `NewInMemoryChallengeStore`, keeps the production interval capped at 30 seconds, and uses short TTLs as the interval in tests so expiry cleanup can be verified quickly.

Issue
- Closes #552

Changes
- Added `defaultChallengeCleanupInterval` and started a cleanup goroutine when the in-memory challenge store is constructed.
- Added `evictExpired` to scan the in-memory map under the existing mutex and delete entries whose expiry has passed.
- Added `challengeCleanupInterval` so normal stores sweep at most every 30 seconds while short-lived test stores can sweep promptly.
- Added a regression test that inserts 100 short-lived challenges, waits past TTL, and confirms the background cleanup removes them from the store without a process restart.

Validation
- Attempted `go version`; not run because `go` is not installed on this machine.
- Attempted `gofmt -w internal/service/challenge_store.go internal/service/challenge_store_test.go`; not run because `gofmt` is not installed on this machine.
- Attempted `go test ./internal/service -run ChallengeStore`; not run because `go` is not installed on this machine.
- Verified the GitHub compare diff only includes `apps/api/internal/service/challenge_store.go` and `apps/api/internal/service/challenge_store_test.go`.

Notes
- Local `git clone` of the fork repeatedly stalled during pack indexing and left only `.git` directories, so the branch and commit were created through the GitHub git API from upstream `main`.
- No lockfiles or dependency files were modified.