### PR TITLE
WebSocket client heartbeat and exponential-backoff auto-reconnect for real-time balance updates

### DIFF
--- a/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
+++ b/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+    useWebSocket,
+    getReconnectDelay,
+    MAX_BACKOFF_MS,
+} from "@/hooks/useWebSocket";
+
+// ---------------------------------------------------------------------------
+// Minimal controllable WebSocket mock
+// ---------------------------------------------------------------------------
+
+type Handler = ((ev: unknown) => void) | null;
+
+class MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    onopen: Handler = null;
+    onclose: Handler = null;
+    onerror: Handler = null;
+    onmessage: Handler = null;
+    readyState = MockWebSocket.OPEN;
+    sent: string[] = [];
+
+    constructor(public url: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    send(data: string) {
+        this.sent.push(data);
+    }
+
+    close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({});
+    }
+
+    // Test helpers
+    open() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.({});
+    }
+
+    receive(obj: unknown) {
+        this.onmessage?.({ data: JSON.stringify(obj) });
+    }
+
+    static last() {
+        return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    }
+
+    static reset() {
+        MockWebSocket.instances = [];
+    }
+}
+
+const WS_URL = "wss://example.test/ws";
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.reset();
+    // @ts-expect-error — replace global for the hook under test
+    global.WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Back-off schedule
+// ---------------------------------------------------------------------------
+
+describe("getReconnectDelay", () => {
+    it("produces the exponential back-off schedule capped at 30s", () => {
+        const schedule = [0, 1, 2, 3, 4, 5, 6].map((a) => getReconnectDelay(a));
+        expect(schedule).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+    });
+
+    it("never exceeds the maximum back-off", () => {
+        expect(getReconnectDelay(20)).toBe(MAX_BACKOFF_MS);
+    });
+
+    it("respects a custom base interval", () => {
+        expect(getReconnectDelay(0, 500)).toBe(500);
+        expect(getReconnectDelay(2, 500)).toBe(2000);
+    });
+
+    it("treats negative attempts as the first attempt", () => {
+        expect(getReconnectDelay(-3)).toBe(1000);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// State transitions
+// ---------------------------------------------------------------------------
+
+describe("useWebSocket state transitions", () => {
+    const baseOpts = {
+        url: WS_URL,
+        token: "jwt",
+        channels: ["user:abc", "vaults:global"],
+        onEvent: () => {},
+    };
+
+    it("reports 'connected' once the socket opens", () => {
+        const { result } = renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+        expect(result.current.status).toBe("connected");
+        expect(result.current.isConnected).toBe(true);
+    });
+
+    it("subscribes to every channel exactly once on connect (no duplicates)", () => {
+        renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+
+        const subs = MockWebSocket.last().sent.filter((m) =>
+            m.includes('"subscribe"')
+        );
+        expect(subs).toHaveLength(2);
+    });
+
+    it("goes 'reconnecting' on close and reconnects after the back-off delay", () => {
+        const { result } = renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+
+        const before = MockWebSocket.instances.length;
+        act(() => MockWebSocket.last().close());
+        expect(result.current.status).toBe("reconnecting");
+
+        // First back-off is 1000ms.
+        act(() => vi.advanceTimersByTime(1000));
+        expect(MockWebSocket.instances.length).toBe(before + 1);
+    });
+
+    it("resets the attempt counter after a successful reconnect", () => {
+        const { result } = renderHook(() =>
+            useWebSocket({ ...baseOpts, reconnectAttempts: 5 })
+        );
+        act(() => MockWebSocket.last().open());
+
+        // Drop once, reconnect fires after 1s, then succeeds.
+        act(() => MockWebSocket.last().close());
+        act(() => vi.advanceTimersByTime(1000));
+        act(() => MockWebSocket.last().open());
+        expect(result.current.status).toBe("connected");
+
+        // Next drop should again use the *first* back-off (1000ms), proving reset.
+        const before = MockWebSocket.instances.length;
+        act(() => MockWebSocket.last().close());
+        act(() => vi.advanceTimersByTime(999));
+        expect(MockWebSocket.instances.length).toBe(before); // not yet
+        act(() => vi.advanceTimersByTime(1));
+        expect(MockWebSocket.instances.length).toBe(before + 1);
+    });
+
+    it("falls back to 'offline' polling after the retries are exhausted", () => {
+        const onPoll = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() =>
+            useWebSocket({ ...baseOpts, reconnectAttempts: 2, onPoll })
+        );
+        act(() => MockWebSocket.last().open());
+
+        // Attempt 1
+        act(() => MockWebSocket.last().close());
+        act(() => vi.advanceTimersByTime(1000));
+        // Attempt 2
+        act(() => MockWebSocket.last().close());
+        act(() => vi.advanceTimersByTime(2000));
+        // Exhausted -> offline + polling
+        act(() => MockWebSocket.last().close());
+        expect(result.current.status).toBe("offline");
+
+        act(() => vi.advanceTimersByTime(30_000));
+        expect(onPoll).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Heartbeat
+// ---------------------------------------------------------------------------
+
+describe("useWebSocket heartbeat", () => {
+    const baseOpts = {
+        url: WS_URL,
+        token: "jwt",
+        channels: ["user:abc"],
+        onEvent: () => {},
+    };
+
+    it("sends a ping every 30s while connected", () => {
+        renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+
+        act(() => vi.advanceTimersByTime(30_000));
+        const pings = MockWebSocket.last().sent.filter((m) => m.includes('"ping"'));
+        expect(pings).toHaveLength(1);
+
+        // Answer the pong so the link stays alive, then expect a second ping.
+        act(() => MockWebSocket.last().receive({ type: "pong" }));
+        act(() => vi.advanceTimersByTime(30_000));
+        const pings2 = MockWebSocket.last().sent.filter((m) => m.includes('"ping"'));
+        expect(pings2).toHaveLength(2);
+    });
+
+    it("reconnects if no pong is received within the timeout", () => {
+        const { result } = renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+
+        act(() => vi.advanceTimersByTime(30_000)); // ping sent
+        act(() => vi.advanceTimersByTime(10_000)); // no pong -> close
+        expect(result.current.status).toBe("reconnecting");
+    });
+
+    it("stays connected when a pong arrives in time", () => {
+        const { result } = renderHook(() => useWebSocket(baseOpts));
+        act(() => MockWebSocket.last().open());
+
+        act(() => vi.advanceTimersByTime(30_000)); // ping
+        act(() => MockWebSocket.last().receive({ type: "pong" }));
+        act(() => vi.advanceTimersByTime(10_000)); // timeout would have fired
+        expect(result.current.status).toBe("connected");
+    });
+
+    it("does not forward heartbeat frames as domain events", () => {
+        const onEvent = vi.fn();
+        renderHook(() => useWebSocket({ ...baseOpts, onEvent }));
+        act(() => MockWebSocket.last().open());
+
+        act(() => MockWebSocket.last().receive({ type: "pong" }));
+        act(() => MockWebSocket.last().receive({ type: "ping" }));
+        expect(onEvent).not.toHaveBeenCalled();
+    });
+});

--- a/apps/dapp/frontend/components/connection-status-badge.tsx
+++ b/apps/dapp/frontend/components/connection-status-badge.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useWebSocketContext } from "@/components/websocket-provider";
+import { type WSConnectionStatus } from "@/lib/ws-events";
+import { cn } from "@/lib/utils";
+
+interface StatusMeta {
+    dot: string;
+    text: string;
+    bg: string;
+    label: string;
+    title: string;
+    pulse: boolean;
+}
+
+// Visual + copy for each connection state. "offline" means every reconnect
+// attempt was exhausted and we have fallen back to REST polling, so the user
+// is still seeing data — just on a delay.
+function statusMeta(status: WSConnectionStatus): StatusMeta {
+    switch (status) {
+        case "connected":
+            return {
+                dot: "bg-emerald-500",
+                text: "text-emerald-700",
+                bg: "bg-emerald-50 border-emerald-200",
+                label: "Live",
+                title: "Connected and receiving real-time updates",
+                pulse: true,
+            };
+        case "reconnecting":
+            return {
+                dot: "bg-amber-500",
+                text: "text-amber-700",
+                bg: "bg-amber-50 border-amber-200",
+                label: "Reconnecting…",
+                title: "Connection lost — retrying with back-off",
+                pulse: true,
+            };
+        case "offline":
+        default:
+            return {
+                dot: "bg-red-500",
+                text: "text-red-700",
+                bg: "bg-red-50 border-red-200",
+                label: "Using delayed updates",
+                title: "Disconnected — falling back to polling every 30s",
+                pulse: false,
+            };
+    }
+}
+
+/**
+ * Compact connection-status badge for the app header.
+ *
+ * Reflects the live WebSocket state:
+ *   - green "Live" when connected
+ *   - amber "Reconnecting…" while backing off between attempts
+ *   - red "Using delayed updates" once retries are exhausted (polling fallback)
+ */
+export function ConnectionStatusBadge({ className }: { className?: string }) {
+    const { status } = useWebSocketContext();
+    const meta = statusMeta(status);
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            title={meta.title}
+            className={cn(
+                "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium",
+                meta.bg,
+                meta.text,
+                className
+            )}
+        >
+            <span className="relative flex h-2 w-2">
+                {meta.pulse && (
+                    <span
+                        className={cn(
+                            "absolute inline-flex h-full w-full animate-ping rounded-full opacity-60",
+                            meta.dot
+                        )}
+                    />
+                )}
+                <span className={cn("relative inline-flex h-2 w-2 rounded-full", meta.dot)} />
+            </span>
+            <span className="hidden sm:inline">{meta.label}</span>
+        </div>
+    );
+}

--- a/apps/dapp/frontend/components/navbar.tsx
+++ b/apps/dapp/frontend/components/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useWallet } from "@/components/wallet-provider";
 import { NotificationBell } from "@/components/notification-bell";
+import { ConnectionStatusBadge } from "@/components/connection-status-badge";
 import { truncateAddress, cn } from "@/lib/utils";
 import { LogOut, Copy, Check, ChevronDown, Menu, X } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -123,6 +124,7 @@ export function Navbar() {
                         <div className="flex items-center gap-2">
                             {isConnected && address ? (
                                 <>
+                                    <ConnectionStatusBadge className="hidden md:flex" />
                                     <NotificationBell />
 
                                     {/* Wallet dropdown (desktop) */}

--- a/apps/dapp/frontend/components/websocket-provider.tsx
+++ b/apps/dapp/frontend/components/websocket-provider.tsx
@@ -71,7 +71,7 @@ const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "";
  */
 export function WebSocketProvider({ children }: { children: ReactNode }) {
     const { address } = useWallet();
-    const { applyBalanceUpdate, applyYieldAccrual } = usePortfolio();
+    const { applyBalanceUpdate, applyYieldAccrual, refreshBalances } = usePortfolio();
     const { addNotification } = useNotifications();
 
     // Derive a simple JWT placeholder from the wallet address.
@@ -196,6 +196,8 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         token,
         channels,
         onEvent: handleEvent,
+        // Once reconnects are exhausted, keep balances fresh via REST polling.
+        onPoll: refreshBalances,
     });
 
     const value = useMemo<WebSocketContextValue>(

--- a/apps/dapp/frontend/hooks/useWebSocket.ts
+++ b/apps/dapp/frontend/hooks/useWebSocket.ts
@@ -25,6 +25,10 @@ interface UseWebSocketOptions {
     pollInterval?: number;
     /** Optional: called to fetch latest snapshot via REST when polling */
     onPoll?: () => Promise<void>;
+    /** How often to send a heartbeat ping in ms (default: 30 000) */
+    heartbeatInterval?: number;
+    /** How long to wait for a pong before assuming the link is dead (default: 10 000) */
+    heartbeatTimeout?: number;
 }
 
 export interface UseWebSocketReturn {
@@ -40,6 +44,27 @@ export interface UseWebSocketReturn {
 const MAX_RECONNECT_ATTEMPTS = 5;
 const BASE_RECONNECT_INTERVAL_MS = 1000;
 const POLL_INTERVAL_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+
+/** Maximum back-off between reconnect attempts (matches the issue spec). */
+export const MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Exponential back-off schedule for reconnect attempts.
+ *
+ * delay = base * 2^attempt, capped at MAX_BACKOFF_MS. With the default base of
+ * 1000ms this yields the schedule 1s, 2s, 4s, 8s, 16s, 30s, 30s…
+ *
+ * Exported so the schedule can be unit-tested independently of the socket.
+ */
+export function getReconnectDelay(
+    attempt: number,
+    base: number = BASE_RECONNECT_INTERVAL_MS,
+): number {
+    const safeAttempt = Math.max(0, attempt);
+    return Math.min(base * 2 ** safeAttempt, MAX_BACKOFF_MS);
+}
 
 export function useWebSocket({
     url,
@@ -50,6 +75,8 @@ export function useWebSocket({
     reconnectInterval = BASE_RECONNECT_INTERVAL_MS,
     pollInterval = POLL_INTERVAL_MS,
     onPoll,
+    heartbeatInterval = HEARTBEAT_INTERVAL_MS,
+    heartbeatTimeout = HEARTBEAT_TIMEOUT_MS,
 }: UseWebSocketOptions): UseWebSocketReturn {
     const [status, setStatus] = useState<WSConnectionStatus>("offline");
     const [lastEvent, setLastEvent] = useState<WSEvent | null>(null);
@@ -60,6 +87,8 @@ export function useWebSocket({
     const isMountedRef = useRef(true);
     const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pongTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const channelsRef = useRef<string[]>(channels);
     const onEventRef = useRef(onEvent);
     const onPollRef = useRef(onPoll);
@@ -89,6 +118,33 @@ export function useWebSocket({
         }, pollInterval);
     }, [pollInterval]);
 
+    const stopHeartbeat = useCallback(() => {
+        if (heartbeatTimerRef.current !== null) {
+            clearInterval(heartbeatTimerRef.current);
+            heartbeatTimerRef.current = null;
+        }
+        if (pongTimerRef.current !== null) {
+            clearTimeout(pongTimerRef.current);
+            pongTimerRef.current = null;
+        }
+    }, []);
+
+    // Send a ping every `heartbeatInterval`; if no pong arrives within
+    // `heartbeatTimeout`, assume the link is dead and force a reconnect by
+    // closing the socket (which triggers onclose → back-off).
+    const startHeartbeat = useCallback((ws: WebSocket) => {
+        stopHeartbeat();
+        heartbeatTimerRef.current = setInterval(() => {
+            if (ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({ type: "ping" }));
+            if (pongTimerRef.current !== null) clearTimeout(pongTimerRef.current);
+            pongTimerRef.current = setTimeout(() => {
+                // No pong in time — drop the connection so onclose reconnects.
+                ws.close();
+            }, heartbeatTimeout);
+        }, heartbeatInterval);
+    }, [heartbeatInterval, heartbeatTimeout, stopHeartbeat]);
+
     const sendSubscriptions = useCallback((ws: WebSocket) => {
         if (ws.readyState !== WebSocket.OPEN) return;
         for (const channel of channelsRef.current) {
@@ -100,6 +156,7 @@ export function useWebSocket({
         if (!isMountedRef.current) return;
 
         // Close any existing socket cleanly.
+        stopHeartbeat();
         if (wsRef.current) {
             wsRef.current.onopen = null;
             wsRef.current.onclose = null;
@@ -130,26 +187,47 @@ export function useWebSocket({
             // Authenticate, then subscribe to channels.
             ws.send(JSON.stringify({ type: "auth", token: tokenRef.current }));
             sendSubscriptions(ws);
+
+            // Begin liveness pings now that the link is open.
+            startHeartbeat(ws);
         };
 
         ws.onmessage = (evt: MessageEvent) => {
             if (!isMountedRef.current) return;
             try {
-                const data = JSON.parse(evt.data as string) as WSEvent;
-                setLastEvent(data);
-                onEventRef.current(data);
+                const data = JSON.parse(evt.data as string) as
+                    | WSEvent
+                    | { type: "pong" | "ping" };
+
+                // Heartbeat frames are protocol-level, not domain events.
+                if (data.type === "pong") {
+                    if (pongTimerRef.current !== null) {
+                        clearTimeout(pongTimerRef.current);
+                        pongTimerRef.current = null;
+                    }
+                    return;
+                }
+                if (data.type === "ping") {
+                    ws.send(JSON.stringify({ type: "pong" }));
+                    return;
+                }
+
+                setLastEvent(data as WSEvent);
+                onEventRef.current(data as WSEvent);
             } catch {
                 // Ignore malformed frames.
             }
         };
 
         ws.onclose = () => {
+            stopHeartbeat();
             if (!isMountedRef.current) return;
 
             if (attemptsRef.current < reconnectAttempts) {
+                // Back-off uses the current attempt index (0-based) before
+                // incrementing: 1 s, 2 s, 4 s, 8 s, 16 s, 30 s…
+                const delay = getReconnectDelay(attemptsRef.current, reconnectInterval);
                 attemptsRef.current += 1;
-                // Exponential back-off: 1 s, 2 s, 4 s, 8 s, 16 s
-                const delay = reconnectInterval * Math.pow(2, attemptsRef.current - 1);
                 setStatus("reconnecting");
                 reconnectTimerRef.current = setTimeout(connect, delay);
             } else {
@@ -162,7 +240,7 @@ export function useWebSocket({
             // onerror is always followed by onclose; handle backoff there.
             ws.close();
         };
-    }, [url, reconnectAttempts, reconnectInterval, sendSubscriptions, startPoll, stopPoll]);
+    }, [url, reconnectAttempts, reconnectInterval, sendSubscriptions, startPoll, stopPoll, startHeartbeat, stopHeartbeat]);
 
     // Cleanup helper — tears down socket and timers without triggering reconnect.
     const teardown = useCallback(() => {
@@ -171,6 +249,7 @@ export function useWebSocket({
             reconnectTimerRef.current = null;
         }
         stopPoll();
+        stopHeartbeat();
         if (wsRef.current) {
             wsRef.current.onopen = null;
             wsRef.current.onclose = null;
@@ -179,7 +258,7 @@ export function useWebSocket({
             wsRef.current.close();
             wsRef.current = null;
         }
-    }, [stopPoll]);
+    }, [stopPoll, stopHeartbeat]);
 
     const disconnect = useCallback(() => {
         attemptsRef.current = reconnectAttempts; // prevent auto-reconnect


### PR DESCRIPTION

Body:

Closes #582

Overview
The DApp WebSocket client previously had no heartbeat or liveness detection, so after a network interruption the connection could silently die and users would see stale balances until a manual refresh. This PR adds a ping/pong heartbeat, a capped exponential-backoff reconnect schedule, a header connection-status indicator, and a polling fallback once retries are exhausted.

This is the client-side counterpart to the server-side hub work tracked in #487 (required for full end-to-end real-time).

Changes
Heartbeat (ping/pong): The client sends {"type":"ping"} every 30s. If no pong is received within 10s the socket is closed, which triggers the reconnect path. Heartbeat frames are handled at the protocol level and are never surfaced as domain events.
Exponential-backoff reconnect: Reconnect delays follow base * 2^attempt capped at 30s (1s, 2s, 4s, 8s, 16s, 30s…), extracted into an exported getReconnectDelay() helper for testability. The attempt counter resets to 0 on a successful reconnect.
Connection status indicator: A new header badge reflects live state — green "Live", amber "Reconnecting…", and red "Using delayed updates" (polling fallback), with appropriate ARIA roles.
Polling fallback: After the configured reconnect attempts (default 5) are exhausted, the hook falls back to REST polling every 30s, wired to refreshBalances in the provider, and the badge shows the delayed-updates warning.
No duplicate subscriptions: Each reconnect creates a fresh socket and re-subscribes exactly once; all timers (reconnect, poll, heartbeat, pong) are cleaned up on close and unmount.
Tests
Added 13 unit tests covering the backoff schedule, connection state transitions, attempt-counter reset, single-subscription guarantee, polling-fallback activation, and heartbeat (ping cadence, reconnect-on-missing-pong, pong keep-alive). Full suite passes (35/35); lint clean on changed files.

Acceptance criteria
 Ping/pong heartbeat sends every 30s
 Reconnect fires on connection close with exponential backoff
 Status badge shows correct state in all three scenarios
 Polling fallback activates after retries are exhausted
 No duplicate subscriptions after reconnect
 Unit tests for backoff schedule and state transitions
 attempt counter resets on successful reconnect