### PR TITLE
feat(contracts): add minimum allocation weight enforcement in allocat…

### DIFF
--- a/packages/contracts/contracts/allocation_strategy/src/lib.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/lib.rs
@@ -1,14 +1,15 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Env, Error,
-    IntoVal, Symbol, Val, Vec,
+    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Bytes, Env,
+    Error, IntoVal, Symbol, Val, Vec,
 };
 
 use nester_access_control::{AccessControl, Role};
 use nester_common::{
     emit_event, fees::mul_div, ContractError, ProtocolType, SourceStatus, BASIS_POINT_SCALE,
 };
+use nester_timelock::Timelock;
 
 const STRATEGY: Symbol = symbol_short!("STRATEGY");
 const WEIGHTS_UPDATED: Symbol = symbol_short!("WTS_SET");
@@ -123,6 +124,8 @@ enum DataKey {
     Allocation(Symbol),
     RebalanceThresholdBps,
     MaxWeightBps,
+    MinAllocationBps,
+    MaxSingleAllocationBps,
 }
 
 #[contract]
@@ -157,6 +160,14 @@ impl AllocationStrategyContract {
             .instance()
             .set(&DataKey::MaxWeightBps, &params.max_weight_bps);
 
+        // Initialize allocation weight thresholds
+        env.storage()
+            .instance()
+            .set(&DataKey::MinAllocationBps, &500u32); // 5% minimum
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxSingleAllocationBps, &7000u32); // 70% maximum
+
         let default_weights = build_default_weights(&env, &registry_id, &vault_type);
         env.storage()
             .instance()
@@ -180,6 +191,78 @@ impl AllocationStrategyContract {
                 .get(&DataKey::MaxWeightBps)
                 .unwrap(),
         }
