### PR TITLE
Add push notification settings and device tokens

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -17,12 +17,12 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/redis/go-redis/v9"
 
-	"github.com/suncrestlabs/nester/apps/api/internal/auth"
-	"github.com/suncrestlabs/nester/apps/api/internal/config"
-	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/golang-migrate/migrate/v4"
 	migratedb "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/config"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/suncrestlabs/nester/apps/api/internal/handler"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
@@ -70,19 +70,19 @@ func run() error {
 
 	if cfg.Startup().EnableAutoMigrate() {
 		baseLogger.Info("running database migrations", "dir", cfg.Startup().MigrationsDir())
-		
+
 		driver, err := migratedb.WithInstance(db, &migratedb.Config{})
 		if err != nil {
 			return fmt.Errorf("auto-migrate: init driver: %w", err)
 		}
-		
+
 		m, err := migrate.NewWithDatabaseInstance(
 			"file://"+cfg.Startup().MigrationsDir(),
 			"postgres", driver)
 		if err != nil {
 			return fmt.Errorf("auto-migrate: new migrate instance: %w", err)
 		}
-		
+
 		if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 			return fmt.Errorf("auto-migrate: up: %w", err)
 		}
@@ -118,6 +118,8 @@ func run() error {
 	userHandler := handler.NewUserHandler(userService)
 	userVaultsSvc := service.NewUserVaultsService(vaultRepository)
 	userHandler.SetUserVaultsService(userVaultsSvc)
+	notificationRepository := postgres.NewNotificationRepository(db)
+	notificationHandler := handler.NewNotificationHandler(notificationRepository)
 
 	settlementRepository := postgres.NewSettlementRepository(db)
 	settlementService := service.NewSettlementService(settlementRepository)
@@ -314,6 +316,7 @@ func run() error {
 	transactionHandler.Register(mux)
 	settlementHandler.Register(mux)
 	userHandler.Register(mux)
+	notificationHandler.Register(mux)
 	adminHandler.Register(mux)
 	authHandler.Register(mux)
 	rateHandler.Register(mux)
@@ -321,7 +324,7 @@ func run() error {
 	tvlHandler.Register(mux)
 	analyticsHandler := handler.NewAnalyticsHandler(performanceService)
 	analyticsHandler.Register(mux)
-	
+
 	// Risk service
 	riskService := services.NewRiskService(vaultRepository)
 	riskHandler := handler.NewRiskHandler(riskService)
@@ -670,4 +673,3 @@ func pingStellarDependencies(logger *slog.Logger, cfg *config.Config) error {
 
 	return nil
 }
-

--- a/apps/api/internal/handler/notification_handler.go
+++ b/apps/api/internal/handler/notification_handler.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+type NotificationSettingsStore interface {
+	UpsertDeviceToken(ctx context.Context, userID uuid.UUID, token string, platform string) (notifications.DeviceToken, error)
+	Get(ctx context.Context, userID uuid.UUID) (notifications.Preferences, error)
+	Set(ctx context.Context, userID uuid.UUID, prefs notifications.Preferences) (notifications.Preferences, error)
+}
+
+type NotificationHandler struct {
+	store NotificationSettingsStore
+}
+
+func NewNotificationHandler(store NotificationSettingsStore) *NotificationHandler {
+	return &NotificationHandler{store: store}
+}
+
+func (h *NotificationHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/users/device-tokens", h.RegisterDeviceToken)
+	mux.HandleFunc("GET /api/v1/users/notification-preferences", h.GetPreferences)
+	mux.HandleFunc("PATCH /api/v1/users/notification-preferences", h.UpdatePreferences)
+}
+
+type registerDeviceTokenRequest struct {
+	Token    string `json:"token"`
+	Platform string `json:"platform"`
+}
+
+func (h *NotificationHandler) RegisterDeviceToken(w http.ResponseWriter, r *http.Request) {
+	userID, ok := notificationUserID(w, r)
+	if !ok {
+		return
+	}
+
+	var req registerDeviceTokenRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("token is required"))
+		return
+	}
+
+	platform := strings.ToLower(strings.TrimSpace(req.Platform))
+	if platform == "" {
+		platform = "unknown"
+	}
+
+	device, err := h.store.UpsertDeviceToken(r.Context(), userID, token, platform)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("register device token failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusCreated, response.Created(device))
+}
+
+func (h *NotificationHandler) GetPreferences(w http.ResponseWriter, r *http.Request) {
+	userID, ok := notificationUserID(w, r)
+	if !ok {
+		return
+	}
+
+	prefs, err := h.store.Get(r.Context(), userID)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("get notification preferences failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(prefs))
+}
+
+type updateNotificationPreferencesRequest struct {
+	Email     *bool `json:"email"`
+	WebSocket *bool `json:"websocket"`
+	Push      *bool `json:"push"`
+}
+
+func (h *NotificationHandler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
+	userID, ok := notificationUserID(w, r)
+	if !ok {
+		return
+	}
+
+	var req updateNotificationPreferencesRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	prefs, err := h.store.Get(r.Context(), userID)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("get notification preferences failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+	if req.Email != nil {
+		prefs.Email = *req.Email
+	}
+	if req.WebSocket != nil {
+		prefs.WebSocket = *req.WebSocket
+	}
+	if req.Push != nil {
+		prefs.Push = *req.Push
+	}
+
+	prefs, err = h.store.Set(r.Context(), userID, prefs)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("update notification preferences failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(prefs))
+}
+
+func notificationUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "authentication required"))
+		return uuid.Nil, false
+	}
+
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid user identity"))
+		return uuid.Nil, false
+	}
+
+	return userID, true
+}

