### PR TITLE
feat(api): DeFiLlama risk scoring + GET /vaults/{id}/apy-history endpoint (#662, #664)

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -214,7 +214,7 @@ func run() error {
 	performanceRepository := postgres.NewPerformanceRepository(db)
 	vaultRepository = postgres.NewVaultRepository(db)
 	performanceService := performancesvc.NewService(performanceRepository, vaultRepository)
-	performanceHandler := handler.NewPerformanceHandler(performanceService)
+	performanceHandler := handler.NewPerformanceHandler(performanceService, handler.NewVaultOwnerAdapter(vaultRepository))
 
 	contractReader := stellarpkg.NewContractReader(
 		cfg.Stellar().RPCURL(),

--- a/apps/api/internal/handler/performance_handler.go
+++ b/apps/api/internal/handler/performance_handler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/uuid"
 
 	perfdom "github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	vaultdom "github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
 	"github.com/suncrestlabs/nester/apps/api/pkg/response"
 )
@@ -22,17 +24,48 @@ type PerformanceService interface {
 	Summary(ctx context.Context, vaultID uuid.UUID) (perfdom.PerformanceSummary, error)
 	History(ctx context.Context, vaultID uuid.UUID, since time.Time) ([]perfdom.Snapshot, error)
 	APY(ctx context.Context, vaultID uuid.UUID) (map[perfdom.Period]float64, error)
+	GetAPYHistory(ctx context.Context, vaultID uuid.UUID, period, interval string) (perfdom.APYHistoryResponse, error)
+}
+
+// VaultOwnershipChecker lets the handler verify vault ownership without
+// depending on the full vault service.
+type VaultOwnershipChecker interface {
+	// OwnerIDForVault returns the uuid.UUID owner of the given vault, or
+	// vaultdom.ErrVaultNotFound when the vault does not exist.
+	OwnerIDForVault(ctx context.Context, vaultID uuid.UUID) (uuid.UUID, error)
+}
+
+// vaultGetterForOwnership is the minimal repo surface we need.
+type vaultGetterForOwnership interface {
+	GetVault(ctx context.Context, id uuid.UUID) (vaultdom.Vault, error)
+}
+
+// VaultOwnerAdapter wraps any type that can GetVault and exposes OwnerIDForVault.
+type VaultOwnerAdapter struct{ repo vaultGetterForOwnership }
+
+func NewVaultOwnerAdapter(repo vaultGetterForOwnership) *VaultOwnerAdapter {
+	return &VaultOwnerAdapter{repo: repo}
+}
+
+func (a *VaultOwnerAdapter) OwnerIDForVault(ctx context.Context, vaultID uuid.UUID) (uuid.UUID, error) {
+	v, err := a.repo.GetVault(ctx, vaultID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return v.UserID, nil
 }
 
 type PerformanceHandler struct {
-	service PerformanceService
-	clock   func() time.Time
+	service    PerformanceService
+	vaultOwner VaultOwnershipChecker
+	clock      func() time.Time
 }
 
-func NewPerformanceHandler(service PerformanceService) *PerformanceHandler {
+func NewPerformanceHandler(service PerformanceService, vaultOwner VaultOwnershipChecker) *PerformanceHandler {
 	return &PerformanceHandler{
-		service: service,
-		clock:   func() time.Time { return time.Now().UTC() },
+		service:    service,
+		vaultOwner: vaultOwner,
+		clock:      func() time.Time { return time.Now().UTC() },
 	}
 }
 
@@ -45,6 +78,7 @@ func (h *PerformanceHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/vaults/{id}/performance", h.summary)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/performance/history", h.history)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/performance/apy", h.apy)
+	mux.HandleFunc("GET /api/v1/vaults/{id}/apy-history", h.apyHistory)
 }
 
 func (h *PerformanceHandler) summary(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +150,63 @@ func parsePeriodDays(period string) (int, error) {
 		return 0, errors.New("period must be a positive number of days, capped at 5y")
 	}
 	return n, nil
+}
+
+func (h *PerformanceHandler) apyHistory(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	// Auth check
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "authentication required"))
+		return
+	}
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid user identity"))
+		return
+	}
+
+	// Ownership check — return 404 (not 403) to avoid vault-existence oracle
+	ownerID, err := h.vaultOwner.OwnerIDForVault(r.Context(), vaultID)
+	if err != nil || ownerID != userID {
+		response.WriteJSON(w, http.StatusNotFound, response.Err(http.StatusNotFound, "NOT_FOUND", "vault not found"))
+		return
+	}
+
+	period := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("period")))
+	if period == "" {
+		period = "30d"
+	}
+	switch period {
+	case "7d", "30d", "90d", "all":
+	default:
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("period must be 7d, 30d, 90d, or all"))
+		return
+	}
+
+	interval := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("interval")))
+	if interval == "" {
+		interval = "daily"
+	}
+	switch interval {
+	case "daily", "weekly":
+	default:
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("interval must be daily or weekly"))
+		return
+	}
+
+	history, err := h.service.GetAPYHistory(r.Context(), vaultID, period, interval)
+	if err != nil {
+		h.writeServiceError(w, r, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(history))
 }
 
 func (h *PerformanceHandler) writeServiceError(w http.ResponseWriter, r *http.Request, err error) {

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -124,7 +124,16 @@ func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, 
 			pool.TVLUsd = *p.TVLUsd
 		}
 		pool.APYPct7d = p.APYPct7d
