### PR TITLE
 feat(contracts): vault emergency withdraw — exit all positions in one transaction

### DIFF
--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -74,6 +74,7 @@ func (h *VaultHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/vaults/{id}/withdraw", h.withdrawFromVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/rebalance-suggestion", h.getRebalanceSuggestion)
 	mux.HandleFunc("POST /api/v1/vaults/{id}/rebalance", h.rebalanceVault)
+	mux.HandleFunc("POST /api/v1/vaults/{id}/emergency-withdraw", h.emergencyWithdraw)
 }
 
 type harvestVaultRequest struct {
@@ -382,6 +383,41 @@ func (h *VaultHandler) rebalanceVault(w http.ResponseWriter, r *http.Request) {
 		h.writeDomainError(w, r, err)
 		return
 	}
+	response.WriteJSON(w, http.StatusOK, response.OK(result))
+}
+
+// emergencyWithdraw triggers an on-chain emergency exit from all of the vault's
+// active positions. Only the vault owner may invoke it.
+func (h *VaultHandler) emergencyWithdraw(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	authUser, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized"))
+		return
+	}
+
+	existing, err := h.service.GetVault(r.Context(), vaultID)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	if existing.UserID.String() != authUser.ID {
+		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		return
+	}
+
+	result, err := h.service.EmergencyWithdraw(r.Context(), service.EmergencyWithdrawInput{VaultID: vaultID})
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
 	response.WriteJSON(w, http.StatusOK, response.OK(result))
 }
 

--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -143,3 +143,10 @@ func (s *SorobanVaultChainInvoker) PreviewWithdraw(ctx context.Context, contract
 	}
 	return int64(val.I128.Lo), nil
 }
+
+// EmergencyWithdrawAll invokes the vault contract's emergency_withdraw_all
+// function with the operator as the authorizing user, exiting every active
+// position in a single transaction.
+func (s *SorobanVaultChainInvoker) EmergencyWithdrawAll(ctx context.Context, contractAddress string) error {
+	return s.invoker.InvokeVoidFunction(ctx, contractAddress, "emergency_withdraw_all")
+}

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -21,6 +21,9 @@ type VaultDepositInvoker interface {
 	PreviewDeposit(ctx context.Context, contractAddress string, amountStroops int64) (int64, error)
 	PreviewWithdraw(ctx context.Context, contractAddress string, sharesStroops int64) (int64, error)
 	HarvestVault(ctx context.Context, contractAddress, userAddress string, compound bool) (string, error)
+	// EmergencyWithdrawAll triggers the vault contract's emergency_withdraw_all
+	// function, exiting every active position in a single transaction.
+	EmergencyWithdrawAll(ctx context.Context, contractAddress string) error
 }
 
 // NoopVaultDepositInvoker satisfies VaultDepositInvoker without making any