+    }
+
+    pub fn get_allocation_thresholds(env: Env) -> (u32, u32) {
+        let min_allocation_bps: u32 = env.storage().instance().get(&DataKey::MinAllocationBps).unwrap();
+        let max_single_allocation_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxSingleAllocationBps)
+            .unwrap();
+        (min_allocation_bps, max_single_allocation_bps)
+    }
+
+    pub fn propose_update_allocation_thresholds(
+        env: Env,
+        caller: Address,
+        min_allocation_bps: u32,
+        max_single_allocation_bps: u32,
+    ) -> u64 {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        // Validate thresholds
+        if min_allocation_bps == 0
+            || min_allocation_bps > BASIS_POINT_SCALE
+            || max_single_allocation_bps == 0
+            || max_single_allocation_bps > BASIS_POINT_SCALE
+            || min_allocation_bps > max_single_allocation_bps
+        {
+            panic_with_error!(&env, ContractError::ConfigOutOfRange);
+        }
+
+        // Encode both thresholds into payload: min_allocation_bps (4 bytes) + max_single_allocation_bps (4 bytes)
+        let mut payload_bytes = Vec::new(&env);
+        for byte in min_allocation_bps.to_be_bytes() {
+            payload_bytes.push_back(byte);
+        }
+        for byte in max_single_allocation_bps.to_be_bytes() {
+            payload_bytes.push_back(byte);
+        }
+        let payload = Bytes::from_slice(&env, &payload_bytes);
+
+        Timelock::propose(&env, &caller, symbol_short!("SET_THR"), payload)
+    }
+
+    pub fn execute_update_allocation_thresholds(env: Env, caller: Address, op_id: u64) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        let payload = Timelock::execute(&env, &caller, op_id);
+
+        // Decode payload: first 4 bytes = min_allocation_bps, next 4 bytes = max_single_allocation_bps
+        let mut buf = [0u8; 8];
+        payload.copy_into_slice(&mut buf);
+        let min_allocation_bps = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        let max_single_allocation_bps = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+
+        // Validate thresholds again on execution
+        if min_allocation_bps == 0
+            || min_allocation_bps > BASIS_POINT_SCALE
+            || max_single_allocation_bps == 0
+            || max_single_allocation_bps > BASIS_POINT_SCALE
+            || min_allocation_bps > max_single_allocation_bps
+        {
+            panic_with_error!(&env, ContractError::ConfigOutOfRange);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinAllocationBps, &min_allocation_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxSingleAllocationBps, &max_single_allocation_bps);
     }
 
     pub fn update_strategy_params(
@@ -213,9 +296,18 @@ impl AllocationStrategyContract {
         validate_weight_sum(&env, &weights);
 
         let registry_id: Address = env.storage().instance().get(&DataKey::RegistryId).unwrap();
+        let min_allocation_bps: u32 = env.storage().instance().get(&DataKey::MinAllocationBps).unwrap();
+        let max_single_allocation_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxSingleAllocationBps)
+            .unwrap();
 
         for weight in weights.iter() {
-            if weight.weight_bps < 100 {
+            if weight.weight_bps < min_allocation_bps {
+                panic_with_error!(&env, ContractError::ConfigOutOfRange);
+            }
+            if weight.weight_bps > max_single_allocation_bps {
                 panic_with_error!(&env, ContractError::ConfigOutOfRange);
             }
             if !registry_has_source(&env, &registry_id, &weight.source_id) {

--- a/packages/contracts/contracts/allocation_strategy/src/test.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/test.rs
@@ -1044,3 +1044,239 @@ fn rebalance_withdraws_to_vault_when_all_unhealthy() {
     assert_eq!(delta_sum(&deltas), -1000);
     assert_eq!(delta_for(&deltas, symbol_short!("aave")), -1000);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #514 — minimum allocation weight enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allocation_thresholds_initialized_with_defaults() {
+    let (env, _, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    let (min_bps, max_bps) = client.get_allocation_thresholds();
+    assert_eq!(min_bps, 500); // 5% minimum
+    assert_eq!(max_bps, 7000); // 70% maximum
+}
+
+#[test]
+#[should_panic]
+fn rejects_weight_below_minimum_threshold() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Try to set weight to 4% (400 bps), below the 5% minimum
+    client.set_weights(
+        &admin,
+        &vec![
+            &env,
+            AllocationWeight {
+                source_id: symbol_short!("aave"),
+                weight_bps: 400,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("blend"),
+                weight_bps: 9_600,
+            },
+        ],
+    );
+}
+
+#[test]
+#[should_panic]
+fn rejects_weight_above_maximum_threshold() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Try to set weight to 75% (7500 bps), above the 70% maximum
+    client.set_weights(
+        &admin,
+        &vec![
+            &env,
+            AllocationWeight {
+                source_id: symbol_short!("aave"),
+                weight_bps: 7_500,
+            },
+            AllocationWeight {
+                source_id: symbol_short!("blend"),
+                weight_bps: 2_500,
+            },
+        ],
+    );
+}
+
+#[test]
+fn accepts_weight_within_thresholds() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Set weight to 50%, which is within the 5%-70% range
+    let weights = vec![
+        &env,
+        AllocationWeight {
+            source_id: symbol_short!("aave"),
+            weight_bps: 5_000,
+        },
+        AllocationWeight {
+            source_id: symbol_short!("blend"),
+            weight_bps: 3_000,
+        },
+        AllocationWeight {
+            source_id: symbol_short!("comp"),
+            weight_bps: 2_000,
+        },
+    ];
+
+    client.set_weights(&admin, &weights);
+    assert_eq!(client.get_weights(), weights);
+}
+
+#[test]
+fn admin_can_propose_threshold_update() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Propose updating thresholds to 10% minimum and 80% maximum
+    let op_id = client.propose_update_allocation_thresholds(&admin, &1000, &8000);
+    assert!(op_id > 0);
+}
+
+#[test]
+#[should_panic]
+fn rejects_invalid_threshold_proposal_min_zero() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Try to set minimum to 0
+    client.propose_update_allocation_thresholds(&admin, &0, &7000);
+}
+
+#[test]
+#[should_panic]
+fn rejects_invalid_threshold_proposal_min_exceeds_max() {
+    let (env, admin, _, strategy_id) = setup_with_type(VaultType::Balanced);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Try to set minimum (8000) greater than maximum (7000)
+    client.propose_update_allocation_thresholds(&admin, &8000, &7000);
+}
+
+#[test]
+fn admin_can_execute_threshold_update_after_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry_id = env.register_contract(None, YieldRegistryContract);
+    let strategy_id = env.register_contract(None, AllocationStrategyContract);
+
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    registry.initialize(&admin);
+    reg(&registry, &env, &admin, symbol_short!("aave"));
+    reg(&registry, &env, &admin, symbol_short!("blend"));
+    reg(&registry, &env, &admin, symbol_short!("comp"));
+
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+    client.initialize_with_vault_type(&admin, &registry_id, &VaultType::Balanced);
+
+    // Initialize timelock
+    nester_timelock::Timelock::initialize(&env);
+
+    // Propose updating thresholds to 10% minimum and 80% maximum
+    let op_id = client.propose_update_allocation_thresholds(&admin, &1000, &8000);
+
+    // Fast-forward past the timelock delay
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400 + 1);
+
+    // Execute the proposal
+    client.execute_update_allocation_thresholds(&admin, op_id);
+
+    // Verify thresholds were updated
+    let (min_bps, max_bps) = client.get_allocation_thresholds();
+    assert_eq!(min_bps, 1000); // 10% minimum
+    assert_eq!(max_bps, 8000); // 80% maximum
+}
+
+#[test]
+fn updated_thresholds_enforce_new_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry_id = env.register_contract(None, YieldRegistryContract);
+    let strategy_id = env.register_contract(None, AllocationStrategyContract);
+
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    registry.initialize(&admin);
+    reg(&registry, &env, &admin, symbol_short!("aave"));
+    reg(&registry, &env, &admin, symbol_short!("blend"));
+    reg(&registry, &env, &admin, symbol_short!("comp"));
+
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+    client.initialize_with_vault_type(&admin, &registry_id, &VaultType::Balanced);
+
+    // Initialize timelock
+    nester_timelock::Timelock::initialize(&env);
+
+    // Propose and execute updating thresholds to 10% minimum and 80% maximum
+    let op_id = client.propose_update_allocation_thresholds(&admin, &1000, &8000);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400 + 1);
+    client.execute_update_allocation_thresholds(&admin, op_id);
+
+    // Now 5% (500 bps) should be rejected as below the new 10% minimum
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.set_weights(
+            &admin,
+            &vec![
+                &env,
+                AllocationWeight {
+                    source_id: symbol_short!("aave"),
+                    weight_bps: 500,
+                },
+                AllocationWeight {
+                    source_id: symbol_short!("blend"),
+                    weight_bps: 9_500,
+                },
+            ],
+        );
+    }));
+    assert!(result.is_err());
+
+    // And 85% (8500 bps) should be rejected as above the new 80% maximum
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.set_weights(
+            &admin,
+            &vec![
+                &env,
+                AllocationWeight {
+                    source_id: symbol_short!("aave"),
+                    weight_bps: 8_500,
+                },
+                AllocationWeight {
+                    source_id: symbol_short!("blend"),
+                    weight_bps: 1_500,
+                },
+            ],
+        );
+    }));
+    assert!(result.is_err());
+
+    // But 10% and 80% should be accepted
+    let weights = vec![
+        &env,
+        AllocationWeight {
+            source_id: symbol_short!("aave"),
+            weight_bps: 1_000,
+        },
+        AllocationWeight {
+            source_id: symbol_short!("blend"),
+            weight_bps: 8_000,
+        },
+        AllocationWeight {
+            source_id: symbol_short!("comp"),
+            weight_bps: 1_000,
+        },
+    ];
+    client.set_weights(&admin, &weights);
+    assert_eq!(client.get_weights(), weights);
+}


### PR DESCRIPTION
…ion_strategy

- Add configurable MIN_ALLOCATION_BPS (default 500 bps = 5%) and MAX_SINGLE_ALLOCATION_BPS (default 7000 bps = 70%) storage keys
- Initialize thresholds in initialize_with_vault_type with default values
- Add validation in set_weights to reject weights below minimum or above maximum thresholds
- Add get_allocation_thresholds() to retrieve current thresholds
- Add propose_update_allocation_thresholds() for timelocked threshold updates
- Add execute_update_allocation_thresholds() to execute proposed changes after timelock delay
- Add comprehensive tests for validation scenarios and timelock flow

Closes #514

## Summary
What does this PR do? (1-3 sentences)

## Related Issues
Closes #XX

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- 
- 

## Testing Done
How was this tested?

## Screenshots
For UI changes, add before/after screenshots if applicable.

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
- [ ] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications
