### PR TITLE
feat(dapp): add deadline countdown and days-remaining badge to saving…

### DIFF
--- a/apps/dapp/frontend/__tests__/deadline-badge.test.tsx
+++ b/apps/dapp/frontend/__tests__/deadline-badge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DeadlineBadge } from "@/components/savings/DeadlineBadge";
+
+const FUTURE = new Date(Date.now() + 1000 * 60 * 60 * 24 * 10).toISOString();
+
+describe("DeadlineBadge", () => {
+  it("renders an aria-label conveying days remaining", () => {
+    render(<DeadlineBadge deadline={FUTURE} status="active" />);
+    const badge = screen.getByRole("status");
+    expect(badge.getAttribute("aria-label")).toMatch(/remaining until goal deadline/);
+  });
+
+  it("shows a tooltip with the full deadline date on focus", () => {
+    render(<DeadlineBadge deadline={FUTURE} status="active" />);
+    fireEvent.focus(screen.getByRole("status"));
+    expect(screen.getByRole("tooltip").textContent).toMatch(/Goal deadline:/);
+  });
+
+  it("renders 'Goal Achieved' for completed goals", () => {
+    render(<DeadlineBadge deadline="2026-01-01T00:00:00Z" status="completed" />);
+    expect(screen.getByText("Goal Achieved")).toBeInTheDocument();
+  });
+
+  it("renders 'Overdue' for past, incomplete goals", () => {
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24 * 5).toISOString();
+    render(<DeadlineBadge deadline={past} status="active" />);
+    expect(screen.getByText("Overdue")).toBeInTheDocument();
+  });
+});

--- a/apps/dapp/frontend/__tests__/deadline.test.ts
+++ b/apps/dapp/frontend/__tests__/deadline.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  daysRemaining,
+  isPastDeadline,
+  getDeadlineBadgeInfo,
+} from "@/lib/savings/deadline";
+
+const NOW = new Date("2026-06-24T12:00:00Z");
+
+describe("daysRemaining", () => {
+  it("returns the correct number of whole days for a future deadline", () => {
+    expect(daysRemaining("2026-07-24T12:00:00Z", NOW)).toBe(30);
+  });
+
+  it("rounds up partial days", () => {
+    expect(daysRemaining("2026-06-25T01:00:00Z", NOW)).toBe(1);
+  });
+
+  it("returns 0 when the deadline is exactly now", () => {
+    expect(daysRemaining("2026-06-24T12:00:00Z", NOW)).toBe(0);
+  });
+
+  it("never returns a negative number for a past deadline", () => {
+    expect(daysRemaining("2026-06-01T12:00:00Z", NOW)).toBe(0);
+  });
+});
+
+describe("isPastDeadline", () => {
+  it("returns false for a future deadline", () => {
+    expect(isPastDeadline("2026-07-01T00:00:00Z", NOW)).toBe(false);
+  });
+
+  it("returns true for a past deadline", () => {
+    expect(isPastDeadline("2026-01-01T00:00:00Z", NOW)).toBe(true);
+  });
+});
+
+describe("getDeadlineBadgeInfo", () => {
+  it("returns a green badge for > 30 days remaining", () => {
+    const info = getDeadlineBadgeInfo("2026-08-24T12:00:00Z", "active", NOW);
+    expect(info.variant).toBe("green");
+    expect(info.label).toBe("61 days left");
+  });
+
+  it("returns an amber badge for 7-30 days remaining", () => {
+    const info = getDeadlineBadgeInfo("2026-07-10T12:00:00Z", "active", NOW);
+    expect(info.variant).toBe("amber");
+    expect(info.label).toBe("16 days left");
+  });
+
+  it("returns a red badge for 1-6 days remaining", () => {
+    const info = getDeadlineBadgeInfo("2026-06-27T12:00:00Z", "active", NOW);
+    expect(info.variant).toBe("red");
+    expect(info.label).toBe("3 days left");
+  });
+
+  it("returns a due-today badge when 0 days remain and not past", () => {
+    const info = getDeadlineBadgeInfo("2026-06-24T12:00:00Z", "active", NOW);
+    expect(info.variant).toBe("due-today");
+    expect(info.label).toBe("Due today");
+  });
+
+  it("returns an overdue badge for a past deadline that is not completed", () => {
+    const info = getDeadlineBadgeInfo("2026-06-01T00:00:00Z", "active", NOW);
+    expect(info.variant).toBe("overdue");
+    expect(info.label).toBe("Overdue");
+  });
+
+  it("returns a completed badge for a completed goal regardless of deadline", () => {
+    const info = getDeadlineBadgeInfo("2026-01-01T00:00:00Z", "completed", NOW);
+    expect(info.variant).toBe("completed");
+    expect(info.label).toBe("Goal Achieved");
+  });
+
+  it("includes a descriptive aria-label conveying the full meaning", () => {
+    const info = getDeadlineBadgeInfo("2026-07-15T12:00:00Z", "active", NOW);
+    expect(info.ariaLabel).toMatch(/\d+ days remaining until goal deadline/);
+  });
+});

