### PR TITLE
feat(api): auto-complete savings goals when current_amount reaches target_amount

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -15,7 +15,33 @@ var (
 	ErrGoalNotFound = errors.New("savings goal not found")
 	ErrInvalidGoal  = errors.New("invalid savings goal")
 	ErrUnauthorized = errors.New("unauthorized")
+	// ErrGoalCompleted is returned when an edit is attempted on a goal that has
+	// already reached its target (#684).
+	ErrGoalCompleted = errors.New("goal is already completed")
 )
+
+// GoalStatus is the lifecycle state of a savings goal (#684).
+type GoalStatus string
+
+const (
+	GoalStatusActive    GoalStatus = "active"
+	GoalStatusCompleted GoalStatus = "completed"
+	GoalStatusArchived  GoalStatus = "archived"
+)
+
+// ParseStatus validates a status filter/value.
+func ParseStatus(value string) (GoalStatus, error) {
+	switch GoalStatus(strings.ToLower(strings.TrimSpace(value))) {
+	case GoalStatusActive:
+		return GoalStatusActive, nil
+	case GoalStatusCompleted:
+		return GoalStatusCompleted, nil
+	case GoalStatusArchived:
+		return GoalStatusArchived, nil
+	default:
+		return "", fmt.Errorf("%w: invalid status", ErrInvalidGoal)
+	}
+}
 
 type GoalCategory string
 
