### PR TITLE
feat(dapp): render real APY history in SavingsChart

### DIFF
--- a/apps/dapp/frontend/__tests__/savings-chart.test.tsx
+++ b/apps/dapp/frontend/__tests__/savings-chart.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SavingsChart, { type SavingsChartPoint } from "@/components/analytics/SavingsChart";
+
+const points: SavingsChartPoint[] = [
+    { date: "Jun 15", apy: "8.23", value: 8.23 },
+    { date: "Jun 16", apy: "9.10", value: 9.1 },
+];
+
+describe("SavingsChart", () => {
+    it("shows a skeleton pulse while loading", () => {
+        render(<SavingsChart data={[]} isLoading />);
+        expect(screen.getByLabelText(/loading chart data/i)).toBeInTheDocument();
+    });
+
+    it("shows the descriptive empty state when there is no data", () => {
+        render(<SavingsChart data={[]} />);
+        expect(
+            screen.getByText(/chart data will appear after your vault has been active/i)
+        ).toBeInTheDocument();
+    });
+
+    it("renders the chart when data is present", () => {
+        render(<SavingsChart data={points} />);
+        expect(
+            screen.getByRole("img", { name: /vault apy performance over time/i })
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/chart data will appear/i)).not.toBeInTheDocument();
+    });
+});

--- a/apps/dapp/frontend/__tests__/useSavingsChartData.test.tsx
+++ b/apps/dapp/frontend/__tests__/useSavingsChartData.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useSavingsChartData } from "@/hooks/useSavingsChartData";
+import { vaultsApi } from "@/lib/api/vaults";
+
+vi.mock("@/lib/api/vaults", () => ({
+    vaultsApi: { getApyHistory: vi.fn() },
+}));
+
+const getApyHistory = vi.mocked(vaultsApi.getApyHistory);
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useSavingsChartData", () => {
+    beforeEach(() => {
+        getApyHistory.mockReset();
+    });
+
+    it("is disabled and returns no data when vaultId is undefined", () => {
+        const { result } = renderHook(() => useSavingsChartData(undefined), { wrapper });
+        expect(result.current.fetchStatus).toBe("idle");
+        expect(getApyHistory).not.toHaveBeenCalled();
+    });
+
+    it("maps API points into chart-ready points (fraction -> percentage)", async () => {
+        getApyHistory.mockResolvedValue({
+            vault_id: "v1",
+            period: "30d",
+            points: [
+                { timestamp: "2026-06-15T00:00:00Z", apy: 0.0823 },
+                { timestamp: "2026-06-16T00:00:00Z", apy: 0.091 },
+            ],
+        });
+
+        const { result } = renderHook(() => useSavingsChartData("v1", "30d"), { wrapper });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(getApyHistory).toHaveBeenCalledWith("v1", "30d");
+        expect(result.current.data).toEqual([
+            { date: "Jun 15", apy: "8.23", value: 8.23 },
+            { date: "Jun 16", apy: "9.10", value: 9.1 },
+        ]);
+    });
+
+    it("returns an empty array when the vault has no snapshots", async () => {
+        getApyHistory.mockResolvedValue({ vault_id: "v1", period: "7d", points: [] });
+        const { result } = renderHook(() => useSavingsChartData("v1", "7d"), { wrapper });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual([]);
+    });
+
+    it("re-fetches when the period changes", async () => {
+        getApyHistory.mockResolvedValue({ vault_id: "v1", period: "90d", points: [] });
+        const { rerender } = renderHook(
+            ({ p }: { p: "7d" | "30d" | "90d" }) => useSavingsChartData("v1", p),
+            { wrapper, initialProps: { p: "30d" as const } }
+        );
+        await waitFor(() => expect(getApyHistory).toHaveBeenCalledWith("v1", "30d"));
+
+        rerender({ p: "90d" });
+        await waitFor(() => expect(getApyHistory).toHaveBeenCalledWith("v1", "90d"));
+    });
+});

