### PR TITLE
feat(api): add status filter and archived status to savings goals

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -26,7 +26,23 @@ const (
 	GoalStatusActive    = "active"
 	GoalStatusPaused    = "paused"
 	GoalStatusCompleted = "completed"
+	// GoalStatusArchived is a terminal state a user can move a goal into (e.g.
+	// after it completes) to hide it without deleting it (#684).
+	GoalStatusArchived = "archived"
 )
+
+// ParseStatusFilter validates a status used to filter the goal list. An empty
+// value means "no filter" and returns ("", nil).
+func ParseStatusFilter(value string) (string, error) {
+	switch status := strings.ToLower(strings.TrimSpace(value)); status {
+	case "":
+		return "", nil
+	case GoalStatusActive, GoalStatusPaused, GoalStatusCompleted, GoalStatusArchived:
+		return status, nil
+	default:
+		return "", fmt.Errorf("%w: invalid status", ErrInvalidGoal)
+	}
+}
 
 type GoalCategory string
 

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -22,13 +22,14 @@ import (
 type SavingsGoalManager interface {
 	Create(ctx context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
-	List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error)
+	List(ctx context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error)
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
 	Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error)
 	Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Complete(ctx context.Context, userID, goalID uuid.UUID, action string) (savingsgoal.SavingsGoal, error)
+	Archive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 }
 
 type SavingsGoalHandler struct {
@@ -51,6 +52,8 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
 	// #716 manual completion
 	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/complete", h.complete)
+	// #684 archive
+	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/archive", h.archive)
 }
 
 type createSavingsGoalRequest struct {
@@ -131,7 +134,12 @@ func (h *SavingsGoalHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	goals, err := h.svc.List(r.Context(), userID, strings.TrimSpace(r.URL.Query().Get("category")))
+	goals, err := h.svc.List(
+		r.Context(),
+		userID,
+		strings.TrimSpace(r.URL.Query().Get("category")),
+		strings.TrimSpace(r.URL.Query().Get("status")),
+	)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -252,6 +260,24 @@ func (h *SavingsGoalHandler) resume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	goal, err := h.svc.Resume(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
+func (h *SavingsGoalHandler) archive(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Archive(r.Context(), userID, goalID)
 	if err != nil {
 		h.writeError(w, r, err)
 		return

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -61,11 +61,15 @@ func (m *mockSavingsGoalService) Get(_ context.Context, userID, goalID uuid.UUID
 	return g, nil
 }
 
-func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error) {
 	if category != "" {
 		if _, err := savingsgoal.ParseCategory(category); err != nil {
 			return nil, err
 		}
+	}
+	filterStatus, err := savingsgoal.ParseStatusFilter(status)
+	if err != nil {
+		return nil, err
 	}
 	var out []savingsgoal.SavingsGoal
 	for _, g := range m.goals {
@@ -73,6 +77,9 @@ func (m *mockSavingsGoalService) List(_ context.Context, userID uuid.UUID, categ
 			continue
 		}
 		if category != "" && string(g.Category) != category {
+			continue
+		}
+		if filterStatus != "" && g.Status != filterStatus {
 			continue
 		}
 		out = append(out, g)
@@ -145,6 +152,15 @@ func (m *mockSavingsGoalService) Resume(_ context.Context, userID, goalID uuid.U
 	if !ok || g.UserID != userID {
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
 	}
+	return g, nil
+}
+func (m *mockSavingsGoalService) Archive(_ context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	g.Status = savingsgoal.GoalStatusArchived
+	m.goals[goalID] = g
 	return g, nil
 }
 
@@ -332,4 +348,99 @@ func TestSavingsGoalHandler_Create_InvalidCurrency(t *testing.T) {
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("create status = %d, want 400", resp.StatusCode)
 	}
+}
+
+func TestSavingsGoalHandler_List_FilterByStatus(t *testing.T) {
+	userID := uuid.New()
+	activeID, completedID := uuid.New(), uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		activeID: {ID: activeID, UserID: userID, TargetAmount: decimal.NewFromInt(1000),
+			Currency: "USDC", Category: savingsgoal.CategoryEducation, Status: savingsgoal.GoalStatusActive},
+		completedID: {ID: completedID, UserID: userID, TargetAmount: decimal.NewFromInt(500),
+			Currency: "USDC", Category: savingsgoal.CategoryTravel, Status: savingsgoal.GoalStatusCompleted},
+	}}
+	h := NewSavingsGoalHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals?status=completed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", resp.StatusCode)
+	}
+	goals := decodeGoalList(t, resp)
+	if len(goals) != 1 || goals[0].Status != savingsgoal.GoalStatusCompleted {
+		t.Fatalf("goals = %+v, want one completed goal", goals)
+	}
+
+	// Invalid status → 400.
+	bad, err := http.Get(server.URL + "/api/v1/users/savings-goals?status=bogus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bad.Body.Close()
+	if bad.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid status = %d, want 400", bad.StatusCode)
+	}
+}
+
+func TestSavingsGoalHandler_Archive(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: userID, TargetAmount: decimal.NewFromInt(500),
+			Currency: "USDC", Category: savingsgoal.CategoryOther, Status: savingsgoal.GoalStatusCompleted},
+	}}
+	h := NewSavingsGoalHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodPatch,
+		server.URL+"/api/v1/users/savings-goals/"+goalID.String()+"/archive", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive status = %d, want 200", resp.StatusCode)
+	}
+
+	var envelope response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(envelope.Data)
+	var goal savingsgoal.SavingsGoal
+	if err := json.Unmarshal(data, &goal); err != nil {
+		t.Fatal(err)
+	}
+	if goal.Status != savingsgoal.GoalStatusArchived {
+		t.Fatalf("archived goal status = %q, want archived", goal.Status)
+	}
+}
+
+// decodeGoalList decodes a list-of-goals response envelope.
+func decodeGoalList(t *testing.T, resp *http.Response) []savingsgoal.SavingsGoal {
+	t.Helper()
+	var envelope response.Response
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var goals []savingsgoal.SavingsGoal
+	if err := json.Unmarshal(data, &goals); err != nil {
+		t.Fatal(err)
+	}
+	return goals
 }

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -78,7 +78,7 @@ func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) 
 	return s.enrichProgress(ctx, *goal)
 }
 
