### PR TITLE
feat(api): add system_state KV table for operational persistence (#558)

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -94,6 +94,8 @@ func run() error {
 		return err
 	}
 
+	systemStateRepository := postgres.NewSystemStateRepository(db)
+
 	vaultRepository := postgres.NewVaultRepository(db)
 	vaultService := service.NewVaultService(vaultRepository)
 	vaultService.SetHarvestDefaultCompound(cfg.Stellar().HarvestDefaultCompound())
@@ -143,9 +145,10 @@ func run() error {
 	)
 	adminHandler := handler.NewAdminHandler(adminService)
 	adminHandler.SetEventSyncer(&stellarpkg.EventSyncer{
-		DB:     db,
-		RPCURL: cfg.Stellar().RPCURL(),
-		Logger: baseLogger,
+		DB:      db,
+		SysRepo: systemStateRepository,
+		RPCURL:  cfg.Stellar().RPCURL(),
+		Logger:  baseLogger,
 	})
 
 	var challengeStore service.ChallengeStore
@@ -337,7 +340,7 @@ func run() error {
 	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	stellarpkg.StartEventIndexer(shutdownCtx, baseLogger, db, cfg.Stellar().RPCURL())
+	stellarpkg.StartEventIndexer(shutdownCtx, baseLogger, db, systemStateRepository, cfg.Stellar().RPCURL())
 
 	serverErr := make(chan error, 1)
 	go func() {

--- a/apps/api/internal/domain/systemstate/systemstate.go
+++ b/apps/api/internal/domain/systemstate/systemstate.go
@@ -1,0 +1,32 @@
+// Package systemstate defines the domain types and repository interface for the
+// system_state key-value store.  Operational values that must survive process
+// restarts (e.g. the event-indexer ledger cursor, feature flags) are kept here
+// rather than scattered across one-off columns in domain tables.
+package systemstate
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrKeyNotFound is returned by Get when the requested key does not exist in
+// the store.  Callers should treat this as a typed sentinel rather than a
+// hard error so they can supply a default value.
+var ErrKeyNotFound = errors.New("system_state: key not found")
+
+// Well-known keys used by the application.
+const (
+	// KeyLastLedger is the event-indexer cursor: the last Stellar ledger
+	// sequence that was successfully processed.
+	KeyLastLedger = "event_indexer.last_ledger"
+)
+
+// Repository is the persistence interface for the system_state table.
+type Repository interface {
+	// Get returns the value stored under key.  If the key does not exist it
+	// returns ("", ErrKeyNotFound).
+	Get(ctx context.Context, key string) (string, error)
+
+	// Set upserts the value for key, updating updated_at to NOW().
+	Set(ctx context.Context, key string, value string) error
+}

--- a/apps/api/internal/repository/postgres/system_state_repository.go
+++ b/apps/api/internal/repository/postgres/system_state_repository.go
@@ -1,0 +1,53 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/systemstate"
+)
+
+// SystemStateRepository implements systemstate.Repository backed by the
+// system_state PostgreSQL table.
+type SystemStateRepository struct {
+	db *sql.DB
+}
+
+// NewSystemStateRepository returns a new SystemStateRepository.
+func NewSystemStateRepository(db *sql.DB) *SystemStateRepository {
+	return &SystemStateRepository{db: db}
+}
+
+// Get returns the value stored under key.  If the key does not exist it
+// returns ("", systemstate.ErrKeyNotFound).
+func (r *SystemStateRepository) Get(ctx context.Context, key string) (string, error) {
+	var value string
+	err := r.db.QueryRowContext(
+		ctx,
+		`SELECT value FROM system_state WHERE key = $1`,
+		key,
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", systemstate.ErrKeyNotFound
+	}
+	if err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+// Set upserts the value for key, refreshing updated_at to NOW().
+func (r *SystemStateRepository) Set(ctx context.Context, key string, value string) error {
+	_, err := r.db.ExecContext(
+		ctx,
+		`INSERT INTO system_state (key, value, updated_at)
+		 VALUES ($1, $2, NOW())
+		 ON CONFLICT (key) DO UPDATE
+		     SET value      = EXCLUDED.value,
+		         updated_at = NOW()`,
+		key,
+		value,
+	)
+	return err
+}

--- a/apps/api/internal/repository/postgres/system_state_repository_test.go
+++ b/apps/api/internal/repository/postgres/system_state_repository_test.go
@@ -1,0 +1,98 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/systemstate"
+)
+
+func newSystemStateMock(t *testing.T) (*SystemStateRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewSystemStateRepository(db), mock
+}
+
+func TestSystemStateRepository_Get_found(t *testing.T) {
+	repo, mock := newSystemStateMock(t)
+
+	mock.ExpectQuery(`SELECT value FROM system_state WHERE key = \$1`).
+		WithArgs("event_indexer.last_ledger").
+		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("42"))
+
+	val, err := repo.Get(context.Background(), "event_indexer.last_ledger")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "42" {
+		t.Fatalf("expected '42', got %q", val)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSystemStateRepository_Get_missingKey(t *testing.T) {
+	repo, mock := newSystemStateMock(t)
+
+	mock.ExpectQuery(`SELECT value FROM system_state WHERE key = \$1`).
+		WithArgs("nonexistent.key").
+		WillReturnError(sql.ErrNoRows)
+
+	val, err := repo.Get(context.Background(), "nonexistent.key")
+	if !errors.Is(err, systemstate.ErrKeyNotFound) {
+		t.Fatalf("expected ErrKeyNotFound, got err=%v val=%q", err, val)
+	}
+	if val != "" {
+		t.Fatalf("expected empty string on missing key, got %q", val)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSystemStateRepository_Set_insert(t *testing.T) {
+	repo, mock := newSystemStateMock(t)
+
+	mock.ExpectExec(`INSERT INTO system_state`).
+		WithArgs("event_indexer.last_ledger", "100").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.Set(context.Background(), "event_indexer.last_ledger", "100"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSystemStateRepository_Set_upsert(t *testing.T) {
+	repo, mock := newSystemStateMock(t)
+
+	// First Set
+	mock.ExpectExec(`INSERT INTO system_state`).
+		WithArgs("event_indexer.last_ledger", "50").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Second Set (conflict → update)
+	mock.ExpectExec(`INSERT INTO system_state`).
+		WithArgs("event_indexer.last_ledger", "75").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.Set(context.Background(), "event_indexer.last_ledger", "50"); err != nil {
+		t.Fatalf("first Set: %v", err)
+	}
+	if err := repo.Set(context.Background(), "event_indexer.last_ledger", "75"); err != nil {
+		t.Fatalf("second Set: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/apps/api/internal/stellar/indexer.go
+++ b/apps/api/internal/stellar/indexer.go
@@ -5,24 +5,24 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/systemstate"
 )
 
-func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, rpcURL string) {
+func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, sysRepo systemstate.Repository, rpcURL string) {
 	if strings.TrimSpace(rpcURL) == "" {
 		logger.Warn("event indexer disabled: STELLAR_RPC_URL is empty")
-		return
-	}
-	if err := ensureIndexerTables(ctx, db); err != nil {
-		logger.Error("event indexer disabled: failed to initialize tables", "error", err)
 		return
 	}
 
@@ -36,7 +36,7 @@ func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, rpc
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				startLedger, err := getLastIndexedLedger(ctx, db)
+				startLedger, err := getLastIndexedLedger(ctx, sysRepo)
 				if err != nil {
 					logger.Error("event indexer failed to load cursor", "error", err)
 					continue
@@ -68,7 +68,7 @@ func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, rpc
 					}
 				}
 
-				if err := setLastIndexedLedger(ctx, db, latestLedger); err != nil {
+				if err := setLastIndexedLedger(ctx, sysRepo, latestLedger); err != nil {
 					logger.Error("event indexer failed to persist cursor", "ledger", latestLedger, "error", err)
 				}
 			}
@@ -325,50 +325,36 @@ func fetchSorobanEvents(
 	return events, rpcResp.Result.LatestLedger, nil
 }
 
-func ensureIndexerTables(ctx context.Context, db *sql.DB) error {
-	if _, err := db.ExecContext(ctx, `
-CREATE TABLE IF NOT EXISTS event_indexer_state (
-    id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-    last_indexed_ledger BIGINT NOT NULL DEFAULT 0,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`); err != nil {
-		return err
+// getLastIndexedLedger reads the event-indexer cursor from system_state.
+// A missing key is treated as ledger 0 (start from genesis).
+func getLastIndexedLedger(ctx context.Context, sysRepo systemstate.Repository) (uint64, error) {
+	raw, err := sysRepo.Get(ctx, systemstate.KeyLastLedger)
+	if errors.Is(err, systemstate.ErrKeyNotFound) {
+		return 0, nil
 	}
-
-	if _, err := db.ExecContext(ctx, `
-CREATE TABLE IF NOT EXISTS processed_chain_events (
-    event_id TEXT PRIMARY KEY,
-    contract_id TEXT NOT NULL,
-    event_type TEXT NOT NULL,
-    ledger BIGINT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`); err != nil {
-		return err
-	}
-
-	_, err := db.ExecContext(ctx, `
-INSERT INTO event_indexer_state (id, last_indexed_ledger)
-VALUES (1, 0)
-ON CONFLICT (id) DO NOTHING`)
-	return err
-}
-
-func getLastIndexedLedger(ctx context.Context, db *sql.DB) (uint64, error) {
-	var ledger uint64
-	err := db.QueryRowContext(ctx, `SELECT last_indexed_ledger FROM event_indexer_state WHERE id = 1`).Scan(&ledger)
 	if err != nil {
 		return 0, err
+	}
+	ledger, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse last ledger %q: %w", raw, err)
 	}
 	return ledger, nil
 }
 
-func setLastIndexedLedger(ctx context.Context, db *sql.DB, ledger uint64) error {
-	_, err := db.ExecContext(ctx, `
-UPDATE event_indexer_state
-SET last_indexed_ledger = GREATEST(last_indexed_ledger, $1::bigint),
-    updated_at = NOW()
-WHERE id = 1`, ledger)
-	return err
+// setLastIndexedLedger persists the event-indexer cursor to system_state.
+// It only advances the cursor (never moves it backwards).
+func setLastIndexedLedger(ctx context.Context, sysRepo systemstate.Repository, ledger uint64) error {
+	// Read current value so we can apply GREATEST semantics without a raw SQL
+	// UPDATE … GREATEST.
+	current, err := getLastIndexedLedger(ctx, sysRepo)
+	if err != nil {
+		return err
+	}
+	if ledger <= current {
+		return nil
+	}
+	return sysRepo.Set(ctx, systemstate.KeyLastLedger, strconv.FormatUint(ledger, 10))
 }
 
 func markEventProcessed(ctx context.Context, tx *sql.Tx, event indexedEvent) (bool, error) {
@@ -391,18 +377,16 @@ ON CONFLICT (event_id) DO NOTHING`,
 	return rowsAffected == 1, nil
 }
 
+// EventSyncer is used by the admin handler to trigger a one-shot sync.
 type EventSyncer struct {
-	DB     *sql.DB
-	RPCURL string
-	Logger *slog.Logger
+	DB      *sql.DB
+	SysRepo systemstate.Repository
+	RPCURL  string
+	Logger  *slog.Logger
 }
 
 func (s *EventSyncer) SyncEvents(ctx context.Context) (int, error) {
-	if err := ensureIndexerTables(ctx, s.DB); err != nil {
-		return 0, fmt.Errorf("indexer tables: %w", err)
-	}
-
-	startLedger, err := getLastIndexedLedger(ctx, s.DB)
+	startLedger, err := getLastIndexedLedger(ctx, s.SysRepo)
 	if err != nil {
 		return 0, fmt.Errorf("load cursor: %w", err)
 	}
@@ -433,7 +417,7 @@ func (s *EventSyncer) SyncEvents(ctx context.Context) (int, error) {
 		}
 	}
 
-	if err := setLastIndexedLedger(ctx, s.DB, latestLedger); err != nil {
+	if err := setLastIndexedLedger(ctx, s.SysRepo, latestLedger); err != nil {
 		s.Logger.Error("admin sync: failed to persist cursor", "ledger", latestLedger, "error", err)
 	}
 

--- a/apps/api/migrations/025_create_system_state_table.down.sql
+++ b/apps/api/migrations/025_create_system_state_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS system_state;

--- a/apps/api/migrations/025_create_system_state_table.up.sql
+++ b/apps/api/migrations/025_create_system_state_table.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS system_state (
+    key        TEXT        PRIMARY KEY,
+    value      TEXT        NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the event-indexer cursor so the indexer can always do a plain Get.
+INSERT INTO system_state (key, value)
+VALUES ('event_indexer.last_ledger', '0')
+ON CONFLICT (key) DO NOTHING;

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -72,6 +72,17 @@ CREATE TABLE IF NOT EXISTS user_roles (
     PRIMARY KEY (user_id, role)
 );
 
+CREATE TABLE IF NOT EXISTS system_state (
+    key        TEXT        PRIMARY KEY,
+    value      TEXT        NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the event-indexer cursor.
+INSERT INTO system_state (key, value)
+VALUES ('event_indexer.last_ledger', '0')
+ON CONFLICT (key) DO NOTHING;
+
 -- Seed data
 
 INSERT INTO users (id, wallet_address, display_name, kyc_status, created_at, updated_at) VALUES


### PR DESCRIPTION
- Add migration 025: CREATE TABLE system_state (key TEXT PK, value TEXT, updated_at TIMESTAMPTZ)
- Seed event_indexer.last_ledger = '0' in migration and scripts/seed.sql
- Add domain/systemstate package: Repository interface, ErrKeyNotFound sentinel, KeyLastLedger constant
- Add postgres.SystemStateRepository with Get/Set (upsert) implementation
- Add unit tests for Get (found), Get (missing key  ErrKeyNotFound), Set (insert), Set (upsert)
- Refactor stellar/indexer.go: replace raw event_indexer_state SQL with SystemStateRepository
  - getLastIndexedLedger / setLastIndexedLedger now use sysRepo; GREATEST logic preserved in Go
  - Remove ensureIndexerTables (tables now managed by migrations)
  - StartEventIndexer and EventSyncer accept systemstate.Repository
- Wire SystemStateRepository in cmd/api/main.go

Resolves #558, addresses root cause of #441

## Summary
What does this PR do? (1-3 sentences)

## Related Issues


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- 
- 

## Testing Done
How was this tested?

## Screenshots
For UI changes, add before/after screenshots if applicable.

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
- [ ] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications

Closes #558