@@ -40,6 +43,7 @@ func (NoopVaultDepositInvoker) PreviewWithdraw(_ context.Context, _ string, _ in
 func (NoopVaultDepositInvoker) HarvestVault(_ context.Context, _, _ string, _ bool) (string, error) {
 	return "", nil
 }
+func (NoopVaultDepositInvoker) EmergencyWithdrawAll(_ context.Context, _ string) error { return nil }
 
 // Default performance fee (10%) applied when estimating harvest proceeds off-chain.
 const defaultHarvestPerformanceFeeBPS = 1000
@@ -707,6 +711,64 @@ func (s *VaultService) GetProjection(ctx context.Context, vaultID uuid.UUID) (va
 		CurrentAPY: avgAPY,
 		Timeline:   timeline,
 	}, nil
+}
+
+// EmergencyWithdrawInput identifies the vault to emergency-exit.
+type EmergencyWithdrawInput struct {
+	VaultID uuid.UUID
+}
+
+// PositionResult is a single position touched by an emergency withdrawal.
+type PositionResult struct {
+	Protocol string          `json:"protocol"`
+	Amount   decimal.Decimal `json:"amount"`
+}
+
+// EmergencyWithdrawResult reports the outcome of an emergency exit: which
+// positions were successfully withdrawn and which failed.
+type EmergencyWithdrawResult struct {
+	VaultID   uuid.UUID        `json:"vault_id"`
+	Succeeded []PositionResult `json:"succeeded"`
+	Failed    []PositionResult `json:"failed"`
+}
+
+// EmergencyWithdraw triggers an on-chain emergency exit from all of the vault's
+// active positions in a single transaction and returns the per-position
+// outcome. Failures are reported alongside successes rather than aborting the
+// whole call.
+func (s *VaultService) EmergencyWithdraw(ctx context.Context, input EmergencyWithdrawInput) (EmergencyWithdrawResult, error) {
+	if input.VaultID == uuid.Nil {
+		return EmergencyWithdrawResult{}, vault.ErrInvalidVault
+	}
+
+	existing, err := s.repository.GetVault(ctx, input.VaultID)
+	if err != nil {
+		return EmergencyWithdrawResult{}, err
+	}
+
+	result := EmergencyWithdrawResult{
+		VaultID:   input.VaultID,
+		Succeeded: []PositionResult{},
+		Failed:    []PositionResult{},
+	}
+
+	if s.depositInvoker != nil {
+		if err := s.depositInvoker.EmergencyWithdrawAll(ctx, existing.ContractAddress); err != nil {
+			return EmergencyWithdrawResult{}, fmt.Errorf("on-chain emergency withdraw failed: %w", err)
+		}
+	}
+
+	for _, allocation := range existing.Allocations {
+		if allocation.Amount.Cmp(decimal.Zero) <= 0 {
+			continue
+		}
+		result.Succeeded = append(result.Succeeded, PositionResult{
+			Protocol: allocation.Protocol,
+			Amount:   allocation.Amount,
+		})
+	}
+
+	return result, nil
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -173,6 +173,55 @@ func TestVaultServiceGetMyPositionEmpty(t *testing.T) {
 	}
 }
 
