### PR TITLE
chore(ci): ensure cargo test -p vault-contract passes with vault_token.wasm

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -50,6 +50,24 @@ make test
 
 Executes all unit and integration tests across the workspace.
 
+> **Important — vault-contract tests require a pre-built WASM artifact.**
+> The `vault-contract` test suite depends on `vault-token-contract` being compiled
+> to WebAssembly before the tests run. Without this artifact the tests will fail
+> or be silently skipped.
+>
+> Build the artifact first, then run the vault-contract tests:
+>
+> ```bash
+> # 1. Build vault_token.wasm (run from packages/contracts/)
+> cargo build --release --target wasm32-unknown-unknown -p vault-token-contract
+>
+> # 2. Run vault-contract tests
+> cargo test -p vault-contract
+> ```
+>
+> CI handles this automatically — the `contracts` job builds `vault_token.wasm`
+> before executing `cargo test -p vault-contract`.
+
 ### Format Code
 
 ```bash


### PR DESCRIPTION
## Summary

The vault-contract tests depend on `vault_token.wasm` being compiled before `cargo test -p vault-contract` runs. Without it, tests fail or are silently skipped in CI while passing locally (where developers have a stale artifact in `target/`).

## Changes

### CI (already in place)
The `contracts` job in `.github/workflows/ci.yml` already has the required steps:
- **Build vault_token WASM** — `cargo build --release --target wasm32-unknown-unknown -p vault-token-contract`
- **Ensure vault_token.wasm is present** — `test -f target/wasm32-unknown-unknown/release/vault_token.wasm`
- **Run vault-contract tests** — `cargo test -p vault-contract` with a guard that fails if 0 tests execute

### Documentation
Added a note to `packages/contracts/README.md` under the **Run Tests** section explaining that `vault_token.wasm` must be built before running vault-contract tests locally, with the exact commands.

## Acceptance Criteria
- [x] CI contract test job builds `vault_token.wasm` before running tests
- [x] `cargo test -p vault-contract` passes in CI without manual intervention  
- [x] No test cases are silently skipped (0-tests guard in CI step)
- [x] `packages/contracts/README.md` documents the WASM pre-build requirement
- [x] CI step is idempotent — `cargo build` with same inputs is a no-op on repeat runs

Closes #674