-func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
+func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category, status string) ([]savingsgoal.SavingsGoal, error) {
 	filterCategory := ""
 	if strings.TrimSpace(category) != "" {
 		parsed, err := savingsgoal.ParseCategory(category)
@@ -86,6 +86,14 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 			return nil, err
 		}
 		filterCategory = string(parsed)
+	}
+
+	// Status is filtered after enrichment so the dynamic auto-complete (#716) is
+	// reflected: a stored-active goal that has reached its target reads as
+	// "completed" here, matching ?status=completed and excluded by ?status=active.
+	filterStatus, err := savingsgoal.ParseStatusFilter(status)
+	if err != nil {
+		return nil, err
 	}
 
 	goals, err := s.repo.ListByUser(ctx, userID, filterCategory)
@@ -97,6 +105,9 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 		enriched, err := s.enrichProgress(ctx, g)
 		if err != nil {
 			return nil, err
+		}
+		if filterStatus != "" && enriched.Status != filterStatus {
+			continue
 		}
 		out = append(out, enriched)
 	}
@@ -345,6 +356,27 @@ func (s *SavingsGoalService) Complete(ctx context.Context, userID, goalID uuid.U
 	goal.CompletionAction = action
 	now := time.Now().UTC()
 	goal.CompletedAt = &now
+	return s.enrichProgress(ctx, *goal)
+}
+
+// Archive moves a goal into the terminal "archived" state, hiding it without
+// deleting it. This is the only mutation allowed on a completed goal (#684);
+// already-archived goals are returned unchanged.
+func (s *SavingsGoalService) Archive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByID(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.Status == savingsgoal.GoalStatusArchived {
+		return s.enrichProgress(ctx, *goal)
+	}
+	if err := s.repo.UpdateStatus(ctx, goalID, userID, savingsgoal.GoalStatusArchived); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.Status = savingsgoal.GoalStatusArchived
 	return s.enrichProgress(ctx, *goal)
 }
 

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -319,7 +319,7 @@ func TestSavingsGoalService_List_FilterByCategory(t *testing.T) {
 	}
 	svc := NewSavingsGoalService(repo, nil)
 
