### PR TITLE
feat(contracts): add APY deviation guard (should_rebalance + get_optimal_allocation) to allocation_strategy

### DIFF
--- a/packages/contracts/contracts/allocation_strategy/src/lib.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/lib.rs
@@ -343,6 +343,42 @@ impl AllocationStrategyContract {
         false
     }
 
+    /// Returns the yield-maximizing allocation for `vault_id` given current
+    /// registry data: 100% (10_000 bps) to the highest-APY active source.
+    /// Weights sum to 10_000 bps; empty when the registry has no active sources.
+    ///
+    /// `vault_id` is accepted for the rebalancing scheduler's interface (and
+    /// future per-vault keying); this strategy instance represents the vault.
+    pub fn get_optimal_allocation(env: Env, vault_id: Address) -> Vec<AllocationWeight> {
+        let _ = &vault_id;
+        let registry_id: Address = env.storage().instance().get(&DataKey::RegistryId).unwrap();
+        let sources = registry_get_active_sources(&env, &registry_id);
+        optimal_allocation_from_sources(&env, &sources)
+    }
+
+    /// Returns true when rebalancing `vault_id` is warranted: the spread
+    /// between the optimal allocation's APY and the vault's current weighted
+    /// APY (computed from live registry APYs) exceeds `threshold_bps`.
+    ///
+    /// The Go rebalancing scheduler invokes this read-only check via Soroban
+    /// RPC to decide whether to trigger a rebalance.
+    pub fn should_rebalance(env: Env, vault_id: Address, threshold_bps: u32) -> bool {
+        let _ = &vault_id;
+        let registry_id: Address = env.storage().instance().get(&DataKey::RegistryId).unwrap();
+        let sources = registry_get_active_sources(&env, &registry_id);
+        if sources.is_empty() {
+            return false;
+        }
+
+        let current_weights = Self::get_weights(env.clone());
+        let current_apy = weighted_apy_for(&current_weights, &sources);
+
+        let optimal = optimal_allocation_from_sources(&env, &sources);
+        let optimal_apy = weighted_apy_for(&optimal, &sources);
+
+        optimal_apy.saturating_sub(current_apy) > threshold_bps
+    }
+
     /// Compute per-source transfers required to move from `current_allocations`
     /// to the stored target weights, given `total` assets across all sources.
     ///
@@ -627,6 +663,50 @@ fn source_score(source: &RegistrySource) -> i128 {
     };
 
     apy * risk_factor
+}
+
+/// Yield-maximizing allocation: 100% (10_000 bps) to the highest-APY active
+/// source. Returns an empty vector when there are no sources.
+fn optimal_allocation_from_sources(
+    env: &Env,
+    sources: &Vec<RegistrySource>,
+) -> Vec<AllocationWeight> {
+    let mut weights = Vec::new(env);
+    if sources.is_empty() {
+        return weights;
+    }
+    let mut best = sources.get(0).unwrap();
+    for source in sources.iter() {
+        if source.current_apy_bps > best.current_apy_bps {
+            best = source;
+        }
+    }
+    weights.push_back(AllocationWeight {
+        source_id: best.id.clone(),
+        weight_bps: BASIS_POINT_SCALE,
+    });
+    weights
+}
+
+/// Weighted APY (in bps) of `weights` using live source APYs. Sources absent
+/// from `sources` (inactive/removed) contribute 0 APY, correctly lowering the
+/// weighted result so drift is detected.
+fn weighted_apy_for(weights: &Vec<AllocationWeight>, sources: &Vec<RegistrySource>) -> u32 {
+    let mut acc: u64 = 0;
+    for weight in weights.iter() {
+        let apy = apy_for_source(sources, &weight.source_id);
+        acc += (weight.weight_bps as u64) * (apy as u64);
+    }
+    (acc / BASIS_POINT_SCALE as u64) as u32
+}
+
+fn apy_for_source(sources: &Vec<RegistrySource>, source_id: &Symbol) -> u32 {
+    for source in sources.iter() {
+        if &source.id == source_id {
+            return source.current_apy_bps;
+        }
+    }
+    0
 }
 
 /// Panic with [`ContractError::Unauthorized`] unless `account` holds Admin or

--- a/packages/contracts/contracts/allocation_strategy/src/test.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/test.rs
@@ -1044,3 +1044,75 @@ fn rebalance_withdraws_to_vault_when_all_unhealthy() {
     assert_eq!(delta_sum(&deltas), -1000);
     assert_eq!(delta_for(&deltas, symbol_short!("aave")), -1000);
 }
