### PR TITLE
feat(api): savings goal deadline reminders and pre-built templates

### DIFF
--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -178,6 +178,7 @@ type SavingsGoal struct {
 	CurrentAmount      decimal.Decimal `json:"current_amount"`
 	ProgressPct        float64         `json:"progress_pct"`
 	NotifiedMilestones []int           `json:"-"`
+	DeadlineRemindersSent []int        `json:"-"`
 	CreatedAt          time.Time       `json:"created_at"`
 	UpdatedAt          time.Time       `json:"updated_at"`
 	// Completion fields (#716).
@@ -235,6 +236,8 @@ type Repository interface {
 	Delete(ctx context.Context, id, userID uuid.UUID) error
 	SumVaultBalance(ctx context.Context, userID uuid.UUID, currency string) (decimal.Decimal, error)
 	UpdateMilestones(ctx context.Context, goalID uuid.UUID, milestones []int) error
+	UpdateDeadlineReminders(ctx context.Context, goalID uuid.UUID, reminders []int) error
+	ListActiveApproachingDeadline(ctx context.Context, maxDays int) ([]SavingsGoal, error)
 	ListContributions(ctx context.Context, goalID, userID uuid.UUID, params interface{}) ([]GoalContribution, int, string, error)
 	// SumRecentDeposits sums vault deposit amounts for the user in the given currency since `since` (#714).
 	SumRecentDeposits(ctx context.Context, userID uuid.UUID, currency string, since time.Time) (decimal.Decimal, error)

--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -287,3 +287,20 @@ func DefaultColorForCategory(cat GoalCategory) string {
 	}
 	return "slate"
 }
+
+// GoalTemplate represents a pre-built savings goal configuration.
+type GoalTemplate struct {
+	ID              uuid.UUID       `json:"id"`
+	Name            string          `json:"name"`
+	Description     string          `json:"description"`
+	Category        GoalCategory    `json:"category"`
+	SuggestedAmount decimal.Decimal `json:"suggested_amount"`
+	Currency        string          `json:"currency"`
+	SuggestedMonths int             `json:"suggested_months"`
+	Icon            string          `json:"icon"`
+}
+
+type TemplateRepository interface {
+	List(ctx context.Context) ([]GoalTemplate, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*GoalTemplate, error)
+}

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -38,6 +38,8 @@ type SavingsGoalManager interface {
 	Unshare(ctx context.Context, userID, goalID uuid.UUID) error
 	GetShared(ctx context.Context, token uuid.UUID) (savingsgoal.SharedGoalView, error)
 	ListContributions(ctx context.Context, userID, goalID uuid.UUID, params listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error)
+	ListTemplates(ctx context.Context) ([]savingsgoal.GoalTemplate, error)
+	CreateFromTemplate(ctx context.Context, userID uuid.UUID, in service.CreateFromTemplateInput) (savingsgoal.SavingsGoal, error)
 }
 
 type SavingsGoalHandler struct {
@@ -75,6 +77,10 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/share", h.share)
 	mux.HandleFunc("DELETE /api/v1/users/savings-goals/{id}/share", h.unshare)
 	mux.HandleFunc("GET /api/v1/savings-goals/shared/{token}", h.getShared)
+
+	// #7xx templates
+	mux.HandleFunc("GET /api/v1/savings-goal-templates", h.listTemplates)
+	mux.HandleFunc("POST /api/v1/users/savings-goals/from-template", h.createFromTemplate)
 }
 
 type createSavingsGoalRequest struct {
@@ -138,6 +144,73 @@ func (h *SavingsGoalHandler) create(w http.ResponseWriter, r *http.Request) {
 		Emoji:        req.Emoji,
 		VaultID:      vaultID,
 	})
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusCreated, response.Created(goal))
+}
+
+func (h *SavingsGoalHandler) listTemplates(w http.ResponseWriter, r *http.Request) {
+	templates, err := h.svc.ListTemplates(r.Context())
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(templates))
+}
+
+type createFromTemplateRequest struct {
+	TemplateID     string       `json:"template_id"`
+	OverrideAmount *json.Number `json:"override_amount"`
+	OverrideMonths *int         `json:"override_months"`
+	VaultID        *string      `json:"vault_id,omitempty"`
+}
+
+func (h *SavingsGoalHandler) createFromTemplate(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	body, err := readJSONBody(r)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+	var req createFromTemplateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid JSON"))
+		return
+	}
+
+	templateID, err := uuid.Parse(req.TemplateID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("template_id must be a valid UUID"))
+		return
+	}
+
+	in := service.CreateFromTemplateInput{
+		TemplateID: templateID,
+	}
+	if req.OverrideAmount != nil {
+		amount, err := parseTargetAmount(*req.OverrideAmount)
+		if err != nil {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+			return
+		}
+		in.OverrideAmount = &amount
+	}
+	if req.OverrideMonths != nil {
+		in.OverrideMonths = req.OverrideMonths
+	}
+	vaultID, err := parseOptionalUUID(req.VaultID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault_id must be a valid UUID"))
+		return
+	}
+	in.VaultID = vaultID
+
+	goal, err := h.svc.CreateFromTemplate(r.Context(), userID, in)
 	if err != nil {
 		h.writeError(w, r, err)
 		return

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -230,13 +230,13 @@ func (m *mockSavingsGoalService) GetShared(_ context.Context, token uuid.UUID) (
 	for _, g := range m.goals {
 		if g.ShareToken != nil && *g.ShareToken == token {
 			return savingsgoal.SharedGoalView{
-				Name:          g.Description,
-				Emoji:         g.Emoji,
-				TargetAmount:  g.TargetAmount,
-				Currency:      g.Currency,
-				Deadline:      g.Deadline,
-				Category:      g.Category,
-				Status:        string(g.Status),
+				Name:         g.Description,
+				Emoji:        g.Emoji,
+				TargetAmount: g.TargetAmount,
+				Currency:     g.Currency,
+				Deadline:     g.Deadline,
+				Category:     g.Category,
+				Status:       string(g.Status),
 			}, nil
 		}
 	}
@@ -269,6 +269,14 @@ func (m *mockSavingsGoalService) DepositSplit(_ context.Context, userID uuid.UUI
 		Currency:       in.Currency,
 		Goals:          results,
 	}, nil
+}
+
+func (m *mockSavingsGoalService) ListTemplates(_ context.Context) ([]savingsgoal.GoalTemplate, error) {
+	return nil, nil
+}
+
+func (m *mockSavingsGoalService) CreateFromTemplate(_ context.Context, _ uuid.UUID, _ service.CreateFromTemplateInput) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
 }
 
 func withAuthUser(next http.Handler, userID uuid.UUID) http.Handler {

--- a/apps/api/internal/handler/savings_goal_template_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_template_handler_test.go
@@ -132,7 +132,7 @@ func TestGoalTemplateHandler(t *testing.T) {
 	h.Register(mux)
 
 	authedClient := func(req *http.Request) *http.Request {
-		return req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: userID.String()}))
+		return req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
 	}
 
 	t.Run("list templates", func(t *testing.T) {

--- a/apps/api/internal/handler/savings_goal_template_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_template_handler_test.go
@@ -1,0 +1,182 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/handler"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
+)
+
+type mockGoalTemplateService struct {
+	Templates []savingsgoal.GoalTemplate
+	Goals     []savingsgoal.SavingsGoal
+}
+
+func (m *mockGoalTemplateService) Create(ctx context.Context, userID uuid.UUID, in service.CreateSavingsGoalInput) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) List(ctx context.Context, userID uuid.UUID, category, status string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
+	return nil, nil
+}
+func (m *mockGoalTemplateService) Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Delete(ctx context.Context, userID, goalID uuid.UUID) error {
+	return nil
+}
+func (m *mockGoalTemplateService) Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error) {
+	return savingsgoal.SavingsGoalsSummary{}, nil
+}
+func (m *mockGoalTemplateService) Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Complete(ctx context.Context, userID, goalID uuid.UUID, action string) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Archive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Unarchive(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) DepositSplit(ctx context.Context, userID uuid.UUID, in service.DepositSplitInput) (service.SplitDepositResult, error) {
+	return service.SplitDepositResult{}, nil
+}
+func (m *mockGoalTemplateService) Share(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
+func (m *mockGoalTemplateService) Unshare(ctx context.Context, userID, goalID uuid.UUID) error {
+	return nil
+}
+func (m *mockGoalTemplateService) GetShared(ctx context.Context, token uuid.UUID) (savingsgoal.SharedGoalView, error) {
+	return savingsgoal.SharedGoalView{}, nil
+}
+func (m *mockGoalTemplateService) ListContributions(ctx context.Context, userID, goalID uuid.UUID, params listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error) {
+	return nil, 0, "", nil
+}
+func (m *mockGoalTemplateService) ListTemplates(ctx context.Context) ([]savingsgoal.GoalTemplate, error) {
+	return m.Templates, nil
+}
+func (m *mockGoalTemplateService) CreateFromTemplate(ctx context.Context, userID uuid.UUID, in service.CreateFromTemplateInput) (savingsgoal.SavingsGoal, error) {
+	var template *savingsgoal.GoalTemplate
+	for _, t := range m.Templates {
+		if t.ID == in.TemplateID {
+			template = &t
+			break
+		}
+	}
+	if template == nil {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	amount := template.SuggestedAmount
+	if in.OverrideAmount != nil {
+		amount = *in.OverrideAmount
+	}
+	months := template.SuggestedMonths
+	if in.OverrideMonths != nil {
+		months = *in.OverrideMonths
+	}
+	deadline := time.Now().UTC().AddDate(0, months, 0)
+
+	goal := savingsgoal.SavingsGoal{
+		ID:           uuid.New(),
+		UserID:       userID,
+		Name:         template.Name,
+		Description:  template.Description,
+		TargetAmount: amount,
+		Currency:     template.Currency,
+		Deadline:     deadline,
+		Category:     template.Category,
+	}
+	m.Goals = append(m.Goals, goal)
+	return goal, nil
+}
+
+func TestGoalTemplateHandler(t *testing.T) {
+	userID := uuid.New()
+	templateID := uuid.New()
+
+	svc := &mockGoalTemplateService{
+		Templates: []savingsgoal.GoalTemplate{
+			{
+				ID:              templateID,
+				Name:            "Vacation",
+				SuggestedAmount: decimal.NewFromInt(1500),
+				Currency:        "USDC",
+				SuggestedMonths: 12,
+			},
+		},
+	}
+	h := handler.NewSavingsGoalHandler(svc, nil)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	authedClient := func(req *http.Request) *http.Request {
+		return req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: userID.String()}))
+	}
+
+	t.Run("list templates", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/savings-goal-templates", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, authedClient(req))
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Vacation")
+	})
+
+	t.Run("create from template without overrides", func(t *testing.T) {
+		body := map[string]any{"template_id": templateID.String()}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users/savings-goals/from-template", bytes.NewReader(b))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, authedClient(req))
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Contains(t, rec.Body.String(), "1500")
+	})
+
+	t.Run("create from template with overrides", func(t *testing.T) {
+		body := map[string]any{
+			"template_id":     templateID.String(),
+			"override_amount": "5000",
+			"override_months": 6,
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users/savings-goals/from-template", bytes.NewReader(b))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, authedClient(req))
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Contains(t, rec.Body.String(), "5000")
+	})
+
+	t.Run("invalid template returns 404", func(t *testing.T) {
+		body := map[string]any{"template_id": uuid.New().String()}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/users/savings-goals/from-template", bytes.NewReader(b))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, authedClient(req))
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}

--- a/apps/api/internal/repository/postgres/goal_template_repository.go
+++ b/apps/api/internal/repository/postgres/goal_template_repository.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+type GoalTemplateRepository struct {
+	db *sql.DB
+}
+
+func NewGoalTemplateRepository(db *sql.DB) *GoalTemplateRepository {
+	return &GoalTemplateRepository{db: db}
+}
+
+func (r *GoalTemplateRepository) List(ctx context.Context) ([]savingsgoal.GoalTemplate, error) {
+	query := `
+		SELECT id, name, description, category, suggested_amount, currency, suggested_months, icon
+		FROM goal_templates
+		ORDER BY name ASC
+	`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var templates []savingsgoal.GoalTemplate
+	for rows.Next() {
+		var t savingsgoal.GoalTemplate
+		var amountStr string
+		var category string
+		if err := rows.Scan(&t.ID, &t.Name, &t.Description, &category, &amountStr, &t.Currency, &t.SuggestedMonths, &t.Icon); err != nil {
+			return nil, err
+		}
+		t.Category = savingsgoal.GoalCategory(category)
+		t.SuggestedAmount, _ = decimal.NewFromString(amountStr)
+		templates = append(templates, t)
+	}
+	return templates, rows.Err()
+}
+
+func (r *GoalTemplateRepository) GetByID(ctx context.Context, id uuid.UUID) (*savingsgoal.GoalTemplate, error) {
+	query := `
+		SELECT id, name, description, category, suggested_amount, currency, suggested_months, icon
+		FROM goal_templates
+		WHERE id = $1
+	`
+	var t savingsgoal.GoalTemplate
+	var amountStr string
+	var category string
+	if err := r.db.QueryRowContext(ctx, query, id).Scan(&t.ID, &t.Name, &t.Description, &category, &amountStr, &t.Currency, &t.SuggestedMonths, &t.Icon); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, savingsgoal.ErrGoalNotFound
+		}
+		return nil, err
+	}
+	t.Category = savingsgoal.GoalCategory(category)
+	t.SuggestedAmount, _ = decimal.NewFromString(amountStr)
+	return &t, nil
+}

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -233,7 +233,7 @@ func (r *SavingsGoalRepository) ListActiveApproachingDeadline(ctx context.Contex
 		       status, completed_at, completion_action, name, emoji,
 		       share_token, share_enabled_at
 		FROM savings_goals
-		WHERE status = 'active' OR status IS NULL OR status = ''
+		WHERE (status = 'active' OR status IS NULL OR status = '')
 		  AND deadline BETWEEN NOW() AND NOW() + ($1 || ' days')::INTERVAL
 	`
 	rows, err := r.db.QueryContext(ctx, query, maxDays)
@@ -467,26 +467,26 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 		shareEnabledAtPtr = &t
 	}
 	return savingsgoal.SavingsGoal{
-		ID:                 parsedID,
-		UserID:             parsedUserID,
-		VaultID:            parsedVaultID,
-		TargetAmount:       target,
-		Currency:           currency,
-		Deadline:           deadline,
-		Description:        desc,
-		Name:               name.String,
-		Emoji:              emoji.String,
-		Category:           savingsgoal.GoalCategory(category),
-		Status:             goalStatus,
-		NotifiedMilestones: milestones,
+		ID:                    parsedID,
+		UserID:                parsedUserID,
+		VaultID:               parsedVaultID,
+		TargetAmount:          target,
+		Currency:              currency,
+		Deadline:              deadline,
+		Description:           desc,
+		Name:                  name.String,
+		Emoji:                 emoji.String,
+		Category:              savingsgoal.GoalCategory(category),
+		Status:                goalStatus,
+		NotifiedMilestones:    milestones,
 		DeadlineRemindersSent: reminders,
-		CreatedAt:        createdAt,
-		UpdatedAt:        updatedAt,
-		CompletedAt:      completedAtPtr,
-		CompletionAction: completionAction.String,
-		ShareToken:       shareTokenPtr,
-		ShareEnabledAt:   shareEnabledAtPtr,
-		IsShared:         shareTokenPtr != nil,
+		CreatedAt:             createdAt,
+		UpdatedAt:             updatedAt,
+		CompletedAt:           completedAtPtr,
+		CompletionAction:      completionAction.String,
+		ShareToken:            shareTokenPtr,
+		ShareEnabledAt:        shareEnabledAtPtr,
+		IsShared:              shareTokenPtr != nil,
 	}, nil
 }
 

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -74,7 +74,7 @@ func (r *SavingsGoalRepository) ClearShareToken(ctx context.Context, goalID, use
 func (r *SavingsGoalRepository) GetByShareToken(ctx context.Context, token uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
 		       share_token, share_enabled_at
 		FROM savings_goals WHERE share_token = $1
@@ -92,7 +92,7 @@ func (r *SavingsGoalRepository) GetByShareToken(ctx context.Context, token uuid.
 func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID, category string) ([]savingsgoal.SavingsGoal, error) {
 	query := `
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
 		       share_token, share_enabled_at
 		FROM savings_goals
@@ -125,7 +125,7 @@ func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID
 func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
-		       notified_milestones, created_at, updated_at,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
 		       share_token, share_enabled_at
 		FROM savings_goals WHERE id = $1
@@ -205,6 +205,52 @@ func (r *SavingsGoalRepository) UpdateMilestones(ctx context.Context, goalID uui
 		return savingsgoal.ErrGoalNotFound
 	}
 	return nil
+}
+
+func (r *SavingsGoalRepository) UpdateDeadlineReminders(ctx context.Context, goalID uuid.UUID, reminders []int) error {
+	if reminders == nil {
+		reminders = []int{}
+	}
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET deadline_reminders_sent = $1, updated_at = NOW()
+		WHERE id = $2
+	`, pq.Array(reminders), goalID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+func (r *SavingsGoalRepository) ListActiveApproachingDeadline(ctx context.Context, maxDays int) ([]savingsgoal.SavingsGoal, error) {
+	query := `
+		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
+		       status, completed_at, completion_action, name, emoji,
+		       share_token, share_enabled_at
+		FROM savings_goals
+		WHERE status = 'active' OR status IS NULL OR status = ''
+		  AND deadline BETWEEN NOW() AND NOW() + ($1 || ' days')::INTERVAL
+	`
+	rows, err := r.db.QueryContext(ctx, query, maxDays)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var goals []savingsgoal.SavingsGoal
+	for rows.Next() {
+		g, err := scanSavingsGoalWithShare(rows)
+		if err != nil {
+			return nil, err
+		}
+		goals = append(goals, g)
+	}
+	return goals, rows.Err()
 }
 
 func (r *SavingsGoalRepository) UpdateStatus(ctx context.Context, goalID, userID uuid.UUID, status string) error {
@@ -362,7 +408,7 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 		vaultID                                   sql.NullString
 		deadline, createdAt, updatedAt            time.Time
 		description                               sql.NullString
-		notifiedMilestones                        pq.Int32Array
+		notifiedMilestones, deadlineReminders     pq.Int32Array
 		status                                    sql.NullString
 		completedAt                               sql.NullTime
 		completionAction                          sql.NullString
@@ -372,7 +418,7 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 	)
 	if err := row.Scan(
 		&id, &userID, &vaultID, &targetStr, &currency, &deadline, &description, &category,
-		&notifiedMilestones, &createdAt, &updatedAt,
+		&notifiedMilestones, &deadlineReminders, &createdAt, &updatedAt,
 		&status, &completedAt, &completionAction, &name, &emoji,
 		&shareToken, &shareEnabledAt,
 	); err != nil {
@@ -394,6 +440,10 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 	milestones := make([]int, 0, len(notifiedMilestones))
 	for _, m := range notifiedMilestones {
 		milestones = append(milestones, int(m))
+	}
+	reminders := make([]int, 0, len(deadlineReminders))
+	for _, m := range deadlineReminders {
+		reminders = append(reminders, int(m))
 	}
 	goalStatus := savingsgoal.GoalStatusActive
 	if status.Valid && status.String != "" {
@@ -429,6 +479,7 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 		Category:           savingsgoal.GoalCategory(category),
 		Status:             goalStatus,
 		NotifiedMilestones: milestones,
+		DeadlineRemindersSent: reminders,
 		CreatedAt:        createdAt,
 		UpdatedAt:        updatedAt,
 		CompletedAt:      completedAtPtr,

--- a/apps/api/internal/scheduler/goal_deadline_reminder.go
+++ b/apps/api/internal/scheduler/goal_deadline_reminder.go
@@ -1,0 +1,184 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+// GoalDeadlineRepository fetches goals approaching their deadlines and updates sent reminders.
+type GoalDeadlineRepository interface {
+	ListActiveApproachingDeadline(ctx context.Context, maxDays int) ([]savingsgoal.SavingsGoal, error)
+	UpdateDeadlineReminders(ctx context.Context, goalID uuid.UUID, reminders []int) error
+}
+
+// GoalProgressResolver gets the current progress of a goal.
+type GoalProgressResolver interface {
+	EnrichProgress(ctx context.Context, goal savingsgoal.SavingsGoal) (savingsgoal.SavingsGoal, error)
+}
+
+// DeadlineNotifier sends the deadline reminder notification.
+type DeadlineNotifier interface {
+	Send(ctx context.Context, userID uuid.UUID, evt notifications.EventType, title, body string, payload map[string]any) error
+}
+
+// GoalDeadlineReminderConfig controls the deadline reminder job.
+type GoalDeadlineReminderConfig struct {
+	Enabled  bool
+	Interval time.Duration
+}
+
+// GoalDeadlineReminderJob runs daily and sends notifications at 7, 3, and 1 days before deadline.
+type GoalDeadlineReminderJob struct {
+	cfg       GoalDeadlineReminderConfig
+	repo      GoalDeadlineRepository
+	progress  GoalProgressResolver
+	notifier  DeadlineNotifier
+	logger    *slog.Logger
+	clock     func() time.Time
+	lastTickEnd atomic.Int64
+}
+
+// NewGoalDeadlineReminderJob constructs the job.
+func NewGoalDeadlineReminderJob(
+	cfg GoalDeadlineReminderConfig,
+	repo GoalDeadlineRepository,
+	progress GoalProgressResolver,
+	notifier DeadlineNotifier,
+	logger *slog.Logger,
+) *GoalDeadlineReminderJob {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	return &GoalDeadlineReminderJob{
+		cfg:      cfg,
+		repo:     repo,
+		progress: progress,
+		notifier: notifier,
+		logger:   logger,
+		clock:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (j *GoalDeadlineReminderJob) SetClock(clock func() time.Time) {
+	j.clock = clock
+}
+
+// Run drives the check loop until ctx is cancelled.
+func (j *GoalDeadlineReminderJob) Run(ctx context.Context) {
+	if !j.cfg.Enabled {
+		j.logger.Info("goal-deadline-reminder: disabled; not starting")
+		return
+	}
+	j.logger.Info("goal-deadline-reminder: starting", "interval", j.cfg.Interval)
+
+	j.Tick(ctx)
+
+	ticker := time.NewTicker(j.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			j.logger.Info("goal-deadline-reminder: stopping")
+			return
+		case <-ticker.C:
+			j.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single pass over all goals approaching their deadlines. Exported for tests.
+func (j *GoalDeadlineReminderJob) Tick(ctx context.Context) {
+	defer j.lastTickEnd.Store(j.clock().UnixNano())
+
+	goals, err := j.repo.ListActiveApproachingDeadline(ctx, 7)
+	if err != nil {
+		j.logger.Error("goal-deadline-reminder: list active approaching deadline failed", "error", err)
+		return
+	}
+
+	for _, goal := range goals {
+		j.processGoal(ctx, goal)
+	}
+}
+
+func (j *GoalDeadlineReminderJob) processGoal(ctx context.Context, goal savingsgoal.SavingsGoal) {
+	enriched, err := j.progress.EnrichProgress(ctx, goal)
+	if err != nil {
+		j.logger.Error("goal-deadline-reminder: get progress failed", "goal_id", goal.ID, "error", err)
+		return
+	}
+
+	if enriched.ProgressPct >= 100 {
+		return
+	}
+
+	now := j.clock()
+	daysLeft := int(math.Ceil(enriched.Deadline.Sub(now).Hours() / 24.0))
+
+	var threshold int
+	if daysLeft <= 1 {
+		threshold = 1
+	} else if daysLeft <= 3 {
+		threshold = 3
+	} else if daysLeft <= 7 {
+		threshold = 7
+	} else {
+		return
+	}
+
+	for _, sent := range enriched.DeadlineRemindersSent {
+		if sent == threshold {
+			return
+		}
+	}
+
+	var title, body string
+	goalName := enriched.Name
+	if goalName == "" {
+		goalName = "your goal"
+	}
+
+	switch threshold {
+	case 7:
+		title = "7 days left!"
+		body = fmt.Sprintf("You have 7 days to reach %s. You're at %.0f%%.", goalName, enriched.ProgressPct)
+	case 3:
+		title = "3 days remaining"
+		body = fmt.Sprintf("Only 3 days left on %s. Deposit now to stay on track.", goalName)
+	case 1:
+		title = "Last day!"
+		body = fmt.Sprintf("Today is your last day to fund %s.", goalName)
+	}
+
+	if err := j.notifier.Send(ctx, enriched.UserID, notifications.EventGoalMilestone, title, body, map[string]any{
+		"goal_id": enriched.ID.String(),
+		"days_left": threshold,
+		"progress_pct": enriched.ProgressPct,
+	}); err != nil {
+		j.logger.Error("goal-deadline-reminder: send notification failed", "goal_id", enriched.ID, "error", err)
+		return
+	}
+
+	newReminders := append(enriched.DeadlineRemindersSent, threshold)
+	if err := j.repo.UpdateDeadlineReminders(ctx, enriched.ID, newReminders); err != nil {
+		j.logger.Error("goal-deadline-reminder: update reminders failed", "goal_id", enriched.ID, "error", err)
+	}
+}
+
+// LastTickEnd returns the wall-clock time of the last completed tick.
+func (j *GoalDeadlineReminderJob) LastTickEnd() time.Time {
+	v := j.lastTickEnd.Load()
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v)
+}

--- a/apps/api/internal/scheduler/goal_deadline_reminder_test.go
+++ b/apps/api/internal/scheduler/goal_deadline_reminder_test.go
@@ -1,0 +1,137 @@
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+	"github.com/suncrestlabs/nester/apps/api/internal/scheduler"
+)
+
+type mockGoalDeadlineRepo struct {
+	Goals         []savingsgoal.SavingsGoal
+	UpdatedGoalID uuid.UUID
+	Reminders     []int
+}
+
+func (m *mockGoalDeadlineRepo) ListActiveApproachingDeadline(ctx context.Context, maxDays int) ([]savingsgoal.SavingsGoal, error) {
+	return m.Goals, nil
+}
+
+func (m *mockGoalDeadlineRepo) UpdateDeadlineReminders(ctx context.Context, goalID uuid.UUID, reminders []int) error {
+	m.UpdatedGoalID = goalID
+	m.Reminders = reminders
+	return nil
+}
+
+type mockGoalProgressResolver struct{}
+
+func (m *mockGoalProgressResolver) EnrichProgress(ctx context.Context, goal savingsgoal.SavingsGoal) (savingsgoal.SavingsGoal, error) {
+	// For tests, just return the goal passed in.
+	return goal, nil
+}
+
+type mockDeadlineNotifier struct {
+	Called bool
+	Title  string
+}
+
+func (m *mockDeadlineNotifier) Send(ctx context.Context, userID uuid.UUID, evt notifications.EventType, title, body string, payload map[string]any) error {
+	m.Called = true
+	m.Title = title
+	return nil
+}
+
+func TestGoalDeadlineReminderJob_Tick(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name       string
+		goal       savingsgoal.SavingsGoal
+		wantNotify bool
+		wantTitle  string
+		wantReminders []int
+	}{
+		{
+			name: "7 days left",
+			goal: savingsgoal.SavingsGoal{
+				ID: uuid.New(),
+				Deadline: now.Add(7 * 24 * time.Hour),
+				ProgressPct: 50,
+			},
+			wantNotify: true,
+			wantTitle: "7 days left!",
+			wantReminders: []int{7},
+		},
+		{
+			name: "3 days left",
+			goal: savingsgoal.SavingsGoal{
+				ID: uuid.New(),
+				Deadline: now.Add(3 * 24 * time.Hour),
+				ProgressPct: 50,
+			},
+			wantNotify: true,
+			wantTitle: "3 days remaining",
+			wantReminders: []int{3},
+		},
+		{
+			name: "1 day left",
+			goal: savingsgoal.SavingsGoal{
+				ID: uuid.New(),
+				Deadline: now.Add(23 * time.Hour),
+				ProgressPct: 50,
+			},
+			wantNotify: true,
+			wantTitle: "Last day!",
+			wantReminders: []int{1},
+		},
+		{
+			name: "already notified for 3 days, now 3 days left",
+			goal: savingsgoal.SavingsGoal{
+				ID: uuid.New(),
+				Deadline: now.Add(3 * 24 * time.Hour),
+				ProgressPct: 50,
+				DeadlineRemindersSent: []int{7, 3},
+			},
+			wantNotify: false,
+		},
+		{
+			name: "completed goal skipped",
+			goal: savingsgoal.SavingsGoal{
+				ID: uuid.New(),
+				Deadline: now.Add(3 * 24 * time.Hour),
+				ProgressPct: 100,
+			},
+			wantNotify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockGoalDeadlineRepo{Goals: []savingsgoal.SavingsGoal{tt.goal}}
+			resolver := &mockGoalProgressResolver{}
+			notifier := &mockDeadlineNotifier{}
+
+			job := scheduler.NewGoalDeadlineReminderJob(
+				scheduler.GoalDeadlineReminderConfig{Enabled: true, Interval: time.Hour},
+				repo,
+				resolver,
+				notifier,
+				nil,
+			)
+			job.SetClock(func() time.Time { return now })
+			job.Tick(context.Background())
+
+			assert.Equal(t, tt.wantNotify, notifier.Called)
+			if tt.wantNotify {
+				assert.Equal(t, tt.wantTitle, notifier.Title)
+				assert.Equal(t, tt.wantReminders, repo.Reminders)
+			}
+		})
+	}
+}

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -26,6 +26,7 @@ type VaultReader interface {
 
 type SavingsGoalService struct {
 	repo           savingsgoal.Repository
+	templateRepo   savingsgoal.TemplateRepository
 	vaultRepo      VaultReader
 	notifier       GoalMilestoneNotifier
 	streakRepo     savingsstreak.Repository
@@ -38,10 +39,16 @@ func NewSavingsGoalService(repo savingsgoal.Repository, vaultRepo VaultReader, n
 	}
 	return &SavingsGoalService{
 		repo:           repo,
+		templateRepo:   nil,
 		vaultRepo:      vaultRepo,
 		notifier:       notifier,
 		streakNotifier: noopStreakMilestoneNotifier{},
 	}
+}
+
+// SetTemplateRepository attaches the template repository.
+func (s *SavingsGoalService) SetTemplateRepository(repo savingsgoal.TemplateRepository) {
+	s.templateRepo = repo
 }
 
 // SetStreakRepository attaches the streak persistence layer.
@@ -125,6 +132,51 @@ func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in Cr
 		return savingsgoal.SavingsGoal{}, err
 	}
 	return s.EnrichProgress(ctx, *goal)
+}
+
+type CreateFromTemplateInput struct {
+	TemplateID     uuid.UUID
+	OverrideAmount *decimal.Decimal
+	OverrideMonths *int
+	VaultID        *uuid.UUID
+}
+
+func (s *SavingsGoalService) ListTemplates(ctx context.Context) ([]savingsgoal.GoalTemplate, error) {
+	if s.templateRepo == nil {
+		return nil, fmt.Errorf("goal templates not configured")
+	}
+	return s.templateRepo.List(ctx)
+}
+
+func (s *SavingsGoalService) CreateFromTemplate(ctx context.Context, userID uuid.UUID, in CreateFromTemplateInput) (savingsgoal.SavingsGoal, error) {
+	if s.templateRepo == nil {
+		return savingsgoal.SavingsGoal{}, fmt.Errorf("goal templates not configured")
+	}
+	template, err := s.templateRepo.GetByID(ctx, in.TemplateID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	amount := template.SuggestedAmount
+	if in.OverrideAmount != nil {
+		amount = *in.OverrideAmount
+	}
+	months := template.SuggestedMonths
+	if in.OverrideMonths != nil {
+		months = *in.OverrideMonths
+	}
+	deadline := time.Now().UTC().AddDate(0, months, 0)
+
+	createIn := CreateSavingsGoalInput{
+		TargetAmount: amount,
+		Currency:     template.Currency,
+		Deadline:     deadline,
+		Description:  template.Description,
+		Category:     string(template.Category),
+		Name:         template.Name,
+		Emoji:        "", // Optional: could map template.Icon to emoji if needed
+		VaultID:      in.VaultID,
+	}
+	return s.Create(ctx, userID, createIn)
 }
 
 func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -200,39 +200,6 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 		filterCategory = string(parsed)
 	}
 
-	// Status is filtered after enrichment so the dynamic auto-complete (#716) is
-	// reflected: a stored-active goal that has reached its target reads as
-	// "completed" here, matching ?status=completed and excluded by ?status=active.
-	filterStatus, err := savingsgoal.ParseStatusFilter(status)
-	if err != nil {
-		return nil, err
-	}
-
-	goals, err := s.repo.ListByUser(ctx, userID, filterCategory)
-	if err != nil {
-		return nil, err
-	}
-	var goals []savingsgoal.SavingsGoal
-	for rows.Next() {
-		g, err := scanSavingsGoalWithShare(rows)
-		if err != nil {
-			return nil, err
-		}
-		goals = append(goals, g)
-	}
-	return goals, rows.Err()
-}
-
-func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category, status string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
-	filterCategory := ""
-	if strings.TrimSpace(category) != "" {
-		parsed, err := savingsgoal.ParseCategory(category)
-		if err != nil {
-			return nil, err
-		}
-		filterCategory = string(parsed)
-	}
-
 	filterStatus, err := savingsgoal.ParseStatusFilter(status)
 	if err != nil {
 		return nil, err
@@ -546,7 +513,7 @@ func (s *SavingsGoalService) Resume(ctx context.Context, userID, goalID uuid.UUI
 		return savingsgoal.SavingsGoal{}, err
 	}
 	goal.Status = savingsgoal.GoalStatusActive
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // Complete explicitly marks a goal as completed with a disposition action (#716).

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -124,7 +124,7 @@ func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in Cr
 	if err := s.repo.Create(ctx, goal); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
@@ -135,7 +135,7 @@ func (s *SavingsGoalService) Get(ctx context.Context, userID, goalID uuid.UUID) 
 	if goal.UserID != userID {
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
 	}
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category, status string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
@@ -160,9 +160,39 @@ func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, categor
 	if err != nil {
 		return nil, err
 	}
+	var goals []savingsgoal.SavingsGoal
+	for rows.Next() {
+		g, err := scanSavingsGoalWithShare(rows)
+		if err != nil {
+			return nil, err
+		}
+		goals = append(goals, g)
+	}
+	return goals, rows.Err()
+}
+
+func (s *SavingsGoalService) List(ctx context.Context, userID uuid.UUID, category, status string, includeArchived bool) ([]savingsgoal.SavingsGoal, error) {
+	filterCategory := ""
+	if strings.TrimSpace(category) != "" {
+		parsed, err := savingsgoal.ParseCategory(category)
+		if err != nil {
+			return nil, err
+		}
+		filterCategory = string(parsed)
+	}
+
+	filterStatus, err := savingsgoal.ParseStatusFilter(status)
+	if err != nil {
+		return nil, err
+	}
+
+	goals, err := s.repo.ListByUser(ctx, userID, filterCategory)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]savingsgoal.SavingsGoal, 0, len(goals))
 	for _, g := range goals {
-		enriched, err := s.enrichProgress(ctx, g)
+		enriched, err := s.EnrichProgress(ctx, g)
 		if err != nil {
 			return nil, err
 		}
@@ -238,7 +268,7 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 	if err := s.repo.Update(ctx, goal); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 func (s *SavingsGoalService) Delete(ctx context.Context, userID, goalID uuid.UUID) error {
@@ -266,7 +296,7 @@ func (s *SavingsGoalService) Summary(ctx context.Context, userID uuid.UUID) (sav
 
 	now := time.Now().UTC()
 	for _, goal := range goals {
-		enriched, err := s.enrichProgress(ctx, goal)
+		enriched, err := s.EnrichProgress(ctx, goal)
 		if err != nil {
 			return savingsgoal.SavingsGoalsSummary{}, err
 		}
@@ -346,7 +376,7 @@ func (s *SavingsGoalService) validateGoalVault(ctx context.Context, userID, vaul
 	return nil
 }
 
-func (s *SavingsGoalService) enrichProgress(ctx context.Context, goal savingsgoal.SavingsGoal) (savingsgoal.SavingsGoal, error) {
+func (s *SavingsGoalService) EnrichProgress(ctx context.Context, goal savingsgoal.SavingsGoal) (savingsgoal.SavingsGoal, error) {
 	balance, err := s.currentAmount(ctx, goal)
 	if err != nil {
 		return savingsgoal.SavingsGoal{}, err
@@ -445,7 +475,7 @@ func (s *SavingsGoalService) Pause(ctx context.Context, userID, goalID uuid.UUID
 		return savingsgoal.SavingsGoal{}, err
 	}
 	goal.Status = savingsgoal.GoalStatusPaused
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // Resume reactivates a paused goal (#718).
@@ -496,7 +526,7 @@ func (s *SavingsGoalService) Complete(ctx context.Context, userID, goalID uuid.U
 	goal.CompletionAction = action
 	now := time.Now().UTC()
 	goal.CompletedAt = &now
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // Share generates a unique share token for the goal, enabling read-only public access.
@@ -517,7 +547,7 @@ func (s *SavingsGoalService) Share(ctx context.Context, userID, goalID uuid.UUID
 		goal.ShareToken = &token
 		goal.IsShared = true
 	}
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // Unshare revokes the share token, making the goal private again.
@@ -539,7 +569,7 @@ func (s *SavingsGoalService) GetShared(ctx context.Context, token uuid.UUID) (sa
 	if err != nil {
 		return savingsgoal.SharedGoalView{}, err
 	}
-	enriched, err := s.enrichProgress(ctx, *goal)
+	enriched, err := s.EnrichProgress(ctx, *goal)
 	if err != nil {
 		return savingsgoal.SharedGoalView{}, err
 	}
@@ -569,13 +599,13 @@ func (s *SavingsGoalService) Archive(ctx context.Context, userID, goalID uuid.UU
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
 	}
 	if goal.Status == savingsgoal.GoalStatusArchived {
-		return s.enrichProgress(ctx, *goal)
+		return s.EnrichProgress(ctx, *goal)
 	}
 	if err := s.repo.UpdateStatus(ctx, goalID, userID, savingsgoal.GoalStatusArchived); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
 	goal.Status = savingsgoal.GoalStatusArchived
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // Unarchive restores an archived goal to active status (#721).
@@ -588,13 +618,13 @@ func (s *SavingsGoalService) Unarchive(ctx context.Context, userID, goalID uuid.
 		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
 	}
 	if goal.Status != savingsgoal.GoalStatusArchived {
-		return s.enrichProgress(ctx, *goal)
+		return s.EnrichProgress(ctx, *goal)
 	}
 	if err := s.repo.UpdateStatus(ctx, goalID, userID, savingsgoal.GoalStatusActive); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
 	goal.Status = savingsgoal.GoalStatusActive
-	return s.enrichProgress(ctx, *goal)
+	return s.EnrichProgress(ctx, *goal)
 }
 
 // isoWeekKey returns an "YYYY-Www" string uniquely identifying the ISO calendar week of t.

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -105,6 +105,32 @@ func (m *memorySavingsGoalRepo) ListContributions(context.Context, uuid.UUID, uu
 	return nil, 0, "", nil
 }
 
+func (m *memorySavingsGoalRepo) UpdateDeadlineReminders(_ context.Context, goalID uuid.UUID, reminders []int) error {
+	g, ok := m.goals[goalID]
+	if !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.DeadlineRemindersSent = append([]int(nil), reminders...)
+	m.goals[goalID] = g
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) ListActiveApproachingDeadline(_ context.Context, maxDays int) ([]savingsgoal.SavingsGoal, error) {
+	now := time.Now().UTC()
+	cutoff := now.AddDate(0, 0, maxDays)
+	var out []savingsgoal.SavingsGoal
+	for _, g := range m.goals {
+		if g.Status != "" && g.Status != savingsgoal.GoalStatusActive {
+			continue
+		}
+		if g.Deadline.Before(now) || g.Deadline.After(cutoff) {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
 func (m *memorySavingsGoalRepo) SumRecentDeposits(context.Context, uuid.UUID, string, time.Time) (decimal.Decimal, error) {
 	return decimal.Zero, nil
 }

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -143,6 +143,18 @@ func (m *memoryGoalRepo) UpdateMilestones(_ context.Context, goalID uuid.UUID, m
 	m.goals[goalID] = g
 	return nil
 }
+func (m *memoryGoalRepo) UpdateDeadlineReminders(_ context.Context, goalID uuid.UUID, reminders []int) error {
+	g, ok := m.goals[goalID]
+	if !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.DeadlineRemindersSent = append([]int(nil), reminders...)
+	m.goals[goalID] = g
+	return nil
+}
+func (m *memoryGoalRepo) ListActiveApproachingDeadline(context.Context, int) ([]savingsgoal.SavingsGoal, error) {
+	return nil, nil
+}
 func (m *memoryGoalRepo) SetShareToken(_ context.Context, goalID, userID uuid.UUID, token uuid.UUID) error {
 	g, ok := m.goals[goalID]
 	if !ok || g.UserID != userID {
@@ -171,6 +183,7 @@ func (m *memoryGoalRepo) GetByShareToken(_ context.Context, token uuid.UUID) (*s
 	}
 	return nil, savingsgoal.ErrGoalNotFound
 }
+
 type memoryVaultRepo struct {
 	vaults map[uuid.UUID]vault.Vault
 }

--- a/apps/api/migrations/055_add_savings_goal_deadline_reminders.down.sql
+++ b/apps/api/migrations/055_add_savings_goal_deadline_reminders.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE savings_goals DROP COLUMN IF EXISTS deadline_reminders_sent;

--- a/apps/api/migrations/055_add_savings_goal_deadline_reminders.up.sql
+++ b/apps/api/migrations/055_add_savings_goal_deadline_reminders.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE savings_goals
+    ADD COLUMN IF NOT EXISTS deadline_reminders_sent INTEGER[] NOT NULL DEFAULT '{}';

--- a/apps/api/migrations/056_create_goal_templates.down.sql
+++ b/apps/api/migrations/056_create_goal_templates.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS goal_templates;

--- a/apps/api/migrations/056_create_goal_templates.up.sql
+++ b/apps/api/migrations/056_create_goal_templates.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE goal_templates (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name             VARCHAR(100) NOT NULL,
+    description      TEXT NOT NULL,
+    category         VARCHAR(50)  NOT NULL,
+    suggested_amount NUMERIC(20,8) NOT NULL,
+    currency         VARCHAR(10)  NOT NULL DEFAULT 'USDC',
+    suggested_months INT NOT NULL,
+    icon             VARCHAR(50)  NOT NULL
+);
+
+INSERT INTO goal_templates (name, description, category, suggested_amount, currency, suggested_months, icon) VALUES
+('Emergency Fund', 'Build a 3-month safety net for unexpected expenses.', 'emergency_fund', 3000, 'USDC', 6, 'shield-check'),
+('Vacation', 'Save up for your dream getaway without the financial stress.', 'travel', 1500, 'USDC', 12, 'plane'),
+('New Device', 'Upgrade your phone, laptop, or tablet.', 'other', 800, 'USDC', 3, 'smartphone'),
+('Home Down Payment', 'Start the journey toward owning your own place.', 'housing', 10000, 'USDC', 24, 'home'),
+('School Fees', 'Prepare for upcoming tuition and educational expenses.', 'education', 2000, 'USDC', 9, 'graduation-cap');


### PR DESCRIPTION
# Description
This PR implements two major enhancements to the savings goals API to help users achieve their financial targets more effectively:

## 1. Savings Goal Deadline Reminders
Users with deadline-bound savings goals will now receive push notifications as their deadline approaches, helping them stay on track.
- Added `deadline_reminders_sent` array column to `savings_goals` to track notified thresholds without duplication.
- Implemented `GoalDeadlineReminderJob` that runs daily to query active goals nearing their deadline.
- Automatically sends a push notification to users at 7, 3, and 1 day(s) before their goal deadline.
- Skips notifications if the goal has already been fully funded (progress >= 100%).
- Integrated corresponding repository methods and unit tests for the scheduled job.

## 2. Savings Goal Templates
First-time users can now create savings goals much faster by using pre-built templates that come with suggested targets and timelines.
- Created `goal_templates` table and seeded it with 5 starter templates: Emergency Fund, Vacation, New Device, Home Down Payment, and School Fees.
- Added `GoalTemplateRepository` for querying available templates.
- Created `GET /api/v1/savings-goal-templates` endpoint to list templates.
- Created `POST /api/v1/users/savings-goals/from-template` endpoint to instantiate a goal from a template, supporting user overrides for `amount` and `months`.
- Comprehensive testing for template generation endpoints, including missing template `404` verification.


Closes #715 
Closes #717 