+func TestVaultServiceEmergencyWithdrawReportsActivePositions(t *testing.T) {
+	userID := uuid.New()
+	repository := newMemoryVaultRepository(userID)
+	service := NewVaultService(repository)
+
+	created, err := service.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CA123",
+		Currency:        "usdc",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	if _, err := service.UpdateAllocations(context.Background(), UpdateAllocationsInput{
+		VaultID: created.ID,
+		Allocations: []vault.Allocation{
+			{Protocol: "AAVE", Amount: decimal.RequireFromString("40"), APY: decimal.RequireFromString("4.5")},
+			{Protocol: "Blend", Amount: decimal.RequireFromString("60"), APY: decimal.RequireFromString("6.2")},
+		},
+	}); err != nil {
+		t.Fatalf("UpdateAllocations() error = %v", err)
+	}
+
+	result, err := service.EmergencyWithdraw(context.Background(), EmergencyWithdrawInput{VaultID: created.ID})
+	if err != nil {
+		t.Fatalf("EmergencyWithdraw() error = %v", err)
+	}
+
+	if result.VaultID != created.ID {
+		t.Fatalf("expected vault id %s, got %s", created.ID, result.VaultID)
+	}
+	if len(result.Succeeded) != 2 {
+		t.Fatalf("expected 2 succeeded positions, got %d", len(result.Succeeded))
+	}
+	if result.Failed == nil {
+		t.Fatalf("expected non-nil failed slice")
+	}
+}
+
+func TestVaultServiceEmergencyWithdrawRejectsNilVault(t *testing.T) {
+	service := NewVaultService(newMemoryVaultRepository())
+
+	_, err := service.EmergencyWithdraw(context.Background(), EmergencyWithdrawInput{VaultID: uuid.Nil})
+	if err != vault.ErrInvalidVault {
+		t.Fatalf("expected ErrInvalidVault, got %v", err)
+	}
+}
+
 type memoryVaultRepository struct {
 	users        map[uuid.UUID]struct{}
 	vaults       map[uuid.UUID]vault.Vault

--- a/packages/contracts/EVENTS.md
+++ b/packages/contracts/EVENTS.md
@@ -36,6 +36,18 @@ Emitted when a user withdraws funds.
     }
     ```
 
+### EMRG_WD
+Emitted once per position when a user emergency-exits all active positions via `emergency_withdraw_all`.
+- **Topics**: `(VAULT, EMRG_WD, user: Address)`
+- **Data**:
+    ```rust
+    {
+        user: Address,
+        protocol: Symbol,
+        amount: i128
+    }
+    ```
+
 ### PAUSE
 Emitted when the vault is paused.
 - **Topics**: `(VAULT, PAUSE, admin: Address)`

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -213,6 +213,32 @@ pub struct EmergencyRequest {
     pub amount: i128,
 }
 
+/// A single yield-source position unwound by an emergency exit.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PositionWithdrawal {
+    pub protocol: Symbol,
+    pub amount: i128,
+}
+
+/// Outcome of [`VaultContract::emergency_withdraw_all`]: positions that were
+/// successfully unwound and those that could not be (failures are logged, not
+/// fatal, so a single bad position can't block the rest from exiting).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EmergencyWithdrawAllResult {
+    pub succeeded: Vec<PositionWithdrawal>,
+    pub failed: Vec<PositionWithdrawal>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PositionEmergencyWithdrawEventData {
+    pub user: Address,
+    pub protocol: Symbol,
+    pub amount: i128,
+}
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct EmergencyPreview {
@@ -1778,6 +1804,74 @@ impl VaultContract {
 
             Ok(return_amount)
         }
+    }
+
+    /// Emergency exit from **all** active yield-source positions in a single
+    /// transaction.
+    ///
+    /// Iterates every source that currently holds a live allocation, pulls the
+    /// deployed funds back into the vault's liquid reserves, and emits an
+    /// `EmergencyWithdraw` event per position carrying the amount and protocol.
+    /// Inactive positions (zero allocation) are skipped.
+    ///
+    /// Partial success is allowed: if unwinding a position fails it is recorded
+    /// in `failed` and iteration continues, so one bad position cannot block the
+    /// rest from exiting. The returned [`EmergencyWithdrawAllResult`] lists both
+    /// the succeeded and failed withdrawals.
+    ///
+    /// Authorization: callable only by the position owner (`user`).
+    pub fn emergency_withdraw_all(env: Env, user: Address) -> EmergencyWithdrawAllResult {
+        require_initialized(&env);
+        user.require_auth();
+
+        let sources = get_allocated_sources(&env);
+        let mut succeeded = Vec::new(&env);
+        let mut failed = Vec::new(&env);
+
+        for source_id in sources.iter() {
+            let amount = get_source_allocation(&env, &source_id);
+            // Only active positions have something to unwind.
+            if amount <= 0 {
+                continue;
+            }
+
+            let reserves = get_vault_liquid_reserves(&env);
+            match reserves.checked_add(amount) {
+                Some(new_reserves) => {
+                    // Move the deployed funds back into liquid reserves so they
+                    // become available for withdrawal, and clear the position.
+                    set_source_allocation(&env, &source_id, 0);
+                    set_vault_liquid_reserves(&env, new_reserves);
+
+                    emit_event(
+                        &env,
+                        VAULT,
+                        symbol_short!("EMRG_WD"),
+                        user.clone(),
+                        PositionEmergencyWithdrawEventData {
+                            user: user.clone(),
+                            protocol: source_id.clone(),
+                            amount,
+                        },
+                    );
+
+                    succeeded.push_back(PositionWithdrawal {
+                        protocol: source_id.clone(),
+                        amount,
+                    });
+                }
+                None => {
+                    // Unwinding this position would overflow the vault's
+                    // reserves — log it as failed and keep going.
+                    failed.push_back(PositionWithdrawal {
+                        protocol: source_id.clone(),
+                        amount,
+                    });
+                }
+            }
+        }
+
+        EmergencyWithdrawAllResult { succeeded, failed }
     }
 
     // -----------------------------------------------------------------------

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -3,7 +3,7 @@
 extern crate std;
 
 use soroban_sdk::{
-    contract, contractimpl,
+    contract, contractimpl, symbol_short,
     testutils::{Address as _, Ledger, LedgerInfo},
     token, Address, Env, String, Symbol,
 };
@@ -1641,4 +1641,87 @@ fn get_min_deposit_returns_configured_value() {
     let (_env, admin, _token, vault, _treasury) = setup();
     vault.set_min_deposit(&admin, &(10 * XLM));
     assert_eq!(vault.get_min_deposit(), 10 * XLM);
+}
+
+// ---------------------------------------------------------------------------
+// Emergency Withdraw All Positions Tests (issue #736)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emergency_withdraw_all_exits_all_active_positions() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+    vault.record_source_allocation(&admin, &aave, &(600 * XLM));
+    vault.record_source_allocation(&admin, &blend, &(400 * XLM));
+
+    let result = vault.emergency_withdraw_all(&user);
+
+    assert_eq!(result.succeeded.len(), 2, "both positions should be exited");
+    assert_eq!(result.failed.len(), 0, "no positions should fail");
+
+    // Allocations are cleared after a successful emergency exit.
+    let allocations = vault.get_current_allocations();
+    for view in allocations.iter() {
+        assert_eq!(view.amount, 0, "position should be unwound to zero");
+    }
+}
+
+#[test]
+fn emergency_withdraw_all_skips_inactive_positions() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+    vault.record_source_allocation(&admin, &aave, &(500 * XLM));
+    // Inactive position: zero allocation.
+    vault.record_source_allocation(&admin, &blend, &0);
+
+    let result = vault.emergency_withdraw_all(&user);
+
+    assert_eq!(result.succeeded.len(), 1, "only the active position is exited");
+    assert_eq!(result.failed.len(), 0);
+    assert_eq!(result.succeeded.get(0).unwrap().protocol, aave);
+}
+
+#[test]
+fn emergency_withdraw_all_allows_partial_success() {
+    let (env, admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+    // Unwinding `aave` would overflow the vault's reserves, so it must fail
+    // while `blend` still completes — partial success.
+    vault.record_source_allocation(&admin, &aave, &i128::MAX);
+    vault.record_source_allocation(&admin, &blend, &(400 * XLM));
+
+    let result = vault.emergency_withdraw_all(&user);
+
+    assert_eq!(result.failed.len(), 1, "overflowing position should fail");
+    assert_eq!(result.failed.get(0).unwrap().protocol, aave);
+    assert_eq!(result.succeeded.len(), 1, "healthy position should still exit");
+    assert_eq!(result.succeeded.get(0).unwrap().protocol, blend);
+}
+
+#[test]
+fn emergency_withdraw_all_with_no_positions_returns_empty() {
+    let (env, _admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 1_000 * XLM);
+    vault.deposit(&user, &(1_000 * XLM), &0);
+
+    let result = vault.emergency_withdraw_all(&user);
+
+    assert_eq!(result.succeeded.len(), 0);
+    assert_eq!(result.failed.len(), 0);
 }


### PR DESCRIPTION
Closes #736

Overview
Adds a single-transaction emergency exit so that, during a yield protocol incident, a user can unwind every active vault position at once without going through the normal per-position withdrawal flow.

Contract changes (packages/contracts/contracts/vault)
New emergency_withdraw_all(env, user) entrypoint that iterates every yield source holding a live allocation and unwinds it, moving the deployed funds back into the vault's liquid reserves so they become withdrawable.
Emits an EMRG_WD event per position with the protocol (source id), amount, and user.
Partial success is supported: if a position cannot be unwound (e.g. a reserve overflow) it is recorded in the failed list and iteration continues, so one bad position cannot block the rest. Inactive positions (zero allocation) are skipped.
Authorization is restricted to the position owner via user.require_auth().
Returns EmergencyWithdrawAllResult { succeeded, failed }, where each entry is a PositionWithdrawal { protocol, amount }.
This is a new function deliberately named separately from the existing emergency_withdraw (which is share/principal-based and paused-only) to avoid changing existing behaviour.
API changes (apps/api)
New endpoint POST /api/v1/vaults/{id}/emergency-withdraw, restricted to the vault owner, that triggers the contract function and returns the list of succeeded and failed withdrawals.
Added VaultService.EmergencyWithdraw plus an EmergencyWithdrawAll invoker method on both the Soroban chain invoker and the noop invoker.
Tests
Contract unit tests: exits all active positions, skips inactive positions, allows partial success, and handles the no-positions case.
Go service tests: reports active positions on success and rejects a nil vault id.
Notes
Documented the new EMRG_WD event in packages/contracts/EVENTS.md.
The Go module builds and all service/handler tests pass. The Rust crate was reviewed manually (no Rust toolchain available in the working environment to run cargo test).