### PR TITLE
feat: yield harvest history, savings goal webhooks, vault min deposit, APY history

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -107,6 +107,10 @@ func run() error {
 	vaultService.SetHarvestDefaultCompound(cfg.Stellar().HarvestDefaultCompound())
 	vaultHandler := handler.NewVaultHandler(vaultService)
 
+	yieldHarvestRepository := postgres.NewYieldHarvestRepository(db)
+	yieldHarvestService := service.NewYieldHarvestService(yieldHarvestRepository)
+	vaultService.SetYieldHarvestRecorder(yieldHarvestService)
+
 	portfolioService := service.NewPortfolioService(vaultRepository)
 	portfolioHandler := handler.NewPortfolioHandler(portfolioService)
 
@@ -342,6 +346,9 @@ func run() error {
 		environment:  cfg.Environment(),
 		buildVersion: version,
 	}))
+	yieldHarvestHandler := handler.NewYieldHarvestHandler(yieldHarvestService)
+	yieldHarvestHandler.Register(mux)
+
 	vaultHandler.Register(mux)
 	portfolioHandler.Register(mux)
 	transactionHandler.Register(mux)

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -386,9 +386,18 @@ func run() error {
 		notificationRepository,
 		nil,
 	)
+	webhookRepo := postgres.NewWebhookRepository(db)
+	webhookSvc := service.NewWebhookService(webhookRepo)
+	webhookHandler := handler.NewWebhookHandler(webhookSvc)
+	webhookHandler.Register(mux)
 	savingsGoalSvc := service.NewSavingsGoalService(
 		savingsGoalRepo,
-		service.DispatcherGoalMilestoneNotifier{Dispatcher: notificationDispatcher2},
+		service.CompositeGoalMilestoneNotifier{
+			Notifiers: []service.GoalMilestoneNotifier{
+				service.DispatcherGoalMilestoneNotifier{Dispatcher: notificationDispatcher2},
+				service.WebhookGoalMilestoneNotifier{Svc: webhookSvc},
+			},
+		},
 	)
 	savingsGoalHandler := handler.NewSavingsGoalHandler(savingsGoalSvc)
 	savingsGoalHandler.Register(mux)

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -448,6 +448,15 @@ func run() error {
 
 	mux.HandleFunc("GET /ws", wsHub.ServeWs)
 
+	// APY snapshot scheduler and history endpoint
+	apySnapshotRepo := postgres.NewAPYSnapshotRepository(db)
+	apySvc := service.NewAPYService(apySnapshotRepo)
+	apyHandler := handler.NewAPYHandler(apySvc)
+	apyHandler.Register(mux)
+	apySchedulerCtx, cancelAPYScheduler := context.WithCancel(context.Background())
+	defer cancelAPYScheduler()
+	go apySvc.StartScheduler(apySchedulerCtx)
+
 	authRules := []middleware.RouteRule{
 		{PathPrefix: "/health", Public: true},
 		{PathPrefix: "/healthz", Public: true},
@@ -455,6 +464,7 @@ func run() error {
 		{PathPrefix: "/ws", Public: true},
 		{PathPrefix: "/api/v1/auth/", Public: true},
 		{PathPrefix: "/api/v1/banks/", Public: true},
+		{PathPrefix: "/api/v1/yields/", Public: true},
 		{PathPrefix: "/api/v1/admin/", Public: false, Role: "admin"},
 		{PathPrefix: "/api/v1/", Public: false},
 	}

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	github.com/redis/go-redis/v9 v9.18.0

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -70,8 +70,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/apps/api/internal/domain/apysnapshot/model.go
+++ b/apps/api/internal/domain/apysnapshot/model.go
@@ -1,0 +1,26 @@
+package apysnapshot
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+var ErrProtocolNotFound = errors.New("protocol not found")
+
+type APYSnapshot struct {
+	ID           uuid.UUID       `json:"id"`
+	ProtocolSlug string          `json:"protocol_slug"`
+	APY          decimal.Decimal `json:"apy"`
+	TVL          decimal.Decimal `json:"tvl"`
+	CapturedAt   time.Time       `json:"captured_at"`
+}
+
+type Repository interface {
+	Upsert(ctx context.Context, snap APYSnapshot) error
+	ListByProtocol(ctx context.Context, slug string, since time.Time) ([]APYSnapshot, error)
+	PruneOlderThan(ctx context.Context, age time.Duration) error
+}

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -33,6 +33,7 @@ var (
 	ErrAllocationNotFound   = errors.New("allocation not found")
 	ErrAllocationHasBalance = errors.New("allocation has non-zero balance; set force=true to remove")
 	ErrDuplicateProtocol    = errors.New("protocol already allocated")
+	ErrBelowMinDeposit      = errors.New("deposit amount is below the minimum required for this protocol")
 )
 
 const (

--- a/apps/api/internal/domain/webhook/model.go
+++ b/apps/api/internal/domain/webhook/model.go
@@ -1,0 +1,29 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrWebhookNotFound = errors.New("webhook not found")
+	ErrInvalidWebhook  = errors.New("invalid webhook")
+)
+
+type Webhook struct {
+	ID        uuid.UUID `json:"id"`
+	UserID    uuid.UUID `json:"user_id"`
+	URL       string    `json:"url"`
+	Secret    string    `json:"secret,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type Repository interface {
+	Create(ctx context.Context, wh *Webhook) error
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]Webhook, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*Webhook, error)
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+}

--- a/apps/api/internal/domain/yieldharvest/model.go
+++ b/apps/api/internal/domain/yieldharvest/model.go
@@ -1,0 +1,49 @@
+package yieldharvest
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+var ErrNotFound = errors.New("yield harvest not found")
+
+// YieldHarvest represents a single recorded harvest event.
+type YieldHarvest struct {
+	ID          uuid.UUID       `json:"id"`
+	UserID      uuid.UUID       `json:"user_id"`
+	VaultID     uuid.UUID       `json:"vault_id"`
+	Amount      decimal.Decimal `json:"amount"`
+	Currency    string          `json:"currency"`
+	Protocol    string          `json:"protocol,omitempty"`
+	HarvestedAt time.Time       `json:"harvested_at"`
+	TxHash      string          `json:"tx_hash,omitempty"`
+}
+
+// CreateInput carries the fields needed to persist a new harvest record.
+type CreateInput struct {
+	UserID      uuid.UUID
+	VaultID     uuid.UUID
+	Amount      decimal.Decimal
+	Currency    string
+	HarvestedAt time.Time
+	TxHash      string
+}
+
+// ListFilter carries pagination and optional filtering parameters.
+type ListFilter struct {
+	UserID uuid.UUID
+	// CursorTime and CursorID together form the keyset cursor (harvested_at DESC, id DESC).
+	CursorTime *time.Time
+	CursorID   *uuid.UUID
+	Limit      int
+}
+
+// Repository is the persistence contract for yield harvest records.
+type Repository interface {
+	Create(ctx context.Context, input CreateInput) (YieldHarvest, error)
+	ListForUser(ctx context.Context, filter ListFilter) ([]YieldHarvest, error)
+}

--- a/apps/api/internal/handler/apy_handler.go
+++ b/apps/api/internal/handler/apy_handler.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/apysnapshot"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+type APYHistoryProvider interface {
+	GetHistory(ctx context.Context, slug string) (*service.APYHistoryResponse, error)
+}
+
+type APYHandler struct {
+	svc APYHistoryProvider
+}
+
+func NewAPYHandler(svc APYHistoryProvider) *APYHandler {
+	return &APYHandler{svc: svc}
+}
+
+func (h *APYHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/yields/{protocol_slug}/apy-history", h.getAPYHistory)
+}
+
+func (h *APYHandler) getAPYHistory(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("protocol_slug")
+	if slug == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("protocol_slug is required"))
+		return
+	}
+
+	history, err := h.svc.GetHistory(r.Context(), slug)
+	if err != nil {
+		if errors.Is(err, apysnapshot.ErrProtocolNotFound) {
+			response.WriteJSON(w, http.StatusNotFound, response.NotFound("protocol"))
+			return
+		}
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "failed to retrieve APY history"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(history))
+}

--- a/apps/api/internal/handler/apy_handler_test.go
+++ b/apps/api/internal/handler/apy_handler_test.go
@@ -1,0 +1,241 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/apysnapshot"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// mockAPYRepo is an in-memory implementation of apysnapshot.Repository for tests.
+type mockAPYRepo struct {
+	snapshots []apysnapshot.APYSnapshot
+	upserted  []apysnapshot.APYSnapshot
+	pruned    []time.Duration
+}
+
+func (m *mockAPYRepo) Upsert(_ context.Context, snap apysnapshot.APYSnapshot) error {
+	m.upserted = append(m.upserted, snap)
+	m.snapshots = append(m.snapshots, snap)
+	return nil
+}
+
+func (m *mockAPYRepo) ListByProtocol(_ context.Context, slug string, since time.Time) ([]apysnapshot.APYSnapshot, error) {
+	var out []apysnapshot.APYSnapshot
+	for _, s := range m.snapshots {
+		if s.ProtocolSlug == slug && !s.CapturedAt.Before(since) {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func (m *mockAPYRepo) PruneOlderThan(_ context.Context, age time.Duration) error {
+	m.pruned = append(m.pruned, age)
+	cutoff := time.Now().UTC().Add(-age)
+	var remaining []apysnapshot.APYSnapshot
+	for _, s := range m.snapshots {
+		if !s.CapturedAt.Before(cutoff) {
+			remaining = append(remaining, s)
+		}
+	}
+	m.snapshots = remaining
+	return nil
+}
+
+// newAPYTestServer wires a mock DeFiLlama server → APYService → APYHandler.
+func newAPYTestServer(t *testing.T, defiLlamaBody string) (*httptest.Server, *mockAPYRepo) {
+	t.Helper()
+
+	defiLlama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(defiLlamaBody))
+	}))
+	t.Cleanup(defiLlama.Close)
+
+	repo := &mockAPYRepo{}
+	svc := service.NewAPYServiceWithClient(repo, defiLlama.URL, defiLlama.Client())
+	mux := http.NewServeMux()
+	NewAPYHandler(svc).Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, repo
+}
+
+// TestAPYPoller_SuccessfulPolling verifies that snapshots are written for Stellar pools.
+func TestAPYPoller_SuccessfulPolling(t *testing.T) {
+	const body = `{"data":[
+		{"project":"blend","chain":"Stellar","apy":5.23,"tvlUsd":1000000},
+		{"project":"aqua","chain":"Stellar","apy":8.10,"tvlUsd":500000},
+		{"project":"ethereum-pool","chain":"Ethereum","apy":4.00,"tvlUsd":9000000}
+	]}`
+
+	repo := &mockAPYRepo{}
+	defiLlama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(defiLlama.Close)
+
+	svc := service.NewAPYServiceWithClient(repo, defiLlama.URL, defiLlama.Client())
+	svc.PollOnce(context.Background())
+
+	if len(repo.upserted) != 2 {
+		t.Fatalf("expected 2 upserted snapshots (Stellar only), got %d", len(repo.upserted))
+	}
+	slugs := map[string]bool{}
+	for _, s := range repo.upserted {
+		slugs[s.ProtocolSlug] = true
+	}
+	if !slugs["blend"] || !slugs["aqua"] {
+		t.Fatalf("expected blend and aqua, got %v", slugs)
+	}
+}
+
+// TestAPYHandler_APIResponse verifies GET /api/v1/yields/{slug}/apy-history shape.
+func TestAPYHandler_APIResponse(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockAPYRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.23), TVL: decimal.NewFromFloat(1000000), CapturedAt: now.Add(-2 * 24 * time.Hour)},
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.50), TVL: decimal.NewFromFloat(1100000), CapturedAt: now.Add(-1 * 24 * time.Hour)},
+		},
+	}
+	svc := service.NewAPYService(repo)
+	mux := http.NewServeMux()
+	NewAPYHandler(svc).Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/blend/apy-history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Data service.APYHistoryResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+
+	if body.Data.ProtocolSlug != "blend" {
+		t.Errorf("protocol_slug = %q, want %q", body.Data.ProtocolSlug, "blend")
+	}
+	if len(body.Data.Snapshots) != 2 {
+		t.Fatalf("snapshots count = %d, want 2", len(body.Data.Snapshots))
+	}
+	if body.Data.Snapshots[0].APY != "5.2300" {
+		t.Errorf("snapshot[0].apy = %q, want %q", body.Data.Snapshots[0].APY, "5.2300")
+	}
+}
+
+// TestAPYHandler_SummaryCalculations verifies avg/min/max computation.
+func TestAPYHandler_SummaryCalculations(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockAPYRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(4.00), TVL: decimal.Zero, CapturedAt: now.Add(-3 * 24 * time.Hour)},
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(6.00), TVL: decimal.Zero, CapturedAt: now.Add(-2 * 24 * time.Hour)},
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.00), TVL: decimal.Zero, CapturedAt: now.Add(-1 * 24 * time.Hour)},
+		},
+	}
+	svc := service.NewAPYService(repo)
+	history, err := svc.GetHistory(context.Background(), "blend")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if history.Summary.AvgAPY != "5.0000" {
+		t.Errorf("avg_apy = %q, want %q", history.Summary.AvgAPY, "5.0000")
+	}
+	if history.Summary.MinAPY != "4.0000" {
+		t.Errorf("min_apy = %q, want %q", history.Summary.MinAPY, "4.0000")
+	}
+	if history.Summary.MaxAPY != "6.0000" {
+		t.Errorf("max_apy = %q, want %q", history.Summary.MaxAPY, "6.0000")
+	}
+}
+
+// TestAPYHandler_Pruning verifies records older than 90 days are pruned.
+func TestAPYHandler_Pruning(t *testing.T) {
+	old := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	recent := time.Now().UTC().Add(-1 * 24 * time.Hour)
+
+	repo := &mockAPYRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.0), TVL: decimal.Zero, CapturedAt: old},
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.5), TVL: decimal.Zero, CapturedAt: recent},
+		},
+	}
+
+	if err := repo.PruneOlderThan(context.Background(), 90*24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(repo.snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot after pruning, got %d", len(repo.snapshots))
+	}
+	if repo.snapshots[0].CapturedAt.Equal(old) {
+		t.Error("old snapshot should have been pruned")
+	}
+}
+
+// TestAPYHandler_EmptyHistory verifies 404 when no snapshots exist for a protocol.
+func TestAPYHandler_EmptyHistory(t *testing.T) {
+	repo := &mockAPYRepo{}
+	svc := service.NewAPYService(repo)
+	mux := http.NewServeMux()
+	NewAPYHandler(svc).Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/unknown-protocol/apy-history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestAPYHandler_ProtocolNotFound verifies 404 when protocol has no data.
+func TestAPYHandler_ProtocolNotFound(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockAPYRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ID: uuid.New(), ProtocolSlug: "blend", APY: decimal.NewFromFloat(5.23), TVL: decimal.Zero, CapturedAt: now},
+		},
+	}
+	svc := service.NewAPYService(repo)
+	mux := http.NewServeMux()
+	NewAPYHandler(svc).Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/nonexistent/apy-history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -576,6 +576,8 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("user"))
 	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	case errors.Is(err, vault.ErrBelowMinDeposit):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:
 		logpkg.FromContext(r.Context()).Error("vault handler failed", "error", err.Error())
 		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))

--- a/apps/api/internal/handler/webhook_handler.go
+++ b/apps/api/internal/handler/webhook_handler.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+type WebhookManager interface {
+	Register(ctx context.Context, userID uuid.UUID, in service.RegisterWebhookInput) (webhook.Webhook, error)
+	List(ctx context.Context, userID uuid.UUID) ([]webhook.Webhook, error)
+	Delete(ctx context.Context, userID, id uuid.UUID) error
+}
+
+type WebhookHandler struct {
+	svc WebhookManager
+}
+
+func NewWebhookHandler(svc WebhookManager) *WebhookHandler {
+	return &WebhookHandler{svc: svc}
+}
+
+func (h *WebhookHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/webhooks", h.create)
+	mux.HandleFunc("GET /api/v1/webhooks", h.list)
+	mux.HandleFunc("DELETE /api/v1/webhooks/{id}", h.delete)
+}
+
+type registerWebhookRequest struct {
+	URL    string `json:"url"`
+	Secret string `json:"secret"`
+}
+
+func (h *WebhookHandler) create(w http.ResponseWriter, r *http.Request) {
+	userID, ok := webhookAuthenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8*1024))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("could not read request body"))
+		return
+	}
+	var req registerWebhookRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid JSON"))
+		return
+	}
+	if strings.TrimSpace(req.URL) == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("url is required"))
+		return
+	}
+	wh, err := h.svc.Register(r.Context(), userID, service.RegisterWebhookInput{
+		URL:    req.URL,
+		Secret: req.Secret,
+	})
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusCreated, response.Created(wh))
+}
+
+func (h *WebhookHandler) list(w http.ResponseWriter, r *http.Request) {
+	userID, ok := webhookAuthenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	hooks, err := h.svc.List(r.Context(), userID)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	if hooks == nil {
+		hooks = []webhook.Webhook{}
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(hooks))
+}
+
+func (h *WebhookHandler) delete(w http.ResponseWriter, r *http.Request) {
+	userID, ok := webhookAuthenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("webhook id must be a valid UUID"))
+		return
+	}
+	if err := h.svc.Delete(r.Context(), userID, id); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *WebhookHandler) writeError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, webhook.ErrWebhookNotFound):
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("webhook"))
+	case errors.Is(err, webhook.ErrInvalidWebhook):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	default:
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+	}
+}
+
+func webhookAuthenticatedUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return uuid.UUID{}, false
+	}
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "invalid user id"))
+		return uuid.UUID{}, false
+	}
+	return userID, true
+}

--- a/apps/api/internal/handler/webhook_handler_test.go
+++ b/apps/api/internal/handler/webhook_handler_test.go
@@ -1,0 +1,198 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+	"github.com/suncrestlabs/nester/apps/api/internal/handler"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// --- stub WebhookService ---
+
+type stubWebhookSvc struct {
+	hooks  []webhook.Webhook
+	err    error
+	called int
+}
+
+func (s *stubWebhookSvc) Register(_ context.Context, userID uuid.UUID, in service.RegisterWebhookInput) (webhook.Webhook, error) {
+	if s.err != nil {
+		return webhook.Webhook{}, s.err
+	}
+	wh := webhook.Webhook{
+		ID:        uuid.New(),
+		UserID:    userID,
+		URL:       in.URL,
+		Secret:    in.Secret,
+		CreatedAt: time.Now().UTC(),
+	}
+	s.hooks = append(s.hooks, wh)
+	return wh, nil
+}
+
+func (s *stubWebhookSvc) List(_ context.Context, _ uuid.UUID) ([]webhook.Webhook, error) {
+	return s.hooks, s.err
+}
+
+func (s *stubWebhookSvc) Delete(_ context.Context, _, id uuid.UUID) error {
+	s.called++
+	if s.err != nil {
+		return s.err
+	}
+	for i, wh := range s.hooks {
+		if wh.ID == id {
+			s.hooks = append(s.hooks[:i], s.hooks[i+1:]...)
+			return nil
+		}
+	}
+	return webhook.ErrWebhookNotFound
+}
+
+// --- helpers ---
+
+func authedRequest(method, target string, body []byte, userID uuid.UUID) *http.Request {
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, target, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+	ctx := auth.NewContext(req.Context(), auth.User{ID: userID.String()})
+	return req.WithContext(ctx)
+}
+
+// --- tests ---
+
+func TestWebhookHandler_Create_Returns201(t *testing.T) {
+	svc := &stubWebhookSvc{}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	userID := uuid.New()
+	body, _ := json.Marshal(map[string]string{"url": "https://example.com/hook", "secret": "s3cr3t"})
+	req := authedRequest(http.MethodPost, "/api/v1/webhooks", body, userID)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["success"] != true {
+		t.Errorf("expected success=true, got %v", out["success"])
+	}
+	data := out["data"].(map[string]any)
+	if data["url"] != "https://example.com/hook" {
+		t.Errorf("unexpected url: %v", data["url"])
+	}
+}
+
+func TestWebhookHandler_Create_MissingURL_Returns400(t *testing.T) {
+	svc := &stubWebhookSvc{}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	userID := uuid.New()
+	body, _ := json.Marshal(map[string]string{"url": "", "secret": ""})
+	req := authedRequest(http.MethodPost, "/api/v1/webhooks", body, userID)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestWebhookHandler_List_ReturnsWebhooks(t *testing.T) {
+	userID := uuid.New()
+	svc := &stubWebhookSvc{
+		hooks: []webhook.Webhook{
+			{ID: uuid.New(), UserID: userID, URL: "https://example.com/hook", CreatedAt: time.Now()},
+		},
+	}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := authedRequest(http.MethodGet, "/api/v1/webhooks", nil, userID)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &out)
+	data := out["data"].([]any)
+	if len(data) != 1 {
+		t.Errorf("expected 1 webhook, got %d", len(data))
+	}
+}
+
+func TestWebhookHandler_Delete_Returns204(t *testing.T) {
+	userID := uuid.New()
+	whID := uuid.New()
+	svc := &stubWebhookSvc{
+		hooks: []webhook.Webhook{
+			{ID: whID, UserID: userID, URL: "https://example.com/hook", CreatedAt: time.Now()},
+		},
+	}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := authedRequest(http.MethodDelete, "/api/v1/webhooks/"+whID.String(), nil, userID)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWebhookHandler_Delete_NotFound_Returns404(t *testing.T) {
+	svc := &stubWebhookSvc{err: webhook.ErrWebhookNotFound}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	userID := uuid.New()
+	req := authedRequest(http.MethodDelete, "/api/v1/webhooks/"+uuid.New().String(), nil, userID)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestWebhookHandler_Unauthenticated_Returns401(t *testing.T) {
+	svc := &stubWebhookSvc{}
+	h := handler.NewWebhookHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/webhooks", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}

--- a/apps/api/internal/handler/yield_harvest_handler.go
+++ b/apps/api/internal/handler/yield_harvest_handler.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// yieldHarvestServicer is the service surface the handler depends on.
+type yieldHarvestServicer interface {
+	ListHarvests(ctx context.Context, input service.ListYieldHarvestsInput) (service.ListYieldHarvestsOutput, error)
+}
+
+// YieldHarvestHandler serves GET /api/v1/yields/harvests.
+type YieldHarvestHandler struct {
+	svc yieldHarvestServicer
+}
+
+// NewYieldHarvestHandler constructs a YieldHarvestHandler.
+func NewYieldHarvestHandler(svc yieldHarvestServicer) *YieldHarvestHandler {
+	return &YieldHarvestHandler{svc: svc}
+}
+
+// Register mounts the handler's routes on mux.
+func (h *YieldHarvestHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/yields/harvests", h.ListHarvests)
+}
+
+// ListHarvests handles GET /api/v1/yields/harvests.
+func (h *YieldHarvestHandler) ListHarvests(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid token subject"))
+		return
+	}
+
+	q := r.URL.Query()
+
+	limit := 20
+	if raw := q.Get("limit"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 1 {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("limit must be a positive integer"))
+			return
+		}
+		if v > 100 {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("limit must not exceed 100"))
+			return
+		}
+		limit = v
+	}
+
+	out, err := h.svc.ListHarvests(r.Context(), service.ListYieldHarvestsInput{
+		UserID: userID,
+		Cursor: q.Get("cursor"),
+		Limit:  limit,
+	})
+	if err != nil {
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "failed to list yield harvests"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(out))
+}

--- a/apps/api/internal/handler/yield_harvest_handler_test.go
+++ b/apps/api/internal/handler/yield_harvest_handler_test.go
@@ -1,0 +1,189 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/yieldharvest"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// fakeYieldHarvestService is a test double for yieldHarvestServicer.
+type fakeYieldHarvestService struct {
+	output service.ListYieldHarvestsOutput
+	err    error
+	// captures the last call arguments for assertion
+	lastInput service.ListYieldHarvestsInput
+}
+
+func (f *fakeYieldHarvestService) ListHarvests(_ context.Context, input service.ListYieldHarvestsInput) (service.ListYieldHarvestsOutput, error) {
+	f.lastInput = input
+	return f.output, f.err
+}
+
+func newYieldHarvestServer(t *testing.T, userID uuid.UUID, svc yieldHarvestServicer) *httptest.Server {
+	t.Helper()
+	h := NewYieldHarvestHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return httptest.NewServer(
+		fakeAuthMiddleware(userID)(
+			middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux),
+		),
+	)
+}
+
+func decodeYieldHarvestData(t *testing.T, body io.Reader) service.ListYieldHarvestsOutput {
+	t.Helper()
+	var env struct {
+		Success bool                        `json:"success"`
+		Data    service.ListYieldHarvestsOutput `json:"data"`
+	}
+	if err := json.NewDecoder(body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return env.Data
+}
+
+func TestYieldHarvestHandler_Unauthenticated(t *testing.T) {
+	svc := &fakeYieldHarvestService{}
+	h := NewYieldHarvestHandler(svc)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	// No auth middleware — context has no user.
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/harvests")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestYieldHarvestHandler_EmptyHistory(t *testing.T) {
+	userID := uuid.New()
+	svc := &fakeYieldHarvestService{
+		output: service.ListYieldHarvestsOutput{Items: []yieldharvest.YieldHarvest{}, NextCursor: ""},
+	}
+	srv := newYieldHarvestServer(t, userID, svc)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/harvests")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	out := decodeYieldHarvestData(t, resp.Body)
+	if len(out.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(out.Items))
+	}
+	if out.NextCursor != "" {
+		t.Errorf("expected empty next_cursor, got %q", out.NextCursor)
+	}
+}
+
+func TestYieldHarvestHandler_MultipleHarvests(t *testing.T) {
+	userID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+	items := []yieldharvest.YieldHarvest{
+		{ID: uuid.New(), UserID: userID, VaultID: uuid.New(), Amount: decimal.NewFromFloat(10.5), Currency: "USDC", Protocol: "blend", HarvestedAt: now, TxHash: "abc123"},
+		{ID: uuid.New(), UserID: userID, VaultID: uuid.New(), Amount: decimal.NewFromFloat(5.25), Currency: "USDC", Protocol: "blend", HarvestedAt: now.Add(-time.Hour), TxHash: "def456"},
+	}
+	svc := &fakeYieldHarvestService{
+		output: service.ListYieldHarvestsOutput{Items: items, NextCursor: ""},
+	}
+	srv := newYieldHarvestServer(t, userID, svc)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/harvests")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	out := decodeYieldHarvestData(t, resp.Body)
+	if len(out.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(out.Items))
+	}
+}
+
+func TestYieldHarvestHandler_Pagination(t *testing.T) {
+	userID := uuid.New()
+	nextCursor := "bmV4dC1wYWdl" // arbitrary base64
+	svc := &fakeYieldHarvestService{
+		output: service.ListYieldHarvestsOutput{
+			Items:      []yieldharvest.YieldHarvest{{ID: uuid.New(), UserID: userID, VaultID: uuid.New(), Amount: decimal.NewFromInt(1), Currency: "USDC"}},
+			NextCursor: nextCursor,
+		},
+	}
+	srv := newYieldHarvestServer(t, userID, svc)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/harvests?limit=1")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	out := decodeYieldHarvestData(t, resp.Body)
+	if out.NextCursor != nextCursor {
+		t.Errorf("expected next_cursor %q, got %q", nextCursor, out.NextCursor)
+	}
+	if svc.lastInput.Limit != 1 {
+		t.Errorf("expected limit 1 forwarded to service, got %d", svc.lastInput.Limit)
+	}
+}
+
+func TestYieldHarvestHandler_CursorForwarded(t *testing.T) {
+	userID := uuid.New()
+	cursor := "dGVzdC1jdXJzb3I="
+	svc := &fakeYieldHarvestService{
+		output: service.ListYieldHarvestsOutput{Items: nil, NextCursor: ""},
+	}
+	srv := newYieldHarvestServer(t, userID, svc)
+	defer srv.Close()
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/yields/harvests?cursor=%s", srv.URL, cursor))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if svc.lastInput.Cursor != cursor {
+		t.Errorf("expected cursor %q forwarded, got %q", cursor, svc.lastInput.Cursor)
+	}
+}
+
+func TestYieldHarvestHandler_InvalidLimit(t *testing.T) {
+	userID := uuid.New()
+	svc := &fakeYieldHarvestService{}
+	srv := newYieldHarvestServer(t, userID, svc)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/yields/harvests?limit=abc")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/repository/postgres/apy_snapshot_repository.go
+++ b/apps/api/internal/repository/postgres/apy_snapshot_repository.go
@@ -1,0 +1,110 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/apysnapshot"
+)
+
+type APYSnapshotRepository struct {
+	db *sql.DB
+}
+
+func NewAPYSnapshotRepository(db *sql.DB) *APYSnapshotRepository {
+	return &APYSnapshotRepository{db: db}
+}
+
+func (r *APYSnapshotRepository) Upsert(ctx context.Context, snap apysnapshot.APYSnapshot) error {
+	const q = `
+		INSERT INTO apy_snapshots (id, protocol_slug, apy, tvl, captured_at)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT DO NOTHING`
+	_, err := r.db.ExecContext(ctx, q,
+		snap.ID,
+		snap.ProtocolSlug,
+		snap.APY.String(),
+		snap.TVL.String(),
+		snap.CapturedAt,
+	)
+	return err
+}
+
+func (r *APYSnapshotRepository) ListByProtocol(ctx context.Context, slug string, since time.Time) ([]apysnapshot.APYSnapshot, error) {
+	const q = `
+		SELECT id, protocol_slug, apy, tvl, captured_at
+		FROM apy_snapshots
+		WHERE protocol_slug = $1
+		  AND captured_at >= $2
+		ORDER BY captured_at ASC`
+
+	rows, err := r.db.QueryContext(ctx, q, slug, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var snaps []apysnapshot.APYSnapshot
+	for rows.Next() {
+		s, err := scanAPYSnapshot(rows)
+		if err != nil {
+			return nil, err
+		}
+		snaps = append(snaps, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return snaps, nil
+}
+
+func (r *APYSnapshotRepository) PruneOlderThan(ctx context.Context, age time.Duration) error {
+	cutoff := time.Now().UTC().Add(-age)
+	const q = `DELETE FROM apy_snapshots WHERE captured_at < $1`
+	_, err := r.db.ExecContext(ctx, q, cutoff)
+	return err
+}
+
+func scanAPYSnapshot(row interface {
+	Scan(dest ...any) error
+}) (apysnapshot.APYSnapshot, error) {
+	var (
+		id           string
+		protocolSlug string
+		apy          string
+		tvl          string
+		capturedAt   time.Time
+	)
+	if err := row.Scan(&id, &protocolSlug, &apy, &tvl, &capturedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apysnapshot.APYSnapshot{}, apysnapshot.ErrProtocolNotFound
+		}
+		return apysnapshot.APYSnapshot{}, err
+	}
+
+	parsedID, err := uuid.Parse(id)
+	if err != nil {
+		return apysnapshot.APYSnapshot{}, err
+	}
+	apyDec, err := decimal.NewFromString(apy)
+	if err != nil {
+		return apysnapshot.APYSnapshot{}, err
+	}
+	tvlDec, err := decimal.NewFromString(tvl)
+	if err != nil {
+		return apysnapshot.APYSnapshot{}, err
+	}
+
+	return apysnapshot.APYSnapshot{
+		ID:           parsedID,
+		ProtocolSlug: protocolSlug,
+		APY:          apyDec,
+		TVL:          tvlDec,
+		CapturedAt:   capturedAt,
+	}, nil
+}

--- a/apps/api/internal/repository/postgres/webhook_repository.go
+++ b/apps/api/internal/repository/postgres/webhook_repository.go
@@ -1,0 +1,109 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+)
+
+type WebhookRepository struct {
+	db *sql.DB
+}
+
+func NewWebhookRepository(db *sql.DB) *WebhookRepository {
+	return &WebhookRepository{db: db}
+}
+
+func (r *WebhookRepository) Create(ctx context.Context, wh *webhook.Webhook) error {
+	return r.db.QueryRowContext(ctx, `
+		INSERT INTO webhooks (id, user_id, url, secret)
+		VALUES ($1, $2, $3, $4)
+		RETURNING created_at
+	`, wh.ID, wh.UserID, wh.URL, nullSQLString(wh.Secret)).Scan(&wh.CreatedAt)
+}
+
+func (r *WebhookRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]webhook.Webhook, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, user_id, url, secret, created_at
+		FROM webhooks
+		WHERE user_id = $1
+		ORDER BY created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []webhook.Webhook
+	for rows.Next() {
+		wh, err := scanWebhook(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, wh)
+	}
+	return out, rows.Err()
+}
+
+func (r *WebhookRepository) GetByID(ctx context.Context, id uuid.UUID) (*webhook.Webhook, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, user_id, url, secret, created_at
+		FROM webhooks WHERE id = $1
+	`, id)
+	wh, err := scanWebhook(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, webhook.ErrWebhookNotFound
+		}
+		return nil, err
+	}
+	return &wh, nil
+}
+
+func (r *WebhookRepository) Delete(ctx context.Context, id, userID uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM webhooks WHERE id = $1 AND user_id = $2
+	`, id, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return webhook.ErrWebhookNotFound
+	}
+	return nil
+}
+
+type webhookScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanWebhook(row webhookScanner) (webhook.Webhook, error) {
+	var (
+		id, userID string
+		url        string
+		secret     sql.NullString
+		createdAt  time.Time
+	)
+	if err := row.Scan(&id, &userID, &url, &secret, &createdAt); err != nil {
+		return webhook.Webhook{}, err
+	}
+	parsedID, _ := uuid.Parse(id)
+	parsedUserID, _ := uuid.Parse(userID)
+	secretVal := ""
+	if secret.Valid {
+		secretVal = secret.String
+	}
+	return webhook.Webhook{
+		ID:        parsedID,
+		UserID:    parsedUserID,
+		URL:       url,
+		Secret:    secretVal,
+		CreatedAt: createdAt,
+	}, nil
+}

--- a/apps/api/internal/repository/postgres/yield_harvest_repository.go
+++ b/apps/api/internal/repository/postgres/yield_harvest_repository.go
@@ -1,0 +1,156 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/yieldharvest"
+)
+
+// YieldHarvestRepository implements yieldharvest.Repository using Postgres.
+type YieldHarvestRepository struct {
+	db *sql.DB
+}
+
+// NewYieldHarvestRepository constructs a YieldHarvestRepository.
+func NewYieldHarvestRepository(db *sql.DB) *YieldHarvestRepository {
+	return &YieldHarvestRepository{db: db}
+}
+
+// Create inserts a new yield_harvests row and returns the persisted record.
+func (r *YieldHarvestRepository) Create(ctx context.Context, input yieldharvest.CreateInput) (yieldharvest.YieldHarvest, error) {
+	if input.HarvestedAt.IsZero() {
+		input.HarvestedAt = time.Now().UTC()
+	}
+
+	const q = `
+		INSERT INTO yield_harvests (user_id, vault_id, amount, currency, harvested_at, tx_hash)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, user_id, vault_id, amount, currency, harvested_at, tx_hash`
+
+	row := r.db.QueryRowContext(ctx, q,
+		input.UserID,
+		input.VaultID,
+		input.Amount,
+		input.Currency,
+		input.HarvestedAt,
+		nullableString(input.TxHash),
+	)
+
+	return scanYieldHarvest(row)
+}
+
+// ListForUser returns harvest records for a user with keyset cursor pagination.
+// Results are ordered (harvested_at DESC, id DESC). An optional protocol value
+// is resolved by joining vault_allocations to surface the primary protocol.
+func (r *YieldHarvestRepository) ListForUser(ctx context.Context, filter yieldharvest.ListFilter) ([]yieldharvest.YieldHarvest, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	args := []any{filter.UserID, limit}
+	where := "yh.user_id = $1"
+
+	if filter.CursorTime != nil && filter.CursorID != nil {
+		args = append(args, *filter.CursorTime, *filter.CursorID)
+		idx := len(args) - 1
+		where += fmt.Sprintf(" AND (yh.harvested_at, yh.id) < ($%d, $%d)", idx, idx+1)
+	}
+
+	q := fmt.Sprintf(`
+		SELECT
+			yh.id,
+			yh.user_id,
+			yh.vault_id,
+			yh.amount,
+			yh.currency,
+			COALESCE(va.protocol, '') AS protocol,
+			yh.harvested_at,
+			COALESCE(yh.tx_hash, '') AS tx_hash
+		FROM yield_harvests yh
+		LEFT JOIN LATERAL (
+			SELECT protocol
+			FROM vault_allocations
+			WHERE vault_id = yh.vault_id
+			ORDER BY allocated_at DESC
+			LIMIT 1
+		) va ON true
+		WHERE %s
+		ORDER BY yh.harvested_at DESC, yh.id DESC
+		LIMIT $2`, where)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("yield_harvests list: %w", err)
+	}
+	defer rows.Close()
+
+	var results []yieldharvest.YieldHarvest
+	for rows.Next() {
+		var h yieldharvest.YieldHarvest
+		var amountStr string
+		if err := rows.Scan(
+			&h.ID,
+			&h.UserID,
+			&h.VaultID,
+			&amountStr,
+			&h.Currency,
+			&h.Protocol,
+			&h.HarvestedAt,
+			&h.TxHash,
+		); err != nil {
+			return nil, fmt.Errorf("yield_harvests scan: %w", err)
+		}
+		h.Amount, err = decimal.NewFromString(amountStr)
+		if err != nil {
+			return nil, fmt.Errorf("yield_harvests parse amount: %w", err)
+		}
+		results = append(results, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("yield_harvests rows: %w", err)
+	}
+	return results, nil
+}
+
+func scanYieldHarvest(row *sql.Row) (yieldharvest.YieldHarvest, error) {
+	var h yieldharvest.YieldHarvest
+	var amountStr string
+	var txHash sql.NullString
+	if err := row.Scan(
+		&h.ID,
+		&h.UserID,
+		&h.VaultID,
+		&amountStr,
+		&h.Currency,
+		&h.HarvestedAt,
+		&txHash,
+	); err != nil {
+		return yieldharvest.YieldHarvest{}, fmt.Errorf("yield_harvest scan: %w", err)
+	}
+	amount, err := decimal.NewFromString(amountStr)
+	if err != nil {
+		return yieldharvest.YieldHarvest{}, fmt.Errorf("yield_harvest parse amount: %w", err)
+	}
+	h.Amount = amount
+	if txHash.Valid {
+		h.TxHash = txHash.String
+	}
+	return h, nil
+}
+
+// nullableString returns nil when s is empty so Postgres stores NULL instead of "".
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/apps/api/internal/service/apy_service.go
+++ b/apps/api/internal/service/apy_service.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/apysnapshot"
+)
+
+const (
+	apyPollInterval  = 6 * time.Hour
+	apyHistoryWindow = 30 * 24 * time.Hour
+	apyPruneAge      = 90 * 24 * time.Hour
+)
+
+type APYHistoryEntry struct {
+	Date string `json:"date"`
+	APY  string `json:"apy"`
+	TVL  string `json:"tvl"`
+}
+
+type APYHistorySummary struct {
+	AvgAPY string `json:"avg_apy"`
+	MinAPY string `json:"min_apy"`
+	MaxAPY string `json:"max_apy"`
+}
+
+type APYHistoryResponse struct {
+	ProtocolSlug string            `json:"protocol_slug"`
+	Snapshots    []APYHistoryEntry `json:"snapshots"`
+	Summary      APYHistorySummary `json:"summary"`
+}
+
+type APYService struct {
+	repo         apysnapshot.Repository
+	httpClient   *http.Client
+	defiLlamaURL string
+	logger       *slog.Logger
+}
+
+func NewAPYService(repo apysnapshot.Repository) *APYService {
+	return &APYService{
+		repo:            repo,
+		httpClient:      &http.Client{Timeout: 15 * time.Second},
+		defiLlamaURL:    "https://yields.llama.fi/pools",
+		logger:          slog.Default(),
+	}
+}
+
+// NewAPYServiceWithClient creates an APYService with a custom HTTP client and base URL,
+// used for testing with a mock DeFiLlama server.
+func NewAPYServiceWithClient(repo apysnapshot.Repository, defiLlamaURL string, client *http.Client) *APYService {
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &APYService{
+		repo:         repo,
+		httpClient:   client,
+		defiLlamaURL: defiLlamaURL + "/pools",
+		logger:       slog.Default(),
+	}
+}
+
+// PollOnce runs a single poll cycle (fetch + upsert + prune). Exported for testing.
+func (s *APYService) PollOnce(ctx context.Context) {
+	s.poll(ctx)
+}
+
+func (s *APYService) StartScheduler(ctx context.Context) {
+	ticker := time.NewTicker(apyPollInterval)
+	defer ticker.Stop()
+	s.poll(ctx)
+	for {
+		select {
+		case <-ticker.C:
+			s.poll(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *APYService) poll(ctx context.Context) {
+	snapshots, err := s.fetchFromDeFiLlama(ctx)
+	if err != nil {
+		s.logger.Error("apy poller: fetch failed", "error", err.Error())
+		return
+	}
+	for _, snap := range snapshots {
+		if err := s.repo.Upsert(ctx, snap); err != nil {
+			s.logger.Error("apy poller: upsert failed", "protocol", snap.ProtocolSlug, "error", err.Error())
+		}
+	}
+	if err := s.repo.PruneOlderThan(ctx, apyPruneAge); err != nil {
+		s.logger.Error("apy poller: prune failed", "error", err.Error())
+	}
+}
+
+func (s *APYService) fetchFromDeFiLlama(ctx context.Context) ([]apysnapshot.APYSnapshot, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.defiLlamaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data []struct {
+			Project string  `json:"project"`
+			Chain   string  `json:"chain"`
+			APY     float64 `json:"apy"`
+			TVLUsd  float64 `json:"tvlUsd"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	var snapshots []apysnapshot.APYSnapshot
+	seen := map[string]bool{}
+	for _, pool := range result.Data {
+		if strings.EqualFold(pool.Chain, "Stellar") && !seen[pool.Project] {
+			seen[pool.Project] = true
+			snapshots = append(snapshots, apysnapshot.APYSnapshot{
+				ID:           uuid.New(),
+				ProtocolSlug: pool.Project,
+				APY:          decimal.NewFromFloat(pool.APY),
+				TVL:          decimal.NewFromFloat(pool.TVLUsd),
+				CapturedAt:   now,
+			})
+		}
+	}
+	return snapshots, nil
+}
+
+func (s *APYService) GetHistory(ctx context.Context, slug string) (*APYHistoryResponse, error) {
+	since := time.Now().UTC().Add(-apyHistoryWindow)
+	snaps, err := s.repo.ListByProtocol(ctx, slug, since)
+	if err != nil {
+		return nil, err
+	}
+	if len(snaps) == 0 {
+		return nil, apysnapshot.ErrProtocolNotFound
+	}
+
+	entries := make([]APYHistoryEntry, len(snaps))
+	minAPY := snaps[0].APY
+	maxAPY := snaps[0].APY
+	sumAPY := decimal.Zero
+
+	for i, snap := range snaps {
+		entries[i] = APYHistoryEntry{
+			Date: snap.CapturedAt.Format("2006-01-02"),
+			APY:  snap.APY.StringFixed(4),
+			TVL:  snap.TVL.StringFixed(6),
+		}
+		if snap.APY.LessThan(minAPY) {
+			minAPY = snap.APY
+		}
+		if snap.APY.GreaterThan(maxAPY) {
+			maxAPY = snap.APY
+		}
+		sumAPY = sumAPY.Add(snap.APY)
+	}
+
+	avgAPY := sumAPY.Div(decimal.NewFromInt(int64(len(snaps))))
+
+	return &APYHistoryResponse{
+		ProtocolSlug: slug,
+		Snapshots:    entries,
+		Summary: APYHistorySummary{
+			AvgAPY: avgAPY.StringFixed(4),
+			MinAPY: minAPY.StringFixed(4),
+			MaxAPY: maxAPY.StringFixed(4),
+		},
+	}, nil
+}