@@ -87,6 +113,8 @@ type SavingsGoal struct {
 	Category      GoalCategory    `json:"category"`
 	CurrentAmount      decimal.Decimal `json:"current_amount"`
 	ProgressPct        float64         `json:"progress_pct"`
+	Status             GoalStatus      `json:"status"`
+	CompletedAt        *time.Time      `json:"completed_at,omitempty"`
 	NotifiedMilestones []int           `json:"-"`
 	CreatedAt          time.Time       `json:"created_at"`
 	UpdatedAt     time.Time       `json:"updated_at"`

--- a/apps/api/internal/handler/savings_goal_autocomplete_test.go
+++ b/apps/api/internal/handler/savings_goal_autocomplete_test.go
@@ -1,0 +1,232 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// inMemGoalRepo is a minimal savingsgoal.Repository for exercising the real
+// SavingsGoalService end-to-end through the handler. (The service package's own
+// *_test.go does not compile on main, so these integration-style tests for the
+// auto-complete behaviour (#684) live in the handler package.)
+type inMemGoalRepo struct {
+	goals    map[uuid.UUID]savingsgoal.SavingsGoal
+	balances map[string]decimal.Decimal
+}
+
+func newInMemGoalRepo() *inMemGoalRepo {
+	return &inMemGoalRepo{
+		goals:    make(map[uuid.UUID]savingsgoal.SavingsGoal),
+		balances: make(map[string]decimal.Decimal),
+	}
+}
+
+func (r *inMemGoalRepo) balKey(userID uuid.UUID, currency string) string {
+	return userID.String() + ":" + savingsgoal.NormalizeCurrency(currency)
+}
+
+func (r *inMemGoalRepo) setBalance(userID uuid.UUID, currency string, amount decimal.Decimal) {
+	r.balances[r.balKey(userID, currency)] = amount
+}
+
+func (r *inMemGoalRepo) Create(_ context.Context, goal *savingsgoal.SavingsGoal) error {
+	now := time.Now().UTC()
+	goal.CreatedAt = now
+	goal.UpdatedAt = now
+	r.goals[goal.ID] = *goal
+	return nil
+}
+
+func (r *inMemGoalRepo) ListByUser(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+	var out []savingsgoal.SavingsGoal
+	for _, g := range r.goals {
+		if g.UserID != userID {
+			continue
+		}
+		if category != "" && string(g.Category) != category {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+func (r *inMemGoalRepo) GetByID(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	g, ok := r.goals[id]
+	if !ok {
+		return nil, savingsgoal.ErrGoalNotFound
+	}
+	return &g, nil
+}
+
+func (r *inMemGoalRepo) Update(_ context.Context, goal *savingsgoal.SavingsGoal) error {
+	if _, ok := r.goals[goal.ID]; !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	r.goals[goal.ID] = *goal
+	return nil
+}
+
+func (r *inMemGoalRepo) Delete(_ context.Context, id, userID uuid.UUID) error {
+	delete(r.goals, id)
+	return nil
+}
+
+func (r *inMemGoalRepo) SumVaultBalance(_ context.Context, userID uuid.UUID, currency string) (decimal.Decimal, error) {
+	if bal, ok := r.balances[r.balKey(userID, currency)]; ok {
+		return bal, nil
+	}
+	return decimal.Zero, nil
+}
+
+func (r *inMemGoalRepo) UpdateMilestones(_ context.Context, goalID uuid.UUID, milestones []int) error {
+	g, ok := r.goals[goalID]
+	if !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.NotifiedMilestones = append([]int(nil), milestones...)
+	r.goals[goalID] = g
+	return nil
+}
+
+func realGoalServer(t *testing.T, repo *inMemGoalRepo, userID uuid.UUID) *httptest.Server {
+	t.Helper()
+	svc := service.NewSavingsGoalService(repo, nil)
+	mux := http.NewServeMux()
+	NewSavingsGoalHandler(svc).Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func createGoal(t *testing.T, server *httptest.Server, target int) savingsgoal.SavingsGoal {
+	t.Helper()
+	deadline := time.Now().UTC().Add(60 * 24 * time.Hour).Format(time.RFC3339)
+	body := fmt.Sprintf(`{"target_amount":%d,"currency":"USDC","deadline":%q}`, target, deadline)
+	resp, err := http.Post(server.URL+"/api/v1/users/savings-goals", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", resp.StatusCode)
+	}
+	return decodeGoal(t, resp)
+}
+
+func decodeGoal(t *testing.T, resp *http.Response) savingsgoal.SavingsGoal {
+	t.Helper()
+	var env response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(env.Data)
+	var goal savingsgoal.SavingsGoal
+	if err := json.Unmarshal(raw, &goal); err != nil {
+		t.Fatal(err)
+	}
+	return goal
+}
+
+func TestSavingsGoal_StaysActiveBelowTarget(t *testing.T) {
+	repo := newInMemGoalRepo()
+	userID := uuid.New()
+	repo.setBalance(userID, "USDC", decimal.NewFromInt(990)) // 99% of 1000
+	server := realGoalServer(t, repo, userID)
+
+	goal := createGoal(t, server, 1000)
+	if goal.Status != savingsgoal.GoalStatusActive {
+		t.Fatalf("status = %q, want active (99%%)", goal.Status)
+	}
+	if goal.CompletedAt != nil {
+		t.Fatalf("completed_at = %v, want nil", goal.CompletedAt)
+	}
+}
+
+func TestSavingsGoal_AutoCompletesAtTarget(t *testing.T) {
+	repo := newInMemGoalRepo()
+	userID := uuid.New()
+	repo.setBalance(userID, "USDC", decimal.NewFromInt(1000)) // 100% of 1000
+	server := realGoalServer(t, repo, userID)
+
+	goal := createGoal(t, server, 1000)
+	if goal.Status != savingsgoal.GoalStatusCompleted {
+		t.Fatalf("status = %q, want completed (100%%)", goal.Status)
+	}
+	if goal.CompletedAt == nil {
+		t.Fatal("completed_at = nil, want a timestamp")
+	}
+}
+
+func TestSavingsGoal_ListFilterByStatus(t *testing.T) {
+	repo := newInMemGoalRepo()
+	userID := uuid.New()
+	repo.setBalance(userID, "USDC", decimal.NewFromInt(50)) // both goals below target
+	server := realGoalServer(t, repo, userID)
+
+	// One active goal.
+	createGoal(t, server, 1000)
+	// One that we drive to completion by raising the balance, then re-reading.
+	completed := createGoal(t, server, 40) // 50 >= 40 → completes on create
+	if completed.Status != savingsgoal.GoalStatusCompleted {
+		t.Fatalf("expected the small-target goal to complete, got %q", completed.Status)
+	}
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals?status=completed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var env response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(env.Data)
+	var goals []savingsgoal.SavingsGoal
+	if err := json.Unmarshal(raw, &goals); err != nil {
+		t.Fatal(err)
+	}
+	if len(goals) != 1 || goals[0].Status != savingsgoal.GoalStatusCompleted {
+		t.Fatalf("status=completed returned %+v, want exactly 1 completed goal", goals)
+	}
+}
+
+func TestSavingsGoal_PatchCompletedReturns409(t *testing.T) {
+	repo := newInMemGoalRepo()
+	userID := uuid.New()
+	repo.setBalance(userID, "USDC", decimal.NewFromInt(500))
+	server := realGoalServer(t, repo, userID)
+
+	goal := createGoal(t, server, 500) // completes on create
+	if goal.Status != savingsgoal.GoalStatusCompleted {
+		t.Fatalf("precondition: goal not completed (%q)", goal.Status)
+	}
+
+	req, _ := http.NewRequest(
+		http.MethodPatch,
+		server.URL+"/api/v1/users/savings-goals/"+goal.ID.String(),
+		bytes.NewBufferString(`{"target_amount":2000}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("PATCH completed goal status = %d, want 409", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -22,7 +22,7 @@ import (
 type SavingsGoalManager interface {
 	Create(ctx context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
-	List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error)
+	List(ctx context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error)
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
 	Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error)
@@ -59,6 +59,7 @@ type updateSavingsGoalRequest struct {
 	Deadline     *string      `json:"deadline"`
 	Description  *string      `json:"description"`
 	Category     *string      `json:"category"`
+	Status       *string      `json:"status"`
 }
 
 func (h *SavingsGoalHandler) create(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +124,12 @@ func (h *SavingsGoalHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	goals, err := h.svc.List(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("category")))
+	goals, err := h.svc.List(
+		r.Context(),
+		userID,
+		strings.TrimSpace(r.URL.Query().Get("category")),
+		strings.TrimSpace(r.URL.Query().Get("status")),
+	)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -189,6 +195,7 @@ func (h *SavingsGoalHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 	in.Description = req.Description
 	in.Category = req.Category
+	in.Status = req.Status
 
 	goal, err := h.svc.Update(r.Context(), userID, goalID, in)
 	if err != nil {
@@ -233,6 +240,8 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 	switch {
 	case errors.Is(err, savingsgoal.ErrGoalNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("savings goal"))
+	case errors.Is(err, savingsgoal.ErrGoalCompleted):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_COMPLETED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -61,7 +61,7 @@ func (m *mockSavingsGoalService) Get(_ context.Context, userID, goalID uuid.UUID
 	return g, nil
 }
 
-func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error) {
 	if category != "" {
 		if _, err := savingsgoal.ParseCategory(category); err != nil {
 			return nil, err
@@ -73,6 +73,9 @@ func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, categ
 			continue
 		}
 		if category != "" && string(g.Category) != category {
+			continue
+		}
+		if status != "" && string(g.Status) != status {
 			continue
 		}
 		out = append(out, g)

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -36,7 +36,7 @@ func (r *SavingsGoalRepository) Create(ctx context.Context, goal *savingsgoal.Sa
 func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
 	query := `
 		SELECT id, user_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at
+		       notified_milestones, created_at, updated_at, status, completed_at
 		FROM savings_goals
 		WHERE user_id = $1
 	`
@@ -67,7 +67,7 @@ func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID
 func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT id, user_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at
+		       notified_milestones, created_at, updated_at, status, completed_at
 		FROM savings_goals WHERE id = $1
 	`, id)
 	g, err := scanSavingsGoal(row)
@@ -83,9 +83,10 @@ func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*sav
 func (r *SavingsGoalRepository) Update(ctx context.Context, goal *savingsgoal.SavingsGoal) error {
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE savings_goals
-		SET target_amount = $1, currency = $2, deadline = $3, description = $4, category = $5, updated_at = NOW()
-		WHERE id = $6 AND user_id = $7
-	`, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), string(goal.Category), goal.ID, goal.UserID)
+		SET target_amount = $1, currency = $2, deadline = $3, description = $4, category = $5,
+		    status = $6, completed_at = $7, updated_at = NOW()
+		WHERE id = $8 AND user_id = $9
+	`, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), string(goal.Category), string(goal.Status), nullSQLTime(goal.CompletedAt), goal.ID, goal.UserID)
 	if err != nil {
 		return err
 	}
@@ -154,10 +155,12 @@ func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 		deadline, createdAt, updatedAt          time.Time
 		description                             sql.NullString
 		notifiedMilestones                      pq.Int32Array
+		status                                  sql.NullString
+		completedAt                             sql.NullTime
 	)
 	if err := row.Scan(
 		&id, &userID, &targetStr, &currency, &deadline, &description, &category,
-		&notifiedMilestones, &createdAt, &updatedAt,
+		&notifiedMilestones, &createdAt, &updatedAt, &status, &completedAt,
 	); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
@@ -172,6 +175,15 @@ func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 	for _, m := range notifiedMilestones {
 		milestones = append(milestones, int(m))
 	}
+	goalStatus := savingsgoal.GoalStatusActive
+	if status.Valid && status.String != "" {
+		goalStatus = savingsgoal.GoalStatus(status.String)
+	}
+	var completedAtPtr *time.Time
+	if completedAt.Valid {
+		t := completedAt.Time
+		completedAtPtr = &t
+	}
 	return savingsgoal.SavingsGoal{
 		ID:                 parsedID,
 		UserID:             parsedUserID,
@@ -180,6 +192,8 @@ func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 		Deadline:           deadline,
 		Description:        desc,
 		Category:           savingsgoal.GoalCategory(category),
+		Status:             goalStatus,
+		CompletedAt:        completedAtPtr,
 		NotifiedMilestones: milestones,
 		CreatedAt:          createdAt,
 		UpdatedAt:          updatedAt,
@@ -191,4 +205,11 @@ func nullSQLString(s string) sql.NullString {
 		return sql.NullString{}
 	}
 	return sql.NullString{String: s, Valid: true}
+}
+
+func nullSQLTime(t *time.Time) sql.NullTime {
+	if t == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: *t, Valid: true}
 }

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -38,6 +38,7 @@ type UpdateSavingsGoalInput struct {
 	Deadline     *time.Time       `json:"deadline"`
 	Description  *string          `json:"description"`
 	Category     *string          `json:"category"`
+	Status       *string          `json:"status"`
 }
 
 func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error) {
@@ -56,6 +57,7 @@ func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in Cr
 		Deadline:     in.Deadline.UTC(),
 		Description:  strings.TrimSpace(in.Description),
 		Category:     category,
+		Status:       savingsgoal.GoalStatusActive,
 	}
 	if err := s.repo.Create(ctx, goal); err != nil {
 		return savingsgoal.SavingsGoal{}, err
@@ -74,7 +76,7 @@ func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) 
 	return s.enrichProgress(ctx, *goal)
 }
 
-func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error) {
 	filterCategory := ""
 	if strings.TrimSpace(category) != "" {
 		parsed, err := savingsgoal.ParseCategory(category)
@@ -84,15 +86,29 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 		filterCategory = string(parsed)
 	}
 
+	var filterStatus savingsgoal.GoalStatus
+	if strings.TrimSpace(status) != "" {
+		parsed, err := savingsgoal.ParseStatus(status)
+		if err != nil {
+			return nil, err
+		}
+		filterStatus = parsed
+	}
+
 	goals, err := s.repo.ListByUser(ctx, userID, filterCategory)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]savingsgoal.SavingsGoal, 0, len(goals))
 	for _, g := range goals {
+		// enrichProgress may auto-complete the goal, so filter on the
+		// post-enrichment status to reflect freshly completed goals (#684).
 		enriched, err := s.enrichProgress(ctx, g)
 		if err != nil {
 			return nil, err
+		}
+		if filterStatus != "" && enriched.Status != filterStatus {
+			continue
 		}
 		out = append(out, enriched)
 	}
