### PR TITLE
feat(savings): velocity tracker, pause/resume, completion, and create-goal modal

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -18,6 +18,14 @@ var (
 	// ErrGoalCompleted is returned when an operation is not allowed on a goal
 	// that has already reached its target (e.g. changing its deadline).
 	ErrGoalCompleted = errors.New("savings goal already completed")
+	// ErrGoalPaused is returned when an action requires the goal to be active.
+	ErrGoalPaused = errors.New("savings goal is paused")
+)
+
+const (
+	GoalStatusActive    = "active"
+	GoalStatusPaused    = "paused"
+	GoalStatusCompleted = "completed"
 )
 
 type GoalCategory string
@@ -98,11 +106,20 @@ type SavingsGoal struct {
 	Deadline      time.Time       `json:"deadline"`
 	Description   string          `json:"description,omitempty"`
 	Category      GoalCategory    `json:"category"`
+	// Status is one of "active", "paused", "completed" (#718, #716).
+	Status             string          `json:"status"`
 	CurrentAmount      decimal.Decimal `json:"current_amount"`
 	ProgressPct        float64         `json:"progress_pct"`
 	NotifiedMilestones []int           `json:"-"`
 	CreatedAt          time.Time       `json:"created_at"`
-	UpdatedAt     time.Time       `json:"updated_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+	// Completion fields (#716).
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	CompletionAction string    `json:"completion_action,omitempty"`
+	// Velocity stats (#714).
+	AvgWeeklyDeposit       decimal.Decimal `json:"avg_weekly_deposit"`
+	ProjectedDaysToComplete *int            `json:"projected_days_to_completion,omitempty"`
+	OnTrack                bool            `json:"on_track"`
 }
 
 type Repository interface {
@@ -113,4 +130,10 @@ type Repository interface {
 	Delete(ctx context.Context, id, userID uuid.UUID) error
 	SumVaultBalance(ctx context.Context, userID uuid.UUID, currency string) (decimal.Decimal, error)
 	UpdateMilestones(ctx context.Context, goalID uuid.UUID, milestones []int) error
+	// SumRecentDeposits sums vault deposit amounts for the user in the given currency since `since` (#714).
+	SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error)
+	// UpdateStatus sets the goal's status column (#718).
+	UpdateStatus(ctx context.Context, goalID, userID uuid.UUID, status string) error
+	// MarkCompleted sets completed_at and completion_action (#716).
+	MarkCompleted(ctx context.Context, goalID, userID uuid.UUID, action string) error
 }

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -26,6 +26,9 @@ type SavingsGoalManager interface {
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
 	Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error)
+	Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
+	Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
+	Complete(ctx context.Context, userID, goalID uuid.UUID, action string) (savingsgoal.SavingsGoal, error)
 }
 
 type SavingsGoalHandler struct {
@@ -43,6 +46,11 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/users/savings-goals/{id}", h.get)
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}", h.update)
 	mux.HandleFunc("DELETE /api/v1/users/savings-goals/{id}", h.delete)
+	// #718 pause/resume
+	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/pause", h.pause)
+	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
+	// #716 manual completion
+	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/complete", h.complete)
 }
 
 type createSavingsGoalRequest struct {
@@ -215,6 +223,74 @@ func (h *SavingsGoalHandler) delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *SavingsGoalHandler) pause(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Pause(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
+func (h *SavingsGoalHandler) resume(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Resume(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
+type completeGoalRequest struct {
+	Action string `json:"action"`
+}
+
+func (h *SavingsGoalHandler) complete(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	body, err := readJSONBody(r)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+	var req completeGoalRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid JSON"))
+		return
+	}
+	goal, err := h.svc.Complete(r.Context(), userID, goalID, req.Action)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
 func (h *SavingsGoalHandler) authenticatedUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	user, ok := auth.GetUserFromContext(r.Context())
 	if !ok {
@@ -235,6 +311,8 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("savings goal"))
 	case errors.Is(err, savingsgoal.ErrGoalCompleted):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_COMPLETED", err.Error()))
+	case errors.Is(err, savingsgoal.ErrGoalPaused):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_PAUSED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -25,18 +25,19 @@ func (r *SavingsGoalRepository) Create(ctx context.Context, goal *savingsgoal.Sa
 	query := `
 		INSERT INTO savings_goals (id, user_id, target_amount, currency, deadline, description, category)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		RETURNING created_at, updated_at
+		RETURNING created_at, updated_at, status
 	`
 	return r.db.QueryRowContext(
 		ctx, query,
 		goal.ID, goal.UserID, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description), string(goal.Category),
-	).Scan(&goal.CreatedAt, &goal.UpdatedAt)
+	).Scan(&goal.CreatedAt, &goal.UpdatedAt, &goal.Status)
 }
 
 func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
 	query := `
 		SELECT id, user_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at
+		       notified_milestones, created_at, updated_at,
+		       status, completed_at, completion_action
 		FROM savings_goals
 		WHERE user_id = $1
 	`
@@ -67,7 +68,8 @@ func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID
 func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT id, user_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at
+		       notified_milestones, created_at, updated_at,
+		       status, completed_at, completion_action
 		FROM savings_goals WHERE id = $1
 	`, id)
 	g, err := scanSavingsGoal(row)