-	goals, err := svc.List(ctx, userID, "education")
+	goals, err := svc.List(ctx, userID, "education", "")
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -336,9 +336,104 @@ func TestSavingsGoalService_List_InvalidCategoryFilter(t *testing.T) {
 	userID := uuid.New()
 	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil)
 
-	_, err := svc.List(ctx, userID, "invalid")
+	_, err := svc.List(ctx, userID, "invalid", "")
 	if err == nil {
 		t.Fatal("List() error = nil, want invalid category")
+	}
+}
+
+func TestSavingsGoalService_List_StatusFilter(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+
+	// An active goal under target — stays "active" after enrichment.
+	activeID := uuid.New()
+	repo.goals[activeID] = savingsgoal.SavingsGoal{
+		ID: activeID, UserID: userID, TargetAmount: decimal.NewFromInt(1000),
+		Currency: "USDC", Deadline: testDeadline(), Category: savingsgoal.CategoryEducation,
+		Status: savingsgoal.GoalStatusActive,
+	}
+	// An active goal whose balance has reached target — auto-completes (#716),
+	// so it must read as "completed" and be excluded from ?status=active.
+	completedID := uuid.New()
+	repo.goals[completedID] = savingsgoal.SavingsGoal{
+		ID: completedID, UserID: userID, TargetAmount: decimal.NewFromInt(500),
+		Currency: "XLM", Deadline: testDeadline(), Category: savingsgoal.CategoryTravel,
+		Status: savingsgoal.GoalStatusActive,
+	}
+	repo.setBalance(userID, "XLM", decimal.NewFromInt(500))
+	// An archived goal.
+	archivedID := uuid.New()
+	repo.goals[archivedID] = savingsgoal.SavingsGoal{
+		ID: archivedID, UserID: userID, TargetAmount: decimal.NewFromInt(200),
+		Currency: "USDC", Deadline: testDeadline(), Category: savingsgoal.CategoryHousing,
+		Status: savingsgoal.GoalStatusArchived,
+	}
+
+	svc := NewSavingsGoalService(repo, nil)
+
+	cases := map[string]uuid.UUID{
+		savingsgoal.GoalStatusActive:    activeID,
+		savingsgoal.GoalStatusCompleted: completedID,
+		savingsgoal.GoalStatusArchived:  archivedID,
+	}
+	for status, wantID := range cases {
+		goals, err := svc.List(ctx, userID, "", status)
+		if err != nil {
+			t.Fatalf("List(status=%q) error = %v", status, err)
+		}
+		if len(goals) != 1 {
+			t.Fatalf("List(status=%q) returned %d goals, want 1", status, len(goals))
+		}
+		if goals[0].ID != wantID {
+			t.Fatalf("List(status=%q) returned goal %s, want %s", status, goals[0].ID, wantID)
+		}
+		if goals[0].Status != status {
+			t.Fatalf("List(status=%q) goal status = %q, want %q", status, goals[0].Status, status)
+		}
+	}
+
+	// No filter returns all three.
+	all, err := svc.List(ctx, userID, "", "")
+	if err != nil {
+		t.Fatalf("List(no filter) error = %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("List(no filter) returned %d goals, want 3", len(all))
+	}
+}
+
+func TestSavingsGoalService_List_InvalidStatusFilter(t *testing.T) {
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil)
+	if _, err := svc.List(context.Background(), uuid.New(), "", "bogus"); err == nil {
+		t.Fatal("List() error = nil, want invalid status")
+	}
+}
+
+func TestSavingsGoalService_Archive(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	goalID := uuid.New()
+	repo.goals[goalID] = savingsgoal.SavingsGoal{
+		ID: goalID, UserID: userID, TargetAmount: decimal.NewFromInt(1000),
+		Currency: "USDC", Deadline: testDeadline(), Category: savingsgoal.CategoryEducation,
+		Status: savingsgoal.GoalStatusCompleted,
+	}
+	svc := NewSavingsGoalService(repo, nil)
+
+	goal, err := svc.Archive(ctx, userID, goalID)
+	if err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+	if goal.Status != savingsgoal.GoalStatusArchived {
+		t.Fatalf("status = %q, want archived", goal.Status)
+	}
+
+	// Archiving someone else's goal is not found.
+	if _, err := svc.Archive(ctx, uuid.New(), goalID); err != savingsgoal.ErrGoalNotFound {
+		t.Fatalf("Archive(other user) error = %v, want ErrGoalNotFound", err)
 	}
 }
 

