### PR TITLE
feat(api): savings goal contribution history endpoint

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -209,6 +209,17 @@ type GoalDeposit struct {
 	Currency string
 }
 
+type GoalContribution struct {
+	ID        uuid.UUID       `json:"id"`
+	GoalID    uuid.UUID       `json:"goal_id"`
+	UserID    uuid.UUID       `json:"user_id"`
+	Amount    decimal.Decimal `json:"amount"`
+	Currency  string          `json:"currency"`
+	Type      string          `json:"type"`
+	TxHash    string          `json:"tx_hash,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
 type Repository interface {
 	Create(ctx context.Context, goal *SavingsGoal) error
 	ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]SavingsGoal, error)
@@ -217,6 +228,7 @@ type Repository interface {
 	Delete(ctx context.Context, id, userID uuid.UUID) error
 	SumVaultBalance(ctx context.Context, userID uuid.UUID, currency string) (decimal.Decimal, error)
 	UpdateMilestones(ctx context.Context, goalID uuid.UUID, milestones []int) error
+	ListContributions(ctx context.Context, goalID, userID uuid.UUID, params interface{}) ([]GoalContribution, int, string, error)
 	// SumRecentDeposits sums vault deposit amounts for the user in the given currency since `since` (#714).
 	SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error)
 	// UpdateStatus sets the goal's status column (#718).

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsschedule"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
 	"github.com/suncrestlabs/nester/apps/api/pkg/response"
 )
@@ -36,6 +37,7 @@ type SavingsGoalManager interface {
 	Share(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Unshare(ctx context.Context, userID, goalID uuid.UUID) error
 	GetShared(ctx context.Context, token uuid.UUID) (savingsgoal.SharedGoalView, error)
+	ListContributions(ctx context.Context, userID, goalID uuid.UUID, params listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error)
 }
 
 type SavingsGoalHandler struct {
@@ -61,6 +63,7 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	// #718 pause/resume
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/pause", h.pause)
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
+	mux.HandleFunc("GET /api/v1/users/savings-goals/{id}/contributions", h.listContributions)
 	// #716 manual completion
 	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/complete", h.complete)
 	// #684 archive / #721 unarchive
@@ -382,9 +385,9 @@ type splitDepositAllocationRequest struct {
 }
 
 type splitDepositRequest struct {
-	TotalAmount string                           `json:"total_amount"`
-	Currency    string                           `json:"currency"`
-	Allocations []splitDepositAllocationRequest  `json:"allocations"`
+	TotalAmount string                          `json:"total_amount"`
+	Currency    string                          `json:"currency"`
+	Allocations []splitDepositAllocationRequest `json:"allocations"`
 }
 
 func (h *SavingsGoalHandler) splitDeposit(w http.ResponseWriter, r *http.Request) {
@@ -449,6 +452,29 @@ func (h *SavingsGoalHandler) splitDeposit(w http.ResponseWriter, r *http.Request
 		return
 	}
 	response.WriteJSON(w, http.StatusCreated, response.Created(result))
+}
+
+func (h *SavingsGoalHandler) listContributions(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	params, err := listquery.ParsePage(r)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+	contributions, total, nextCursor, err := h.svc.ListContributions(r.Context(), userID, goalID, params)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.PaginatedOK(contributions, params.Page, params.PerPage, total, nextCursor))
 }
 
 func (h *SavingsGoalHandler) authenticatedUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 	"github.com/suncrestlabs/nester/apps/api/pkg/response"
 )
 
@@ -108,6 +109,23 @@ func (m *mockSavingsGoalService) Update(_ context.Context, userID, goalID uuid.U
 	}
 	m.goals[goalID] = g
 	return g, nil
+}
+
+func (m *mockSavingsGoalService) ListContributions(_ context.Context, userID, goalID uuid.UUID, _ listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error) {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return nil, 0, "", savingsgoal.ErrGoalNotFound
+	}
+	items := []savingsgoal.GoalContribution{{
+		ID:        uuid.New(),
+		GoalID:    goalID,
+		UserID:    userID,
+		Amount:    decimal.NewFromInt(100),
+		Currency:  g.Currency,
+		Type:      "deposit",
+		CreatedAt: time.Now().UTC(),
+	}}
+	return items, len(items), "", nil
 }
 
 func (m *mockSavingsGoalService) Delete(_ context.Context, userID, goalID uuid.UUID) error {
@@ -706,6 +724,54 @@ func TestSavingsGoalHandler_SplitDeposit(t *testing.T) {
 			t.Fatalf("status = %d, want 400", resp.StatusCode)
 		}
 	})
+}
+
+func TestSavingsGoalHandler_ListContributions(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {
+			ID:       goalID,
+			UserID:   userID,
+			Currency: savingsgoal.CurrencyUSDC,
+		},
+	}}
+	h := NewSavingsGoalHandler(svc, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals/" + goalID.String() + "/contributions?per_page=5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("contributions status = %d, want 200", resp.StatusCode)
+	}
+
+	var envelope response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Meta == nil {
+		t.Fatal("expected pagination meta")
+	}
+	data, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var contributions []savingsgoal.GoalContribution
+	if err := json.Unmarshal(data, &contributions); err != nil {
+		t.Fatal(err)
+	}
+	if len(contributions) != 1 {
+		t.Fatalf("contributions len = %d, want 1", len(contributions))
+	}
+	if contributions[0].Type != "deposit" {
+		t.Fatalf("contribution type = %q, want deposit", contributions[0].Type)
+	}
 }
 
 // decodeGoalList decodes a list-of-goals response envelope.

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -3,7 +3,10 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 )
 
 type SavingsGoalRepository struct {
@@ -234,6 +238,98 @@ func (r *SavingsGoalRepository) MarkCompleted(ctx context.Context, goalID, userI
 	return nil
 }
 
+func (r *SavingsGoalRepository) ListContributions(ctx context.Context, goalID, userID uuid.UUID, params interface{}) ([]savingsgoal.GoalContribution, int, string, error) {
+	pageParams, ok := params.(listquery.PageParams)
+	if !ok {
+		return nil, 0, "", fmt.Errorf("invalid pagination params")
+	}
+	if pageParams.PerPage <= 0 {
+		pageParams.PerPage = listquery.DefaultPerPage
+	}
+	if pageParams.Page <= 0 {
+		pageParams.Page = listquery.DefaultPage
+	}
+
+	countQuery := `
+		SELECT COUNT(*)
+		FROM vault_transactions vt
+		JOIN vaults v ON vt.vault_id = v.id
+		JOIN savings_schedules ss ON ss.vault_id = v.id
+		WHERE ss.goal_id = $1 AND ss.user_id = $2 AND vt.type = 'deposit' AND v.deleted_at IS NULL
+	`
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, goalID, userID).Scan(&total); err != nil {
+		return nil, 0, "", err
+	}
+
+	query := `
+               SELECT vt.id, vt.vault_id, v.user_id, vt.amount, v.currency, vt.type, vt.tx_hash, vt.created_at
+               FROM vault_transactions vt
+               JOIN vaults v ON vt.vault_id = v.id
+               JOIN savings_schedules ss ON ss.vault_id = v.id
+               WHERE ss.goal_id = $1 AND ss.user_id = $2 AND vt.type = 'deposit' AND v.deleted_at IS NULL
+       `
+	args := []any{goalID, userID}
+	if pageParams.Cursor != "" {
+		createdAt, cursorID, err := decodeGoalContributionCursor(pageParams.Cursor)
+		if err != nil {
+			return nil, 0, "", err
+		}
+		query += ` AND (vt.created_at < $3 OR (vt.created_at = $3 AND vt.id < $4))`
+		args = append(args, createdAt.UTC(), cursorID)
+	}
+	query += fmt.Sprintf(` ORDER BY vt.created_at DESC, vt.id DESC LIMIT $%d`, len(args)+1)
+	args = append(args, pageParams.PerPage+1)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	defer rows.Close()
+
+	items := make([]savingsgoal.GoalContribution, 0, pageParams.PerPage+1)
+	for rows.Next() {
+		var (
+			id, vaultID, userIDStr, amountStr, currency, txType string
+			txHash                                              sql.NullString
+			createdAt                                           time.Time
+		)
+		if err := rows.Scan(&id, &vaultID, &userIDStr, &amountStr, &currency, &txType, &txHash, &createdAt); err != nil {
+			return nil, 0, "", err
+		}
+		parsedID, _ := uuid.Parse(id)
+		parsedVaultID, _ := uuid.Parse(vaultID)
+		parsedUserID, _ := uuid.Parse(userIDStr)
+		amount, _ := decimal.NewFromString(amountStr)
+		var txHashStr string
+		if txHash.Valid {
+			txHashStr = txHash.String
+		}
+		items = append(items, savingsgoal.GoalContribution{
+			ID:        parsedID,
+			GoalID:    goalID,
+			UserID:    parsedUserID,
+			Amount:    amount,
+			Currency:  currency,
+			Type:      txType,
+			TxHash:    txHashStr,
+			CreatedAt: createdAt.UTC(),
+		})
+		_ = parsedVaultID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, "", err
+	}
+
+	nextCursor := ""
+	if len(items) > pageParams.PerPage {
+		last := items[pageParams.PerPage-1]
+		nextCursor = encodeGoalContributionCursor(last.CreatedAt, last.ID)
+		items = items[:pageParams.PerPage]
+	}
+	return items, total, nextCursor, nil
+}
+
 func (r *SavingsGoalRepository) SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error) {
 	var total sql.NullString
 	err := r.db.QueryRowContext(ctx, `
@@ -381,4 +477,29 @@ func (r *SavingsGoalRepository) SumGoalDeposits(ctx context.Context, goalID uuid
 		return decimal.Zero, nil
 	}
 	return decimal.NewFromString(total.String)
+}
+
+func encodeGoalContributionCursor(createdAt time.Time, contributionID uuid.UUID) string {
+	payload := createdAt.UTC().Format(time.RFC3339Nano) + "|" + contributionID.String()
+	return base64.RawStdEncoding.EncodeToString([]byte(payload))
+}
+
+func decodeGoalContributionCursor(cursor string) (time.Time, uuid.UUID, error) {
+	decoded, err := base64.RawStdEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, uuid.Nil, err
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid contribution cursor")
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, uuid.Nil, err
+	}
+	contributionID, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, err
+	}
+	return createdAt, contributionID, nil
 }

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsstreak"
+	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 )
 
 type SavingsGoalService struct {
@@ -225,6 +226,17 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 
 func (s *SavingsGoalService) Delete(ctx context.Context, userID, goalID uuid.UUID) error {
 	return s.repo.Delete(ctx, goalID, userID)
+}
+
+func (s *SavingsGoalService) ListContributions(ctx context.Context, userID, goalID uuid.UUID, params listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	if goal.UserID != userID {
+		return nil, 0, "", savingsgoal.ErrGoalNotFound
+	}
+	return s.repo.ListContributions(ctx, goalID, userID, params)
 }
 
 func (s *SavingsGoalService) Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error) {

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -98,6 +98,11 @@ func (m *memorySavingsGoalRepo) UpdateMilestones(_ context.Context, goalID uuid.
 	m.goals[goalID] = g
 	return nil
 }
+
+func (m *memorySavingsGoalRepo) ListContributions(context.Context, uuid.UUID, uuid.UUID, interface{}) ([]savingsgoal.GoalContribution, int, string, error) {
+	return nil, 0, "", nil
+}
+
 func (m *memorySavingsGoalRepo) SumRecentDeposits(context.Context, uuid.UUID, string, time.Time) (decimal.Decimal, error) {
 	return decimal.Zero, nil
 }

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -131,6 +131,9 @@ func (m *memoryGoalRepo) RecordGoalDeposits(context.Context, []savingsgoal.GoalD
 func (m *memoryGoalRepo) SumGoalDeposits(context.Context, uuid.UUID) (decimal.Decimal, error) {
 	return decimal.Zero, nil
 }
+func (m *memoryGoalRepo) ListContributions(_ context.Context, _, _ uuid.UUID, _ interface{}) ([]savingsgoal.GoalContribution, int, string, error) {
+	return nil, 0, "", nil
+}
 func (m *memoryGoalRepo) UpdateMilestones(_ context.Context, goalID uuid.UUID, milestones []int) error {
 	g, ok := m.goals[goalID]
 	if !ok {


### PR DESCRIPTION
Closes #727

---

This PR adds an endpoint to list all deposits made to a savings goal:
- GET /api/v1/users/savings-goals/{id}/contributions returns paginated vault deposit transactions
- Each entry includes amount, currency, tx_hash, timestamp
- Pagination via cursor (created_at + id)
- Returns 404 if goal doesn't belong to user
- Ordered newest first