### PR TITLE
feat(api): add GET /api/v1/yield-opportunities/compare — side-by-side protocol comparison

### DIFF
--- a/apps/api/internal/handler/yield_handler.go
+++ b/apps/api/internal/handler/yield_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ import (
 // YieldOpportunitiesProvider is the service surface the handler depends on.
 type YieldOpportunitiesProvider interface {
 	GetYieldOpportunities(ctx context.Context, chain string, limit int) (*service.YieldOpportunitiesResponse, error)
+	CompareProtocols(ctx context.Context, protocols []string) ([]service.ProtocolSummary, error)
 }
 
 // YieldHandler serves GET /api/v1/yield-opportunities.
@@ -27,7 +29,37 @@ func NewYieldHandler(svc YieldOpportunitiesProvider) *YieldHandler {
 
 func (h *YieldHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/yield-opportunities", h.list)
+	mux.HandleFunc("GET /api/v1/yield-opportunities/compare", h.compare)
 }
+
+func (h *YieldHandler) compare(w http.ResponseWriter, r *http.Request) {
+	raw := r.URL.Query().Get("protocols")
+	protocols := make([]string, 0, maxYieldCompare)
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			protocols = append(protocols, p)
+		}
+	}
+
+	summaries, err := h.svc.CompareProtocols(r.Context(), protocols)
+	if err != nil {
+		if errors.Is(err, service.ErrInvalidProtocolCount) {
+			response.WriteJSON(w, http.StatusBadRequest, response.Err(http.StatusBadRequest, "INVALID_PROTOCOLS", err.Error()))
+			return
+		}
+		logpkg.FromContext(r.Context()).Error("yield protocol comparison failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UPSTREAM_ERROR", "yield data temporarily unavailable"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.Response{
+		Success: true,
+		Data:    map[string]interface{}{"data": summaries},
+	})
+}
+
+// maxYieldCompare mirrors the service's upper bound for query parsing capacity.
+const maxYieldCompare = 5
 
 func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
 	chain := strings.TrimSpace(r.URL.Query().Get("chain"))

--- a/apps/api/internal/handler/yield_handler_test.go
+++ b/apps/api/internal/handler/yield_handler_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// newYieldServerWithRealSvc wires the handler to a real YieldService backed by a
+// mock DeFiLlama server, so the comparison is exercised end-to-end. (The
+// service package's own *_test.go does not compile on main, so these
+// integration-style tests live in the handler package.)
+func newYieldServerWithRealSvc(t *testing.T) *httptest.Server {
+	t.Helper()
+	defiLlama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"pool":"b1","project":"blend","symbol":"USDC","apy":6.0,"apyBase":6.0,"apyReward":0.0,"tvlUsd":2000000,"chain":"Stellar"},
+				{"pool":"b2","project":"blend","symbol":"XLM","apy":8.23,"apyBase":7.0,"apyReward":1.23,"tvlUsd":2200000,"chain":"Stellar"},
+				{"pool":"a1","project":"aqua","symbol":"AQUA","apy":11.0,"apyBase":2.0,"apyReward":9.0,"tvlUsd":890000,"chain":"Stellar"}
+			]
+		}`))
+	}))
+	t.Cleanup(defiLlama.Close)
+
+	mux := http.NewServeMux()
+	NewYieldHandler(service.NewYieldService(defiLlama.URL)).Register(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func fetchCompare(t *testing.T, server *httptest.Server, query string) (*http.Response, []service.ProtocolSummary) {
+	t.Helper()
+	resp, err := http.Get(server.URL + "/api/v1/yield-opportunities/compare?protocols=" + query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, nil
+	}
+	var body struct {
+		Data struct {
+			Data []service.ProtocolSummary `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp, body.Data.Data
+}
+
+func findSummary(summaries []service.ProtocolSummary, name string) (service.ProtocolSummary, bool) {
+	for _, s := range summaries {
+		if s.Protocol == name {
+			return s, true
+		}
+	}
+	return service.ProtocolSummary{}, false
+}
+
+func TestYieldCompare_TwoKnownOneUnknown(t *testing.T) {
+	server := newYieldServerWithRealSvc(t)
+
+	// Case-insensitive + whitespace tolerant query.
+	resp, summaries := fetchCompare(t, server, "Blend,%20AQUA,unknown")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(summaries) != 3 {
+		t.Fatalf("got %d summaries, want 3: %+v", len(summaries), summaries)
+	}
+
+	blend, ok := findSummary(summaries, "Blend")
+	if !ok || !blend.Found {
+		t.Fatalf("blend missing/!found: %+v", summaries)
+	}
+	if blend.BestAPY != 8.23 || blend.TVLUsd != 4_200_000 || blend.PoolCount != 2 || blend.TopPool != "XLM" {
+		t.Fatalf("blend aggregation wrong: %+v", blend)
+	}
+
+	aqua, ok := findSummary(summaries, "AQUA")
+	if !ok || !aqua.Found || aqua.BestAPY != 11.0 || aqua.PoolCount != 1 {
+		t.Fatalf("aqua aggregation wrong: %+v", aqua)
+	}
+
+	unknown, ok := findSummary(summaries, "unknown")
+	if !ok || unknown.Found {
+		t.Fatalf("unknown should be present with found=false: %+v", unknown)
+	}
+}
+
+func TestYieldCompare_TooFewReturns400(t *testing.T) {
+	server := newYieldServerWithRealSvc(t)
+	resp, _ := fetchCompare(t, server, "blend")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestYieldCompare_TooManyReturns400(t *testing.T) {
+	server := newYieldServerWithRealSvc(t)
+	resp, _ := fetchCompare(t, server, "a,b,c,d,e,f")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -135,6 +137,94 @@ func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, 
 
 	// No data available at all
 	return nil, fetchErr
+}
+
+// ProtocolSummary is an aggregated, comparable view of one protocol's pools.
+type ProtocolSummary struct {
+	Protocol  string  `json:"protocol"`
+	Found     bool    `json:"found"`
+	BestAPY   float64 `json:"best_apy"`
+	BaseAPY   float64 `json:"base_apy"`
+	RewardAPY float64 `json:"reward_apy"`
+	TVLUsd    float64 `json:"tvl_usd"`
+	APYPct7d  float64 `json:"apy_pct_7d"`
+	RiskScore float64 `json:"risk_score"`
+	PoolCount int     `json:"pool_count"`
+	TopPool   string  `json:"top_pool_symbol"`
+}
+
+const (
+	minCompareProtocols = 2
+	maxCompareProtocols = 5
+)
+
+// ErrInvalidProtocolCount is returned when fewer than 2 or more than 5
+// protocols are requested for comparison.
+var ErrInvalidProtocolCount = errors.New("protocols must be between 2 and 5")
+
+// CompareProtocols returns a side-by-side summary for each requested protocol.
+// It aggregates from the shared DeFiLlama pool cache (a single fetch for the
+// whole comparison — no per-protocol HTTP calls). Protocol names are
+// case-insensitive; unknown protocols are returned with Found=false rather
+// than failing the request.
+func (s *YieldService) CompareProtocols(ctx context.Context, protocols []string) ([]ProtocolSummary, error) {
+	if len(protocols) < minCompareProtocols || len(protocols) > maxCompareProtocols {
+		return nil, ErrInvalidProtocolCount
+	}
+
+	// limit=0 → all pools for the chain, served from the shared cache.
+	resp, err := s.GetYieldOpportunities(ctx, "Stellar", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	byProtocol := make(map[string][]YieldPool)
+	for _, p := range resp.Pools {
+		key := strings.ToLower(p.Project)
+		byProtocol[key] = append(byProtocol[key], p)
+	}
+
+	summaries := make([]ProtocolSummary, 0, len(protocols))
+	for _, name := range protocols {
+		key := strings.ToLower(strings.TrimSpace(name))
+		pools := byProtocol[key]
+		if len(pools) == 0 {
+			summaries = append(summaries, ProtocolSummary{Protocol: name, Found: false})
+			continue
+		}
+		summaries = append(summaries, summarizeProtocol(name, pools))
+	}
+	return summaries, nil
+}
+
+// summarizeProtocol reduces a protocol's pools to a single comparison row.
+// BestAPY (and the base/reward/7d/risk/top-pool fields tied to it) come from
+// the highest-APY pool; TVLUsd is summed across all of the protocol's pools.
+func summarizeProtocol(name string, pools []YieldPool) ProtocolSummary {
+	best := pools[0]
+	var tvl float64
+	for _, p := range pools {
+		tvl += p.TVLUsd
+		if p.APY > best.APY {
+			best = p
+		}
+	}
+	var apy7d float64
+	if best.APYPct7d != nil {
+		apy7d = *best.APYPct7d
+	}
+	return ProtocolSummary{
+		Protocol:  name,
+		Found:     true,
+		BestAPY:   best.APY,
+		BaseAPY:   best.APYBase,
+		RewardAPY: best.APYReward,
+		TVLUsd:    tvl,
+		APYPct7d:  apy7d,
+		RiskScore: best.RiskScore,
+		PoolCount: len(pools),
+		TopPool:   best.Symbol,
+	}
 }
 
 // fetchFromUpstream retrieves and processes yield data from DeFiLlama


### PR DESCRIPTION
## Summary
Adds a comparison endpoint so the allocation builder / rebalance UI can evaluate multiple protocols head-to-head in a single call, instead of N requests or client-side aggregation from the raw pool list.

Closes #671

## Endpoint
`GET /api/v1/yield-opportunities/compare?protocols=blend,aqua,ultrastellar` — comma-separated, **2–5** protocols, **case-insensitive**, whitespace-tolerant.

## Service
`CompareProtocols(ctx, protocols []string) ([]ProtocolSummary, error)`:
- Aggregates from the **shared DeFiLlama cache** — one fetch for the whole comparison, **no per-protocol HTTP calls** (uses `GetYieldOpportunities(chain, 0)` so all pools for the chain are served from/into the same cache).
- Groups pools by `project`; per protocol returns **`best_apy`** (the highest-APY pool, with that pool's `base_apy`/`reward_apy`/`apy_pct_7d`/`risk_score`/`top_pool_symbol`) plus **summed `tvl_usd`** and `pool_count`.
- Unknown protocols are returned with **`found: false`** rather than failing the request.
- **`ErrInvalidProtocolCount`** for <2 or >5, mapped to **400** by the handler.

## Acceptance criteria
- [x] Comparison data for 2–5 comma-separated protocols in one call
- [x] Unknown protocols → `found: false` (not 404)
- [x] Fewer than 2 → 400
- [x] More than 5 → 400
- [x] Same DeFiLlama cache — no extra HTTP calls
- [x] Unit test: 2 known + 1 unknown, too-few, too-many

## Tests
End-to-end through the handler with a **real `YieldService` against a mock DeFiLlama server**: 2 known + 1 unknown (asserts best-APY pool, summed TVL, pool count, case-insensitive match), too-few → 400, too-many → 400. `go vet` clean; `go build ./internal/...` clean.

## Notes / judgment calls
- **`found` is always present** and the numeric fields are not `omitempty` — a found protocol with a legitimate `risk_score: 0` (low risk) must not be hidden, so unknown protocols return zeroed fields alongside `found: false` rather than an abbreviated object.
- Tests live in the **handler** package (end-to-end) because `internal/service`'s existing `savings_goal_service_test.go` does **not compile on `main`** (unrelated leftovers from #710) — I kept this PR from touching that file. Same reason I didn't add a service-level `*_test.go`.
- **Pre-existing, unrelated:** `cmd/api/main.go` does not build on `main` (`wsHub` missing `PushToUser`) — untouched here; my packages (`internal/service`, `internal/handler`) build and vet cleanly.