--- a/apps/api/internal/handler/notification_handler_test.go
+++ b/apps/api/internal/handler/notification_handler_test.go
@@ -1,0 +1,173 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+type memoryNotificationSettings struct {
+	tokenUserID uuid.UUID
+	token       string
+	platform    string
+	prefs       map[uuid.UUID]notifications.Preferences
+	err         error
+}
+
+func newMemoryNotificationSettings() *memoryNotificationSettings {
+	return &memoryNotificationSettings{prefs: map[uuid.UUID]notifications.Preferences{}}
+}
+
+func (m *memoryNotificationSettings) UpsertDeviceToken(_ context.Context, userID uuid.UUID, token, platform string) (notifications.DeviceToken, error) {
+	if m.err != nil {
+		return notifications.DeviceToken{}, m.err
+	}
+	m.tokenUserID = userID
+	m.token = token
+	m.platform = platform
+	return notifications.DeviceToken{
+		ID:       uuid.New(),
+		UserID:   userID,
+		Token:    token,
+		Platform: platform,
+		Enabled:  true,
+	}, nil
+}
+
+func (m *memoryNotificationSettings) Get(_ context.Context, userID uuid.UUID) (notifications.Preferences, error) {
+	if m.err != nil {
+		return notifications.Preferences{}, m.err
+	}
+	if p, ok := m.prefs[userID]; ok {
+		return p, nil
+	}
+	return notifications.DefaultPreferences(), nil
+}
+
+func (m *memoryNotificationSettings) Set(_ context.Context, userID uuid.UUID, prefs notifications.Preferences) (notifications.Preferences, error) {
+	if m.err != nil {
+		return notifications.Preferences{}, m.err
+	}
+	m.prefs[userID] = prefs
+	return prefs, nil
+}
+
+func TestNotificationHandler_RegisterDeviceTokenUsesAuthenticatedUser(t *testing.T) {
+	store := newMemoryNotificationSettings()
+	handler := NewNotificationHandler(store)
+	userID := uuid.New()
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/users/device-tokens",
+		bytes.NewBufferString(`{"token":"  ExponentPushToken[abc]  ","platform":"expo"}`),
+	)
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusCreated, res.Body.String())
+	}
+	if store.tokenUserID != userID {
+		t.Fatalf("stored user ID = %s, want %s", store.tokenUserID, userID)
+	}
+	if store.token != "ExponentPushToken[abc]" {
+		t.Fatalf("stored token = %q", store.token)
+	}
+	if store.platform != "expo" {
+		t.Fatalf("stored platform = %q", store.platform)
+	}
+}
+
+func TestNotificationHandler_RegisterDeviceTokenRejectsBlankToken(t *testing.T) {
+	handler := NewNotificationHandler(newMemoryNotificationSettings())
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/device-tokens", bytes.NewBufferString(`{"token":"   ","platform":"ios"}`))
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	handler.RegisterDeviceToken(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusBadRequest, res.Body.String())
+	}
+}
+
+func TestNotificationHandler_UpdatePreferences(t *testing.T) {
+	store := newMemoryNotificationSettings()
+	handler := NewNotificationHandler(store)
+	userID := uuid.New()
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/users/notification-preferences",
+		bytes.NewBufferString(`{"push":false,"email":true,"websocket":false}`),
+	)
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	handler.UpdatePreferences(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusOK, res.Body.String())
+	}
+	if got := store.prefs[userID]; got.Push || !got.Email || got.WebSocket {
+		t.Fatalf("stored prefs = %+v", got)
+	}
+
+	var body struct {
+		Data notifications.Preferences `json:"data"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data.Push || !body.Data.Email || body.Data.WebSocket {
+		t.Fatalf("response prefs = %+v", body.Data)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(res.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw response: %v", err)
+	}
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(raw["data"], &data); err != nil {
+		t.Fatalf("decode raw data: %v", err)
+	}
+	for _, key := range []string{"email", "websocket", "push"} {
+		if _, ok := data[key]; !ok {
+			t.Fatalf("response data missing lower-case key %q: %s", key, res.Body.String())
+		}
+	}
+}
+
+func TestNotificationHandler_StoreErrorReturnsInternalError(t *testing.T) {
+	store := newMemoryNotificationSettings()
+	store.err = errors.New("database down")
+	handler := NewNotificationHandler(store)
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/notification-preferences", nil)
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	handler.GetPreferences(res, req)
+
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusInternalServerError, res.Body.String())
+	}
+}

--- a/apps/api/internal/notifications/notifications.go
+++ b/apps/api/internal/notifications/notifications.go
@@ -43,6 +43,7 @@ const (
 	EventSettlementCompleted EventType = "settlement_completed"
 	EventSettlementFailed    EventType = "settlement_failed"
 	EventDepositConfirmed    EventType = "deposit_confirmed"
+	EventYieldMilestone      EventType = "yield_milestone"
 	EventVaultAPYDrop        EventType = "vault_apy_drop"
 	EventVaultPaused         EventType = "vault_paused"
 	EventRebalanceExecuted   EventType = "rebalance_executed"
@@ -56,15 +57,17 @@ type ChannelKind string
 const (
 	ChannelEmail     ChannelKind = "email"
 	ChannelWebSocket ChannelKind = "websocket"
+	ChannelPush      ChannelKind = "push"
 )
 
 // eventChannelMatrix is the routing table from the issue. The dispatcher
 // computes the union of channels per event, then filters by the user's
 // preferences.
 var eventChannelMatrix = map[EventType][]ChannelKind{
-	EventSettlementCompleted: {ChannelEmail, ChannelWebSocket},
-	EventSettlementFailed:    {ChannelEmail, ChannelWebSocket},
-	EventDepositConfirmed:    {ChannelEmail, ChannelWebSocket},
+	EventSettlementCompleted: {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventSettlementFailed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventDepositConfirmed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventYieldMilestone:      {ChannelPush},
 	EventVaultAPYDrop:        {ChannelEmail},
 	EventVaultPaused:         {ChannelEmail, ChannelWebSocket},
 	EventRebalanceExecuted:   {ChannelWebSocket},
@@ -84,16 +87,17 @@ func ChannelsFor(t EventType) []ChannelKind {
 	return out
 }
 
-// Preferences captures the user's per-channel opt-out. Both default to
+// Preferences captures the user's per-channel opt-out. All channels default to
 // `true` (notifications on) when no row exists yet.
 type Preferences struct {
-	Email     bool
-	WebSocket bool
+	Email     bool `json:"email"`
+	WebSocket bool `json:"websocket"`
+	Push      bool `json:"push"`
 }
 
 // DefaultPreferences returns the "everything on" baseline new users get
 // before they explicitly opt out.
-func DefaultPreferences() Preferences { return Preferences{Email: true, WebSocket: true} }
+func DefaultPreferences() Preferences { return Preferences{Email: true, WebSocket: true, Push: true} }
 
 // Allow returns whether the given channel is permitted by the preferences.
 func (p Preferences) Allow(c ChannelKind) bool {
@@ -102,6 +106,8 @@ func (p Preferences) Allow(c ChannelKind) bool {
 		return p.Email
 	case ChannelWebSocket:
 		return p.WebSocket
+	case ChannelPush:
+		return p.Push
 	default:
 		return false
 	}
@@ -118,6 +124,18 @@ type Notification struct {
 	Body      string
 	Payload   map[string]any
 	CreatedAt time.Time
+}
+
+// DeviceToken is a mobile push destination registered by a user device.
+type DeviceToken struct {
+	ID         uuid.UUID `json:"id"`
+	UserID     uuid.UUID `json:"user_id"`
+	Token      string    `json:"token"`
+	Platform   string    `json:"platform"`
+	Enabled    bool      `json:"enabled"`
+	CreatedAt  time.Time `json:"created_at,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at,omitempty"`
+	LastSeenAt time.Time `json:"last_seen_at,omitempty"`
 }
 
 // Channel is one transport adapter. Implementations must be safe to call
@@ -139,6 +157,11 @@ type PreferenceStore interface {
 // Postgres-backed implementation along with the migration.
 type PersistenceStore interface {
 	Save(ctx context.Context, n Notification) error
+}
+
+// DeviceTokenStore lists active mobile push destinations for a user.
+type DeviceTokenStore interface {
+	ListDeviceTokens(ctx context.Context, userID uuid.UUID) ([]DeviceToken, error)
 }
 
 // NoopPersistenceStore is the MVP default — it discards. The dispatcher
@@ -303,6 +326,48 @@ func (c *WebSocketChannel) Deliver(ctx context.Context, n Notification) error {
 	return c.hub.PushToUser(ctx, n.UserID, "notification", n)
 }
 
+// PushSender is the provider seam for FCM, Expo, or any other mobile push
+// transport. The API stores device tokens; the concrete sender owns provider
+// credentials and delivery details.
+type PushSender interface {
+	Send(ctx context.Context, tokens []string, title string, body string, payload map[string]any) error
+}
+
+// PushChannel sends notifications to every active device token for the user.
+type PushChannel struct {
+	sender PushSender
+	tokens DeviceTokenStore
+}
+
+// NewPushChannel constructs a push notification transport adapter.
+func NewPushChannel(sender PushSender, tokens DeviceTokenStore) *PushChannel {
+	return &PushChannel{sender: sender, tokens: tokens}
+}
+
+// Kind reports ChannelPush.
+func (c *PushChannel) Kind() ChannelKind { return ChannelPush }
+
+// Deliver looks up active device tokens and sends one provider request.
+func (c *PushChannel) Deliver(ctx context.Context, n Notification) error {
+	devices, err := c.tokens.ListDeviceTokens(ctx, n.UserID)
+	if err != nil {
+		return err
+	}
+
+	tokens := make([]string, 0, len(devices))
+	for _, device := range devices {
+		if !device.Enabled || device.Token == "" {
+			continue
+		}
+		tokens = append(tokens, device.Token)
+	}
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	return c.sender.Send(ctx, tokens, n.Title, n.Body, n.Payload)
+}
+
 // --- Test doubles for use by external callers' integration tests ---
 
 // RecordingMailSender captures every send. Safe for concurrent use.
@@ -343,6 +408,69 @@ func (r *RecordingHub) PushToUser(_ context.Context, userID uuid.UUID, eventName
 	defer r.mu.Unlock()
 	r.Calls = append(r.Calls, RecordedPush{UserID: userID, EventName: eventName, Payload: payload})
 	return nil
+}
+
+// RecordingPushSender captures every push send. Safe for concurrent use.
+type RecordingPushSender struct {
+	mu    sync.Mutex
+	Calls []RecordedPushNotification
+}
+
+// RecordedPushNotification is one captured push provider call.
+type RecordedPushNotification struct {
+	Tokens  []string
+	Title   string
+	Body    string
+	Payload map[string]any
+}
+
+// Send records the push request.
+func (r *RecordingPushSender) Send(_ context.Context, tokens []string, title string, body string, payload map[string]any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	copiedTokens := make([]string, len(tokens))
+	copy(copiedTokens, tokens)
+	r.Calls = append(r.Calls, RecordedPushNotification{
+		Tokens:  copiedTokens,
+		Title:   title,
+		Body:    body,
+		Payload: payload,
+	})
+	return nil
+}
+
+// MemoryDeviceTokens is an in-memory DeviceTokenStore for tests.
+type MemoryDeviceTokens struct {
+	mu     sync.Mutex
+	tokens map[uuid.UUID][]DeviceToken
+}
+
+// NewMemoryDeviceTokens returns an empty in-memory token store.
+func NewMemoryDeviceTokens() *MemoryDeviceTokens {
+	return &MemoryDeviceTokens{tokens: map[uuid.UUID][]DeviceToken{}}
+}
+
+// ListDeviceTokens implements DeviceTokenStore.
+func (m *MemoryDeviceTokens) ListDeviceTokens(_ context.Context, userID uuid.UUID) ([]DeviceToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	items := m.tokens[userID]
+	out := make([]DeviceToken, len(items))
+	copy(out, items)
+	return out, nil
+}
+
+// Set replaces a user's device tokens. Returns the receiver for chaining.
+func (m *MemoryDeviceTokens) Set(userID uuid.UUID, tokens []DeviceToken) *MemoryDeviceTokens {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	copied := make([]DeviceToken, len(tokens))
+	copy(copied, tokens)
+	m.tokens[userID] = copied
+	return m
 }
 
 // StaticEmailLookup is a fake EmailLookup that returns a fixed address.

--- a/apps/api/internal/notifications/notifications_test.go
+++ b/apps/api/internal/notifications/notifications_test.go
@@ -10,8 +10,10 @@ import (
 
 func TestChannelsFor_MatchesIssueMatrix(t *testing.T) {
 	cases := map[EventType][]ChannelKind{
-		EventSettlementCompleted: {ChannelEmail, ChannelWebSocket},
-		EventDepositConfirmed:    {ChannelEmail, ChannelWebSocket},
+		EventSettlementCompleted: {ChannelEmail, ChannelWebSocket, ChannelPush},
+		EventSettlementFailed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
+		EventDepositConfirmed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
+		EventYieldMilestone:      {ChannelPush},
 		EventVaultAPYDrop:        {ChannelEmail},
 		EventVaultPaused:         {ChannelEmail, ChannelWebSocket},
 		EventRebalanceExecuted:   {ChannelWebSocket},
@@ -44,16 +46,20 @@ func TestChannelsFor_ReturnsACopy(t *testing.T) {
 func TestDispatcher_SendDeliversToBothChannels(t *testing.T) {
 	mail := &RecordingMailSender{}
 	hub := &RecordingHub{}
+	push := &RecordingPushSender{}
+	tokens := NewMemoryDeviceTokens()
+	uid := uuid.New()
+	tokens.Set(uid, []DeviceToken{{Token: "ExponentPushToken[test]", Enabled: true}})
 	d := New(
 		[]Channel{
 			NewEmailChannel(mail, StaticEmailLookup{Addr: "u@example.com"}),
 			NewWebSocketChannel(hub),
+			NewPushChannel(push, tokens),
 		},
 		NewMemoryPreferences(),
 		nil,
 	)
 
-	uid := uuid.New()
 	if err := d.Send(context.Background(), uid, EventSettlementCompleted, "Done", "Settled $50", map[string]any{"amount": 50}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
@@ -63,6 +69,63 @@ func TestDispatcher_SendDeliversToBothChannels(t *testing.T) {
 	}
 	if len(hub.Calls) != 1 || hub.Calls[0].UserID != uid || hub.Calls[0].EventName != "notification" {
 		t.Errorf("websocket channel not delivered correctly: %+v", hub.Calls)
+	}
+	if len(push.Calls) != 1 || push.Calls[0].Tokens[0] != "ExponentPushToken[test]" || push.Calls[0].Title != "Done" {
+		t.Errorf("push channel not delivered correctly: %+v", push.Calls)
+	}
+}
+
+func TestDispatcher_YieldMilestoneUsesPushOnly(t *testing.T) {
+	mail := &RecordingMailSender{}
+	hub := &RecordingHub{}
+	push := &RecordingPushSender{}
+	tokens := NewMemoryDeviceTokens()
+	uid := uuid.New()
+	tokens.Set(uid, []DeviceToken{{Token: "fcm-device-token", Enabled: true}})
+
+	d := New(
+		[]Channel{
+			NewEmailChannel(mail, StaticEmailLookup{Addr: "u@example.com"}),
+			NewWebSocketChannel(hub),
+			NewPushChannel(push, tokens),
+		},
+		NewMemoryPreferences(),
+		nil,
+	)
+
+	if err := d.Send(context.Background(), uid, EventYieldMilestone, "Yield milestone", "You earned 10 USDC", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(mail.Calls) != 0 {
+		t.Errorf("yield milestone must not email")
+	}
+	if len(hub.Calls) != 0 {
+		t.Errorf("yield milestone must not websocket")
+	}
+	if len(push.Calls) != 1 {
+		t.Errorf("yield milestone must push once, got %d", len(push.Calls))
+	}
+}
+
+func TestDispatcher_RespectsPushOptOut(t *testing.T) {
+	push := &RecordingPushSender{}
+	tokens := NewMemoryDeviceTokens()
+	prefs := NewMemoryPreferences()
+	uid := uuid.New()
+	tokens.Set(uid, []DeviceToken{{Token: "fcm-device-token", Enabled: true}})
+	prefs.Set(uid, Preferences{Email: false, WebSocket: false, Push: false})
+
+	d := New(
+		[]Channel{NewPushChannel(push, tokens)},
+		prefs,
+		nil,
+	)
+
+	if err := d.Send(context.Background(), uid, EventDepositConfirmed, "Deposit confirmed", "100 USDC confirmed", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(push.Calls) != 0 {
+		t.Errorf("push opt-out not honoured: %+v", push.Calls)
 	}
 }
 
@@ -170,7 +233,7 @@ func TestDispatcher_OneChannelFailureDoesNotBlockOthers(t *testing.T) {
 
 func TestPreferences_AllowDefaultsToAllOn(t *testing.T) {
 	p := DefaultPreferences()
-	if !p.Allow(ChannelEmail) || !p.Allow(ChannelWebSocket) {
+	if !p.Allow(ChannelEmail) || !p.Allow(ChannelWebSocket) || !p.Allow(ChannelPush) {
 		t.Errorf("default preferences must permit every channel")
 	}
 	if p.Allow(ChannelKind("imaginary")) {

--- a/apps/api/internal/repository/postgres/notification_repository.go
+++ b/apps/api/internal/repository/postgres/notification_repository.go
@@ -1,0 +1,123 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+type NotificationRepository struct {
+	db *sql.DB
+}
+
+func NewNotificationRepository(db *sql.DB) *NotificationRepository {
+	return &NotificationRepository{db: db}
+}
+
+func (r *NotificationRepository) UpsertDeviceToken(ctx context.Context, userID uuid.UUID, token string, platform string) (notifications.DeviceToken, error) {
+	const query = `
+		INSERT INTO device_tokens (
+			id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+		) VALUES ($1, $2, $3, $4, TRUE, NOW(), NOW(), NOW())
+		ON CONFLICT (user_id, token)
+		DO UPDATE SET
+			platform = EXCLUDED.platform,
+			enabled = TRUE,
+			updated_at = NOW(),
+			last_seen_at = NOW()
+		RETURNING id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+	`
+
+	return scanDeviceToken(r.db.QueryRowContext(ctx, query, uuid.New().String(), userID.String(), token, platform))
+}
+
+func (r *NotificationRepository) ListDeviceTokens(ctx context.Context, userID uuid.UUID) ([]notifications.DeviceToken, error) {
+	const query = `
+		SELECT id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+		FROM device_tokens
+		WHERE user_id = $1 AND enabled = TRUE
+		ORDER BY updated_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	devices := make([]notifications.DeviceToken, 0)
+	for rows.Next() {
+		device, err := scanDeviceToken(rows)
+		if err != nil {
+			return nil, err
+		}
+		devices = append(devices, device)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return devices, nil
+}
+
+func (r *NotificationRepository) Get(ctx context.Context, userID uuid.UUID) (notifications.Preferences, error) {
+	const query = `
+		SELECT email_enabled, websocket_enabled, push_enabled
+		FROM notification_preferences
+		WHERE user_id = $1
+	`
+
+	var prefs notifications.Preferences
+	if err := r.db.QueryRowContext(ctx, query, userID.String()).Scan(&prefs.Email, &prefs.WebSocket, &prefs.Push); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return notifications.DefaultPreferences(), nil
+		}
+		return notifications.Preferences{}, err
+	}
+	return prefs, nil
+}
+
+func (r *NotificationRepository) Set(ctx context.Context, userID uuid.UUID, prefs notifications.Preferences) (notifications.Preferences, error) {
+	const query = `
+		INSERT INTO notification_preferences (
+			user_id, email_enabled, websocket_enabled, push_enabled, updated_at
+		) VALUES ($1, $2, $3, $4, NOW())
+		ON CONFLICT (user_id)
+		DO UPDATE SET
+			email_enabled = EXCLUDED.email_enabled,
+			websocket_enabled = EXCLUDED.websocket_enabled,
+			push_enabled = EXCLUDED.push_enabled,
+			updated_at = NOW()
+		RETURNING email_enabled, websocket_enabled, push_enabled
+	`
+
+	var out notifications.Preferences
+	if err := r.db.QueryRowContext(ctx, query, userID.String(), prefs.Email, prefs.WebSocket, prefs.Push).Scan(&out.Email, &out.WebSocket, &out.Push); err != nil {
+		return notifications.Preferences{}, err
+	}
+	return out, nil
+}
+
+type deviceTokenScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanDeviceToken(row deviceTokenScanner) (notifications.DeviceToken, error) {
+	var device notifications.DeviceToken
+	if err := row.Scan(
+		&device.ID,
+		&device.UserID,
+		&device.Token,
+		&device.Platform,
+		&device.Enabled,
+		&device.CreatedAt,
+		&device.UpdatedAt,
+		&device.LastSeenAt,
+	); err != nil {
+		return notifications.DeviceToken{}, err
+	}
+	return device, nil
+}