@@ -106,6 +122,34 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 	}
 	if goal.UserID != userID {
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+
+	// A completed goal is immutable except for archiving it (#684).
+	if goal.Status == savingsgoal.GoalStatusCompleted {
+		archiving := in.Status != nil &&
+			savingsgoal.GoalStatus(strings.ToLower(strings.TrimSpace(*in.Status))) == savingsgoal.GoalStatusArchived
+		otherEdits := in.TargetAmount != nil || in.Deadline != nil ||
+			in.Description != nil || in.Category != nil || in.Currency != nil
+		if !archiving || otherEdits {
+			return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalCompleted
+		}
+		goal.Status = savingsgoal.GoalStatusArchived
+		if err := s.repo.Update(ctx, goal); err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		return s.enrichProgress(ctx, *goal)
+	}
+
+	if in.Status != nil {
+		parsed, err := savingsgoal.ParseStatus(*in.Status)
+		if err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		// Completion is automatic; callers may only archive (or keep active).
+		if parsed == savingsgoal.GoalStatusCompleted {
+			return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: cannot set status to completed manually", savingsgoal.ErrInvalidGoal)
+		}
+		goal.Status = parsed
 	}
 	if in.TargetAmount != nil {
 		goal.TargetAmount = *in.TargetAmount
@@ -180,6 +224,18 @@ func (s *SavingsGoalService) enrichProgress(ctx context.Context, goal savingsgoa
 			pct = 0
 		}
 		goal.ProgressPct = pct
+	}
+
+	// Auto-complete: once a goal reaches its target, transition it to
+	// completed and stamp completed_at, persisting the change (#684).
+	if goal.ProgressPct >= 100 && goal.Status == savingsgoal.GoalStatusActive {
+		goal.Status = savingsgoal.GoalStatusCompleted
+		now := time.Now().UTC()
+		goal.CompletedAt = &now
+		if err := s.repo.Update(ctx, &goal); err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		// future: fire completion notification here.
 	}
 
 	newMilestones := savingsgoal.DetectNewMilestones(goal.ProgressPct, goal.NotifiedMilestones)

--- a/apps/api/migrations/040_add_savings_goal_status.down.sql
+++ b/apps/api/migrations/040_add_savings_goal_status.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS ix_savings_goals_status;
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS completed_at;
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS status;

--- a/apps/api/migrations/040_add_savings_goal_status.up.sql
+++ b/apps/api/migrations/040_add_savings_goal_status.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE savings_goals
+    ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'completed', 'archived'));
+
+ALTER TABLE savings_goals
+    ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS ix_savings_goals_status ON savings_goals (status);


