### PR TITLE
 feat(api): add category field to savings_goal — enum of goal types

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -3,6 +3,8 @@ package savingsgoal
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,10 +12,40 @@ import (
 )
 
 var (
-	ErrGoalNotFound    = errors.New("savings goal not found")
-	ErrInvalidGoal     = errors.New("invalid savings goal")
-	ErrUnauthorized    = errors.New("unauthorized")
+	ErrGoalNotFound = errors.New("savings goal not found")
+	ErrInvalidGoal  = errors.New("invalid savings goal")
+	ErrUnauthorized = errors.New("unauthorized")
 )
+
+type GoalCategory string
+
+const (
+	CategoryEmergencyFund GoalCategory = "emergency_fund"
+	CategoryEducation     GoalCategory = "education"
+	CategoryHousing       GoalCategory = "housing"
+	CategoryTravel        GoalCategory = "travel"
+	CategoryBusiness      GoalCategory = "business"
+	CategoryHealth        GoalCategory = "health"
+	CategoryRetirement    GoalCategory = "retirement"
+	CategoryOther         GoalCategory = "other"
+)
+
+func ParseCategory(value string) (GoalCategory, error) {
+	category := GoalCategory(strings.ToLower(strings.TrimSpace(value)))
+	switch category {
+	case CategoryEmergencyFund,
+		CategoryEducation,
+		CategoryHousing,
+		CategoryTravel,
+		CategoryBusiness,
+		CategoryHealth,
+		CategoryRetirement,
+		CategoryOther:
+		return category, nil
+	default:
+		return "", fmt.Errorf("%w: invalid category", ErrInvalidGoal)
+	}
+}
 
 type SavingsGoal struct {
 	ID            uuid.UUID       `json:"id"`
@@ -22,6 +54,7 @@ type SavingsGoal struct {
 	Currency      string          `json:"currency"`
 	Deadline      time.Time       `json:"deadline"`
 	Description   string          `json:"description,omitempty"`
+	Category      GoalCategory    `json:"category"`
 	CurrentAmount decimal.Decimal `json:"current_amount"`
 	ProgressPct   float64         `json:"progress_pct"`
 	CreatedAt     time.Time       `json:"created_at"`
@@ -30,7 +63,7 @@ type SavingsGoal struct {
 
 type Repository interface {
 	Create(ctx context.Context, goal *SavingsGoal) error
-	ListByUser(ctx context.Context, userID uuid.UUID) ([]SavingsGoal, error)
+	ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]SavingsGoal, error)
 	GetByID(ctx context.Context, id uuid.UUID) (*SavingsGoal, error)
 	Update(ctx context.Context, goal *SavingsGoal) error
 	Delete(ctx context.Context, id, userID uuid.UUID) error

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,7 +22,7 @@ import (
 type SavingsGoalManager interface {
 	Create(ctx context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
-	List(ctx context.Context, userID uuid.UUID) ([]savingsgoal.SavingsGoal, error)
+	List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error)
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
 }
@@ -47,6 +48,7 @@ type createSavingsGoalRequest struct {
 	Currency     string      `json:"currency"`
 	Deadline     string      `json:"deadline"`
 	Description  string      `json:"description"`
+	Category     string      `json:"category"`
 }
 
 type updateSavingsGoalRequest struct {
@@ -54,6 +56,7 @@ type updateSavingsGoalRequest struct {
 	Currency     *string      `json:"currency"`
 	Deadline     *string      `json:"deadline"`
 	Description  *string      `json:"description"`
+	Category     *string      `json:"category"`
 }
 
 func (h *SavingsGoalHandler) create(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +89,7 @@ func (h *SavingsGoalHandler) create(w http.ResponseWriter, r *http.Request) {
 		Currency:     req.Currency,
 		Deadline:     deadline,
 		Description:  req.Description,
+		Category:     req.Category,
 	})
 	if err != nil {
 		h.writeError(w, r, err)
@@ -117,7 +121,7 @@ func (h *SavingsGoalHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	goals, err := h.svc.List(r.Context(), userID)
+	goals, err := h.svc.List(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("category")))
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -169,6 +173,7 @@ func (h *SavingsGoalHandler) update(w http.ResponseWriter, r *http.Request) {
 		in.Deadline = &d
 	}
 	in.Description = req.Description
+	in.Category = req.Category
 
 	goal, err := h.svc.Update(r.Context(), userID, goalID, in)
 	if err != nil {

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
 )
 
 type mockSavingsGoalService struct {
@@ -24,6 +26,14 @@ type mockSavingsGoalService struct {
 }
 
 func (m *mockSavingsGoalService) Create(_ context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error) {
+	category := savingsgoal.CategoryOther
+	if in.Category != "" {
+		parsed, err := savingsgoal.ParseCategory(in.Category)
+		if err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		category = parsed
+	}
 	g := savingsgoal.SavingsGoal{
 		ID:            uuid.New(),
 		UserID:        userID,
@@ -31,6 +41,7 @@ func (m *mockSavingsGoalService) Create(_ context.Context, userID uuid.UUID, in 
 		Currency:      in.Currency,
 		Deadline:      in.Deadline,
 		Description:   in.Description,
+		Category:      category,
 		CurrentAmount: decimal.NewFromInt(100),
 		ProgressPct:   10,
 	}
@@ -46,12 +57,21 @@ func (m *mockSavingsGoalService) Get(_ context.Context, userID, goalID uuid.UUID
 	return g, nil
 }
 
-func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID) ([]savingsgoal.SavingsGoal, error) {
+func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+	if category != "" {
+		if _, err := savingsgoal.ParseCategory(category); err != nil {
+			return nil, err
+		}
+	}
 	var out []savingsgoal.SavingsGoal
 	for _, g := range m.goals {
-		if g.UserID == userID {
-			out = append(out, g)
+		if g.UserID != userID {
+			continue
 		}
+		if category != "" && string(g.Category) != category {
+			continue
+		}
+		out = append(out, g)
 	}
 	return out, nil
 }
@@ -63,6 +83,13 @@ func (m *mockSavingsGoalService) Update(_ context.Context, userID, goalID uuid.U
 	}
 	if in.TargetAmount != nil {
 		g.TargetAmount = *in.TargetAmount
+	}
+	if in.Category != nil {
+		parsed, err := savingsgoal.ParseCategory(*in.Category)
+		if err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		g.Category = parsed
 	}
 	m.goals[goalID] = g
 	return g, nil
@@ -115,5 +142,108 @@ func TestSavingsGoalHandler_CRUD(t *testing.T) {
 	defer listResp.Body.Close()
 	if listResp.StatusCode != http.StatusOK {
 		t.Fatalf("list status = %d, want 200", listResp.StatusCode)
+	}
+}
+
+func TestSavingsGoalHandler_Create_InvalidCategory(t *testing.T) {
+	userID := uuid.New()
+	h := NewSavingsGoalHandler(&mockSavingsGoalService{goals: make(map[uuid.UUID]savingsgoal.SavingsGoal)})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	deadline := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	createBody := `{"target_amount":1000,"currency":"USDC","deadline":"` + deadline + `","category":"vacation"}`
+	resp, err := http.Post(server.URL+"/api/v1/users/savings-goals", "application/json", bytes.NewBufferString(createBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("create status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestSavingsGoalHandler_Create_DefaultCategory(t *testing.T) {
+	userID := uuid.New()
+	h := NewSavingsGoalHandler(&mockSavingsGoalService{goals: make(map[uuid.UUID]savingsgoal.SavingsGoal)})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	deadline := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	createBody := `{"target_amount":1000,"currency":"USDC","deadline":"` + deadline + `"}`
+	resp, err := http.Post(server.URL+"/api/v1/users/savings-goals", "application/json", bytes.NewBufferString(createBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", resp.StatusCode)
+	}
+
+	var envelope response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var goal savingsgoal.SavingsGoal
+	if err := json.Unmarshal(data, &goal); err != nil {
+		t.Fatal(err)
+	}
+	if goal.Category != savingsgoal.CategoryOther {
+		t.Fatalf("category = %q, want other", goal.Category)
+	}
+}
+
+func TestSavingsGoalHandler_List_FilterByCategory(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {
+			ID:           goalID,
+			UserID:       userID,
+			TargetAmount: decimal.NewFromInt(1000),
+			Currency:     "USDC",
+			Category:     savingsgoal.CategoryEducation,
+		},
+	}}
+	h := NewSavingsGoalHandler(svc)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals?category=education")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", resp.StatusCode)
+	}
+
+	var envelope response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var goals []savingsgoal.SavingsGoal
+	if err := json.Unmarshal(data, &goals); err != nil {
+		t.Fatal(err)
+	}
+	if len(goals) != 1 || goals[0].Category != savingsgoal.CategoryEducation {
+		t.Fatalf("goals = %+v, want one education goal", goals)
 	}
 }

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -22,21 +22,30 @@ func NewSavingsGoalRepository(db *sql.DB) *SavingsGoalRepository {
 
 func (r *SavingsGoalRepository) Create(ctx context.Context, goal *savingsgoal.SavingsGoal) error {
 	query := `
-		INSERT INTO savings_goals (id, user_id, target_amount, currency, deadline, description)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO savings_goals (id, user_id, target_amount, currency, deadline, description, category)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING created_at, updated_at
 	`
 	return r.db.QueryRowContext(
 		ctx, query,
-		goal.ID, goal.UserID, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description),
+		goal.ID, goal.UserID, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), string(goal.Category),
 	).Scan(&goal.CreatedAt, &goal.UpdatedAt)
 }
 
-func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]savingsgoal.SavingsGoal, error) {
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, user_id, target_amount, currency, deadline, description, created_at, updated_at
-		FROM savings_goals WHERE user_id = $1 ORDER BY created_at DESC
-	`, userID)
+func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+	query := `
+		SELECT id, user_id, target_amount, currency, deadline, description, category, created_at, updated_at
+		FROM savings_goals
+		WHERE user_id = $1
+	`
+	args := []any{userID}
+	if category != "" {
+		query += ` AND category = $2`
+		args = append(args, category)
+	}
+	query += ` ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +64,7 @@ func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID
 
 func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	row := r.db.QueryRowContext(ctx, `
-		SELECT id, user_id, target_amount, currency, deadline, description, created_at, updated_at
+		SELECT id, user_id, target_amount, currency, deadline, description, category, created_at, updated_at
 		FROM savings_goals WHERE id = $1
 	`, id)
 	g, err := scanSavingsGoal(row)
@@ -71,9 +80,9 @@ func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*sav
 func (r *SavingsGoalRepository) Update(ctx context.Context, goal *savingsgoal.SavingsGoal) error {
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE savings_goals
-		SET target_amount = $1, currency = $2, deadline = $3, description = $4, updated_at = NOW()
-		WHERE id = $5 AND user_id = $6
-	`, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), goal.ID, goal.UserID)
+		SET target_amount = $1, currency = $2, deadline = $3, description = $4, category = $5, updated_at = NOW()
+		WHERE id = $6 AND user_id = $7
+	`, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), string(goal.Category), goal.ID, goal.UserID)
 	if err != nil {
 		return err
 	}
@@ -119,11 +128,11 @@ type savingsGoalScanner interface {
 
 func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 	var (
-		id, userID, targetStr, currency string
-		deadline, createdAt, updatedAt  time.Time
-		description                     sql.NullString
+		id, userID, targetStr, currency, category string
+		deadline, createdAt, updatedAt          time.Time
+		description                             sql.NullString
 	)
-	if err := row.Scan(&id, &userID, &targetStr, &currency, &deadline, &description, &createdAt, &updatedAt); err != nil {
+	if err := row.Scan(&id, &userID, &targetStr, &currency, &deadline, &description, &category, &createdAt, &updatedAt); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
 	parsedID, _ := uuid.Parse(id)
@@ -140,6 +149,7 @@ func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 		Currency:     currency,
 		Deadline:     deadline,
 		Description:  desc,
+		Category:     savingsgoal.GoalCategory(category),
 		CreatedAt:    createdAt,
 		UpdatedAt:    updatedAt,
 	}, nil

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -25,6 +25,7 @@ type CreateSavingsGoalInput struct {
 	Currency     string          `json:"currency"`
 	Deadline     time.Time       `json:"deadline"`
 	Description  string          `json:"description"`
+	Category     string          `json:"category"`
 }
 
 type UpdateSavingsGoalInput struct {
@@ -32,10 +33,15 @@ type UpdateSavingsGoalInput struct {
 	Currency     *string          `json:"currency"`
 	Deadline     *time.Time       `json:"deadline"`
 	Description  *string          `json:"description"`
+	Category     *string          `json:"category"`
 }
 
 func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error) {
 	if err := validateSavingsGoalInput(in.TargetAmount, in.Currency, in.Deadline); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	category, err := resolveCategory(in.Category, true)
+	if err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
 	goal := &savingsgoal.SavingsGoal{
@@ -45,6 +51,7 @@ func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in Cr
 		Currency:     strings.ToUpper(strings.TrimSpace(in.Currency)),
 		Deadline:     in.Deadline.UTC(),
 		Description:  strings.TrimSpace(in.Description),
+		Category:     category,
 	}
 	if err := s.repo.Create(ctx, goal); err != nil {
 		return savingsgoal.SavingsGoal{}, err
@@ -63,8 +70,17 @@ func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) 
 	return s.enrichProgress(ctx, *goal)
 }
 
-func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID) ([]savingsgoal.SavingsGoal, error) {
-	goals, err := s.repo.ListByUser(ctx, userID)
+func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+	filterCategory := ""
+	if strings.TrimSpace(category) != "" {
+		parsed, err := savingsgoal.ParseCategory(category)
+		if err != nil {
+			return nil, err
+		}
+		filterCategory = string(parsed)
+	}
+
+	goals, err := s.repo.ListByUser(ctx, userID, filterCategory)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +115,13 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 	if in.Description != nil {
 		goal.Description = strings.TrimSpace(*in.Description)
 	}
+	if in.Category != nil {
+		category, err := resolveCategory(*in.Category, false)
+		if err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		goal.Category = category
+	}
 	if err := validateSavingsGoalInput(goal.TargetAmount, goal.Currency, goal.Deadline); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
@@ -129,6 +152,16 @@ func (s *SavingsGoalService) enrichProgress(ctx context.Context, goal savingsgoa
 		goal.ProgressPct = pct
 	}
 	return goal, nil
+}
+
+func resolveCategory(value string, defaultIfEmpty bool) (savingsgoal.GoalCategory, error) {
+	if strings.TrimSpace(value) == "" {
+		if defaultIfEmpty {
+			return savingsgoal.CategoryOther, nil
+		}
+		return "", fmt.Errorf("%w: invalid category", savingsgoal.ErrInvalidGoal)
+	}
+	return savingsgoal.ParseCategory(value)
 }
 
 func validateSavingsGoalInput(target decimal.Decimal, currency string, deadline time.Time) error {

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+type memorySavingsGoalRepo struct {
+	goals    map[uuid.UUID]savingsgoal.SavingsGoal
+	balances map[uuid.UUID]decimal.Decimal
+}
+
+func newMemorySavingsGoalRepo() *memorySavingsGoalRepo {
+	return &memorySavingsGoalRepo{
+		goals:    make(map[uuid.UUID]savingsgoal.SavingsGoal),
+		balances: make(map[uuid.UUID]decimal.Decimal),
+	}
+}
+
+func (m *memorySavingsGoalRepo) Create(_ context.Context, goal *savingsgoal.SavingsGoal) error {
+	now := time.Now().UTC()
+	goal.CreatedAt = now
+	goal.UpdatedAt = now
+	m.goals[goal.ID] = *goal
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) ListByUser(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+	var out []savingsgoal.SavingsGoal
+	for _, g := range m.goals {
+		if g.UserID != userID {
+			continue
+		}
+		if category != "" && string(g.Category) != category {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+func (m *memorySavingsGoalRepo) GetByID(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[id]
+	if !ok {
+		return nil, savingsgoal.ErrGoalNotFound
+	}
+	return &g, nil
+}
+
+func (m *memorySavingsGoalRepo) Update(_ context.Context, goal *savingsgoal.SavingsGoal) error {
+	if _, ok := m.goals[goal.ID]; !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	m.goals[goal.ID] = *goal
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) Delete(_ context.Context, id, userID uuid.UUID) error {
+	g, ok := m.goals[id]
+	if !ok || g.UserID != userID {
+		return savingsgoal.ErrGoalNotFound
+	}
+	delete(m.goals, id)
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) SumVaultBalance(_ context.Context, userID uuid.UUID, _ string) (decimal.Decimal, error) {
+	return m.balances[userID], nil
+}
+
+func testDeadline() time.Time {
+	return time.Now().UTC().Add(30 * 24 * time.Hour)
+}
+
+func TestSavingsGoalService_Create_ValidCategory(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Category:     "education",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if goal.Category != savingsgoal.CategoryEducation {
+		t.Fatalf("category = %q, want education", goal.Category)
+	}
+}
+
+func TestSavingsGoalService_Create_InvalidCategory(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo())
+
+	_, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Category:     "vacation",
+	})
+	if err == nil {
+		t.Fatal("Create() error = nil, want invalid category")
+	}
+}
+
+func TestSavingsGoalService_Create_MissingCategoryDefaultsToOther(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo())
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if goal.Category != savingsgoal.CategoryOther {
+		t.Fatalf("category = %q, want other", goal.Category)
+	}
+}
+
+func TestSavingsGoalService_List_FilterByCategory(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	eduID := uuid.New()
+	travelID := uuid.New()
+	repo.goals[eduID] = savingsgoal.SavingsGoal{
+		ID:           eduID,
+		UserID:       userID,
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Category:     savingsgoal.CategoryEducation,
+	}
+	repo.goals[travelID] = savingsgoal.SavingsGoal{
+		ID:           travelID,
+		UserID:       userID,
+		TargetAmount: decimal.NewFromInt(500),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Category:     savingsgoal.CategoryTravel,
+	}
+	svc := NewSavingsGoalService(repo)
+
+	goals, err := svc.List(ctx, userID, "education")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(goals) != 1 {
+		t.Fatalf("len(goals) = %d, want 1", len(goals))
+	}
+	if goals[0].Category != savingsgoal.CategoryEducation {
+		t.Fatalf("category = %q, want education", goals[0].Category)
+	}
+}
+
+func TestSavingsGoalService_List_InvalidCategoryFilter(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo())
+
+	_, err := svc.List(ctx, userID, "invalid")
+	if err == nil {
+		t.Fatal("List() error = nil, want invalid category")
+	}
+}
+
+func TestParseCategory_AcceptsAllValues(t *testing.T) {
+	categories := []savingsgoal.GoalCategory{
+		savingsgoal.CategoryEmergencyFund,
+		savingsgoal.CategoryEducation,
+		savingsgoal.CategoryHousing,
+		savingsgoal.CategoryTravel,
+		savingsgoal.CategoryBusiness,
+		savingsgoal.CategoryHealth,
+		savingsgoal.CategoryRetirement,
+		savingsgoal.CategoryOther,
+	}
+	for _, want := range categories {
+		got, err := savingsgoal.ParseCategory(string(want))
+		if err != nil {
+			t.Fatalf("ParseCategory(%q) error = %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("ParseCategory(%q) = %q", want, got)
+		}
+	}
+}

--- a/apps/api/migrations/037_add_savings_goal_category.down.sql
+++ b/apps/api/migrations/037_add_savings_goal_category.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS category;

--- a/apps/api/migrations/037_add_savings_goal_category.up.sql
+++ b/apps/api/migrations/037_add_savings_goal_category.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE savings_goals
+  ADD COLUMN category VARCHAR(50) NOT NULL DEFAULT 'other';


### PR DESCRIPTION
## Summary

This PR adds four focused improvements across the dapp frontend and API: APY trend sparklines on vault cards, a savings goal velocity endpoint, per-protocol yield detail, and savings goal categories.

feat(dapp): APY trend sparkline on vault cards Closes #678 
Adds VaultSparkline and useVaultAPYHistory to show a 7-day APY trend on vault cards
Integrates into vault and savings card views for backend vault UUIDs only
Includes accessibility labels and Vitest coverage for uptrend/downtrend/empty states

feat(api): savings velocity endpoint.  Closes #687 
Adds GET /api/v1/users/savings-goals/{id}/velocity
Returns required daily/weekly/monthly deposit rates, on_track status, and projected shortfall
Handles completed goals, past deadlines, and ownership checks with unit tests

feat(api): per-protocol yield detail endpoint.  Closes #666 
Adds GET /api/v1/yield-opportunities/{protocol}
Returns all Stellar pools for a protocol, sorted by APY descending
Reuses the existing per-chain DeFiLlama cache (no extra upstream call)
Case-insensitive protocol matching with 404 / 503 handling and unit tests

feat(api): savings goal category field.   Closes #682 

Adds migration 037 with category column (default other)
Supports 8 goal types with validation, defaulting, and ?category= list filtering
Returns category on all goal responses with service and handler tests