--- a/apps/api/migrations/041_add_savings_goal_archived_status.down.sql
+++ b/apps/api/migrations/041_add_savings_goal_archived_status.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE savings_goals DROP CONSTRAINT IF EXISTS savings_goals_status_check;

--- a/apps/api/migrations/041_add_savings_goal_archived_status.up.sql
+++ b/apps/api/migrations/041_add_savings_goal_archived_status.up.sql
@@ -1,0 +1,6 @@
+-- Constrain savings_goals.status to the known lifecycle values. Migration 040
+-- added the column without a CHECK; this enforces the allowed set and makes
+-- 'archived' a first-class status (#684).
+ALTER TABLE savings_goals
+  ADD CONSTRAINT savings_goals_status_check
+  CHECK (status IN ('active', 'paused', 'completed', 'archived'));


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria of #684. The core auto-complete from that issue already landed upstream (`enrichProgress`, #716) along with the `status`/`completed_at` columns (#718) and the completed-goal deadline guard (#684/#686). This PR fills the two gaps that were still open:

- **`?status=` list filter** — `GET /api/v1/users/savings-goals` now accepts `?status=active|paused|completed|archived`. Filtering happens **after enrichment**, so a stored-active goal that has reached its target reads as `completed` and is correctly returned by `?status=completed` (and excluded from `?status=active`). No filter returns all non-deleted goals. Invalid values return **400**.
- **`archived` status** — adds `GoalStatusArchived`, a migration (041) that constrains `savings_goals.status` to the known set (040 added the column without a `CHECK`), and an **Archive** action (`PATCH /api/v1/users/savings-goals/{id}/archive`) — the one mutation allowed on a completed goal, per the issue.

Kept consistent with the existing upstream lifecycle (which uses `paused`, not the spec's typed `GoalStatus`) rather than re-introducing a parallel model.

## Acceptance criteria

- [x] `archived` is a first-class status; migration adds the `CHECK` constraint
- [x] `GET ...?status=completed` returns only completed goals (incl. auto-completed)
- [x] Completed goals can be archived; editing them still returns 409 (existing guard)
- [x] Unit test: a target-reached goal reads as `completed`, an under-target goal stays `active`
- [x] Handler tests: `?status=` filter, invalid status → 400, archive route

## Verification

- `go build ./...` clean (incl. `cmd/api`); `go vet` clean on the touched packages.
- `go test ./internal/service/ ./internal/handler/` → all pass, including the new `TestSavingsGoalService_List_StatusFilter`, `_InvalidStatusFilter`, `_Archive`, `TestSavingsGoalHandler_List_FilterByStatus`, and `_Archive`.

Closes #684