### PR TITLE
feat: yield risk-tier filtering and savings goal archiving

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -20,12 +20,19 @@ var (
 	ErrGoalCompleted = errors.New("savings goal already completed")
 	// ErrGoalPaused is returned when an action requires the goal to be active.
 	ErrGoalPaused = errors.New("savings goal is paused")
+	// ErrGoalArchived is returned when an operation is not allowed on an archived goal.
+	ErrGoalArchived = errors.New("savings goal is archived")
+	// ErrGoalNotArchived is returned by Unarchive when the goal is not currently archived.
+	ErrGoalNotArchived = errors.New("savings goal is not archived")
 )
 
 const (
 	GoalStatusActive    = "active"
 	GoalStatusPaused    = "paused"
 	GoalStatusCompleted = "completed"
+	// GoalStatusArchived marks a goal as hidden from the default list (#721).
+	// Archived goals are read-only: contributions and status changes are blocked.
+	GoalStatusArchived = "archived"
 )
 
 type GoalCategory string
@@ -106,7 +113,7 @@ type SavingsGoal struct {
 	Deadline      time.Time       `json:"deadline"`
 	Description   string          `json:"description,omitempty"`
 	Category      GoalCategory    `json:"category"`
-	// Status is one of "active", "paused", "completed" (#718, #716).
+	// Status is one of "active", "paused", "completed", "archived" (#718, #716, #721).
 	Status             string          `json:"status"`
 	CurrentAmount      decimal.Decimal `json:"current_amount"`
 	ProgressPct        float64         `json:"progress_pct"`
@@ -116,10 +123,12 @@ type SavingsGoal struct {
 	// Completion fields (#716).
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
 	CompletionAction string    `json:"completion_action,omitempty"`
+	// Archival fields (#721).
+	ArchivedAt *time.Time `json:"archived_at,omitempty"`
 	// Velocity stats (#714).
-	AvgWeeklyDeposit       decimal.Decimal `json:"avg_weekly_deposit"`
+	AvgWeeklyDeposit        decimal.Decimal `json:"avg_weekly_deposit"`
 	ProjectedDaysToComplete *int            `json:"projected_days_to_completion,omitempty"`
-	OnTrack                bool            `json:"on_track"`
+	OnTrack                 bool            `json:"on_track"`
 }
 
 type Repository interface {
@@ -136,4 +145,8 @@ type Repository interface {
 	UpdateStatus(ctx context.Context, goalID, userID uuid.UUID, status string) error
 	// MarkCompleted sets completed_at and completion_action (#716).
 	MarkCompleted(ctx context.Context, goalID, userID uuid.UUID, action string) error
+	// MarkArchived sets status=archived and archived_at timestamp (#721).
+	MarkArchived(ctx context.Context, goalID, userID uuid.UUID) error
+	// MarkUnarchived restores a goal to active status and clears archived_at (#721).
+	MarkUnarchived(ctx context.Context, goalID, userID uuid.UUID) error
 }

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -22,13 +22,17 @@ import (
 type SavingsGoalManager interface {
 	Create(ctx context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
-	List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error)
+	List(ctx context.Context, userID uuid.UUID, category string, includeArchived bool) ([]savingsgoal.SavingsGoal, error)
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
 	Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error)
 	Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Complete(ctx context.Context, userID, goalID uuid.UUID, action string) (savingsgoal.SavingsGoal, error)
+	// Archive moves a goal to archived status so it no longer appears in the default list (#721).
+	Archive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
+	// Unarchive restores an archived goal to active status (#721).
+	Unarchive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 }
 
 type SavingsGoalHandler struct {
@@ -51,6 +55,9 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
 	// #716 manual completion
 	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/complete", h.complete)
+	// #721 archive/unarchive
+	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/archive", h.archive)
+	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/unarchive", h.unarchive)
 }
 
 type createSavingsGoalRequest struct {
@@ -131,7 +138,8 @@ func (h *SavingsGoalHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	goals, err := h.svc.List(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("category")))
+	includeArchived := strings.EqualFold(r.URL.Query().Get("include_archived"), "true")
+	goals, err := h.svc.List(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("category")), includeArchived)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -291,6 +299,44 @@ func (h *SavingsGoalHandler) complete(w http.ResponseWriter, r *http.Request) {
 	response.WriteJSON(w, http.StatusOK, response.OK(goal))
 }
 
+// archive sets a goal's status to "archived" so it no longer appears in the default list (#721).
+func (h *SavingsGoalHandler) archive(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Archive(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
+// unarchive restores an archived goal to active status (#721).
+func (h *SavingsGoalHandler) unarchive(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Unarchive(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
 func (h *SavingsGoalHandler) authenticatedUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	user, ok := auth.GetUserFromContext(r.Context())
 	if !ok {
@@ -313,6 +359,10 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_COMPLETED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrGoalPaused):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_PAUSED", err.Error()))
+	case errors.Is(err, savingsgoal.ErrGoalArchived):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_ARCHIVED", err.Error()))
+	case errors.Is(err, savingsgoal.ErrGoalNotArchived):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_NOT_ARCHIVED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -61,7 +61,7 @@ func (m *mockSavingsGoalService) Get(_ context.Context, userID, goalID uuid.UUID
 	return g, nil
 }
 
-func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
 	if category != "" {
 		if _, err := savingsgoal.ParseCategory(category); err != nil {
 			return nil, err
@@ -70,6 +70,9 @@ func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, categ
 	var out []savingsgoal.SavingsGoal
 	for _, g := range m.goals {
 		if g.UserID != userID {
+			continue
+		}
+		if !includeArchived && g.Status == savingsgoal.GoalStatusArchived {
 			continue
 		}
 		if category != "" && string(g.Category) != category {
@@ -145,6 +148,24 @@ func (m *mockSavingsGoalService) Resume(_ context.Context, userID, goalID uuid.U
 	if !ok || g.UserID != userID {
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
 	}
+	return g, nil
+}
+func (m *mockSavingsGoalService) Archive(_ context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	g.Status = savingsgoal.GoalStatusArchived
+	m.goals[goalID] = g
+	return g, nil
+}
+func (m *mockSavingsGoalService) Unarchive(_ context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	g.Status = savingsgoal.GoalStatusActive
+	m.goals[goalID] = g
 	return g, nil
 }
 

--- a/apps/api/internal/handler/yield_handler.go
+++ b/apps/api/internal/handler/yield_handler.go
@@ -61,6 +61,9 @@ func (h *YieldHandler) compare(w http.ResponseWriter, r *http.Request) {
 // maxYieldCompare mirrors the service's upper bound for query parsing capacity.
 const maxYieldCompare = 5
 
+// validRiskTiers is the set of accepted values for the ?risk= query param.
+var validRiskTiers = map[string]bool{"low": true, "medium": true, "high": true}
+
 func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
 	chain := strings.TrimSpace(r.URL.Query().Get("chain"))
 	if chain == "" {
@@ -74,6 +77,16 @@ func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Optional risk-tier filter (#720): low | medium | high
+	riskFilter := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("risk")))
+	if riskFilter != "" && !validRiskTiers[riskFilter] {
+		response.WriteJSON(w, http.StatusBadRequest, response.Err(
+			http.StatusBadRequest, "INVALID_RISK_TIER",
+			"risk must be one of: low, medium, high",
+		))
+		return
+	}
+
 	yieldResp, err := h.svc.GetYieldOpportunities(r.Context(), chain, limit)
 	if err != nil {
 		logpkg.FromContext(r.Context()).Error("yield opportunities fetch failed", "chain", chain, "error", err.Error())
@@ -81,9 +94,19 @@ func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build response with meta information
+	pools := yieldResp.Pools
+	if riskFilter != "" {
+		filtered := pools[:0]
+		for _, p := range pools {
+			if p.RiskTier == riskFilter {
+				filtered = append(filtered, p)
+			}
+		}
+		pools = filtered
+	}
+
 	responseData := map[string]interface{}{
-		"data": yieldResp.Pools,
+		"data": pools,
 		"meta": yieldResp.Meta,
 	}
 

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -177,6 +177,40 @@ func (r *SavingsGoalRepository) MarkCompleted(ctx context.Context, goalID, userI
 	return nil
 }
 
+// MarkArchived sets status=archived and records archived_at timestamp (#721).
+func (r *SavingsGoalRepository) MarkArchived(ctx context.Context, goalID, userID uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET status = 'archived', archived_at = NOW(), updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`, goalID, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+// MarkUnarchived restores an archived goal to active status and clears archived_at (#721).
+func (r *SavingsGoalRepository) MarkUnarchived(ctx context.Context, goalID, userID uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET status = 'active', archived_at = NULL, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2
+	`, goalID, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
 func (r *SavingsGoalRepository) SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error) {
 	var total sql.NullString
 	err := r.db.QueryRowContext(ctx, `

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -78,7 +78,7 @@ func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) 
 	return s.enrichProgress(ctx, *goal)
 }
 
-func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
 	filterCategory := ""
 	if strings.TrimSpace(category) != "" {
 		parsed, err := savingsgoal.ParseCategory(category)
@@ -94,6 +94,10 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 	}
 	out := make([]savingsgoal.SavingsGoal, 0, len(goals))
 	for _, g := range goals {
+		// Exclude archived goals from the default list unless explicitly requested (#721).
+		if !includeArchived && g.Status == savingsgoal.GoalStatusArchived {
+			continue
+		}
 		enriched, err := s.enrichProgress(ctx, g)
 		if err != nil {
 			return nil, err
@@ -346,6 +350,49 @@ func (s *SavingsGoalService) Complete(ctx context.Context, userID, goalID uuid.U
 	now := time.Now().UTC()
 	goal.CompletedAt = &now
 	return s.enrichProgress(ctx, *goal)
+}
+
+// Archive sets a goal's status to "archived" so it no longer appears in the default list (#721).
+// Any status may be archived; the action is reversible via Unarchive.
+// Archived goals cannot receive contributions.
+func (s *SavingsGoalService) Archive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status == savingsgoal.GoalStatusArchived {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: goal is already archived", savingsgoal.ErrGoalArchived)
+	}
+	if err := s.repo.MarkArchived(ctx, goalID, userID); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	now := time.Now().UTC()
+	goal.Status = savingsgoal.GoalStatusArchived
+	goal.ArchivedAt = &now
+	return *goal, nil
+}
+
+// Unarchive restores an archived goal to active status (#721).
+func (s *SavingsGoalService) Unarchive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status != savingsgoal.GoalStatusArchived {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("%w: goal is not archived", savingsgoal.ErrGoalNotArchived)
+	}
+	if err := s.repo.MarkUnarchived(ctx, goalID, userID); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.Status = savingsgoal.GoalStatusActive
+	goal.ArchivedAt = nil
+	return *goal, nil
 }
 
 func (s *SavingsGoalService) notifyMilestonesAsync(goal savingsgoal.SavingsGoal, milestones []int) {

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -102,7 +102,35 @@ func (m *memorySavingsGoalRepo) SumRecentDeposits(context.Context, uuid.UUID, st
 func (m *memorySavingsGoalRepo) UpdateStatus(context.Context, uuid.UUID, uuid.UUID, string) error {
 	return nil
 }
-func (m *memorySavingsGoalRepo) MarkCompleted(context.Context, uuid.UUID, uuid.UUID, string) error {
+func (m *memorySavingsGoalRepo) MarkCompleted(_ context.Context, goalID, userID uuid.UUID, action string) error {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.Status = savingsgoal.GoalStatusCompleted
+	g.CompletionAction = action
+	m.goals[goalID] = g
+	return nil
+}
+func (m *memorySavingsGoalRepo) MarkArchived(_ context.Context, goalID, userID uuid.UUID) error {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.ErrGoalNotFound
+	}
+	now := time.Now().UTC()
+	g.Status = savingsgoal.GoalStatusArchived
+	g.ArchivedAt = &now
+	m.goals[goalID] = g
+	return nil
+}
+func (m *memorySavingsGoalRepo) MarkUnarchived(_ context.Context, goalID, userID uuid.UUID) error {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.Status = savingsgoal.GoalStatusActive
+	g.ArchivedAt = nil
+	m.goals[goalID] = g
 	return nil
 }
 
@@ -319,7 +347,7 @@ func TestSavingsGoalService_List_FilterByCategory(t *testing.T) {
 	}
 	svc := NewSavingsGoalService(repo, nil)
 
-	goals, err := svc.List(ctx, userID, "education")
+	goals, err := svc.List(ctx, userID, "education", false)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -336,7 +364,7 @@ func TestSavingsGoalService_List_InvalidCategoryFilter(t *testing.T) {
 	userID := uuid.New()
 	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil)
 
-	_, err := svc.List(ctx, userID, "invalid")
+	_, err := svc.List(ctx, userID, "invalid", false)
 	if err == nil {
 		t.Fatal("List() error = nil, want invalid category")
 	}

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -90,6 +90,8 @@ func (m *memoryGoalRepo) SumVaultBalance(context.Context, uuid.UUID, string) (de
 func (m *memoryGoalRepo) MarkCompleted(context.Context, uuid.UUID, uuid.UUID, string) error {
 	return nil
 }
+func (m *memoryGoalRepo) MarkArchived(context.Context, uuid.UUID, uuid.UUID) error   { return nil }
+func (m *memoryGoalRepo) MarkUnarchived(context.Context, uuid.UUID, uuid.UUID) error { return nil }
 func (m *memoryGoalRepo) SumRecentDeposits(context.Context, uuid.UUID, string, time.Time) (decimal.Decimal, error) {
 	return decimal.Zero, nil
 }

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -28,7 +28,22 @@ type YieldPool struct {
 	TVLUsd    float64  `json:"tvlUsd"`
 	APYPct7d  *float64 `json:"apyPct7d"`
 	Chain     string   `json:"chain"`
-	RiskScore float64  `json:"riskScore"`
+	RiskScore float64  `json:"risk_score"`
+	// RiskTier buckets RiskScore: "low" (0–0.33), "medium" (0.34–0.66), "high" (0.67–1.0).
+	RiskTier string `json:"risk_tier"`
+}
+
+// RiskTierFromScore converts a [0.0, 1.0] risk score to a named tier.
+// Thresholds: Low ≤ 0.33, Medium ≤ 0.66, High > 0.66.
+func RiskTierFromScore(score float64) string {
+	switch {
+	case score <= 0.33:
+		return "low"
+	case score <= 0.66:
+		return "medium"
+	default:
+		return "high"
+	}
 }
 
 type yieldCacheEntry struct {
@@ -297,6 +312,7 @@ func (s *YieldService) fetchFromUpstream(ctx context.Context, chain string, limi
 			rewardRatio = pool.APYReward / pool.APY
 		}
 		pool.RiskScore = ComputeRiskScore(pool.TVLUsd, apy7dSwing, rewardRatio)
+		pool.RiskTier = RiskTierFromScore(pool.RiskScore)
 		pools = append(pools, pool)
 	}
 	slog.Debug("yield pools filtered",


### PR DESCRIPTION
Closes #719
Closes #720
Closes #721
Closes #722

## Summary

**Issue #720 — yield opportunity filtering by risk tier**
- `RiskTier string` field added to `YieldPool` (`"low"` / `"medium"` / `"high"`)
- `RiskTierFromScore(score float64) string` helper: low ≤ 0.33, medium ≤ 0.66, high > 0.66
- `RiskTier` set alongside `RiskScore` in `fetchFromUpstream` (after TVL filter)
- `GET /api/v1/yield-opportunities?risk=low|medium|high` filters the returned pools; omitting the param returns all tiers; unknown value → 400 `INVALID_RISK_TIER`

**Issue #721 — savings goal archiving**
- `GoalStatusArchived = "archived"` constant, `ErrGoalArchived`, `ErrGoalNotArchived` sentinel errors
- `ArchivedAt *time.Time` field on `SavingsGoal`
- `Repository` interface extended with `MarkArchived` / `MarkUnarchived`
- Postgres implementation: `UPDATE savings_goals SET status='archived', archived_at=NOW()` with ownership check
- `SavingsGoalService.Archive` / `Unarchive` with ownership + state guards (409 if already archived / not archived)
- `List` gains `includeArchived bool`; archived goals excluded by default, returned when `?include_archived=true`
- New routes: `PATCH /api/v1/users/savings-goals/{id}/archive` and `/unarchive`
- `writeError` handles `ErrGoalArchived` → 409 `GOAL_ARCHIVED` and `ErrGoalNotArchived` → 409 `GOAL_NOT_ARCHIVED`
- All existing mock repos and handler mocks updated; `go test ./internal/handler/... ./internal/service/...` passes

## Test plan
- [ ] `GET /yield-opportunities?risk=low` returns only pools with `risk_tier: "low"`
- [ ] `GET /yield-opportunities` (no filter) returns all tiers
- [ ] `GET /yield-opportunities?risk=invalid` → 400
- [ ] `PATCH /savings-goals/{id}/archive` → goal disappears from `GET /savings-goals`
- [ ] `GET /savings-goals?include_archived=true` → archived goal appears
- [ ] `PATCH /savings-goals/{id}/unarchive` → goal returns to active list
- [ ] Archiving an already-archived goal → 409 `GOAL_ARCHIVED`
- [ ] Unarchiving a non-archived goal → 409 `GOAL_NOT_ARCHIVED`
- [ ] `go test ./internal/handler/... ./internal/service/...` — all pass