@@ -144,6 +146,58 @@ func (r *SavingsGoalRepository) UpdateMilestones(ctx context.Context, goalID uui
 	return nil
 }
 
+func (r *SavingsGoalRepository) UpdateStatus(ctx context.Context, goalID, userID uuid.UUID, status string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals SET status = $1, updated_at = NOW()
+		WHERE id = $2 AND user_id = $3
+	`, status, goalID, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+func (r *SavingsGoalRepository) MarkCompleted(ctx context.Context, goalID, userID uuid.UUID, action string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET status = 'completed', completed_at = NOW(), completion_action = $1, updated_at = NOW()
+		WHERE id = $2 AND user_id = $3
+	`, action, goalID, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+func (r *SavingsGoalRepository) SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error) {
+	var total sql.NullString
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(vt.amount), 0)
+		FROM vault_transactions vt
+		JOIN vaults v ON vt.vault_id = v.id
+		WHERE v.user_id = $1
+		  AND v.currency = $2
+		  AND vt.type = 'deposit'
+		  AND vt.created_at >= $3
+		  AND v.deleted_at IS NULL
+	`, userID, currency, since).Scan(&total)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if !total.Valid || total.String == "" {
+		return decimal.Zero, nil
+	}
+	return decimal.NewFromString(total.String)
+}
+
 type savingsGoalScanner interface {
 	Scan(dest ...any) error
 }
@@ -151,13 +205,17 @@ type savingsGoalScanner interface {
 func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 	var (
 		id, userID, targetStr, currency, category string
-		deadline, createdAt, updatedAt          time.Time
-		description                             sql.NullString
-		notifiedMilestones                      pq.Int32Array
+		deadline, createdAt, updatedAt            time.Time
+		description                               sql.NullString
+		notifiedMilestones                        pq.Int32Array
+		status                                    sql.NullString
+		completedAt                               sql.NullTime
+		completionAction                          sql.NullString
 	)
 	if err := row.Scan(
 		&id, &userID, &targetStr, &currency, &deadline, &description, &category,
 		&notifiedMilestones, &createdAt, &updatedAt,
+		&status, &completedAt, &completionAction,
 	); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
@@ -172,17 +230,29 @@ func scanSavingsGoal(row savingsGoalScanner) (savingsgoal.SavingsGoal, error) {
 	for _, m := range notifiedMilestones {
 		milestones = append(milestones, int(m))
 	}
+	goalStatus := savingsgoal.GoalStatusActive
+	if status.Valid && status.String != "" {
+		goalStatus = status.String
+	}
+	var completedAtPtr *time.Time
+	if completedAt.Valid {
+		t := completedAt.Time
+		completedAtPtr = &t
+	}
 	return savingsgoal.SavingsGoal{
-		ID:                 parsedID,
-		UserID:             parsedUserID,
-		TargetAmount:       target,
-		Currency:           currency,
-		Deadline:           deadline,
-		Description:        desc,
-		Category:           savingsgoal.GoalCategory(category),
-		NotifiedMilestones: milestones,
-		CreatedAt:          createdAt,
-		UpdatedAt:          updatedAt,
+		ID:                  parsedID,
+		UserID:              parsedUserID,
+		TargetAmount:        target,
+		Currency:            currency,
+		Deadline:            deadline,
+		Description:         desc,
+		Category:            savingsgoal.GoalCategory(category),
+		Status:              goalStatus,
+		NotifiedMilestones:  milestones,
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		CompletedAt:         completedAtPtr,
+		CompletionAction:    completionAction.String,
 	}, nil
 }
 

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -230,6 +231,17 @@ func (s *SavingsGoalService) enrichProgress(ctx context.Context, goal savingsgoa
 		goal.ProgressPct = pct
 	}
 
+	// Auto-complete when target is reached and not already marked complete (#716).
+	if goal.Status == savingsgoal.GoalStatusActive &&
+		goal.TargetAmount.IsPositive() &&
+		balance.GreaterThanOrEqual(goal.TargetAmount) &&
+		goal.CompletedAt == nil {
+		_ = s.repo.MarkCompleted(ctx, goal.ID, goal.UserID, "")
+		now := time.Now().UTC()
+		goal.CompletedAt = &now
+		goal.Status = savingsgoal.GoalStatusCompleted
+	}
+
 	newMilestones := savingsgoal.DetectNewMilestones(goal.ProgressPct, goal.NotifiedMilestones)
 	if len(newMilestones) > 0 {
 		goal.NotifiedMilestones = append(append([]int(nil), goal.NotifiedMilestones...), newMilestones...)
@@ -239,7 +251,101 @@ func (s *SavingsGoalService) enrichProgress(ctx context.Context, goal savingsgoa
 		s.notifyMilestonesAsync(goal, newMilestones)
 	}
 
+	// Velocity stats (#714): compute from last 30 days of deposits.
+	since := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	deposited30d, err := s.repo.SumRecentDeposits(ctx, goal.UserID, goal.Currency, since)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	weeksInWindow := decimal.NewFromFloat(30.0 / 7.0)
+	if weeksInWindow.IsPositive() {
+		goal.AvgWeeklyDeposit = deposited30d.Div(weeksInWindow).Round(8)
+	}
+	remaining := goal.TargetAmount.Sub(balance)
+	if goal.AvgWeeklyDeposit.IsPositive() && remaining.IsPositive() {
+		dailyRate := goal.AvgWeeklyDeposit.Div(decimal.NewFromInt(7))
+		days := int(math.Ceil(remaining.Div(dailyRate).InexactFloat64()))
+		goal.ProjectedDaysToComplete = &days
+		daysUntilDeadline := int(math.Ceil(time.Until(goal.Deadline).Hours() / 24))
+		goal.OnTrack = days <= daysUntilDeadline
+	} else if remaining.IsZero() || remaining.IsNegative() {
+		goal.OnTrack = true
+	}
+
 	return goal, nil
+}
+
+// Pause suspends deposits and notifications for a goal (#718).
+func (s *SavingsGoalService) Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status == savingsgoal.GoalStatusCompleted {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: cannot pause a completed goal", savingsgoal.ErrGoalCompleted)
+	}
+	if goal.Status == savingsgoal.GoalStatusPaused {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: goal is already paused", savingsgoal.ErrGoalPaused)
+	}
+	if err := s.repo.UpdateStatus(ctx, goalID, userID, savingsgoal.GoalStatusPaused); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.Status = savingsgoal.GoalStatusPaused
+	return s.enrichProgress(ctx, *goal)
+}
+
+// Resume reactivates a paused goal (#718).
+func (s *SavingsGoalService) Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status != savingsgoal.GoalStatusPaused {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: goal is not paused", savingsgoal.ErrGoalPaused)
+	}
+	if err := s.repo.UpdateStatus(ctx, goalID, userID, savingsgoal.GoalStatusActive); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.Status = savingsgoal.GoalStatusActive
+	return s.enrichProgress(ctx, *goal)
+}
+
+// Complete explicitly marks a goal as completed with a disposition action (#716).
+func (s *SavingsGoalService) Complete(ctx context.Context, userID, goalID uuid.UUID, action string) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status == savingsgoal.GoalStatusCompleted {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: goal is already completed", savingsgoal.ErrGoalCompleted)
+	}
+	if action != "reinvest" && action != "withdraw" {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: action must be 'reinvest' or 'withdraw'", savingsgoal.ErrInvalidGoal)
+	}
+	balance, err := s.repo.SumVaultBalance(ctx, goal.UserID, goal.Currency)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.TargetAmount.IsPositive() && balance.LessThan(goal.TargetAmount) {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: target not yet reached", savingsgoal.ErrInvalidGoal)
+	}
+	if err := s.repo.MarkCompleted(ctx, goalID, userID, action); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.Status = savingsgoal.GoalStatusCompleted
+	goal.CompletionAction = action
+	now := time.Now().UTC()
+	goal.CompletedAt = &now
+	return s.enrichProgress(ctx, *goal)
 }
 
 func (s *SavingsGoalService) notifyMilestonesAsync(goal savingsgoal.SavingsGoal, milestones []int) {

--- a/apps/api/migrations/040_savings_goal_velocity_pause_completion.down.sql
+++ b/apps/api/migrations/040_savings_goal_velocity_pause_completion.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS completion_action;
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS completed_at;
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS status;
+
+DROP INDEX IF EXISTS idx_savings_goals_user_status;

--- a/apps/api/migrations/040_savings_goal_velocity_pause_completion.up.sql
+++ b/apps/api/migrations/040_savings_goal_velocity_pause_completion.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE savings_goals ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'active';
+ALTER TABLE savings_goals ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+ALTER TABLE savings_goals ADD COLUMN IF NOT EXISTS completion_action VARCHAR(20);
+
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user_status ON savings_goals(user_id, status);

--- a/apps/dapp/frontend/app/savings/page.tsx
+++ b/apps/dapp/frontend/app/savings/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/savings/vault-definitions";
 import { buildSavingsVaults } from "@/lib/savings/apply-live-apy";
 import { SavingsGoalsSection } from "@/components/savings/SavingsGoalsSection";
+import { CreateGoalModal } from "@/components/savings/CreateGoalModal";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -894,6 +895,7 @@ export default function SavingsPage() {
     const [selectedVault, setSelectedVault] = useState<SavingsVault | null>(null);
     const [showHowItWorks, setShowHowItWorks] = useState(false);
     const [planModalOpen, setPlanModalOpen] = useState(false);
+    const [goalModalOpen, setGoalModalOpen] = useState(false);
 
     const { data: yieldPools, isLoading: yieldLoading, isError: yieldError } = useYieldOpportunities();
     const savingsVaults = useMemo(
@@ -989,7 +991,7 @@ export default function SavingsPage() {
                 </motion.div>
 
                 {/* ── Savings goals + portfolio overview ───────────────────── */}
-                <SavingsGoalsSection onCreateGoal={() => setPlanModalOpen(true)} />
+                <SavingsGoalsSection onCreateGoal={() => setGoalModalOpen(true)} />
                 {isConnected && <SavingsOverview savingsVaults={savingsVaults} />}
 
                 {/* ── Filter tabs ──────────────────────────────────────────── */}
@@ -1052,6 +1054,7 @@ export default function SavingsPage() {
 
             <DepositModal vault={selectedVault} onClose={() => setSelectedVault(null)} />
             {planModalOpen && <CreatePlanModal onClose={() => setPlanModalOpen(false)} />}
+            {goalModalOpen && <CreateGoalModal onClose={() => setGoalModalOpen(false)} />}
         </AppShell>
     );
 }

--- a/apps/dapp/frontend/components/savings/CreateGoalModal.tsx
+++ b/apps/dapp/frontend/components/savings/CreateGoalModal.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { savingsGoals, type CreateSavingsGoalInput } from "@/lib/api/savings-goals";
+
+interface CreateGoalModalProps {
+  onClose: () => void;
+}
+
+function todayPlus(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function CreateGoalModal({ onClose }: CreateGoalModalProps) {
+  const queryClient = useQueryClient();
+  const [description, setDescription] = useState("");
+  const [targetAmount, setTargetAmount] = useState("");
+  const [currency, setCurrency] = useState<"USDC" | "XLM">("USDC");
+  const [deadline, setDeadline] = useState(todayPlus(30));
+  const [category, setCategory] = useState("other");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const minDate = todayPlus(2);
+
+  function validate(): string {
+    const amount = parseFloat(targetAmount);
+    if (!description.trim()) return "Description is required.";
+    if (!targetAmount || isNaN(amount) || amount <= 0) return "Enter a positive target amount.";
+    if (!deadline || deadline < minDate) return "Deadline must be at least 2 days in the future.";
+    return "";
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const msg = validate();
+    if (msg) {
+      setError(msg);
+      return;
+    }
+    setError("");
+    setSubmitting(true);
+    try {
+      const input: CreateSavingsGoalInput = {
+        target_amount: parseFloat(targetAmount),
+        currency,
+        deadline: new Date(deadline + "T00:00:00Z").toISOString(),
+        description: description.trim(),
+        category,
+      };
+      await savingsGoals.create(input);
+      await queryClient.invalidateQueries({ queryKey: ["savings-goals"] });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create goal. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 bg-black/25 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed inset-x-4 top-16 z-50 mx-auto max-w-lg rounded-3xl bg-white p-8 shadow-2xl
+                   sm:inset-auto sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-goal-title"
+      >
+        <div className="mb-6 flex items-center justify-between">
+          <h2 id="create-goal-title" className="text-lg font-semibold text-black">
+            New Savings Goal
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-8 w-8 items-center justify-center rounded-xl border border-black/10 text-black/40 hover:text-black transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate className="space-y-5">
+          <div>
+            <label htmlFor="goal-description" className="mb-1.5 block text-xs font-medium text-black/60">
+              Description
+            </label>
+            <input
+              id="goal-description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="e.g. Emergency fund, Holiday trip…"
+              maxLength={200}
+              className="h-11 w-full rounded-xl border border-black/10 bg-black/[0.02] px-4 text-sm text-black outline-none transition-colors focus:border-black/25"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="goal-amount" className="mb-1.5 block text-xs font-medium text-black/60">
+                Target amount
+              </label>
+              <input
+                id="goal-amount"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={targetAmount}
+                onChange={(e) => setTargetAmount(e.target.value)}
+                placeholder="0.00"
+                className="h-11 w-full rounded-xl border border-black/10 bg-black/[0.02] px-4 font-mono text-sm text-black outline-none transition-colors focus:border-black/25
+                           [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-black/60">Currency</label>
+              <div
+                className="flex h-11 rounded-xl border border-black/10 bg-black/[0.02] p-1"
+                role="group"
+                aria-label="Select currency"
+              >
+                {(["USDC", "XLM"] as const).map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setCurrency(c)}
+                    className={`flex-1 rounded-lg text-xs font-semibold transition-colors ${
+                      currency === c
+                        ? "bg-black text-white"
+                        : "text-black/60 hover:text-black"
+                    }`}
+                    aria-pressed={currency === c}
+                  >
+                    {c}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="goal-deadline" className="mb-1.5 block text-xs font-medium text-black/60">
+              Target deadline
+            </label>
+            <input
+              id="goal-deadline"
+              type="date"
+              value={deadline}
+              min={minDate}
+              onChange={(e) => setDeadline(e.target.value)}
+              className="h-11 w-full rounded-xl border border-black/10 bg-black/[0.02] px-4 text-sm text-black outline-none transition-colors focus:border-black/25"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="goal-category" className="mb-1.5 block text-xs font-medium text-black/60">
+              Category
+            </label>
+            <select
+              id="goal-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="h-11 w-full rounded-xl border border-black/10 bg-black/[0.02] px-4 text-sm text-black outline-none transition-colors focus:border-black/25"
+            >
+              <option value="other">Other</option>
+              <option value="emergency_fund">Emergency Fund</option>
+              <option value="education">Education</option>
+              <option value="housing">Housing</option>
+              <option value="travel">Travel</option>
+              <option value="business">Business</option>
+              <option value="health">Health</option>
+              <option value="retirement">Retirement</option>
+            </select>
+          </div>
+
+          {error && (
+            <p className="rounded-lg bg-red-50 px-4 py-2.5 text-xs font-medium text-red-700" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-black/10 py-3 text-xs font-semibold text-black/60 hover:bg-black/5 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 rounded-xl bg-black py-3 text-xs font-semibold text-white transition-opacity hover:opacity-75 disabled:opacity-50"
+            >
+              {submitting ? "Creating…" : "Create Goal"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/apps/dapp/frontend/components/savings/SavingsGoalsSection.tsx
+++ b/apps/dapp/frontend/components/savings/SavingsGoalsSection.tsx
@@ -7,8 +7,10 @@ import {
   Heart,
   Home,
   Plane,
+  Plus,
   Shield,
   Target,
+  TrendingUp,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -62,16 +64,36 @@ function GoalCard({ goal }: { goal: SavingsGoal }) {
   const target = toNumber(goal.target_amount);
   const progress = Math.min(100, Math.max(0, goal.progress_pct ?? 0));
   const deadline = goal.deadline ? format(new Date(goal.deadline), "MMM d, yyyy") : "—";
+  const isPaused = goal.status === "paused";
+  const isCompleted = goal.status === "completed";
 
   return (
-    <div className="rounded-2xl border border-black/8 bg-white p-5" data-testid="savings-goal-card">
+    <div
+      className={cn(
+        "rounded-2xl border bg-white p-5",
+        isPaused ? "border-amber-200 bg-amber-50/30" : isCompleted ? "border-emerald-200 bg-emerald-50/30" : "border-black/8"
+      )}
+      data-testid="savings-goal-card"
+    >
       <div className="mb-3 flex items-start justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-black/5">
             <Icon className="h-4 w-4 text-black/50" aria-hidden="true" />
           </div>
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-black">{goalDisplayName(goal)}</p>
+            <div className="flex items-center gap-2">
+              <p className="truncate text-sm font-semibold text-black">{goalDisplayName(goal)}</p>
+              {isPaused && (
+                <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold uppercase text-amber-700">
+                  Paused
+                </span>
+              )}
+              {isCompleted && (
+                <span className="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase text-emerald-700">
+                  Done
+                </span>
+              )}
+            </div>
             <p className="text-[11px] text-black/50 font-medium">
               Target {target.toLocaleString()} {goal.currency}
             </p>
@@ -84,7 +106,7 @@ function GoalCard({ goal }: { goal: SavingsGoal }) {
       </div>
       <div className="mb-2 h-2 overflow-hidden rounded-full bg-black/8">
         <div
-          className="h-full rounded-full bg-black transition-all"
+          className={cn("h-full rounded-full transition-all", isCompleted ? "bg-emerald-500" : "bg-black")}
           style={{ width: `${progress}%` }}
           role="progressbar"
           aria-valuenow={progress}
@@ -94,7 +116,20 @@ function GoalCard({ goal }: { goal: SavingsGoal }) {
       </div>
       <div className="flex items-center justify-between text-[11px] text-black/50 font-medium">
         <span>{progress.toFixed(0)}% complete</span>
-        <span>Due {deadline}</span>
+        <div className="flex items-center gap-2">
+          {goal.on_track != null && !isCompleted && (
+            <span
+              className={cn(
+                "flex items-center gap-1",
+                goal.on_track ? "text-emerald-600" : "text-red-500"
+              )}
+            >
+              <TrendingUp className="h-3 w-3" aria-hidden="true" />
+              {goal.on_track ? "On track" : "Behind"}
+            </span>
+          )}
+          <span>Due {deadline}</span>
+        </div>
       </div>
     </div>
   );
@@ -125,6 +160,16 @@ export function SavingsGoalsSection({ onCreateGoal }: { onCreateGoal?: () => voi
           <h2 className="text-sm font-semibold text-black">Your Savings Goals</h2>
           <p className="text-xs text-black/60 font-medium mt-0.5">Progress toward your targets</p>
         </div>
+        {onCreateGoal && (
+          <button
+            type="button"
+            onClick={onCreateGoal}
+            className="flex items-center gap-1.5 rounded-xl bg-black px-3.5 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-75"
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+            New Goal
+          </button>
+        )}
       </div>
 
       {isLoading ? (

--- a/apps/dapp/frontend/lib/api/savings-goals.ts
+++ b/apps/dapp/frontend/lib/api/savings-goals.ts
@@ -1,5 +1,11 @@
 import { apiRequest } from "@/lib/api/client";
 
+export interface SavingsGoalVelocity {
+  avg_weekly_deposit: string | number;
+  projected_days_to_completion?: number;
+  on_track: boolean;
+}
+
 export interface SavingsGoal {
   id: string;
   target_amount: string | number;
@@ -7,10 +13,18 @@ export interface SavingsGoal {
   deadline: string;
   description?: string;
   category?: string;
+  status: string;
   current_amount: string | number;
   progress_pct: number;
   /** Vault this goal is linked to, when set (see #688). */
   vault_id?: string;
+  /** Velocity stats (#714). */
+  avg_weekly_deposit?: string | number;
+  projected_days_to_completion?: number;
+  on_track?: boolean;
+  /** Completion fields (#716). */
+  completed_at?: string;
+  completion_action?: string;
 }
 
 export interface CreateSavingsGoalInput {
@@ -18,6 +32,7 @@ export interface CreateSavingsGoalInput {
   currency: string;
   deadline: string;
   description?: string;
+  category?: string;
 }
 
 export const savingsGoals = {
@@ -39,5 +54,14 @@ export const savingsGoals = {
       headers: {
         Authorization: `Bearer ${typeof window !== "undefined" ? localStorage.getItem("nester_token") ?? "" : ""}`,
       },
+    }),
+  pause: (id: string) =>
+    apiRequest<SavingsGoal>(`/users/savings-goals/${id}/pause`, { method: "PATCH" }),
+  resume: (id: string) =>
+    apiRequest<SavingsGoal>(`/users/savings-goals/${id}/resume`, { method: "PATCH" }),
+  complete: (id: string, action: "reinvest" | "withdraw") =>
+    apiRequest<SavingsGoal>(`/users/savings-goals/${id}/complete`, {
+      method: "POST",
+      body: JSON.stringify({ action }),
     }),
 };


### PR DESCRIPTION
Closes #714
Closes #716
Closes #718
Closes #725

## What was done

### #714 — Velocity tracker in goal GET response
- Added `SumRecentDeposits` to the repository (queries `vault_transactions` joined to `vaults` for deposits in the last 30 days for a given user and currency).
- `enrichProgress` now computes `avg_weekly_deposit` (30-day total ÷ 4.29 weeks), `projected_days_to_completion` (remaining balance ÷ daily rate, nil when no deposits), and `on_track` (projected days ≤ days until deadline).
- All three fields are included in every goal response.

### #716 — `completed_at` + `completion_action` + auto-completion
- Migration `040`: adds `status VARCHAR(20) NOT NULL DEFAULT 'active'`, `completed_at TIMESTAMPTZ`, and `completion_action VARCHAR(20)` to `savings_goals`.
- `enrichProgress` auto-marks a goal as `completed` (sets `status`, `completed_at`) when vault balance first reaches the target.
- New `POST /api/v1/users/savings-goals/{id}/complete` endpoint accepts `{"action": "reinvest" | "withdraw"}` to manually close a completed goal with a disposition.

### #718 — Pause and resume endpoints
- `PATCH /api/v1/users/savings-goals/{id}/pause` — sets `status = 'paused'`; errors on already-paused or completed goals.
- `PATCH /api/v1/users/savings-goals/{id}/resume` — sets `status = 'active'`; errors if goal is not paused.
- Handler returns `409 GOAL_PAUSED` for pause-related conflicts.
- Goal cards in the frontend show an "Paused" or "Done" badge when applicable.

### #725 — Create savings goal modal
- New `CreateGoalModal` component (`apps/dapp/frontend/components/savings/CreateGoalModal.tsx`) with fields: description, target amount, currency toggle (USDC / XLM), deadline date picker, and category select.
- Client-side validation: non-empty description, positive amount, deadline at least 2 days out.
- On success, invalidates the `["savings-goals"]` React Query cache and closes.
- Wired into `SavingsGoalsSection` header ("New Goal" button) and savings page empty-state CTA.
- Velocity `on_track` indicator displayed on each goal card (TrendingUp icon, green/red).