--- a/apps/dapp/frontend/app/savings/page.tsx
+++ b/apps/dapp/frontend/app/savings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -35,8 +35,11 @@ import {
     TransactionTimeoutError,
     truncateTxHash,
 } from "@/lib/stellar/transaction";
-import SavingsChart, { type ChartDataPoint } from "@/components/analytics/SavingsChart";
-import { vaultsApi } from "@/lib/api/vaults";
+import SavingsChart from "@/components/analytics/SavingsChart";
+import { type APYHistoryPeriod } from "@/lib/api/vaults";
+import { savingsGoals } from "@/lib/api/savings-goals";
+import { useSavingsChartData } from "@/hooks/useSavingsChartData";
+import { useQuery } from "@tanstack/react-query";
 import { intelligenceApi, type SavingsPlanResponse } from "@/lib/api/intelligence";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -779,78 +782,58 @@ function DepositModal({
 }
 
 // ── Savings Overview ──────────────────────────────────────────────────────────
+const CHART_PERIODS: APYHistoryPeriod[] = ["7d", "30d", "90d"];
+
 function SavingsOverview() {
     const { positions } = usePortfolio();
-    const [period, setPeriod] = useState<"30d" | "90d" | "all">("30d");
-    const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
-    const [loading, setLoading] = useState(true);
+    const [period, setPeriod] = useState<APYHistoryPeriod>("30d");
 
     const activeVaultPositions = useMemo(() => {
         const ids = SAVINGS_VAULTS.map((v) => v.id);
         return positions.filter((p) => ids.includes(p.vaultId));
     }, [positions]);
 
-    const fetchData = useCallback(async () => {
-        if (activeVaultPositions.length === 0) {
-            setLoading(false);
-            return;
+    // Distinct vaults the user actually holds, used to decide what to chart.
+    const userVaults = useMemo(() => {
+        const seen = new Map<string, string>();
+        for (const p of activeVaultPositions) {
+            if (!seen.has(p.vaultId)) seen.set(p.vaultId, p.vaultName);
         }
+        return Array.from(seen, ([id, name]) => ({ id, name }));
+    }, [activeVaultPositions]);
 
-        setLoading(true);
-        try {
-            // In a real implementation, we might aggregate multiple vaults or just pick the main one
-            const vaultId = activeVaultPositions[0].vaultId;
-            const [projection] = await Promise.all([
-                vaultsApi.getProjection(vaultId),
-            ]);
+    // Linked savings goals (#688): prefer a goal-linked vault when present.
+    const { data: goals } = useQuery({
+        queryKey: ["savings-goals"],
+        queryFn: () => savingsGoals.list(),
+        staleTime: 5 * 60 * 1000,
+    });
+    const linkedVaultId = useMemo(
+        () =>
+            goals?.find(
+                (g) => g.vault_id && userVaults.some((v) => v.id === g.vault_id)
+            )?.vault_id,
+        [goals, userVaults]
+    );
 
-            // Mock historical data combined with projection
-            // Real historical data would come from transaction history endpoint
-            const now = new Date();
-            const points: ChartDataPoint[] = [];
-            
-            // Generate 30 days of "history"
-            const days = period === "30d" ? 30 : period === "90d" ? 90 : 180;
-            const balance = activeVaultPositions.reduce((s, p) => s + p.currentValue, 0);
-            const principal = activeVaultPositions.reduce((s, p) => s + p.principal, 0);
-            
-            for (let i = days; i > 0; i--) {
-                const date = new Date(now.getTime() - i * 86400000);
-                const progress = (days - i) / days;
-                points.push({
-                    date: date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
-                    actualBalance: principal + (balance - principal) * progress * (0.9 + Math.random() * 0.2),
-                });
-            }
+    // Which vault is currently being charted. When the user holds multiple
+    // unlinked vaults they pick via the dropdown below.
+    const [selectedVaultId, setSelectedVaultId] = useState<string | undefined>(undefined);
 
-            // Add current point
-            points.push({
-                date: "Now",
-                actualBalance: balance,
-                projectedBalance: balance,
-            });
-
-            // Add projection points
-            if (projection && projection.timeline) {
-                const projPoints = projection.timeline.slice(1, 30).map(p => ({
-                    date: new Date(p.date).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
-                    actualBalance: undefined,
-                    projectedBalance: p.balance,
-                }));
-                setChartData([...points, ...projPoints]);
-            } else {
-                setChartData(points);
-            }
-        } catch (err) {
-            console.error("Failed to fetch savings data:", err);
-        } finally {
-            setLoading(false);
+    const primaryVaultId = useMemo(() => {
+        if (linkedVaultId) return linkedVaultId;
+        if (selectedVaultId && userVaults.some((v) => v.id === selectedVaultId)) {
+            return selectedVaultId;
         }
-    }, [activeVaultPositions, period]);
+        return userVaults[0]?.id;
+    }, [linkedVaultId, selectedVaultId, userVaults]);
 
-    useEffect(() => {
-        fetchData();
-    }, [fetchData]);
+    const showVaultPicker = !linkedVaultId && userVaults.length > 1;
+
+    const { data: chartData = [], isLoading: chartLoading } = useSavingsChartData(
+        primaryVaultId,
+        period
+    );
 
     if (activeVaultPositions.length === 0) {
         return (
@@ -873,20 +856,6 @@ function SavingsOverview() {
                     View Savings Plans
                 </button>
             </motion.div>
-        );
-    }
-
-    if (loading) {
-        return (
-            <div className="mb-10 space-y-6" aria-busy="true" aria-label="Loading savings data">
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                    {[1, 2, 3, 4].map(i => (
-                        <div key={i} className="h-28 rounded-2xl bg-black/[0.03] animate-pulse" />
-                    ))}
-                </div>
-                <div className="h-[400px] rounded-3xl bg-black/[0.03] animate-pulse" />
-                <div className="h-40 rounded-2xl bg-black/[0.03] animate-pulse" />
-            </div>
         );
     }
 
@@ -945,30 +914,46 @@ function SavingsOverview() {
 
             {/* Chart Block */}
             <div className="rounded-3xl border border-black/8 bg-white p-6 sm:p-8">
-                <div className="flex items-center justify-between mb-8">
+                <div className="flex items-center justify-between gap-4 mb-8 flex-wrap">
                     <div>
-                        <h3 className="text-sm font-semibold text-black">Balance Growth</h3>
-                        <p className="text-xs text-black/60 font-medium mt-0.5">Historical and projected balance in USD</p>
+                        <h3 className="text-sm font-semibold text-black">APY Performance</h3>
+                        <p className="text-xs text-black/60 font-medium mt-0.5">Historical vault APY over time</p>
                     </div>
-                    <div className="flex bg-black/[0.04] p-1 rounded-xl" role="tablist" aria-label="Chart period">
-                        {(["30d", "90d", "all"] as const).map((p) => (
-                            <button
-                                key={p}
-                                role="tab"
-                                aria-selected={period === p}
-                                onClick={() => setPeriod(p)}
-                                className={cn(
-                                    "px-3 py-1.5 text-[11px] rounded-lg transition-all focus-visible:ring-2 focus-visible:ring-black",
-                                    period === p ? "bg-white text-black shadow-sm font-bold" : "text-black/60 hover:text-black/80 font-medium"
-                                )}
+                    <div className="flex items-center gap-3">
+                        {showVaultPicker && (
+                            <select
+                                value={primaryVaultId ?? ""}
+                                onChange={(e) => setSelectedVaultId(e.target.value)}
+                                aria-label="Select vault to chart"
+                                className="rounded-lg border border-black/10 bg-white px-3 py-1.5 text-[11px] font-medium text-black/70 outline-none focus-visible:ring-2 focus-visible:ring-black"
                             >
-                                {p.toUpperCase()}
-                            </button>
-                        ))}
+                                {userVaults.map((v) => (
+                                    <option key={v.id} value={v.id}>
+                                        {v.name}
+                                    </option>
+                                ))}
+                            </select>
+                        )}
+                        <div className="flex bg-black/[0.04] p-1 rounded-xl" role="tablist" aria-label="Chart period">
+                            {CHART_PERIODS.map((p) => (
+                                <button
+                                    key={p}
+                                    role="tab"
+                                    aria-selected={period === p}
+                                    onClick={() => setPeriod(p)}
+                                    className={cn(
+                                        "px-3 py-1.5 text-[11px] rounded-lg transition-all focus-visible:ring-2 focus-visible:ring-black",
+                                        period === p ? "bg-white text-black shadow-sm font-bold" : "text-black/60 hover:text-black/80 font-medium"
+                                    )}
+                                >
+                                    {p.toUpperCase()}
+                                </button>
+                            ))}
+                        </div>
                     </div>
                 </div>
-                
-                <SavingsChart data={chartData} />
+
+                <SavingsChart data={chartData} isLoading={chartLoading} />
             </div>
         </div>
     );

--- a/apps/dapp/frontend/components/analytics/SavingsChart.tsx
+++ b/apps/dapp/frontend/components/analytics/SavingsChart.tsx
@@ -1,104 +1,132 @@
 "use client";
 
 import {
-    AreaChart,
-    Area,
+    LineChart,
+    Line,
     XAxis,
     YAxis,
     CartesianGrid,
     Tooltip,
     ResponsiveContainer,
+    type TooltipContentProps,
+    type TooltipValueType,
 } from "recharts";
 
-export interface ChartDataPoint {
+/**
+ * A single point on the APY history chart.
+ *
+ * Produced by `useSavingsChartData`, which maps the raw `/apy-history`
+ * response into display-ready values:
+ *   - `date`  short label for the axis/tooltip, e.g. "Jun 15"
+ *   - `apy`   formatted percentage string, e.g. "8.23"
+ *   - `value` numeric percentage used to plot the line, e.g. 8.23
+ */
+export interface SavingsChartPoint {
     date: string;
-    actualBalance?: number;
-    projectedBalance?: number;
+    apy: string;
+    value: number;
 }
 
 interface SavingsChartProps {
-    data: ChartDataPoint[];
+    data: SavingsChartPoint[];
+    isLoading?: boolean;
 }
 
-export default function SavingsChart({ data }: SavingsChartProps) {
+function ApyTooltip({
+    active,
+    payload,
+}: TooltipContentProps<TooltipValueType, number | string>) {
+    if (!active || !payload?.length) return null;
+    const point = payload[0].payload as SavingsChartPoint;
+    return (
+        <div className="rounded-xl border border-black/8 bg-white px-3.5 py-2.5 shadow-lg shadow-black/10">
+            <p className="text-xs font-medium text-black">
+                APY: {point.apy}% <span className="text-black/40">on {point.date}</span>
+            </p>
+        </div>
+    );
+}
+
+export default function SavingsChart({ data, isLoading = false }: SavingsChartProps) {
+    if (isLoading) {
+        return (
+            <div
+                className="h-[320px] w-full animate-pulse rounded-2xl bg-black/[0.03]"
+                aria-busy="true"
+                aria-label="Loading chart data"
+            />
+        );
+    }
+
     if (!data || data.length === 0) {
         return (
-            <div className="h-[300px] flex flex-col items-center justify-center text-black/40 bg-black/[0.02] rounded-2xl border border-dashed border-black/10">
-                <p className="text-sm">No savings history yet</p>
-                <p className="text-xs mt-1">Deposits will appear here over time</p>
+            <div className="h-[320px] flex flex-col items-center justify-center text-center text-black/40 bg-black/[0.02] rounded-2xl border border-dashed border-black/10 px-6">
+                <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="mb-3 text-black/25"
+                    aria-hidden="true"
+                >
+                    <path d="M3 3v18h18" />
+                    <path d="m19 9-5 5-4-4-3 3" />
+                </svg>
+                <p className="text-sm max-w-xs">
+                    Chart data will appear after your vault has been active for a few days.
+                </p>
             </div>
         );
     }
 
-    const fmtUsd = (val: number) => 
-        new Intl.NumberFormat("en-US", {
-            style: "currency",
-            currency: "USD",
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0,
-        }).format(val);
-
     return (
-        <div className="w-full h-[320px]" role="img" aria-label="Savings balance growth chart showing actual and projected balance over time">
+        <div
+            className="w-full h-[320px]"
+            role="img"
+            aria-label="Vault APY performance over time"
+        >
             <ResponsiveContainer width="100%" height="100%">
-                <AreaChart
+                <LineChart
                     data={data}
                     margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
                 >
-                    <defs>
-                        <linearGradient id="colorBalance" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor="#000000" stopOpacity={0.08} />
-                            <stop offset="95%" stopColor="#000000" stopOpacity={0} />
-                        </linearGradient>
-                    </defs>
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#000000" strokeOpacity={0.05} />
-                    <XAxis 
-                        dataKey="date" 
+                    <CartesianGrid
+                        strokeDasharray="3 3"
+                        vertical={false}
+                        stroke="#000000"
+                        strokeOpacity={0.05}
+                    />
+                    <XAxis
+                        dataKey="date"
                         axisLine={false}
                         tickLine={false}
                         tick={{ fontSize: 10, fill: "rgba(0,0,0,0.4)" }}
                         minTickGap={30}
                     />
-                    <YAxis 
+                    <YAxis
                         axisLine={false}
                         tickLine={false}
                         tick={{ fontSize: 10, fill: "rgba(0,0,0,0.4)" }}
-                        tickFormatter={(val) => `$${val}`}
+                        tickFormatter={(val) => `${val}%`}
+                        domain={["auto", "auto"]}
+                        width={48}
                     />
-                    <Tooltip 
-                        contentStyle={{ 
-                            borderRadius: "12px", 
-                            border: "none", 
-                            boxShadow: "0 10px 15px -3px rgba(0,0,0,0.1)",
-                            fontSize: "12px"
-                        }}
-                        formatter={(value) => [
-                            typeof value === "number" ? fmtUsd(value) : "",
-                            "",
-                        ]}
-                        labelStyle={{ color: "rgba(0,0,0,0.4)", marginBottom: "4px" }}
-                    />
-                    <Area
+                    <Tooltip content={ApyTooltip} />
+                    <Line
                         type="monotone"
-                        dataKey="actualBalance"
+                        dataKey="value"
                         stroke="#000000"
                         strokeWidth={2}
-                        fillOpacity={1}
-                        fill="url(#colorBalance)"
+                        dot={false}
+                        activeDot={{ r: 4 }}
                         animationDuration={1200}
-                        name="Actual Balance"
+                        name="APY"
                     />
-                    <Area
-                        type="monotone"
-                        dataKey="projectedBalance"
-                        stroke="#000000"
-                        strokeWidth={1.5}
-                        strokeDasharray="5 5"
-                        fill="transparent"
-                        animationDuration={1200}
-                        name="Projected Balance"
-                    />
-                </AreaChart>
+                </LineChart>
             </ResponsiveContainer>
         </div>
     );

--- a/apps/dapp/frontend/hooks/useSavingsChartData.ts
+++ b/apps/dapp/frontend/hooks/useSavingsChartData.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { vaultsApi, type APYHistoryPeriod } from "@/lib/api/vaults";
+import { type SavingsChartPoint } from "@/components/analytics/SavingsChart";
+
+const STALE_TIME_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Fetches real APY history for a vault from `/vaults/{id}/apy-history` and maps
+ * it into chart-ready points for <SavingsChart />.
+ *
+ * Disabled until a `vaultId` is known, so callers can pass `undefined` while the
+ * primary vault is still being resolved.
+ */
+export function useSavingsChartData(
+    vaultId: string | undefined,
+    period: APYHistoryPeriod = "30d"
+) {
+    return useQuery<SavingsChartPoint[]>({
+        queryKey: ["savings-chart", vaultId, period],
+        queryFn: async () => {
+            if (!vaultId) return [];
+            const res = await vaultsApi.getApyHistory(vaultId, period);
+            return (res.points ?? []).map((p) => {
+                const pct = p.apy * 100;
+                return {
+                    date: new Date(p.timestamp).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                    }),
+                    apy: pct.toFixed(2),
+                    value: pct,
+                };
+            });
+        },
+        enabled: !!vaultId,
+        staleTime: STALE_TIME_MS,
+    });
+}

--- a/apps/dapp/frontend/lib/api/savings-goals.ts
+++ b/apps/dapp/frontend/lib/api/savings-goals.ts
@@ -8,6 +8,8 @@ export interface SavingsGoal {
   description?: string;
   current_amount: string | number;
   progress_pct: number;
+  /** Vault this goal is linked to, when set (see #688). */
+  vault_id?: string;
 }
 
 export interface CreateSavingsGoalInput {

--- a/apps/dapp/frontend/lib/api/vaults.ts
+++ b/apps/dapp/frontend/lib/api/vaults.ts
@@ -42,6 +42,21 @@ export interface RebalanceSuggestion {
   reason: string;
 }
 
+export type APYHistoryPeriod = "7d" | "30d" | "90d";
+
+export interface APYHistoryPoint {
+  /** ISO timestamp of the snapshot */
+  timestamp: string;
+  /** APY as a fraction, e.g. 0.0823 for 8.23% */
+  apy: number;
+}
+
+export interface APYHistoryResponse {
+  vault_id: string;
+  period: APYHistoryPeriod;
+  points: APYHistoryPoint[];
+}
+
 export const vaultsApi = {
   getProjection: async (vaultId: string): Promise<Projection> => {
     const res = await fetch(`${API_BASE}/api/v1/vaults/${vaultId}/projection`, {
@@ -67,6 +82,11 @@ export const vaultsApi = {
     const json = await res.json();
     return json.data ?? [];
   },
+
+  getApyHistory: (vaultId: string, period: APYHistoryPeriod = "30d") =>
+    apiRequest<APYHistoryResponse>(
+      `/vaults/${vaultId}/apy-history?period=${period}`
+    ),
 
   getRebalanceSuggestion: (vaultId: string) =>
     apiRequest<RebalanceSuggestion>(`/vaults/${vaultId}/rebalance-suggestion`),


### PR DESCRIPTION
Closes #696 

Overview
SavingsChart previously received fabricated/random data from savings/page.tsx — the rendered line was meaningless. This PR fetches real APY snapshots from the /vaults/{id}/apy-history endpoint and feeds them into the chart, with period selection, loading, empty, and tooltip states.

Changes
useSavingsChartData hook: Fetches /vaults/{id}/apy-history?period=… via React Query, maps fractional APY values to display percentages, is disabled until a vault is resolved, and caches for 15 minutes.
API layer: Added getApyHistory plus APYHistoryResponse/APYHistoryPoint/APYHistoryPeriod types to lib/api/vaults.ts.
SavingsChart component: Repurposed to plot real APY data as a line chart. Adds a skeleton-pulse loading state, a descriptive empty state, and a tooltip that reads "APY: 8.23% on Jun 15".
Savings page: Resolves the primary vault to chart (goal-linked vault first, then the single held vault, then a dropdown selector when the user holds multiple unlinked vaults), wires the hook in, and switches the period selector to 7D/30D/90D, which re-fetches on change. All mock/hardcoded chart data has been removed.
Forward-compat: Added optional vault_id to the SavingsGoal type so the goal-linkage preference works once #688 lands.
Tests
Added unit tests for the hook (point mapping, disabled state, empty data, period re-fetch) and for the chart's loading/empty/data states. Full suite passes (29/29).

Acceptance criteria
 SavingsChart renders real APY data fetched from /vaults/{id}/apy-history
 Period selector (7D/30D/90D) works and re-fetches on change
 No mock or hardcoded chart data remains in the component tree
 Loading state: chart area shows a skeleton pulse
 Empty data state shows a descriptive message, not a broken chart
 Tooltip shows APY and date on hover
Dependencies
Depends on #664 (the /apy-history endpoint) for live data; the UI degrades to the empty state until it returns snapshots.
Goal-based vault selection activates once #688 adds vault_id to savings goals; the position-based selection works in the meantime.