--- a/apps/dapp/frontend/components/savings/DeadlineBadge.tsx
+++ b/apps/dapp/frontend/components/savings/DeadlineBadge.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Check, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  getDeadlineBadgeInfo,
+  formatFullDeadline,
+  type DeadlineBadgeVariant,
+} from "@/lib/savings/deadline";
+
+const VARIANT_STYLES: Record<DeadlineBadgeVariant, string> = {
+  green: "text-emerald-700 bg-emerald-50",
+  amber: "text-amber-700 bg-amber-50",
+  red: "text-red-700 bg-red-50",
+  "due-today": "text-red-700 bg-red-50 font-bold",
+  completed: "text-emerald-700 bg-emerald-50",
+  overdue: "text-red-700 bg-red-50",
+};
+
+export interface DeadlineBadgeProps {
+  deadline: string;
+  status?: string;
+  className?: string;
+}
+
+export function DeadlineBadge({ deadline, status, className }: DeadlineBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const tooltipId = useRef(
+    `deadline-tooltip-${Math.random().toString(36).slice(2, 9)}`
+  ).current;
+
+  const info = getDeadlineBadgeInfo(deadline, status);
+  const fullDate = formatFullDeadline(deadline);
+
+  return (
+    <div className="relative inline-flex">
+      <span
+        tabIndex={0}
+        role="status"
+        aria-label={info.ariaLabel}
+        aria-describedby={tooltipId}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        onFocus={() => setShowTooltip(true)}
+        onBlur={() => setShowTooltip(false)}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium",
+          "focus-visible:ring-2 focus-visible:ring-black focus-visible:outline-none",
+          VARIANT_STYLES[info.variant],
+          className
+        )}
+      >
+        {info.variant === "completed" && <Check className="h-3 w-3" aria-hidden="true" />}
+        {info.variant === "overdue" && (
+          <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+        )}
+        {info.label}
+      </span>
+
+      {showTooltip && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="absolute bottom-full left-1/2 z-20 mb-2 w-max max-w-[220px] -translate-x-1/2 rounded-lg border border-black/8 bg-white px-3 py-2 text-xs font-medium text-black/70 shadow-lg shadow-black/10"
+        >
+          Goal deadline: {fullDate}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-black/8" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DeadlineBadge;

--- a/apps/dapp/frontend/components/savings/SavingsGoalsSection.tsx
+++ b/apps/dapp/frontend/components/savings/SavingsGoalsSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { format } from "date-fns";
 import {
   Briefcase,
   GraduationCap,
@@ -15,6 +14,7 @@ import { cn } from "@/lib/utils";
 import type { SavingsGoal } from "@/lib/api/savings-goals";
 import { useSavingsGoals } from "@/hooks/useSavingsGoals";
 import { useWallet } from "@/components/wallet-provider";
+import { DeadlineBadge } from "@/components/savings/DeadlineBadge";
 
 const CATEGORY_ICONS: Record<string, LucideIcon> = {
   emergency_fund: Shield,
@@ -61,7 +61,6 @@ function GoalCard({ goal }: { goal: SavingsGoal }) {
   const current = toNumber(goal.current_amount);
   const target = toNumber(goal.target_amount);
   const progress = Math.min(100, Math.max(0, goal.progress_pct ?? 0));
-  const deadline = goal.deadline ? format(new Date(goal.deadline), "MMM d, yyyy") : "—";
 
   return (
     <div className="rounded-2xl border border-black/8 bg-white p-5" data-testid="savings-goal-card">
@@ -94,7 +93,7 @@ function GoalCard({ goal }: { goal: SavingsGoal }) {
       </div>
       <div className="flex items-center justify-between text-[11px] text-black/50 font-medium">
         <span>{progress.toFixed(0)}% complete</span>
-        <span>Due {deadline}</span>
+        <DeadlineBadge deadline={goal.deadline} status={goal.status} />
       </div>
     </div>
   );

--- a/apps/dapp/frontend/lib/api/savings-goals.ts
+++ b/apps/dapp/frontend/lib/api/savings-goals.ts
@@ -13,10 +13,9 @@ export interface SavingsGoal {
   deadline: string;
   description?: string;
   category?: string;
-  status: string;
+  status?: "active" | "completed";
   current_amount: string | number;
   progress_pct: number;
-  status?: "active" | "completed";
   /** Vault this goal is linked to, when set (see #688). */
   vault_id?: string;
   /** Velocity stats (#714). */

--- a/apps/dapp/frontend/lib/api/savings-goals.ts
+++ b/apps/dapp/frontend/lib/api/savings-goals.ts
@@ -9,6 +9,7 @@ export interface SavingsGoal {
   category?: string;
   current_amount: string | number;
   progress_pct: number;
+  status?: "active" | "completed";
   /** Vault this goal is linked to, when set (see #688). */
   vault_id?: string;
 }

--- a/apps/dapp/frontend/lib/savings/deadline.ts
+++ b/apps/dapp/frontend/lib/savings/deadline.ts
@@ -1,0 +1,107 @@
+/**
+ * Helpers for computing and presenting savings-goal deadline urgency.
+ */
+
+export type DeadlineBadgeVariant =
+  | "green"
+  | "amber"
+  | "red"
+  | "due-today"
+  | "completed"
+  | "overdue";
+
+export interface DeadlineBadgeInfo {
+  variant: DeadlineBadgeVariant;
+  label: string;
+  ariaLabel: string;
+}
+
+/**
+ * Returns the number of whole days remaining until `deadline`, measured
+ * from "now". Never returns a negative number — once the deadline has
+ * passed this returns 0. Use `isPastDeadline` if you need to distinguish
+ * "due today" from "already overdue".
+ */
+export function daysRemaining(deadline: string, now: Date = new Date()): number {
+  const end = new Date(deadline);
+  const diffMs = end.getTime() - now.getTime();
+  return Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
+}
+
+/**
+ * Returns true if `deadline` is strictly in the past relative to `now`.
+ */
+export function isPastDeadline(deadline: string, now: Date = new Date()): boolean {
+  const end = new Date(deadline);
+  return end.getTime() < now.getTime();
+}
+
+/**
+ * Resolves the badge variant, display text, and aria-label for a savings
+ * goal, given its deadline and completion status.
+ */
+export function getDeadlineBadgeInfo(
+  deadline: string,
+  status: string | undefined,
+  now: Date = new Date()
+): DeadlineBadgeInfo {
+  const isCompleted = status === "completed";
+  const past = isPastDeadline(deadline, now);
+
+  if (isCompleted) {
+    return {
+      variant: "completed",
+      label: "Goal Achieved",
+      ariaLabel: "Goal achieved",
+    };
+  }
+
+  if (past) {
+    return {
+      variant: "overdue",
+      label: "Overdue",
+      ariaLabel: "Goal deadline has passed and the goal is not yet complete",
+    };
+  }
+
+  const days = daysRemaining(deadline, now);
+
+  if (days === 0) {
+    return {
+      variant: "due-today",
+      label: "Due today",
+      ariaLabel: "Goal deadline is today",
+    };
+  }
+
+  if (days <= 6) {
+    return {
+      variant: "red",
+      label: `${days} day${days === 1 ? "" : "s"} left`,
+      ariaLabel: `${days} day${days === 1 ? "" : "s"} remaining until goal deadline`,
+    };
+  }
+
+  if (days <= 30) {
+    return {
+      variant: "amber",
+      label: `${days} days left`,
+      ariaLabel: `${days} days remaining until goal deadline`,
+    };
+  }
+
+  return {
+    variant: "green",
+    label: `${days} days left`,
+    ariaLabel: `${days} days remaining until goal deadline`,
+  };
+}
+
+export function formatFullDeadline(deadline: string): string {
+  const date = new Date(deadline);
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
Closes #697

Adds a colour-coded deadline countdown badge to savings goal cards:
- green: >30 days left
- amber: 7–30 days left
- red: 1–6 days left
- "Due today" / "Overdue" / "Goal Achieved" for edge cases

Includes a hover/focus tooltip showing the full deadline date, an
accessible aria-label, and Vitest coverage for the date math (daysRemaining)
and badge variant resolution.