--- a/apps/api/internal/service/export_test.go
+++ b/apps/api/internal/service/export_test.go
@@ -1,0 +1,13 @@
+package service
+
+import "github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+
+// DeliverWebhookForTest runs delivery with no sleep between retries (for fast tests).
+func DeliverWebhookForTest(wh webhook.Webhook, payload []byte) {
+	const maxAttempts = 3
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if deliver(wh, payload) {
+			return
+		}
+	}
+}

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -58,6 +58,7 @@ type VaultService struct {
 	repository             vault.Repository
 	depositInvoker         VaultDepositInvoker
 	defaultHarvestCompound bool
+	yieldRecorder          YieldHarvestRecorder
 }
 
 // ── Input types ──────────────────────────────────────────────────────────────
@@ -117,6 +118,12 @@ func (s *VaultService) SetDepositInvoker(invoker VaultDepositInvoker) {
 // SetHarvestDefaultCompound configures the compound flag when the request omits it.
 func (s *VaultService) SetHarvestDefaultCompound(compound bool) {
 	s.defaultHarvestCompound = compound
+}
+
+// SetYieldHarvestRecorder wires an optional recorder that persists yield harvest
+// history entries whenever HarvestVault succeeds.
+func (s *VaultService) SetYieldHarvestRecorder(recorder YieldHarvestRecorder) {
+	s.yieldRecorder = recorder
 }
 
 // ── Existing methods ─────────────────────────────────────────────────────────
@@ -568,6 +575,17 @@ func (s *VaultService) HarvestVault(ctx context.Context, input HarvestVaultInput
 		TransactionHash: txHash,
 	}); err != nil {
 		return HarvestResult{}, err
+	}
+
+	if s.yieldRecorder != nil {
+		_ = s.yieldRecorder.RecordHarvest(ctx, YieldHarvestRecord{
+			UserID:      input.UserID,
+			VaultID:     input.VaultID,
+			Amount:      netYield,
+			Currency:    existing.Currency,
+			HarvestedAt: time.Now().UTC(),
+			TxHash:      txHash,
+		})
 	}
 
 	return HarvestResult{

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -216,6 +216,9 @@ func (s *VaultService) RecordDeposit(ctx context.Context, input RecordDepositInp
 	if s.depositInvoker != nil {
 		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
 		if err := s.depositInvoker.DepositToVault(ctx, existing.ContractAddress, stroops); err != nil {
+			if strings.Contains(err.Error(), "#21") {
+				return vault.Vault{}, vault.ErrBelowMinDeposit
+			}
 			return vault.Vault{}, fmt.Errorf("on-chain deposit failed: %w", err)
 		}
 	}

--- a/apps/api/internal/service/webhook_notifier.go
+++ b/apps/api/internal/service/webhook_notifier.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+// WebhookGoalMilestoneNotifier fires webhooks on goal milestones and deadline breaches.
+type WebhookGoalMilestoneNotifier struct {
+	Svc *WebhookService
+}
+
+func (n WebhookGoalMilestoneNotifier) SendGoalMilestone(
+	ctx context.Context,
+	userID uuid.UUID,
+	goal savingsgoal.SavingsGoal,
+	milestone int,
+) {
+	if n.Svc == nil {
+		return
+	}
+	var event string
+	switch milestone {
+	case 25, 50, 75, 100:
+		event = fmt.Sprintf("goal.milestone.%d", milestone)
+	case -1:
+		event = "goal.deadline_breach"
+	default:
+		event = fmt.Sprintf("goal.milestone.%d", milestone)
+	}
+
+	milestonePct := milestone
+	if milestone == -1 {
+		milestonePct = 0
+	}
+
+	payload, err := BuildWebhookPayload(
+		event,
+		goal.ID,
+		userID,
+		milestonePct,
+		goal.CurrentAmount.String(),
+		goal.TargetAmount.String(),
+	)
+	if err != nil {
+		return
+	}
+	n.Svc.FireForUser(ctx, userID, event, payload)
+}
+
+// CompositeGoalMilestoneNotifier fans out to multiple GoalMilestoneNotifier implementations.
+type CompositeGoalMilestoneNotifier struct {
+	Notifiers []GoalMilestoneNotifier
+}
+
+func (c CompositeGoalMilestoneNotifier) SendGoalMilestone(
+	ctx context.Context,
+	userID uuid.UUID,
+	goal savingsgoal.SavingsGoal,
+	milestone int,
+) {
+	for _, n := range c.Notifiers {
+		n.SendGoalMilestone(ctx, userID, goal, milestone)
+	}
+}

--- a/apps/api/internal/service/webhook_service.go
+++ b/apps/api/internal/service/webhook_service.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+)
+
+type WebhookService struct {
+	repo webhook.Repository
+}
+
+func NewWebhookService(repo webhook.Repository) *WebhookService {
+	return &WebhookService{repo: repo}
+}
+
+type RegisterWebhookInput struct {
+	URL    string `json:"url"`
+	Secret string `json:"secret"`
+}
+
+func (s *WebhookService) Register(ctx context.Context, userID uuid.UUID, in RegisterWebhookInput) (webhook.Webhook, error) {
+	u := strings.TrimSpace(in.URL)
+	if u == "" {
+		return webhook.Webhook{}, fmt.Errorf("%w: url is required", webhook.ErrInvalidWebhook)
+	}
+	wh := &webhook.Webhook{
+		ID:     uuid.New(),
+		UserID: userID,
+		URL:    u,
+		Secret: in.Secret,
+	}
+	if err := s.repo.Create(ctx, wh); err != nil {
+		return webhook.Webhook{}, err
+	}
+	return *wh, nil
+}
+
+func (s *WebhookService) List(ctx context.Context, userID uuid.UUID) ([]webhook.Webhook, error) {
+	return s.repo.ListByUser(ctx, userID)
+}
+
+func (s *WebhookService) Delete(ctx context.Context, userID, id uuid.UUID) error {
+	return s.repo.Delete(ctx, id, userID)
+}
+
+// FireForUser fetches all webhooks registered by userID and delivers the payload to each.
+// event is the event name (e.g. "goal.milestone.50"). payload is the JSON body bytes.
+// Delivery failures are retried up to 3 times with exponential backoff (1s, 2s, 4s).
+func (s *WebhookService) FireForUser(ctx context.Context, userID uuid.UUID, event string, payload []byte) {
+	hooks, err := s.repo.ListByUser(ctx, userID)
+	if err != nil || len(hooks) == 0 {
+		return
+	}
+	for _, wh := range hooks {
+		go deliverWebhook(wh, event, payload)
+	}
+}
+
+func deliverWebhook(wh webhook.Webhook, _ string, payload []byte) {
+	const maxAttempts = 3
+	backoff := time.Second
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+		if deliver(wh, payload) {
+			return
+		}
+	}
+}
+
+func deliver(wh webhook.Webhook, payload []byte) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wh.URL, bytes.NewReader(payload))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if wh.Secret != "" {
+		req.Header.Set("X-Nester-Signature", signPayload([]byte(wh.Secret), payload))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func signPayload(secret, payload []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// BuildWebhookPayload constructs the standard JSON payload for webhook delivery.
+func BuildWebhookPayload(event string, goalID, userID uuid.UUID, milestonePct int, currentAmount, targetAmount string) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"event":          event,
+		"goal_id":        goalID.String(),
+		"user_id":        userID.String(),
+		"milestone_pct":  milestonePct,
+		"current_amount": currentAmount,
+		"target_amount":  targetAmount,
+		"timestamp":      time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/apps/api/internal/service/webhook_service_test.go
+++ b/apps/api/internal/service/webhook_service_test.go
@@ -1,0 +1,142 @@
+package service_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/webhook"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// TestDeliverWebhook_SuccessOnFirstAttempt verifies a 2xx response stops retrying.
+func TestDeliverWebhook_SuccessOnFirstAttempt(t *testing.T) {
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	payload, _ := service.BuildWebhookPayload("goal.milestone.50", uuid.Nil, uuid.Nil, 50, "50", "100")
+	wh := webhook.Webhook{ID: uuid.New(), UserID: uuid.New(), URL: srv.URL}
+	service.DeliverWebhookForTest(wh, payload)
+
+	if got := int(count.Load()); got != 1 {
+		t.Errorf("expected 1 delivery attempt, got %d", got)
+	}
+}
+
+// TestDeliverWebhook_RetriesUpTo3Times verifies persistent failure retries exactly 3 times.
+func TestDeliverWebhook_RetriesUpTo3Times(t *testing.T) {
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	payload, _ := service.BuildWebhookPayload("goal.milestone.50", uuid.Nil, uuid.Nil, 50, "50", "100")
+	wh := webhook.Webhook{ID: uuid.New(), UserID: uuid.New(), URL: srv.URL}
+	service.DeliverWebhookForTest(wh, payload)
+
+	if got := int(count.Load()); got != 3 {
+		t.Errorf("expected 3 delivery attempts, got %d", got)
+	}
+}
+
+// TestDeliverWebhook_SucceedsOnSecondAttempt verifies retry stops on first success.
+func TestDeliverWebhook_SucceedsOnSecondAttempt(t *testing.T) {
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n >= 2 {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadGateway)
+		}
+	}))
+	defer srv.Close()
+
+	payload, _ := service.BuildWebhookPayload("goal.milestone.50", uuid.Nil, uuid.Nil, 50, "50", "100")
+	wh := webhook.Webhook{ID: uuid.New(), UserID: uuid.New(), URL: srv.URL}
+	service.DeliverWebhookForTest(wh, payload)
+
+	if got := int(count.Load()); got != 2 {
+		t.Errorf("expected 2 delivery attempts (success on 2nd), got %d", got)
+	}
+}
+
+// TestDeliverWebhook_SetsHMACSignatureHeader verifies the X-Nester-Signature header is set.
+func TestDeliverWebhook_SetsHMACSignatureHeader(t *testing.T) {
+	var gotSig string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Nester-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	payload := []byte(`{"event":"goal.milestone.50"}`)
+	wh := webhook.Webhook{ID: uuid.New(), UserID: uuid.New(), URL: srv.URL, Secret: "mysecret"}
+	service.DeliverWebhookForTest(wh, payload)
+
+	if gotSig == "" {
+		t.Fatal("expected X-Nester-Signature header, got empty string")
+	}
+	if len(gotSig) < 7 || gotSig[:7] != "sha256=" {
+		t.Errorf("signature must start with sha256=, got %q", gotSig)
+	}
+}
+
+// TestDeliverWebhook_NoSignatureHeaderWhenNoSecret verifies the header is absent without a secret.
+func TestDeliverWebhook_NoSignatureHeaderWhenNoSecret(t *testing.T) {
+	var gotSig string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Nester-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	payload := []byte(`{"event":"goal.milestone.50"}`)
+	wh := webhook.Webhook{ID: uuid.New(), UserID: uuid.New(), URL: srv.URL}
+	service.DeliverWebhookForTest(wh, payload)
+
+	if gotSig != "" {
+		t.Errorf("expected no X-Nester-Signature when secret is empty, got %q", gotSig)
+	}
+}
+
+// TestBuildWebhookPayload_ContainsRequiredFields verifies the JSON payload shape.
+func TestBuildWebhookPayload_ContainsRequiredFields(t *testing.T) {
+	goalID := uuid.New()
+	userID := uuid.New()
+	payload, err := service.BuildWebhookPayload("goal.milestone.75", goalID, userID, 75, "75.0", "100.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{`"event"`, `"goal_id"`, `"user_id"`, `"milestone_pct"`, `"current_amount"`, `"target_amount"`, `"timestamp"`} {
+		if !contains(payload, want) {
+			t.Errorf("payload missing field %s: %s", want, payload)
+		}
+	}
+}
+
+func contains(data []byte, sub string) bool {
+	return len(data) > 0 && string(data) != "" && stringContains(string(data), sub)
+}
+
+func stringContains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && findSubstring(s, sub))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/internal/service/yield_harvest_service.go
+++ b/apps/api/internal/service/yield_harvest_service.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/yieldharvest"
+)
+
+// YieldHarvestRecord is the input type used by VaultService to record a harvest.
+type YieldHarvestRecord struct {
+	UserID      uuid.UUID
+	VaultID     uuid.UUID
+	Amount      decimal.Decimal
+	Currency    string
+	HarvestedAt time.Time
+	TxHash      string
+}
+
+// YieldHarvestRecorder is implemented by YieldHarvestService and consumed by VaultService.
+type YieldHarvestRecorder interface {
+	RecordHarvest(ctx context.Context, record YieldHarvestRecord) error
+}
+
+// ListYieldHarvestsInput carries pagination parameters for GET /yields/harvests.
+type ListYieldHarvestsInput struct {
+	UserID uuid.UUID
+	Cursor string
+	Limit  int
+}
+
+// ListYieldHarvestsOutput is the paginated response.
+type ListYieldHarvestsOutput struct {
+	Items      []yieldharvest.YieldHarvest `json:"items"`
+	NextCursor string                      `json:"next_cursor"`
+}
+
+// YieldHarvestService handles business logic for yield harvest records.
+type YieldHarvestService struct {
+	repo yieldharvest.Repository
+}
+
+// NewYieldHarvestService constructs a YieldHarvestService.
+func NewYieldHarvestService(repo yieldharvest.Repository) *YieldHarvestService {
+	return &YieldHarvestService{repo: repo}
+}
+
+// RecordHarvest persists a harvest record. Implements YieldHarvestRecorder.
+func (s *YieldHarvestService) RecordHarvest(ctx context.Context, record YieldHarvestRecord) error {
+	if record.Amount.IsZero() || record.Amount.IsNegative() {
+		return nil
+	}
+	harvestedAt := record.HarvestedAt
+	if harvestedAt.IsZero() {
+		harvestedAt = time.Now().UTC()
+	}
+	_, err := s.repo.Create(ctx, yieldharvest.CreateInput{
+		UserID:      record.UserID,
+		VaultID:     record.VaultID,
+		Amount:      record.Amount,
+		Currency:    record.Currency,
+		HarvestedAt: harvestedAt,
+		TxHash:      record.TxHash,
+	})
+	return err
+}
+
+// ListHarvests returns a cursor-paginated list of harvest records for the authenticated user.
+func (s *YieldHarvestService) ListHarvests(ctx context.Context, input ListYieldHarvestsInput) (ListYieldHarvestsOutput, error) {
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	filter := yieldharvest.ListFilter{
+		UserID: input.UserID,
+		Limit:  limit + 1, // fetch one extra to determine if there is a next page
+	}
+
+	if input.Cursor != "" {
+		cursorTime, cursorID, err := decodeCursor(input.Cursor)
+		if err != nil {
+			return ListYieldHarvestsOutput{}, fmt.Errorf("invalid cursor: %w", err)
+		}
+		filter.CursorTime = &cursorTime
+		filter.CursorID = &cursorID
+	}
+
+	items, err := s.repo.ListForUser(ctx, filter)
+	if err != nil {
+		return ListYieldHarvestsOutput{}, err
+	}
+
+	var nextCursor string
+	if len(items) > limit {
+		items = items[:limit]
+		last := items[len(items)-1]
+		nextCursor = encodeCursor(last.HarvestedAt, last.ID)
+	}
+
+	return ListYieldHarvestsOutput{
+		Items:      items,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+// encodeCursor encodes harvested_at and id as a base64 opaque cursor.
+func encodeCursor(t time.Time, id uuid.UUID) string {
+	raw := t.UTC().Format(time.RFC3339Nano) + "|" + id.String()
+	return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// decodeCursor reverses encodeCursor.
+func decodeCursor(cursor string) (time.Time, uuid.UUID, error) {
+	b, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, uuid.Nil, err
+	}
+	parts := strings.SplitN(string(b), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, fmt.Errorf("malformed cursor")
+	}
+	t, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("cursor time: %w", err)
+	}
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("cursor id: %w", err)
+	}
+	return t, id, nil
+}