+
+// ---------------------------------------------------------------------------
+// should_rebalance / get_optimal_allocation (issue #637)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_rebalance_false_when_spread_below_threshold() {
+    let (env, admin, registry_id, strategy_id) = setup_with_type(VaultType::Balanced);
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // Equal APYs → optimal APY == current weighted APY → zero spread.
+    registry.update_apy_override(&admin, &symbol_short!("aave"), &500);
+    registry.update_apy_override(&admin, &symbol_short!("blend"), &500);
+    registry.update_apy_override(&admin, &symbol_short!("comp"), &500);
+
+    let vault = Address::generate(&env);
+    assert!(!client.should_rebalance(&vault, &100));
+}
+
+#[test]
+fn should_rebalance_true_when_spread_above_threshold() {
+    let (env, admin, registry_id, strategy_id) = setup_with_type(VaultType::Balanced);
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    // One source far better than the rest → optimal (100% comp) APY >> current.
+    registry.update_apy_override(&admin, &symbol_short!("aave"), &100);
+    registry.update_apy_override(&admin, &symbol_short!("blend"), &100);
+    registry.update_apy_override(&admin, &symbol_short!("comp"), &5_000);
+
+    let vault = Address::generate(&env);
+    assert!(client.should_rebalance(&vault, &500));
+}
+
+#[test]
+fn get_optimal_allocation_picks_highest_apy_and_sums_to_full() {
+    let (env, admin, registry_id, strategy_id) = setup_with_type(VaultType::Balanced);
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+
+    registry.update_apy_override(&admin, &symbol_short!("aave"), &300);
+    registry.update_apy_override(&admin, &symbol_short!("blend"), &900);
+    registry.update_apy_override(&admin, &symbol_short!("comp"), &500);
+
+    let vault = Address::generate(&env);
+    let optimal = client.get_optimal_allocation(&vault);
+    assert_eq!(weight_sum(&optimal), 10_000);
+    assert_eq!(weight_for(&optimal, symbol_short!("blend")), 10_000);
+}
+
+#[test]
+fn should_rebalance_false_for_single_protocol_already_optimal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let registry_id = env.register_contract(None, YieldRegistryContract);
+    let strategy_id = env.register_contract(None, AllocationStrategyContract);
+
+    let registry = YieldRegistryContractClient::new(&env, &registry_id);
+    registry.initialize(&admin);
+    reg(&registry, &env, &admin, symbol_short!("aave"));
+    registry.update_apy_override(&admin, &symbol_short!("aave"), &800);
+
+    let client = AllocationStrategyContractClient::new(&env, &strategy_id);
+    client.initialize_with_vault_type(&admin, &registry_id, &VaultType::Balanced);
+
+    // Default weights for a single source are 100% to it, which is already the
+    // optimal allocation → never warrants a rebalance.
+    let vault = Address::generate(&env);
+    assert!(!client.should_rebalance(&vault, &1));
+}


### PR DESCRIPTION
## Summary
Phase 2 automated rebalancing needs an on-chain APY-drift check the Go rebalancing scheduler can query before triggering a rebalance.

Closes #637

## What's added (allocation_strategy)
- **`get_optimal_allocation(vault_id) -> Vec<AllocationWeight>`** — the yield-maximizing allocation given current registry data: **100% (10_000 bps) to the highest-APY active source**. Weights sum to 100%; empty when there are no active sources.
- **`should_rebalance(vault_id, threshold_bps) -> bool`** — reads live APYs from the `yield_registry` (`get_active_sources`), computes the vault's **current weighted APY** vs the **optimal allocation's APY**, and returns `true` when the spread exceeds `threshold_bps`. It's read-only, so the scheduler can invoke it over Soroban RPC.

Reuses the existing `RegistryClient`/`get_active_sources`; adds small private helpers (`optimal_allocation_from_sources`, `weighted_apy_for`, `apy_for_source`).

## Acceptance criteria
- [x] `should_rebalance` implemented
- [x] `get_optimal_allocation` returns weights summing to 100%
- [x] Tests: spread below threshold (false), spread above threshold (true), single-protocol vault already optimal (false)
- [x] Read-only & invokable by the Go scheduler via Soroban RPC

## Tests
```
test result: ok. 37 passed; 0 failed
```
New: `should_rebalance_false_when_spread_below_threshold`, `should_rebalance_true_when_spread_above_threshold`, `get_optimal_allocation_picks_highest_apy_and_sums_to_full`, `should_rebalance_false_for_single_protocol_already_optimal`. Full suite (33 existing + 4 new) green.

## Notes / judgment calls
- **"Yield-maximizing" = concentrate in the best APY.** I interpreted `get_optimal_allocation` literally: 100% to the highest-APY active source, so the "optimal allocation's APY" equals the max achievable APY and the spread is meaningful. (The existing `suggest_weights` is a separate, risk-*adjusted* diversifier — left untouched.)
- **`vault_id` is accepted for the scheduler's interface** (and future per-vault keying); this strategy instance represents the vault, whose current allocation is its stored `get_weights`. Inactive/removed sources contribute 0 APY to the current weighted figure, so drift is detected.
- Scope is the contract surface; wiring the Go scheduler to invoke it is separate.