### PR TITLE
fix(ci): unblock Rust and Go pipelines (ethnum E0512, govulncheck)

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/suncrestlabs/nester/apps/api
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
@@ -39,8 +39,8 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
-	golang.org/x/text v0.32.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -155,12 +155,12 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -408,9 +408,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"


### PR DESCRIPTION
The Rust and Go pipelines have both been failing on recent PRs, and neither failure is actually coming from the PRs themselves. This cleans up both so `dev` goes green again.

## Rust — `Contracts (Rust)`

The job was dying while compiling the `ethnum` dependency with `error[E0512]`. `ethnum 1.5.0` transmutes `()` into `TryFromIntError`, and those two types no longer have the same size on the current stable toolchain (rustc 1.97.1), so the compile aborts before any of our contract code even runs. ethnum fixed this in 1.5.1, so I've bumped the lockfile to 1.5.3 (the latest 1.5.x). There are no source changes here, just the pinned dependency version and its checksum.

## Go — `Dependency Audit (Go)`

govulncheck was flagging two advisories that aren't in the accepted allowlist:

- `GO-2026-5856` in the standard library's `crypto/tls`, fixed in go1.25.12. I bumped the module's go directive from 1.25.11 to 1.25.12.
- `GO-2026-5970` in `golang.org/x/text`, fixed in v0.39.0. Bumped from v0.32.0 (`x/sync` came along to v0.21.0 during `go mod tidy`).

## Note on sequencing

Once this lands on `dev`, the checks on #797 will re-run against a base that actually compiles, so its new authorization tests finally get exercised in CI before that PR is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain requirement and supporting libraries to newer versions.
  * Includes dependency updates that may improve compatibility, stability, and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->