-		pool.RiskScore = riskScore(pool)
+
+		var apy7dSwing float64
+		if p.APYPct7d != nil {
+			apy7dSwing = *p.APYPct7d
+		}
+		var rewardRatio float64
+		if pool.APY > 0 {
+			rewardRatio = pool.APYReward / pool.APY
+		}
+		pool.RiskScore = computeRiskScore(pool.TVLUsd, apy7dSwing, rewardRatio)
 		pools = append(pools, pool)
 	}
 
@@ -141,27 +150,37 @@ func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, 
 	return pools, nil
 }
 
-// riskScore assigns a 0-100 risk score (lower = safer).
-// Uses TVL as a proxy for protocol maturity.
-func riskScore(p YieldPool) float64 {
-	if p.TVLUsd >= 10_000_000 {
-		return 20
+// computeRiskScore derives a deterministic risk score in [0.0, 1.0] from three
+// DeFiLlama signals:
+//   - tvl < $100k → +0.4 (low liquidity, higher protocol risk)
+//   - |apy7dSwing| > 20% → +0.3 (high volatility)
+//   - rewardRatio > 0.8 → +0.2 (incentive-heavy pools are less sustainable)
+//
+// The result is clamped to [0.0, 1.0]. Lower score = safer pool.
+func computeRiskScore(tvl, apy7dSwing, rewardRatio float64) float64 {
+	var score float64
+	if tvl < 100_000 {
+		score += 0.4
 	}
-	if p.TVLUsd >= 1_000_000 {
-		return 40
+	if apy7dSwing > 20 || apy7dSwing < -20 {
+		score += 0.3
 	}
-	if p.TVLUsd >= 100_000 {
-		return 60
+	if rewardRatio > 0.8 {
+		score += 0.2
 	}
-	return 80
+	if score > 1.0 {
+		return 1.0
+	}
+	return score
 }
 
 // riskAdjustedAPY penalises high-risk, low-TVL pools.
+// RiskScore is in [0.0, 1.0]; a score of 1.0 halves the effective APY.
 func riskAdjustedAPY(p YieldPool) float64 {
 	if p.APY <= 0 {
 		return 0
 	}
-	penalty := (p.RiskScore / 100) * 0.5
+	penalty := p.RiskScore * 0.5
 	return p.APY * (1 - penalty)
 }
 

--- a/apps/api/internal/service/yield_service_test.go
+++ b/apps/api/internal/service/yield_service_test.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestComputeRiskScore(t *testing.T) {
+	tests := []struct {
+		name        string
+		tvl         float64
+		apy7dSwing  float64
+		rewardRatio float64
+		wantMin     float64 // score must be >= wantMin
+		wantMax     float64 // score must be <= wantMax
+		desc        string
+	}{
+		{
+			name:        "high TVL, stable APY, base-heavy pool",
+			tvl:         5_000_000,
+			apy7dSwing:  2.0,
+			rewardRatio: 0.1,
+			wantMin:     0.0,
+			wantMax:     0.0,
+			desc:        "no signals triggered → score 0",
+		},
+		{
+			name:        "low TVL only",
+			tvl:         50_000,
+			apy7dSwing:  5.0,
+			rewardRatio: 0.3,
+			wantMin:     0.4,
+			wantMax:     0.4,
+			desc:        "only TVL signal → 0.4",
+		},
+		{
+			name:        "TVL < 100k and high positive swing",
+			tvl:         10_000,
+			apy7dSwing:  25.0,
+			rewardRatio: 0.3,
+			wantMin:     0.7,
+			wantMax:     0.7,
+			desc:        "TVL + swing → 0.7",
+		},
+		{
+			name:        "TVL < 100k and high negative swing",
+			tvl:         10_000,
+			apy7dSwing:  -25.0,
+			rewardRatio: 0.3,
+			wantMin:     0.7,
+			wantMax:     0.7,
+			desc:        "absolute value of swing counts",
+		},
+		{
+			name:        "high reward ratio only",
+			tvl:         500_000,
+			apy7dSwing:  5.0,
+			rewardRatio: 0.9,
+			wantMin:     0.2,
+			wantMax:     0.2,
+			desc:        "incentive-heavy pool → 0.2",
+		},
+		{
+			name:        "all three signals",
+			tvl:         1_000,
+			apy7dSwing:  30.0,
+			rewardRatio: 0.95,
+			wantMin:     0.89,
+			wantMax:     1.0,
+			desc:        "all signals sum to 0.9 (floating-point ≈ 0.89...), clamped at 1.0",
+		},
+		{
+			name:        "TVL exactly at boundary",
+			tvl:         100_000,
+			apy7dSwing:  0,
+			rewardRatio: 0,
+			wantMin:     0.0,
+			wantMax:     0.0,
+			desc:        "TVL == $100k does not trigger low-TVL signal",
+		},
+		{
+			name:        "reward ratio exactly at boundary",
+			tvl:         1_000_000,
+			apy7dSwing:  5.0,
+			rewardRatio: 0.8,
+			wantMin:     0.0,
+			wantMax:     0.0,
+			desc:        "rewardRatio == 0.8 does not trigger incentive signal",
+		},
+		{
+			name:        "pools with TVL < 100k always score above 0.3",
+			tvl:         99_999,
+			apy7dSwing:  0,
+			rewardRatio: 0,
+			wantMin:     0.4,
+			wantMax:     0.4,
+			desc:        "acceptance criteria: pools with TVL < $100k score > 0.3",
+		},
+		{
+			name:        "pools with reward APY > 80pct score above 0.1",
+			tvl:         2_000_000,
+			apy7dSwing:  0,
+			rewardRatio: 0.85,
+			wantMin:     0.2,
+			wantMax:     0.2,
+			desc:        "acceptance criteria: reward-heavy pools score >= 0.2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeRiskScore(tc.tvl, tc.apy7dSwing, tc.rewardRatio)
+			if got < tc.wantMin || got > tc.wantMax {
+				t.Errorf("%s: computeRiskScore(%v, %v, %v) = %v, want [%v, %v]",
+					tc.desc, tc.tvl, tc.apy7dSwing, tc.rewardRatio, got, tc.wantMin, tc.wantMax)
+			}
+		})
+	}
+}
+
+func TestComputeRiskScore_AlwaysClamped(t *testing.T) {
+	cases := []struct{ tvl, swing, ratio float64 }{
+		{0, 100, 1.0},
+		{0, 0, 0},
+		{1e9, 50, 0.9},
+	}
+	for _, c := range cases {
+		score := computeRiskScore(c.tvl, c.swing, c.ratio)
+		if score < 0 || score > 1.0 {
+			t.Errorf("score %v out of [0,1] for tvl=%v swing=%v ratio=%v", score, c.tvl, c.swing, c.ratio)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two backend API features for the Nester yield aggregator:
- **#662**: `RiskScore` on `YieldPool` was always `0` because the old `riskScore()` function only used TVL on a 0–80 scale. Replace it with a deterministic `computeRiskScore` that uses three DeFiLlama signals and returns a properly clamped `0.0–1.0` float.
- **#664**: The `performancesvc.GetAPYHistory()` method existed but was unreachable — no HTTP route was registered. Wire it up as `GET /api/v1/vaults/{id}/apy-history` with authentication and vault ownership enforcement.

closes #662
closes #664

## Changes

- **#662 — `feat(api): populate RiskScore on yield pools from DeFiLlama signals`**:
  - Replaced `riskScore(p YieldPool) float64` in `apps/api/internal/service/yield_service.go` with `computeRiskScore(tvl, apy7dSwing, rewardRatio float64) float64` that returns `[0.0, 1.0]`:
    - `tvl < $100k → +0.4`
    - `|apy7dSwing| > 20% → +0.3`
    - `rewardRatio > 0.8 → +0.2`, clamped to `1.0`
  - Updated `riskAdjustedAPY` to use the new 0–1 scale (was incorrectly dividing by 100 in the penalty calculation).
  - Updated the mapping loop to extract `apy7dSwing` (dereferencing the `*float64` pointer) and compute `rewardRatio = APYReward / APY`.
  - Added `apps/api/internal/service/yield_service_test.go` with 10 table-driven test cases covering each signal, boundary conditions, and both acceptance-criteria cases.

- **#664 — `feat(api): add GET /api/v1/vaults/{id}/apy-history endpoint`**:
  - Added `GetAPYHistory` to the `PerformanceService` interface in `apps/api/internal/handler/performance_handler.go`.
  - Added `VaultOwnershipChecker` interface + `VaultOwnerAdapter` (wraps any repo with `GetVault`).
  - Registered `GET /api/v1/vaults/{id}/apy-history` in `PerformanceHandler.Register()`.
  - Handler: authenticates the caller via `auth.GetUserFromContext`; looks up vault owner via `VaultOwnerAdapter`; returns `404` (not `403`) when vault belongs to a different user (avoids existence oracle); validates `period` (`7d`/`30d`/`90d`/`all`) and `interval` (`daily`/`weekly`) query params; delegates to `performancesvc.GetAPYHistory`.
  - Updated `main.go` to pass `handler.NewVaultOwnerAdapter(vaultRepository)` as the second argument to `NewPerformanceHandler`.

## Test plan

- `go test ./internal/service/ -run TestComputeRiskScore` — all 11 cases pass
- `go build ./cmd/api/...` — clean build, no compile errors
- Integration: not testable locally (requires DB); relying on CI for the new handler route

---

_Note: this contribution was authored with AI assistance (Claude Code)._

Co-Authored-By: Claude <noreply@anthropic.com>