--- a/apps/api/internal/repository/postgres/notification_repository_test.go
+++ b/apps/api/internal/repository/postgres/notification_repository_test.go
@@ -1,0 +1,159 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+func TestNotificationRepository_UpsertDeviceToken(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+	tokenID := uuid.New()
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		INSERT INTO device_tokens (
+			id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+		) VALUES ($1, $2, $3, $4, TRUE, NOW(), NOW(), NOW())
+		ON CONFLICT (user_id, token)
+		DO UPDATE SET
+			platform = EXCLUDED.platform,
+			enabled = TRUE,
+			updated_at = NOW(),
+			last_seen_at = NOW()
+		RETURNING id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+	`)).
+		WithArgs(sqlmock.AnyArg(), userID.String(), "ExponentPushToken[abc]", "expo").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "token", "platform", "enabled", "created_at", "updated_at", "last_seen_at",
+		}).AddRow(tokenID.String(), userID.String(), "ExponentPushToken[abc]", "expo", true, now, now, now))
+
+	device, err := repo.UpsertDeviceToken(context.Background(), userID, "ExponentPushToken[abc]", "expo")
+	if err != nil {
+		t.Fatalf("UpsertDeviceToken: %v", err)
+	}
+	if device.ID != tokenID || device.UserID != userID || device.Token != "ExponentPushToken[abc]" || !device.Enabled {
+		t.Fatalf("device = %+v", device)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestNotificationRepository_ListDeviceTokens(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+	tokenID := uuid.New()
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT id, user_id, token, platform, enabled, created_at, updated_at, last_seen_at
+		FROM device_tokens
+		WHERE user_id = $1 AND enabled = TRUE
+		ORDER BY updated_at DESC
+	`)).
+		WithArgs(userID.String()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "token", "platform", "enabled", "created_at", "updated_at", "last_seen_at",
+		}).AddRow(tokenID.String(), userID.String(), "fcm-token", "ios", true, now, now, now))
+
+	devices, err := repo.ListDeviceTokens(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListDeviceTokens: %v", err)
+	}
+	if len(devices) != 1 || devices[0].Token != "fcm-token" {
+		t.Fatalf("devices = %+v", devices)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestNotificationRepository_GetPreferencesDefaultsWhenMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT email_enabled, websocket_enabled, push_enabled
+		FROM notification_preferences
+		WHERE user_id = $1
+	`)).
+		WithArgs(userID.String()).
+		WillReturnError(sql.ErrNoRows)
+
+	prefs, err := repo.Get(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if prefs != notifications.DefaultPreferences() {
+		t.Fatalf("prefs = %+v, want %+v", prefs, notifications.DefaultPreferences())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestNotificationRepository_SetPreferences(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+	want := notifications.Preferences{Email: true, WebSocket: false, Push: false}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		INSERT INTO notification_preferences (
+			user_id, email_enabled, websocket_enabled, push_enabled, updated_at
+		) VALUES ($1, $2, $3, $4, NOW())
+		ON CONFLICT (user_id)
+		DO UPDATE SET
+			email_enabled = EXCLUDED.email_enabled,
+			websocket_enabled = EXCLUDED.websocket_enabled,
+			push_enabled = EXCLUDED.push_enabled,
+			updated_at = NOW()
+		RETURNING email_enabled, websocket_enabled, push_enabled
+	`)).
+		WithArgs(userID.String(), true, false, false).
+		WillReturnRows(sqlmock.NewRows([]string{"email_enabled", "websocket_enabled", "push_enabled"}).
+			AddRow(true, false, false))
+
+	prefs, err := repo.Set(context.Background(), userID, want)
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if prefs != want {
+		t.Fatalf("prefs = %+v, want %+v", prefs, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/apps/api/migrations/029_create_device_tokens.down.sql
+++ b/apps/api/migrations/029_create_device_tokens.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS notification_preferences;
+DROP TABLE IF EXISTS device_tokens;

--- a/apps/api/migrations/029_create_device_tokens.up.sql
+++ b/apps/api/migrations/029_create_device_tokens.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS device_tokens (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL CHECK (length(btrim(token)) > 0),
+    platform TEXT NOT NULL DEFAULT 'unknown' CHECK (length(btrim(platform)) > 0),
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_tokens_user_enabled
+    ON device_tokens (user_id, enabled);
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    email_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    websocket_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    push_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,7 +1,13 @@
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import { registerCurrentDeviceToken } from "../lib/notifications";
 
 export default function RootLayout() {
+  useEffect(() => {
+    registerCurrentDeviceToken().catch(() => undefined);
+  }, []);
+
   return (
     <>
       <StatusBar style="light" />
@@ -15,6 +21,7 @@ export default function RootLayout() {
       >
         <Stack.Screen name="index" options={{ title: "Nester" }} />
         <Stack.Screen name="dashboard/index" options={{ title: "Dashboard" }} />
+        <Stack.Screen name="settings/index" options={{ title: "Settings" }} />
         <Stack.Screen name="vaults/index" options={{ title: "Vaults" }} />
       </Stack>
     </>

--- a/apps/mobile/app/dashboard/index.tsx
+++ b/apps/mobile/app/dashboard/index.tsx
@@ -1,4 +1,5 @@
-import { View, Text, ScrollView, StyleSheet } from "react-native";
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { useRouter } from "expo-router";
 
 const metrics = [
   { label: "Total Balance", value: "$0.00", sub: "USDC" },
@@ -7,6 +8,8 @@ const metrics = [
 ];
 
 export default function DashboardScreen() {
+  const router = useRouter();
+
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <Text style={styles.heading}>Portfolio Overview</Text>
@@ -17,6 +20,9 @@ export default function DashboardScreen() {
           <Text style={styles.cardSub}>{m.sub}</Text>
         </View>
       ))}
+      <TouchableOpacity style={styles.secondaryButton} onPress={() => router.push("/settings")}>
+        <Text style={styles.secondaryButtonText}>Notification Settings</Text>
+      </TouchableOpacity>
       <Text style={styles.hint}>Connect a wallet to see live data.</Text>
     </ScrollView>
   );
@@ -30,5 +36,7 @@ const styles = StyleSheet.create({
   cardLabel: { color: "#94a3b8", fontSize: 13, marginBottom: 4 },
   cardValue: { color: "#ffffff", fontSize: 28, fontWeight: "bold", marginBottom: 2 },
   cardSub: { color: "#64748b", fontSize: 12 },
+  secondaryButton: { borderColor: "#334155", borderWidth: 1, borderRadius: 10, paddingVertical: 14, alignItems: "center", marginTop: 8 },
+  secondaryButtonText: { color: "#cbd5e1", fontSize: 15, fontWeight: "600" },
   hint: { color: "#475569", fontSize: 13, textAlign: "center", marginTop: 24 },
 });

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { ActivityIndicator, ScrollView, StyleSheet, Switch, Text, View } from "react-native";
+import {
+  getNotificationPreferences,
+  NotificationPreferences,
+  updateNotificationPreferences,
+} from "../../lib/notifications";
+
+type PreferenceKey = keyof NotificationPreferences;
+
+const rows: Array<{ key: PreferenceKey; label: string; detail: string }> = [
+  { key: "push", label: "Push Notifications", detail: "Deposits, yield milestones, and settlements" },
+  { key: "email", label: "Email", detail: "Account and portfolio updates" },
+  { key: "websocket", label: "Live In-App Updates", detail: "Realtime dashboard events" },
+];
+
+export default function SettingsScreen() {
+  const [preferences, setPreferences] = useState<NotificationPreferences>({
+    email: true,
+    websocket: true,
+    push: true,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<PreferenceKey | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getNotificationPreferences()
+      .then((next) => {
+        if (alive) {
+          setPreferences(next);
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (alive) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const setPreference = async (key: PreferenceKey, value: boolean) => {
+    const previous = preferences;
+    const next = { ...preferences, [key]: value };
+    setPreferences(next);
+    setSaving(key);
+    try {
+      setPreferences(await updateNotificationPreferences({ [key]: value }));
+    } catch {
+      setPreferences(previous);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color="#38bdf8" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Notifications</Text>
+      {rows.map((row) => (
+        <View key={row.key} style={styles.row}>
+          <View style={styles.copy}>
+            <Text style={styles.label}>{row.label}</Text>
+            <Text style={styles.detail}>{row.detail}</Text>
+          </View>
+          <Switch
+            value={preferences[row.key]}
+            onValueChange={(value) => setPreference(row.key, value)}
+            disabled={saving !== null}
+            trackColor={{ false: "#334155", true: "#2563eb" }}
+            thumbColor={preferences[row.key] ? "#eff6ff" : "#94a3b8"}
+          />
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#0f172a" },
+  content: { padding: 20 },
+  centered: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "#0f172a" },
+  heading: { fontSize: 22, fontWeight: "bold", color: "#ffffff", marginBottom: 20 },
+  row: { backgroundColor: "#1e293b", borderRadius: 12, padding: 18, marginBottom: 12, flexDirection: "row", alignItems: "center" },
+  copy: { flex: 1, paddingRight: 16 },
+  label: { color: "#ffffff", fontSize: 16, fontWeight: "600", marginBottom: 4 },
+  detail: { color: "#94a3b8", fontSize: 13, lineHeight: 18 },
+});

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,0 +1,46 @@
+import * as SecureStore from "expo-secure-store";
+
+const runtime = globalThis as typeof globalThis & {
+  process?: { env?: { EXPO_PUBLIC_API_URL?: string } };
+};
+
+const API_BASE_URL = runtime.process?.env?.EXPO_PUBLIC_API_URL ?? "http://localhost:8080";
+const AUTH_TOKEN_KEY = "nester.authToken";
+
+type ApiOptions = {
+  method?: "GET" | "POST" | "PATCH";
+  body?: unknown;
+};
+
+type ApiEnvelope<T> = {
+  success: boolean;
+  data: T;
+  error?: { code: string; message: string };
+};
+
+export async function apiRequest<T>(path: string, options: ApiOptions = {}): Promise<T> {
+  const token = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: options.method ?? "GET",
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const envelope = (await response.json()) as ApiEnvelope<T>;
+
+  if (!response.ok || !envelope.success) {
+    throw new Error(envelope.error?.message ?? `API request failed with ${response.status}`);
+  }
+
+  return envelope.data;
+}

--- a/apps/mobile/lib/notifications.ts
+++ b/apps/mobile/lib/notifications.ts
@@ -1,0 +1,61 @@
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+import { apiRequest } from "./api";
+
+export type NotificationPreferences = {
+  email: boolean;
+  websocket: boolean;
+  push: boolean;
+};
+
+type DeviceTokenResponse = {
+  token: string;
+  platform: string;
+};
+
+export async function requestDevicePushToken(): Promise<string | null> {
+  if (Platform.OS === "web") {
+    return null;
+  }
+
+  const existing = await Notifications.getPermissionsAsync();
+  const finalStatus =
+    existing.status === "granted"
+      ? existing.status
+      : (await Notifications.requestPermissionsAsync()).status;
+
+  if (finalStatus !== "granted") {
+    return null;
+  }
+
+  const token = await Notifications.getDevicePushTokenAsync();
+  return String(token.data);
+}
+
+export async function registerCurrentDeviceToken(): Promise<DeviceTokenResponse | null> {
+  const token = await requestDevicePushToken();
+  if (!token) {
+    return null;
+  }
+
+  return apiRequest<DeviceTokenResponse>("/api/v1/users/device-tokens", {
+    method: "POST",
+    body: {
+      token,
+      platform: Platform.OS,
+    },
+  });
+}
+
+export function getNotificationPreferences(): Promise<NotificationPreferences> {
+  return apiRequest<NotificationPreferences>("/api/v1/users/notification-preferences");
+}
+
+export function updateNotificationPreferences(
+  patch: Partial<NotificationPreferences>,
+): Promise<NotificationPreferences> {
+  return apiRequest<NotificationPreferences>("/api/v1/users/notification-preferences", {
+    method: "PATCH",
+    body: patch,
+  });
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "expo": "~51.0.0",
+    "expo-notifications": "~0.28.19",
     "expo-router": "~3.5.0",
     "expo-secure-store": "~13.0.0",
     "expo-status-bar": "~1.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 3.2.2
       '@creit.tech/stellar-wallets-kit':
         specifier: ^2.0.1
-        version: 2.0.1(4i3hvgxphwvdde2m6bm3x33lum)
+        version: 2.0.1(4vleqsrlou2oy7ipeupalr5gne)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.0(react@19.0.0))
@@ -119,7 +119,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.7
-        version: 16.1.7(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.7(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-security:
         specifier: ^3.0.0
         version: 3.0.1
@@ -141,6 +141,9 @@ importers:
       expo:
         specifier: ~51.0.0
         version: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)
+      expo-notifications:
+        specifier: ~0.28.19
+        version: 0.28.19(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0))
       expo-router:
         specifier: ~3.5.0
         version: 3.5.24(dnka6wg2ncsadb2c5jw5uifscu)
@@ -268,7 +271,7 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
         specifier: 16.1.7
-        version: 16.1.7(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        version: 16.1.7(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       postcss:
         specifier: ^8
         version: 8.5.8
@@ -1316,7 +1319,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -1447,6 +1450,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2251,6 +2257,7 @@ packages:
 
   '@react-navigation/bottom-tabs@6.5.20':
     resolution: {integrity: sha512-ow6Z06iS4VqBO8d7FP+HsGjJLWt2xTWIvuWjpoCvsM/uQXzCRDIjBv9HaKcXbF0yTW7IMir0oDAbU5PFzEDdgA==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -2260,11 +2267,13 @@ packages:
 
   '@react-navigation/core@6.4.17':
     resolution: {integrity: sha512-Nd76EpomzChWAosGqWOYE3ItayhDzIEzzZsT7PfGcRFDgW5miHV2t4MZcq9YIK4tzxZjVVpYbIynOOQQd1e0Cg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
 
   '@react-navigation/elements@1.3.31':
     resolution: {integrity: sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -2282,12 +2291,14 @@ packages:
 
   '@react-navigation/native@6.1.18':
     resolution: {integrity: sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
       react-native: '*'
 
   '@react-navigation/routers@6.1.9':
     resolution: {integrity: sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA==}
+    deprecated: This version is no longer supported
 
   '@react-three/drei@10.7.7':
     resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
@@ -3410,6 +3421,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3871,6 +3883,9 @@ packages:
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3968,6 +3983,9 @@ packages:
 
   babylonjs@8.54.1:
     resolution: {integrity: sha512-3PtaScaXY62RE92KULxcXhRteaY4PsOVx0gOgELd/zGPaZExp5tHQwdV3lmvxMlYRXNUKlHsvsvTgr3J4e9wOA==}
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5079,6 +5097,11 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  expo-application@5.9.1:
+    resolution: {integrity: sha512-uAfLBNZNahnDZLRU41ZFmNSKtetHUT9Ua557/q189ua0AWV7pQjoVAx49E4953feuvqc9swtU3ScZ/hN1XO/FQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@10.0.10:
     resolution: {integrity: sha512-0qoTIihB79k+wGus9wy0JMKq7DdenziVx3iUkGvMAy2azscSgWH6bd2gJ9CGnhC6JRd3qTMFBL0ou/fx7WZl7A==}
     peerDependencies:
@@ -5122,6 +5145,11 @@ packages:
 
   expo-modules-core@1.12.26:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
+
+  expo-notifications@0.28.19:
+    resolution: {integrity: sha512-rKKTnVQQ9XNQyTNwKmI9OlchhVu0XOZfRpImMqPFCJg6IwECM1izdas2SLCbE/GApg2Tw3U5R2fd26OnCtUU/w==}
+    peerDependencies:
+      expo: '*'
 
   expo-router@3.5.24:
     resolution: {integrity: sha512-wFi+PIUrOntF5cgg0PgBMlkxEZlWedIv5dWnPFEzN6Tr3A3bpsqdDLgOEIwvwd+pxn5DLzykTmg9EkQ1pPGspw==}
@@ -5852,6 +5880,10 @@ packages:
 
   is-my-json-valid@2.20.6:
     resolution: {integrity: sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
@@ -7153,6 +7185,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -7743,6 +7779,7 @@ packages:
 
   react-native-worklets@0.8.2:
     resolution: {integrity: sha512-xnTbDclfol+DQHWgUk+2ewRs9cfyFFKqHzEdR75xX3ItQP8i5rB+rvVeRaeZABDvQ8rvEYvSiTfrjtstZ6SGUQ==}
+    deprecated: missing type declarations - use react-native-worklets@0.8.3 instead
     peerDependencies:
       '@babel/core': '*'
       '@react-native/metro-config': '*'
@@ -10512,7 +10549,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@creit.tech/stellar-wallets-kit@2.0.1(4i3hvgxphwvdde2m6bm3x33lum)':
+  '@creit.tech/stellar-wallets-kit@2.0.1(4vleqsrlou2oy7ipeupalr5gne)':
     dependencies:
       '@albedo-link/intent': 0.12.0
       '@creit.tech/xbull-wallet-connect': 0.4.0
@@ -10525,8 +10562,8 @@ snapshots:
       '@reown/appkit': 1.8.12(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@stellar/freighter-api': 6.0.0
       '@stellar/stellar-base': 14.0.1
-      '@trezor/connect-plugin-stellar': 9.2.3(@stellar/stellar-sdk@14.6.1)(@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)
-      '@trezor/connect-web': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/connect-plugin-stellar': 9.2.3(@stellar/stellar-sdk@14.6.1)(@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)
+      '@trezor/connect-web': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@twind/core': 1.1.3(typescript@5.9.3)
       '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
       '@twind/preset-tailwind': 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
@@ -11130,6 +11167,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ide/backoff@1.0.0': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -12131,7 +12170,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.80.12(bufferutil@4.1.0)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.80.12
       node-fetch: 2.7.0
       querystring: 0.2.1
@@ -12828,26 +12867,26 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
   '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -12949,7 +12988,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -12962,11 +13001,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -13045,14 +13084,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/functional': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@solana/rpc-subscriptions-spec@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -13062,7 +13101,7 @@ snapshots:
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.9.3)
@@ -13070,7 +13109,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -13155,7 +13194,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -13163,7 +13202,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -13477,13 +13516,13 @@ snapshots:
       - react-native
       - utf-8-validate
 
-  '@trezor/blockchain-link@2.5.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/blockchain-link@2.5.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@stellar/stellar-sdk': 13.3.0
       '@trezor/blockchain-link-types': 1.4.4(tslib@2.8.1)
@@ -13532,16 +13571,16 @@ snapshots:
       - expo-localization
       - react-native
 
-  '@trezor/connect-plugin-stellar@9.2.3(@stellar/stellar-sdk@14.6.1)(@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)':
+  '@trezor/connect-plugin-stellar@9.2.3(@stellar/stellar-sdk@14.6.1)(@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(tslib@2.8.1)':
     dependencies:
       '@stellar/stellar-sdk': 14.6.1
-      '@trezor/connect': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/connect': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/utils': 9.4.3(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@trezor/connect-web@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/connect-web@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@trezor/connect': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/connect': 9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/connect-common': 0.4.4(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)
       '@trezor/utils': 9.4.4(tslib@2.8.1)
       '@trezor/websocket-client': 1.2.4(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
@@ -13561,7 +13600,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/connect@9.6.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@ethereumjs/common': 10.1.1
       '@ethereumjs/tx': 10.1.1
@@ -13569,12 +13608,12 @@ snapshots:
       '@mobily/ts-belt': 3.13.1
       '@noble/hashes': 1.8.0
       '@scure/bip39': 1.6.0
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@trezor/blockchain-link': 2.5.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/blockchain-link': 2.5.4(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/blockchain-link-types': 1.4.4(tslib@2.8.1)
       '@trezor/blockchain-link-utils': 1.4.4(bufferutil@4.1.0)(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@trezor/connect-analytics': 1.3.6(expo-constants@55.0.15(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(tslib@2.8.1)
@@ -14935,6 +14974,14 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -15055,6 +15102,8 @@ snapshots:
       - supports-color
 
   babylonjs@8.54.1: {}
+
+  badgin@1.2.3: {}
 
   bail@2.0.2: {}
 
@@ -16072,18 +16121,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.1.7(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.1.7(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.7
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16092,18 +16141,18 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.1.7(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.7(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.7
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16131,7 +16180,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -16146,32 +16195,32 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16180,9 +16229,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16194,13 +16243,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16209,9 +16258,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16495,6 +16544,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  expo-application@5.9.1(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)
+
   expo-asset@10.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)):
     dependencies:
       expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)
@@ -16635,6 +16688,21 @@ snapshots:
   expo-modules-core@1.12.26:
     dependencies:
       invariant: 2.2.4
+
+  expo-notifications@0.28.19(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      '@expo/image-utils': 0.5.1
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0)
+      expo-application: 5.9.1(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0))
+      expo-constants: 16.0.2(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(bufferutil@4.1.0)(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.2.79)(bufferutil@4.1.0)(react@18.2.0))(react@18.2.0))
+      fs-extra: 9.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   expo-router@3.5.24(dnka6wg2ncsadb2c5jw5uifscu):
     dependencies:
@@ -17500,6 +17568,11 @@ snapshots:
       is-my-ip-valid: 1.0.1
       jsonpointer: 5.0.1
       xtend: 4.0.2
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -18415,6 +18488,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-cache: 0.80.12
+      metro-core: 0.80.12
+      metro-runtime: 0.80.12
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
+
   metro-config@0.84.4(bufferutil@4.1.0):
     dependencies:
       connect: 3.7.0
@@ -18712,7 +18801,7 @@ snapshots:
       metro-babel-transformer: 0.80.12
       metro-cache: 0.80.12
       metro-cache-key: 0.80.12
-      metro-config: 0.80.12(bufferutil@4.1.0)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.80.12
       metro-file-map: 0.80.12
       metro-resolver: 0.80.12
@@ -19290,6 +19379,11 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 


### PR DESCRIPTION
Fixes #641.

## Summary
- add device-token registration and notification preference endpoints
- persist device tokens and push/email/websocket preferences in Postgres
- add push notification dispatch scaffolding and Expo mobile registration
- add a mobile notification settings screen

## Verification
- docker run --rm -v "$PWD":/app -v /tmp/nester-go-cache:/root/.cache/go-build -v /tmp/nester-go-modcache:/go/pkg/mod -w /app golang:1.25.10-alpine go test ./...
- npx pnpm@9.15.0 --filter nester-mobile typecheck
- git diff --check