--- a/apps/api/migrations/042_create_yield_harvests.down.sql
+++ b/apps/api/migrations/042_create_yield_harvests.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS yield_harvests;

--- a/apps/api/migrations/042_create_yield_harvests.up.sql
+++ b/apps/api/migrations/042_create_yield_harvests.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS yield_harvests (
+    id           UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID           NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    vault_id     UUID           NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    amount       NUMERIC(28, 8) NOT NULL CHECK (amount > 0),
+    currency     TEXT           NOT NULL,
+    harvested_at TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    tx_hash      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_yield_harvests_user_id     ON yield_harvests (user_id);
+CREATE INDEX IF NOT EXISTS idx_yield_harvests_vault_id    ON yield_harvests (vault_id);
+CREATE INDEX IF NOT EXISTS idx_yield_harvests_harvested_at ON yield_harvests (harvested_at DESC);

--- a/apps/api/migrations/043_create_webhooks.down.sql
+++ b/apps/api/migrations/043_create_webhooks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS webhooks;

--- a/apps/api/migrations/043_create_webhooks.up.sql
+++ b/apps/api/migrations/043_create_webhooks.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS webhooks (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    url        TEXT        NOT NULL CHECK (char_length(url) > 0),
+    secret     TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhooks_user_id ON webhooks (user_id);

--- a/apps/api/migrations/044_create_apy_snapshots.down.sql
+++ b/apps/api/migrations/044_create_apy_snapshots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS apy_snapshots;

--- a/apps/api/migrations/044_create_apy_snapshots.up.sql
+++ b/apps/api/migrations/044_create_apy_snapshots.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS apy_snapshots (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    protocol_slug TEXT        NOT NULL,
+    apy           NUMERIC(10, 6) NOT NULL,
+    tvl           NUMERIC(28, 8) NOT NULL DEFAULT 0,
+    captured_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_apy_snapshots_protocol_slug ON apy_snapshots (protocol_slug);
+CREATE INDEX IF NOT EXISTS idx_apy_snapshots_captured_at ON apy_snapshots (captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_apy_snapshots_protocol_time ON apy_snapshots (protocol_slug, captured_at DESC);

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -277,6 +277,7 @@ enum DataKey {
     MinLockPeriod, // For early withdrawal fee
     DepositTime(Address),
     MaxDeposit,
+    MinDeposit,
     RebalanceThreshold,
     CircuitBreakerConfig,
     WithdrawalHistory,
@@ -744,6 +745,23 @@ impl VaultContract {
             panic_with_error!(&env, ContractError::ConfigOutOfRange);
         }
         env.storage().instance().set(&DataKey::MaxDeposit, &amount);
+    }
+
+    pub fn set_min_deposit(env: Env, caller: Address, amount: i128) {
+        require_initialized(&env);
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+        if amount < 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+        env.storage().instance().set(&DataKey::MinDeposit, &amount);
+    }
+
+    pub fn get_min_deposit(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(0)
     }
 
     pub fn set_rebalance_threshold(env: Env, caller: Address, bps: u32) {
@@ -1394,6 +1412,15 @@ impl VaultContract {
             .unwrap_or(i128::MAX);
         if amount > max_deposit {
             panic_with_error!(&env, ContractError::ExceedsLimit);
+        }
+
+        let min_deposit: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(0);
+        if amount < min_deposit {
+            panic_with_error!(&env, ContractError::BelowMinDeposit);
         }
 
         if amount < nester_common::MIN_DEPOSIT_AMOUNT {

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -1579,3 +1579,66 @@ fn rebalance_slippage_guard_reverts_when_below_floor() {
         super::enforce_rebalance_slippage(&env, 100, 99);
     });
 }
+
+// ---------------------------------------------------------------------------
+// Minimum deposit enforcement (issue #730)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #21)")]
+fn deposit_below_min_deposit_panics() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 100 * XLM);
+
+    vault.set_min_deposit(&admin, &(10 * XLM));
+
+    // 5 XLM is below the 10 XLM minimum — must panic.
+    vault.deposit(&user, &(5 * XLM), &0);
+}
+
+#[test]
+fn deposit_exactly_at_min_deposit_succeeds() {
+    let (_env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&_env);
+    mint(&token, &user, 100 * XLM);
+
+    vault.set_min_deposit(&admin, &(10 * XLM));
+
+    let shares = vault.deposit(&user, &(10 * XLM), &0);
+    assert_eq!(shares, 10 * XLM);
+}
+
+#[test]
+fn deposit_above_min_deposit_succeeds() {
+    let (_env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&_env);
+    mint(&token, &user, 100 * XLM);
+
+    vault.set_min_deposit(&admin, &(10 * XLM));
+
+    let shares = vault.deposit(&user, &(50 * XLM), &0);
+    assert_eq!(shares, 50 * XLM);
+}
+
+#[test]
+#[should_panic]
+fn set_min_deposit_by_non_admin_panics() {
+    let (env, _admin, _token, vault, _treasury) = setup();
+    let outsider = Address::generate(&env);
+
+    vault.set_min_deposit(&outsider, &(10 * XLM));
+}
+
+#[test]
+fn get_min_deposit_returns_zero_when_unset() {
+    let (_env, _admin, _token, vault, _treasury) = setup();
+    assert_eq!(vault.get_min_deposit(), 0);
+}
+
+#[test]
+fn get_min_deposit_returns_configured_value() {
+    let (_env, admin, _token, vault, _treasury) = setup();
+    vault.set_min_deposit(&admin, &(10 * XLM));
+    assert_eq!(vault.get_min_deposit(), 10 * XLM);
+}

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -78,7 +78,7 @@ fn setup() -> (
 
     // Create token client
     let sac: token::StellarAssetClient<'static> =
-        token::StellarAssetClient::new(unsafe { core::mem::transmute(&env) }, &token_id);
+        token::StellarAssetClient::new(unsafe { core::mem::transmute::<&Env, &'static Env>(&env) }, &token_id);
 
     // -----------------------------
     // Vault setup
@@ -90,7 +90,7 @@ fn setup() -> (
     let vault_token_id = env.register_contract(None, VaultTokenContract);
 
     let vault: VaultContractClient<'static> =
-        VaultContractClient::new(unsafe { core::mem::transmute(&env) }, &vault_id);
+        VaultContractClient::new(unsafe { core::mem::transmute::<&Env, &'static Env>(&env) }, &vault_id);
 
     // Pass admin, deposit token, vault token, and treasury.
     vault.initialize(&admin, &token_id, &vault_token_id, &treasury);
@@ -278,7 +278,7 @@ fn deposit_of_zero_is_rejected() {
 fn deposit_of_negative_amount_is_rejected() {
     let (_env, _admin, _token, vault, _treasury) = setup();
     let user = Address::generate(&_env);
-    vault.deposit(&user, &(-1 * XLM), &0);
+    vault.deposit(&user, &(-XLM), &0);
 }
 
 #[test]
@@ -992,7 +992,7 @@ fn emergency_withdraw_queues_when_liquidity_insufficient() {
     let preview = vault.emergency_withdraw_preview(&user);
     assert_eq!(preview.vault_liquid_reserves, 9995890411);
     assert_eq!(preview.estimated_return, 10000000000);
-    assert_eq!(preview.can_process, false);
+    assert!(!preview.can_process);
 
     let returned = vault.emergency_withdraw(&user);
 

--- a/packages/contracts/libs/common/src/errors.rs
+++ b/packages/contracts/libs/common/src/errors.rs
@@ -23,4 +23,5 @@ pub enum ContractError {
     FeeTooHigh = 18,
     ConfigOutOfRange = 19,
     ArithmeticOverflow = 20,
+    BelowMinDeposit = 21,
 }


### PR DESCRIPTION
## Summary

- **#728** â€” Yield harvest history endpoint (`GET /api/v1/yields/harvests`) with cursor-based pagination; auto-records harvests on successful `HarvestVault` calls
- **#729** â€” Savings goal progress webhooks: register/list/delete endpoints, HMAC-SHA256 signed delivery, exponential backoff retry (3 attempts), milestone notifications at 25/50/75/100%
- **#730** â€” Vault min deposit enforcement: `BelowMinDeposit` error (#21) in Soroban contract; `set_min_deposit`/`get_min_deposit` admin functions; HTTP 400 mapped in API handler
- **#731** â€” APY snapshot history: 6-hour DeFiLlama polling scheduler (Stellar chain), 30-day retention, `GET /api/v1/yields/{protocol_slug}/apy-history` with avg/min/max summary

## Migrations

- `042_create_yield_harvests` â€” yield_harvests table
- `043_create_webhooks` â€” webhooks table
- `044_create_apy_snapshots` â€” apy_snapshots table

## Test plan

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` â€” clean
- [ ] `cargo test --all` â€” all contract tests pass (including 6 new min-deposit tests)
- [ ] `go test ./...` â€” all Go tests pass (handler + service tests for all 4 features)
- [ ] Yield harvest: POST deposit â†’ harvest â†’ GET /api/v1/yields/harvests returns record
- [ ] Webhooks: POST /api/v1/webhooks â†’ goal milestone fires â†’ delivery with X-Nester-Signature header
- [ ] Min deposit: deposit below min â†’ HTTP 400; at/above min â†’ success
- [ ] APY history: GET /api/v1/yields/{slug}/apy-history â†’ 200 with snapshots and summary

Closes #728
Closes #729
Closes #730
Closes #731
