### PR TITLE
feat(api): filter yield opportunities by risk tier

### DIFF
--- a/apps/api/internal/handler/yield_handler.go
+++ b/apps/api/internal/handler/yield_handler.go
@@ -14,7 +14,7 @@ import (
 
 // YieldOpportunitiesProvider is the service surface the handler depends on.
 type YieldOpportunitiesProvider interface {
-	GetYieldOpportunities(ctx context.Context, chain string, limit int) (*service.YieldOpportunitiesResponse, error)
+	GetYieldOpportunitiesByTier(ctx context.Context, chain string, limit int, tier string) (*service.YieldOpportunitiesResponse, error)
 	CompareProtocols(ctx context.Context, protocols []string) ([]service.ProtocolSummary, error)
 }
 
@@ -74,7 +74,14 @@ func (h *YieldHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	yieldResp, err := h.svc.GetYieldOpportunities(r.Context(), chain, limit)
+	// Optional risk-tier filter: low|medium|high. Omitting it returns all tiers.
+	tier := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("risk")))
+	if tier != "" && !service.IsValidRiskTier(tier) {
+		response.WriteJSON(w, http.StatusBadRequest, response.Err(http.StatusBadRequest, "INVALID_RISK_TIER", "risk must be one of: low, medium, high"))
+		return
+	}
+
+	yieldResp, err := h.svc.GetYieldOpportunitiesByTier(r.Context(), chain, limit, tier)
 	if err != nil {
 		logpkg.FromContext(r.Context()).Error("yield opportunities fetch failed", "chain", chain, "error", err.Error())
 		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UPSTREAM_ERROR", "yield data temporarily unavailable"))

--- a/apps/api/internal/handler/yield_handler_risk_test.go
+++ b/apps/api/internal/handler/yield_handler_risk_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// newYieldServerMixedTiers wires the handler to a real YieldService whose mock
+// DeFiLlama returns Stellar pools spanning all three risk tiers. The min-TVL
+// override lets the low-TVL high-risk pool past the threshold filter.
+func newYieldServerMixedTiers(t *testing.T) *httptest.Server {
+	t.Helper()
+	t.Setenv("YIELD_MIN_TVL_USD", "1000")
+	defiLlama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[
+			{"pool":"p_low","project":"blend","symbol":"USDC","apy":6.0,"apyBase":6.0,"apyReward":0.0,"tvlUsd":5000000,"apyPct7d":1.0,"chain":"Stellar"},
+			{"pool":"p_med","project":"aqua","symbol":"AQUA","apy":10.0,"apyBase":1.0,"apyReward":9.0,"tvlUsd":5000000,"apyPct7d":25.0,"chain":"Stellar"},
+			{"pool":"p_high","project":"risky","symbol":"FOO","apy":10.0,"apyBase":1.0,"apyReward":9.0,"tvlUsd":50000,"apyPct7d":25.0,"chain":"Stellar"}
+		]}`))
+	}))
+	t.Cleanup(defiLlama.Close)
+
+	mux := http.NewServeMux()
+	NewYieldHandler(service.NewYieldService(defiLlama.URL)).Register(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+type yieldListBody struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Data []service.YieldPool `json:"data"`
+	} `json:"data"`
+}
+
+func fetchYields(t *testing.T, server *httptest.Server, query string) (*http.Response, []service.YieldPool) {
+	t.Helper()
+	resp, err := http.Get(server.URL + "/api/v1/yield-opportunities" + query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, nil
+	}
+	var body yieldListBody
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp, body.Data.Data
+}
+
+func TestYieldList_NoRiskParamReturnsAllTiers(t *testing.T) {
+	server := newYieldServerMixedTiers(t)
+	resp, pools := fetchYields(t, server, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(pools) != 3 {
+		t.Fatalf("expected all 3 tiers, got %d: %+v", len(pools), pools)
+	}
+}
+
+func TestYieldList_RiskParamFiltersByTier(t *testing.T) {
+	server := newYieldServerMixedTiers(t)
+
+	for _, tc := range []struct {
+		tier string
+		pool string
+	}{
+		{"low", "p_low"},
+		{"medium", "p_med"},
+		{"high", "p_high"},
+	} {
+		t.Run(tc.tier, func(t *testing.T) {
+			resp, pools := fetchYields(t, server, "?risk="+tc.tier)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if len(pools) != 1 {
+				t.Fatalf("risk=%s should return 1 pool, got %d: %+v", tc.tier, len(pools), pools)
+			}
+			if pools[0].Pool != tc.pool {
+				t.Fatalf("risk=%s returned %q, want %q", tc.tier, pools[0].Pool, tc.pool)
+			}
+			if pools[0].RiskTier != tc.tier {
+				t.Fatalf("risk_tier = %q, want %q", pools[0].RiskTier, tc.tier)
+			}
+		})
+	}
+}
+
+func TestYieldList_ResponseIncludesRiskFields(t *testing.T) {
+	server := newYieldServerMixedTiers(t)
+
+	// Decode into a raw map to assert the exact JSON keys are present per item.
+	httpResp, err := http.Get(server.URL + "/api/v1/yield-opportunities")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer httpResp.Body.Close()
+	var raw struct {
+		Data struct {
+			Data []map[string]json.RawMessage `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(httpResp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if len(raw.Data.Data) == 0 {
+		t.Fatal("expected at least one opportunity")
+	}
+	for i, item := range raw.Data.Data {
+		if _, ok := item["risk_score"]; !ok {
+			t.Errorf("opportunity %d missing risk_score field", i)
+		}
+		if _, ok := item["risk_tier"]; !ok {
+			t.Errorf("opportunity %d missing risk_tier field", i)
+		}
+	}
+}
+
+func TestYieldList_InvalidRiskReturns400(t *testing.T) {
+	server := newYieldServerMixedTiers(t)
+	resp, _ := fetchYields(t, server, "?risk=extreme")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/service/yield_risk_tier_test.go
+++ b/apps/api/internal/service/yield_risk_tier_test.go
@@ -1,0 +1,157 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRiskTierForScore(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		score float64
+		want  string
+	}{
+		{0.0, RiskTierLow},
+		{0.2, RiskTierLow},
+		{0.3, RiskTierLow},     // 30
+		{0.33, RiskTierLow},    // 33 — upper edge of low
+		{0.34, RiskTierMedium}, // 34 — lower edge of medium
+		{0.4, RiskTierMedium},
+		{0.5, RiskTierMedium},
+		{0.6, RiskTierMedium},
+		{0.66, RiskTierMedium}, // 66 — upper edge of medium
+		{0.67, RiskTierHigh},   // 67 — lower edge of high
+		{0.7, RiskTierHigh},
+		{0.9, RiskTierHigh},
+		{1.0, RiskTierHigh},
+	}
+	for _, c := range cases {
+		if got := RiskTierForScore(c.score); got != c.want {
+			t.Errorf("RiskTierForScore(%v) = %q, want %q", c.score, got, c.want)
+		}
+	}
+}
+
+func TestIsValidRiskTier(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{RiskTierLow, RiskTierMedium, RiskTierHigh} {
+		if !IsValidRiskTier(s) {
+			t.Errorf("IsValidRiskTier(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"", "LOW", "extreme", "lo", "none"} {
+		if IsValidRiskTier(s) {
+			t.Errorf("IsValidRiskTier(%q) = true, want false", s)
+		}
+	}
+}
+
+// mixedTierDefiLlama serves three Stellar pools that land in distinct tiers once
+// scored: p_low (0.0), p_med (0.5: APY swing + reward dependency), p_high (0.9:
+// also low TVL). The min-TVL env override lets the low-TVL high-risk pool past
+// the threshold filter so all three tiers are representable.
+func mixedTierDefiLlama(t *testing.T) string {
+	t.Helper()
+	t.Setenv("YIELD_MIN_TVL_USD", "1000")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[
+			{"pool":"p_low","project":"blend","symbol":"USDC","apy":6.0,"apyBase":6.0,"apyReward":0.0,"tvlUsd":5000000,"apyPct7d":1.0,"chain":"Stellar"},
+			{"pool":"p_med","project":"aqua","symbol":"AQUA","apy":10.0,"apyBase":1.0,"apyReward":9.0,"tvlUsd":5000000,"apyPct7d":25.0,"chain":"Stellar"},
+			{"pool":"p_high","project":"risky","symbol":"FOO","apy":10.0,"apyBase":1.0,"apyReward":9.0,"tvlUsd":50000,"apyPct7d":25.0,"chain":"Stellar"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func tierOf(t *testing.T, pools []YieldPool, pool string) string {
+	t.Helper()
+	for _, p := range pools {
+		if p.Pool == pool {
+			return p.RiskTier
+		}
+	}
+	t.Fatalf("pool %q not found in %+v", pool, pools)
+	return ""
+}
+
+func TestGetYieldOpportunitiesByTier_EmptyTierReturnsAll(t *testing.T) {
+	svc := NewYieldService(mixedTierDefiLlama(t))
+
+	resp, err := svc.GetYieldOpportunitiesByTier(context.Background(), "Stellar", 20, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Pools) != 3 {
+		t.Fatalf("empty tier should return all 3 pools, got %d: %+v", len(resp.Pools), resp.Pools)
+	}
+	// Each opportunity carries its tier classification.
+	if got := tierOf(t, resp.Pools, "p_low"); got != RiskTierLow {
+		t.Errorf("p_low tier = %q, want low", got)
+	}
+	if got := tierOf(t, resp.Pools, "p_med"); got != RiskTierMedium {
+		t.Errorf("p_med tier = %q, want medium", got)
+	}
+	if got := tierOf(t, resp.Pools, "p_high"); got != RiskTierHigh {
+		t.Errorf("p_high tier = %q, want high", got)
+	}
+}
+
+func TestGetYieldOpportunitiesByTier_FiltersToRequestedTier(t *testing.T) {
+	url := mixedTierDefiLlama(t)
+
+	for _, tc := range []struct {
+		tier string
+		pool string
+	}{
+		{RiskTierLow, "p_low"},
+		{RiskTierMedium, "p_med"},
+		{RiskTierHigh, "p_high"},
+	} {
+		t.Run(tc.tier, func(t *testing.T) {
+			svc := NewYieldService(url)
+			resp, err := svc.GetYieldOpportunitiesByTier(context.Background(), "Stellar", 20, tc.tier)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(resp.Pools) != 1 {
+				t.Fatalf("tier %q should return exactly 1 pool, got %d: %+v", tc.tier, len(resp.Pools), resp.Pools)
+			}
+			if resp.Pools[0].Pool != tc.pool {
+				t.Fatalf("tier %q returned %q, want %q", tc.tier, resp.Pools[0].Pool, tc.pool)
+			}
+			if resp.Pools[0].RiskTier != tc.tier {
+				t.Fatalf("returned pool tier = %q, want %q", resp.Pools[0].RiskTier, tc.tier)
+			}
+		})
+	}
+}
+
+func TestGetYieldOpportunitiesByTier_LimitAppliesAfterFilter(t *testing.T) {
+	svc := NewYieldService(mixedTierDefiLlama(t))
+
+	// limit=1 with no tier truncates the full set to 1.
+	resp, err := svc.GetYieldOpportunitiesByTier(context.Background(), "Stellar", 1, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Pools) != 1 {
+		t.Fatalf("limit=1 should return 1 pool, got %d", len(resp.Pools))
+	}
+
+	// limit=1 with tier=low still finds the single low pool even though it is not
+	// the top pool by risk-adjusted APY (the filter runs before the limit).
+	low, err := svc.GetYieldOpportunitiesByTier(context.Background(), "Stellar", 1, RiskTierLow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(low.Pools) != 1 || low.Pools[0].Pool != "p_low" {
+		t.Fatalf("tier=low,limit=1 should return p_low, got %+v", low.Pools)
+	}
+}

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -28,7 +28,43 @@ type YieldPool struct {
 	TVLUsd    float64  `json:"tvlUsd"`
 	APYPct7d  *float64 `json:"apyPct7d"`
 	Chain     string   `json:"chain"`
-	RiskScore float64  `json:"riskScore"`
+	RiskScore float64  `json:"risk_score"`
+	// RiskTier is the human-facing bucket of RiskScore: "low", "medium", or
+	// "high". Lets clients filter by risk appetite without re-deriving the
+	// thresholds. See RiskTierForScore.
+	RiskTier string `json:"risk_tier"`
+}
+
+// Risk tiers, bucketed from a [0.0, 1.0] risk score viewed as a 0–100 scale:
+// Low (0–33), Medium (34–66), High (67–100).
+const (
+	RiskTierLow    = "low"
+	RiskTierMedium = "medium"
+	RiskTierHigh   = "high"
+)
+
+// IsValidRiskTier reports whether s names one of the known risk tiers.
+func IsValidRiskTier(s string) bool {
+	switch s {
+	case RiskTierLow, RiskTierMedium, RiskTierHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// RiskTierForScore buckets a [0.0, 1.0] risk score into a tier. The score is
+// read as a 0–100 percentage: Low (0–33), Medium (34–66), High (67–100).
+func RiskTierForScore(score float64) string {
+	pct := math.Round(score * 100)
+	switch {
+	case pct <= 33:
+		return RiskTierLow
+	case pct <= 66:
+		return RiskTierMedium
+	default:
+		return RiskTierHigh
+	}
 }
 
 type yieldCacheEntry struct {
@@ -138,6 +174,39 @@ func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, 
 
 	// No data available at all
 	return nil, fetchErr
+}
+
+// GetYieldOpportunitiesByTier returns up to `limit` opportunities on `chain`
+// whose risk score falls in `tier` ("low"|"medium"|"high"). An empty tier means
+// "all tiers" and behaves exactly like GetYieldOpportunities.
+//
+// When a tier is given, it filters the full scored set for the chain (fetched
+// with limit=0) and only then applies the limit, so callers still receive up to
+// `limit` opportunities of the requested tier rather than whatever survived a
+// pre-filter truncation. Risk scoring — and therefore this filter — runs after
+// the DeFiLlama TVL threshold check in fetchFromUpstream.
+func (s *YieldService) GetYieldOpportunitiesByTier(ctx context.Context, chain string, limit int, tier string) (*YieldOpportunitiesResponse, error) {
+	tier = strings.ToLower(strings.TrimSpace(tier))
+	if tier == "" {
+		return s.GetYieldOpportunities(ctx, chain, limit)
+	}
+
+	resp, err := s.GetYieldOpportunities(ctx, chain, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]YieldPool, 0, len(resp.Pools))
+	for _, p := range resp.Pools {
+		if RiskTierForScore(p.RiskScore) == tier {
+			filtered = append(filtered, p)
+		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+
+	return &YieldOpportunitiesResponse{Pools: filtered, Meta: resp.Meta}, nil
 }
 
 // ProtocolSummary is an aggregated, comparable view of one protocol's pools.
@@ -297,6 +366,7 @@ func (s *YieldService) fetchFromUpstream(ctx context.Context, chain string, limi
 			rewardRatio = pool.APYReward / pool.APY
 		}
 		pool.RiskScore = ComputeRiskScore(pool.TVLUsd, apy7dSwing, rewardRatio)
+		pool.RiskTier = RiskTierForScore(pool.RiskScore)
 		pools = append(pools, pool)
 	}
 	slog.Debug("yield pools filtered",


### PR DESCRIPTION
Closes #720

---

## Overview
Adds an optional **`risk` query parameter** to `GET /api/v1/yield-opportunities` so users can filter opportunities by risk appetite — e.g. conservative savers can ask for low-risk options only.

`GET /api/v1/yield-opportunities?risk=low|medium|high`

## How it works
Risk tiers bucket the existing `ComputeRiskScore` (a `[0.0, 1.0]` score) read as a 0–100 scale:

| Tier   | Score range |
|--------|-------------|
| Low    | 0–33        |
| Medium | 34–66       |
| High   | 67–100      |

- New `RiskTierForScore` + `IsValidRiskTier` helpers, plus a `RiskTier` field on `YieldPool`, populated alongside `RiskScore` in `fetchFromUpstream` — i.e. **after the DeFiLlama TVL threshold check**, which is where scoring already happens.
- `GetYieldOpportunitiesByTier` filters the full scored set for the chain and *then* applies the limit, so callers still get up to `limit` opportunities of the requested tier rather than whatever survived a pre-filter truncation.
- The param is **optional**; omitting it returns all tiers. Each opportunity now serializes `risk_score` and `risk_tier`. An invalid `risk` value returns `400 INVALID_RISK_TIER`.

## Acceptance criteria
- [x] `GET /yields?risk=low|medium|high` filters by `ComputeRiskScore` bucket
- [x] Risk tiers: Low (0–33), Medium (34–66), High (67–100)
- [x] Query param is optional; omitting it returns all tiers
- [x] Response includes `risk_score` and `risk_tier` fields per opportunity
- [x] Filter applies after the DeFiLlama TVL threshold check

## Tests
Service- and handler-level tests cover: tier bucketing incl. boundaries, `IsValidRiskTier`, per-tier filtering, the limit-after-filter interaction, presence of `risk_score`/`risk_tier` in the HTTP response, all-tiers default, and the invalid-value 400 path. Existing yield service/handler tests remain green; `go vet` clean.

> Note: the implemented route is the existing `/api/v1/yield-opportunities` endpoint (the issue's `/yields` is its shorthand).