### PR DESCRIPTION
## Summary
Goals had no status field and never transitioned to *completed* at 100%, so the frontend couldn't distinguish an in-progress goal from a fully-funded one, and there was no trigger point for completion notifications / celebration UI.

Closes #684

## What's included
- **Migration 040** — adds `status` (`active|completed|archived`, default `active`, CHECK-constrained) and `completed_at` columns, plus a `status` index.
- **Domain** — `GoalStatus` type + `ParseStatus`; `Status` and `CompletedAt` on `SavingsGoal`; `ErrGoalCompleted`.
- **Auto-complete** — `enrichProgress` transitions an active goal to `completed` once `progress_pct >= 100`, stamps `completed_at`, and persists the change.
- **List filter** — `GET /api/v1/users/savings-goals?status=active|completed|archived` (default returns all). Filtering is applied **post-enrichment** so a goal that just hit 100% shows up under `?status=completed` immediately.
- **Immutability** — `PATCH` on a completed goal returns **409** (`ErrGoalCompleted`); a completed goal may only be **archived**.
- **Repository** — reads/writes the new columns; `Create` defaults `status=active`.

## Acceptance criteria
- [x] Migration adds `status` (default active) + `completed_at`
- [x] Auto-transition to completed at `progress_pct >= 100`
- [x] `completed_at` set on completion
- [x] `?status=completed` returns only completed goals
- [x] `PATCH` on a completed goal → 409
- [x] Unit test: 99% stays active; 100% transitions to completed
- [x] Integration test: reaching target flips status to completed

## Tests
```
ok  github.com/suncrestlabs/nester/apps/api/internal/handler
```
Real `SavingsGoalService` + in-memory repo, driven through the handler: 99% stays active, 100% auto-completes with `completed_at`, `?status=completed` filter, and `PATCH` completed → 409.

## Notes / judgment calls
- **Tests live in the `handler` package** (real service + in-memory repo, end-to-end via HTTP) because `internal/service`'s existing `*_test.go` files (`savings_goal_service_test.go`, `savings_schedule_service_test.go`) **do not compile on `main`** — leftovers from #710 / the savings-schedule merge (stale mocks missing `UpdateMilestones`/`CreateVault`, uuid-keyed balances, missing constructor args). I deliberately kept this PR from touching those files to avoid conflicts with whatever fixes them; the behaviour is fully covered through the handler instead.
- **Pre-existing, unrelated:** `cmd/api/main.go` does not build on `main` (`wsHub` missing `PushToUser`) — untouched here; my `internal/...` packages build and vet cleanly.
- A completed goal is intentionally immutable except for archiving (`status: archived`); manual `status: completed` via PATCH is rejected (completion is automatic).