### PR TITLE
feat(api): extend savings-goals summary with status counts, progress & next deadline

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -58,6 +58,16 @@ type SavingsGoalsSummary struct {
 	TotalSavedXLM   decimal.Decimal `json:"total_saved_xlm"`
 	TotalTargetXLM  decimal.Decimal `json:"total_target_xlm"`
 	GoalCount       int             `json:"goal_count"`
+	// ActiveGoals + CompletedGoals partition GoalCount; a goal counts as
+	// completed once its current amount reaches its target (#683).
+	ActiveGoals    int `json:"active_goals"`
+	CompletedGoals int `json:"completed_goals"`
+	// OverallProgressPct is USDC progress (saved/target, capped at 100). USDC
+	// only, to avoid cross-currency conversion the rest of this type avoids.
+	OverallProgressPct float64 `json:"overall_progress_pct"`
+	// NextDeadline is the nearest future deadline across active goals, or nil.
+	// No omitempty so it serializes as JSON null when absent.
+	NextDeadline *time.Time `json:"next_deadline"`
 }
 
 func ParseCategory(value string) (GoalCategory, error) {

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -147,12 +147,13 @@ func (s *SavingsGoalService) Summary(ctx context.Context, userID uuid.UUID) (sav
 
 	summary := savingsgoal.SavingsGoalsSummary{GoalCount: len(goals)}
 
+	now := time.Now().UTC()
 	for _, goal := range goals {
 		enriched, err := s.enrichProgress(ctx, goal)
 		if err != nil {
 			return savingsgoal.SavingsGoalsSummary{}, err
 		}
-		switch enriched.Currency {
+		switch savingsgoal.NormalizeCurrency(enriched.Currency) {
 		case savingsgoal.CurrencyUSDC:
 			summary.TotalTargetUSDC = summary.TotalTargetUSDC.Add(enriched.TargetAmount)
 			summary.TotalSavedUSDC = summary.TotalSavedUSDC.Add(enriched.CurrentAmount)
@@ -160,6 +161,33 @@ func (s *SavingsGoalService) Summary(ctx context.Context, userID uuid.UUID) (sav
 			summary.TotalTargetXLM = summary.TotalTargetXLM.Add(enriched.TargetAmount)
 			summary.TotalSavedXLM = summary.TotalSavedXLM.Add(enriched.CurrentAmount)
 		}
+
+		// Goal status counts + nearest upcoming deadline across active goals (#683).
+		completed := enriched.TargetAmount.IsPositive() &&
+			enriched.CurrentAmount.GreaterThanOrEqual(enriched.TargetAmount)
+		if completed {
+			summary.CompletedGoals++
+		} else {
+			summary.ActiveGoals++
+			if enriched.Deadline.After(now) &&
+				(summary.NextDeadline == nil || enriched.Deadline.Before(*summary.NextDeadline)) {
+				d := enriched.Deadline
+				summary.NextDeadline = &d
+			}
+		}
+	}
+
+	// Overall progress is USDC-denominated, capped at 100 (#683).
+	if summary.TotalTargetUSDC.IsPositive() {
+		pct, _ := summary.TotalSavedUSDC.Div(summary.TotalTargetUSDC).
+			Mul(decimal.NewFromInt(100)).Float64()
+		if pct > 100 {
+			pct = 100
+		}
+		if pct < 0 {
+			pct = 0
+		}
+		summary.OverallProgressPct = pct
 	}
 
 	return summary, nil

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -150,7 +150,7 @@ func TestSavingsGoalService_MilestoneNotifications(t *testing.T) {
 
 	t.Run("24 percent no notification", func(t *testing.T) {
 		repo := newMemorySavingsGoalRepo()
-		repo.balances[userID] = decimal.NewFromInt(24)
+		repo.setBalance(userID, "USDC", decimal.NewFromInt(24))
 		notifier := &recordingGoalMilestoneNotifier{}
 		svc := NewSavingsGoalService(repo, notifier)
 
@@ -171,7 +171,7 @@ func TestSavingsGoalService_MilestoneNotifications(t *testing.T) {
 
 	t.Run("25 percent fires notification", func(t *testing.T) {
 		repo := newMemorySavingsGoalRepo()
-		repo.balances[userID] = decimal.NewFromInt(25)
+		repo.setBalance(userID, "USDC", decimal.NewFromInt(25))
 		notifier := &recordingGoalMilestoneNotifier{}
 		svc := NewSavingsGoalService(repo, notifier)
 
@@ -195,7 +195,7 @@ func TestSavingsGoalService_MilestoneNotifications(t *testing.T) {
 
 	t.Run("25 percent again no duplicate", func(t *testing.T) {
 		repo := newMemorySavingsGoalRepo()
-		repo.balances[userID] = decimal.NewFromInt(25)
+		repo.setBalance(userID, "USDC", decimal.NewFromInt(25))
 		notifier := &recordingGoalMilestoneNotifier{}
 		svc := NewSavingsGoalService(repo, notifier)
 
@@ -359,7 +359,7 @@ func TestSavingsGoalService_Create_ValidXLMGoal(t *testing.T) {
 	userID := uuid.New()
 	repo := newMemorySavingsGoalRepo()
 	repo.setBalance(userID, "XLM", decimal.NewFromInt(120))
-	svc := NewSavingsGoalService(repo)
+	svc := NewSavingsGoalService(repo, nil)
 
 	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
 		TargetAmount: decimal.NewFromInt(500),
@@ -383,7 +383,7 @@ func TestSavingsGoalService_Create_ValidUSDCGoal(t *testing.T) {
 	userID := uuid.New()
 	repo := newMemorySavingsGoalRepo()
 	repo.setBalance(userID, "USDC", decimal.NewFromInt(250))
-	svc := NewSavingsGoalService(repo)
+	svc := NewSavingsGoalService(repo, nil)
 
 	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
 		TargetAmount: decimal.NewFromInt(1000),
@@ -404,7 +404,7 @@ func TestSavingsGoalService_Create_ValidUSDCGoal(t *testing.T) {
 func TestSavingsGoalService_Create_InvalidCurrency(t *testing.T) {
 	ctx := context.Background()
 	userID := uuid.New()
-	svc := NewSavingsGoalService(newMemorySavingsGoalRepo())
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil)
 
 	_, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
 		TargetAmount: decimal.NewFromInt(1000),
@@ -438,7 +438,7 @@ func TestSavingsGoalService_Summary_MixedCurrencies(t *testing.T) {
 		Currency:     savingsgoal.CurrencyXLM,
 		Deadline:     testDeadline(),
 	}
-	svc := NewSavingsGoalService(repo)
+	svc := NewSavingsGoalService(repo, nil)
 
 	summary, err := svc.Summary(ctx, userID)
 	if err != nil {
@@ -458,5 +458,64 @@ func TestSavingsGoalService_Summary_MixedCurrencies(t *testing.T) {
 	}
 	if !summary.TotalTargetXLM.Equal(decimal.NewFromInt(500)) {
 		t.Fatalf("total_target_xlm = %s, want 500", summary.TotalTargetXLM)
+	}
+	// #683: status counts, USDC overall progress, next deadline.
+	if summary.ActiveGoals != 2 || summary.CompletedGoals != 0 {
+		t.Fatalf("active/completed = %d/%d, want 2/0", summary.ActiveGoals, summary.CompletedGoals)
+	}
+	if summary.OverallProgressPct != 10 { // 100 saved / 1000 target USDC
+		t.Fatalf("overall_progress_pct = %v, want 10", summary.OverallProgressPct)
+	}
+	if summary.NextDeadline == nil {
+		t.Fatal("next_deadline = nil, want the nearest active deadline")
+	}
+}
+
+func TestSavingsGoalService_Summary_NoGoals(t *testing.T) {
+	ctx := context.Background()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil)
+
+	summary, err := svc.Summary(ctx, uuid.New())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	if summary.GoalCount != 0 || summary.ActiveGoals != 0 || summary.CompletedGoals != 0 {
+		t.Fatalf("counts = %+v, want all zero", summary)
+	}
+	if summary.OverallProgressPct != 0 {
+		t.Fatalf("overall_progress_pct = %v, want 0", summary.OverallProgressPct)
+	}
+	if summary.NextDeadline != nil {
+		t.Fatalf("next_deadline = %v, want nil", summary.NextDeadline)
+	}
+}
+
+func TestSavingsGoalService_Summary_CompletedAndProgressCap(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	repo.setBalance(userID, "USDC", decimal.NewFromInt(5000)) // saved exceeds target
+	goalID := uuid.New()
+	repo.goals[goalID] = savingsgoal.SavingsGoal{
+		ID:           goalID,
+		UserID:       userID,
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     savingsgoal.CurrencyUSDC,
+		Deadline:     testDeadline(),
+	}
+	svc := NewSavingsGoalService(repo, nil)
+
+	summary, err := svc.Summary(ctx, userID)
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	if summary.CompletedGoals != 1 || summary.ActiveGoals != 0 {
+		t.Fatalf("active/completed = %d/%d, want 0/1", summary.ActiveGoals, summary.CompletedGoals)
+	}
+	if summary.OverallProgressPct != 100 {
+		t.Fatalf("overall_progress_pct = %v, want 100 (capped)", summary.OverallProgressPct)
+	}
+	if summary.NextDeadline != nil {
+		t.Fatalf("next_deadline = %v, want nil (no active goals)", summary.NextDeadline)
 	}
 }


### PR DESCRIPTION
## Summary
The `GET /api/v1/users/savings-goals/summary` endpoint added in #710 returns per-currency totals (`total_target/saved_usdc/xlm`) and `goal_count`. This PR **extends that existing endpoint** with the remaining fields issue #683 requires, so the dashboard / savings overview can render full savings health from a single call.

Closes #683

> Note: I originally implemented this as a standalone endpoint, but #710 landed a `/summary` route while this was in progress. Rebased and reworked to **build on the existing `SavingsGoalsSummary`** rather than duplicate it.

## Added fields
- `active_goals` / `completed_goals` — a goal counts as completed once its current amount reaches its target.
- `overall_progress_pct` — USDC `saved / target`, **capped at 100**. USDC-only, to avoid the cross-currency conversion this type deliberately avoids.
- `next_deadline` — nearest **future** deadline across **active** goals, serialized as `null` when absent (no `omitempty`).

## Drive-by fix
The service test package **did not compile on `main`**: leftover `NewSavingsGoalService(repo)` calls were missing the `notifier` arg added in #710, and some tests still wrote `repo.balances[userID]` after the balance map moved to string keys. Repaired those so the package builds.

## Tests
Extended `Summary_MixedCurrencies` to assert the new fields, plus:
- `Summary_NoGoals` — zero values, `next_deadline: null`
- `Summary_CompletedAndProgressCap` — completed count + progress capped at 100

```
ok  github.com/suncrestlabs/nester/apps/api/internal/service
ok  github.com/suncrestlabs/nester/apps/api/internal/handler
```
`go build ./...` clean.