### PR TITLE
feat(api): envelope encryption, key versioning & rotation for account cipher

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -151,3 +151,30 @@ FLUTTERWAVE_SECRET_KEY=FLWSECK_TEST-your_flutterwave_key_here
 # Risk-free rate used for Sharpe and Sortino ratio calculations in vault analytics.
 # Expressed as a decimal (0.05 = 5%). Defaults to 0.05 (US T-bill proxy).
 RISK_FREE_RATE=0.05
+
+# --- Account number encryption (envelope + key versioning) ---------------------
+# Saved bank account numbers are encrypted at rest with AES-256-GCM. Each stored
+# row records the key version that sealed it (bank_accounts.key_version) so keys
+# can be rotated without rewriting historical data. See docs/security/key-rotation.md.
+#
+# Preferred (multi-key) configuration:
+#   ACCOUNT_CIPHER_KEYS       Comma-separated "version:base64key" pairs. Each key
+#                             must be 32 raw bytes, base64-encoded. Generate with:
+#                               openssl rand -base64 32
+#   ACCOUNT_CIPHER_ACTIVE_KEY The version used to encrypt new writes. Must name a
+#                             version present in ACCOUNT_CIPHER_KEYS. Legacy keys
+#                             stay listed here so old rows keep decrypting.
+#   ACCOUNT_CIPHER_FINGERPRINT_KEY (optional) Stable base64 pepper for the
+#                             uniqueness fingerprint. Leave empty to default to the
+#                             v1 key. Do NOT rotate this casually — changing it
+#                             breaks duplicate detection for existing accounts.
+#
+# Example (v2 active, v1 retained for decryption of un-rotated rows):
+# ACCOUNT_CIPHER_KEYS=v1:REPLACE_WITH_BASE64_32_BYTE_KEY,v2:REPLACE_WITH_BASE64_32_BYTE_KEY
+# ACCOUNT_CIPHER_ACTIVE_KEY=v2
+# ACCOUNT_CIPHER_FINGERPRINT_KEY=
+
+# Legacy single-key fallback. Used only when ACCOUNT_CIPHER_KEYS is unset; the
+# key is registered as version "v1". Prefer ACCOUNT_CIPHER_KEYS above.
+# In development this defaults to an all-zero test key when left empty.
+BANK_ACCOUNT_ENCRYPTION_KEY=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -164,9 +164,11 @@ RISK_FREE_RATE=0.05
 #   ACCOUNT_CIPHER_ACTIVE_KEY The version used to encrypt new writes. Must name a
 #                             version present in ACCOUNT_CIPHER_KEYS. Legacy keys
 #                             stay listed here so old rows keep decrypting.
-#   ACCOUNT_CIPHER_FINGERPRINT_KEY (optional) Stable base64 pepper for the
-#                             uniqueness fingerprint. Leave empty to default to the
-#                             v1 key. Do NOT rotate this casually — changing it
+#   ACCOUNT_CIPHER_FINGERPRINT_KEY Stable base64 pepper for the uniqueness
+#                             fingerprint. If empty it defaults to the v1 key, so it
+#                             is optional ONLY when a v1 key is configured; a key set
+#                             without v1 MUST set this explicitly (startup fails
+#                             otherwise). Do NOT rotate it casually — changing it
 #                             breaks duplicate detection for existing accounts.
 #
 # Example (v2 active, v1 retained for decryption of un-rotated rows):

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -134,8 +134,8 @@ func run() error {
 
 	bankAccountRepository := postgres.NewBankAccountRepository(db)
 	var accountCipher *cryptopkg.AccountCipher
-	if key := cfg.BankAccountEncryptionKey(); key != "" {
-		cipher, cipherErr := cryptopkg.NewAccountCipher(key)
+	if ac := cfg.AccountCipher(); ac.Configured() {
+		cipher, cipherErr := cryptopkg.NewAccountCipherWithKeys(ac.ActiveVersion(), ac.Keys(), ac.FingerprintKey())
 		if cipherErr != nil {
 			return fmt.Errorf("bank account cipher: %w", cipherErr)
 		}

--- a/apps/api/cmd/rotate_keys/main.go
+++ b/apps/api/cmd/rotate_keys/main.go
@@ -1,0 +1,99 @@
+// Command rotate_keys re-encrypts stored bank account numbers under the active
+// key version. It is safe to run repeatedly (idempotent) and safe to interrupt
+// (resumable): rows already on the active key version are skipped, and each row
+// is committed as it is rotated.
+//
+// Usage:
+//
+//	go run ./cmd/rotate_keys [-batch-size=500] [-timeout=0]
+//
+// Configuration is read from the same environment as the API (see
+// ACCOUNT_CIPHER_KEYS / ACCOUNT_CIPHER_ACTIVE_KEY). It never logs plaintext,
+// keys, or ciphertext — only counts and row IDs.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/config"
+	cryptopkg "github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/repository"
+	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+	"github.com/suncrestlabs/nester/apps/api/internal/rotation"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+)
+
+var version = "dev"
+
+func main() {
+	if err := run(); err != nil {
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	batchSize := flag.Int("batch-size", 500, "number of rows to re-encrypt per batch")
+	timeout := flag.Duration("timeout", 0, "overall timeout for the run (0 = no timeout)")
+	flag.Parse()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	logger, err := logpkg.New(cfg.Log(), version)
+	if err != nil {
+		return err
+	}
+
+	acCfg := cfg.AccountCipher()
+	if !acCfg.Configured() {
+		return fmt.Errorf("account cipher is not configured; set ACCOUNT_CIPHER_KEYS (or BANK_ACCOUNT_ENCRYPTION_KEY)")
+	}
+	cipher, err := cryptopkg.NewAccountCipherWithKeys(acCfg.ActiveVersion(), acCfg.Keys(), acCfg.FingerprintKey())
+	if err != nil {
+		return fmt.Errorf("build account cipher: %w", err)
+	}
+
+	pgPool, err := repository.NewPostgresDB(cfg.Database())
+	if err != nil {
+		return err
+	}
+	defer pgPool.Pool.Close()
+
+	db := stdlib.OpenDBFromPool(pgPool.Pool)
+	defer db.Close()
+
+	repo := postgres.NewBankAccountRepository(db)
+
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	stats, err := rotation.NewRotator(repo, cipher).Run(ctx, rotation.Options{
+		BatchSize: *batchSize,
+		Logger:    logger,
+	})
+	if err != nil {
+		return fmt.Errorf("rotation failed after %d rows rotated: %w", stats.Rotated, err)
+	}
+
+	logger.Info("rotation finished",
+		"active_version", acCfg.ActiveVersion(),
+		"pending_at_start", stats.Pending,
+		"rotated", stats.Rotated,
+		"duration", time.Since(start).String(),
+	)
+	return nil
+}

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -291,6 +291,7 @@ func Load() (*Config, error) {
 		cfg.bankAccountCipherKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 	}
 
+	cfg.accountCipher = loader.accountCipherConfig(cfg.bankAccountCipherKey)
 
 	cfg.validate(&loader)
 
@@ -879,6 +880,63 @@ func (l *envLoader) durationDefault(key string, fallback time.Duration) time.Dur
 		return fallback
 	}
 	return value
+}
+
+// accountCipherConfig parses the versioned encryption key set.
+//
+// When ACCOUNT_CIPHER_KEYS is set it takes precedence and must be a comma-
+// separated list of "version:base64key" pairs, with ACCOUNT_CIPHER_ACTIVE_KEY
+// naming one of those versions. Otherwise it falls back to the single legacy
+// BANK_ACCOUNT_ENCRYPTION_KEY registered as version "v1" (matching the
+// key_version column default), preserving existing single-key deployments.
+func (l *envLoader) accountCipherConfig(legacyKey string) AccountCipherConfig {
+	fingerprintKey := l.stringDefault("ACCOUNT_CIPHER_FINGERPRINT_KEY", "")
+	active := l.stringDefault("ACCOUNT_CIPHER_ACTIVE_KEY", "")
+
+	keysRaw, hasKeys := l.lookup("ACCOUNT_CIPHER_KEYS")
+	if hasKeys {
+		keys := make(map[string]string)
+		for _, pair := range strings.Split(keysRaw, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			version, keyB64, ok := strings.Cut(pair, ":")
+			version = strings.TrimSpace(version)
+			keyB64 = strings.TrimSpace(keyB64)
+			if !ok || version == "" || keyB64 == "" {
+				l.addError(`ACCOUNT_CIPHER_KEYS entries must be "version:base64key"`)
+				continue
+			}
+			if _, dup := keys[version]; dup {
+				l.addError(fmt.Sprintf("ACCOUNT_CIPHER_KEYS has duplicate version %q", version))
+				continue
+			}
+			keys[version] = keyB64
+		}
+
+		if active == "" {
+			l.addError("ACCOUNT_CIPHER_ACTIVE_KEY is required when ACCOUNT_CIPHER_KEYS is set")
+		} else if _, ok := keys[active]; !ok && len(keys) > 0 {
+			l.addError("ACCOUNT_CIPHER_ACTIVE_KEY must match a version listed in ACCOUNT_CIPHER_KEYS")
+		}
+
+		return AccountCipherConfig{activeVersion: active, keys: keys, fingerprintKey: fingerprintKey}
+	}
+
+	// Backward compatibility: fall back to the single legacy key as version "v1".
+	if strings.TrimSpace(legacyKey) != "" {
+		return AccountCipherConfig{
+			activeVersion:  "v1",
+			keys:           map[string]string{"v1": legacyKey},
+			fingerprintKey: fingerprintKey,
+		}
+	}
+
+	if active != "" || fingerprintKey != "" {
+		l.addError("ACCOUNT_CIPHER_ACTIVE_KEY/ACCOUNT_CIPHER_FINGERPRINT_KEY set but no keys are configured (set ACCOUNT_CIPHER_KEYS or BANK_ACCOUNT_ENCRYPTION_KEY)")
+	}
+	return AccountCipherConfig{}
 }
 
 func (l *envLoader) lookup(key string) (string, bool) {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -36,8 +36,44 @@ type Config struct {
 	startup               StartupConfig
 	bank                  BankConfig
 	bankAccountCipherKey  string
+	accountCipher         AccountCipherConfig
 	transactionPoller     TransactionPollerConfig
 	recurringDeposit      RecurringDepositConfig
+}
+
+// AccountCipherConfig holds the versioned key set used to encrypt sensitive
+// account numbers at rest. It supports non-destructive rotation: one active key
+// seals new writes while every configured version remains available to decrypt
+// historical rows.
+type AccountCipherConfig struct {
+	activeVersion  string
+	keys           map[string]string
+	fingerprintKey string
+}
+
+// Configured reports whether at least one encryption key is available.
+func (a AccountCipherConfig) Configured() bool {
+	return len(a.keys) > 0
+}
+
+// ActiveVersion is the key version used for new encryptions.
+func (a AccountCipherConfig) ActiveVersion() string {
+	return a.activeVersion
+}
+
+// Keys returns a copy of the version -> base64 key map.
+func (a AccountCipherConfig) Keys() map[string]string {
+	out := make(map[string]string, len(a.keys))
+	for k, v := range a.keys {
+		out[k] = v
+	}
+	return out
+}
+
+// FingerprintKey is the optional stable pepper (base64) for uniqueness
+// fingerprints. An empty value lets the cipher default to the legacy key.
+func (a AccountCipherConfig) FingerprintKey() string {
+	return a.fingerprintKey
 }
 
 // TransactionPollerConfig governs the background loop that reconciles pending
@@ -391,6 +427,11 @@ func (c Config) Bank() BankConfig {
 
 func (c Config) BankAccountEncryptionKey() string {
 	return c.bankAccountCipherKey
+}
+
+// AccountCipher returns the versioned key set used to encrypt account numbers.
+func (c Config) AccountCipher() AccountCipherConfig {
+	return c.accountCipher
 }
 
 func (c Config) TransactionPoller() TransactionPollerConfig {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -17,6 +17,10 @@ import (
 // enough to pass the length check, so it is rejected explicitly outside development.
 const defaultDevJWTSecret = "dev-nester-jwt-secret-change-in-production"
 
+// maxKeyVersionLen bounds an account cipher key version label so it fits the
+// bank_accounts.key_version VARCHAR(32) column.
+const maxKeyVersionLen = 32
+
 type Config struct {
 	environment           string
 	server                ServerConfig
@@ -908,6 +912,12 @@ func (l *envLoader) accountCipherConfig(legacyKey string) AccountCipherConfig {
 				l.addError(`ACCOUNT_CIPHER_KEYS entries must be "version:base64key"`)
 				continue
 			}
+			// key_version is persisted as VARCHAR(32); reject anything that would
+			// pass startup only to fail at the database boundary on write/rotation.
+			if len(version) > maxKeyVersionLen {
+				l.addError(fmt.Sprintf("ACCOUNT_CIPHER_KEYS version %q exceeds %d characters", version, maxKeyVersionLen))
+				continue
+			}
 			if _, dup := keys[version]; dup {
 				l.addError(fmt.Sprintf("ACCOUNT_CIPHER_KEYS has duplicate version %q", version))
 				continue
@@ -915,10 +925,23 @@ func (l *envLoader) accountCipherConfig(legacyKey string) AccountCipherConfig {
 			keys[version] = keyB64
 		}
 
+		// A non-empty setting that parses to zero usable entries (e.g. "," or
+		// ": ") must fail closed rather than silently disabling encryption.
+		if len(keys) == 0 {
+			l.addError("ACCOUNT_CIPHER_KEYS must contain at least one valid version:base64key entry")
+		}
 		if active == "" {
 			l.addError("ACCOUNT_CIPHER_ACTIVE_KEY is required when ACCOUNT_CIPHER_KEYS is set")
 		} else if _, ok := keys[active]; !ok && len(keys) > 0 {
 			l.addError("ACCOUNT_CIPHER_ACTIVE_KEY must match a version listed in ACCOUNT_CIPHER_KEYS")
+		}
+		// Without a v1 key, an empty fingerprint pepper would track the active key
+		// and shift the blind index on every rotation, permitting duplicate
+		// accounts. Require an explicit, rotation-independent pepper in that case.
+		if len(keys) > 0 && fingerprintKey == "" {
+			if _, hasV1 := keys["v1"]; !hasV1 {
+				l.addError("ACCOUNT_CIPHER_FINGERPRINT_KEY is required when ACCOUNT_CIPHER_KEYS has no v1 key")
+			}
 		}
 
 		return AccountCipherConfig{activeVersion: active, keys: keys, fingerprintKey: fingerprintKey}

--- a/apps/api/internal/config/config_cipher_test.go
+++ b/apps/api/internal/config/config_cipher_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -98,5 +99,54 @@ func TestAccountCipher_MalformedPairFails(t *testing.T) {
 	})
 	if _, err := Load(); err == nil {
 		t.Fatal("expected error for malformed ACCOUNT_CIPHER_KEYS entry")
+	}
+}
+
+func TestAccountCipher_EmptyKeysetFails(t *testing.T) {
+	// A non-empty setting that parses to zero entries must fail closed, not
+	// silently disable encryption.
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       ",",
+		"ACCOUNT_CIPHER_ACTIVE_KEY": "v1",
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when ACCOUNT_CIPHER_KEYS yields no usable entries")
+	}
+}
+
+func TestAccountCipher_VersionTooLongFails(t *testing.T) {
+	long := "v" + strings.Repeat("9", 40) // > 32 chars
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       long + ":" + b64key(1),
+		"ACCOUNT_CIPHER_ACTIVE_KEY": long,
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error for key version exceeding 32 characters")
+	}
+}
+
+func TestAccountCipher_NoV1RequiresFingerprintKey(t *testing.T) {
+	// A key set without v1 and without an explicit pepper must be rejected.
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       "v2:" + b64key(2) + ",v3:" + b64key(3),
+		"ACCOUNT_CIPHER_ACTIVE_KEY": "v2",
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when a v1-less key set omits ACCOUNT_CIPHER_FINGERPRINT_KEY")
+	}
+}
+
+func TestAccountCipher_NoV1WithFingerprintKeyOK(t *testing.T) {
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":            "v2:" + b64key(2) + ",v3:" + b64key(3),
+		"ACCOUNT_CIPHER_ACTIVE_KEY":      "v2",
+		"ACCOUNT_CIPHER_FINGERPRINT_KEY": b64key(9),
+	})
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AccountCipher().FingerprintKey() != b64key(9) {
+		t.Fatal("expected explicit fingerprint key to be carried through")
 	}
 }

--- a/apps/api/internal/config/config_cipher_test.go
+++ b/apps/api/internal/config/config_cipher_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func b64key(b byte) string {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// cipherEnv sets the minimum required config plus the caller's cipher-related
+// overrides, then loads. It clears the cipher keys first so ambient CI env does
+// not leak in.
+func cipherEnv(t *testing.T, overrides map[string]string) {
+	t.Helper()
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	for _, k := range []string{
+		"BANK_ACCOUNT_ENCRYPTION_KEY",
+		"ACCOUNT_CIPHER_KEYS",
+		"ACCOUNT_CIPHER_ACTIVE_KEY",
+		"ACCOUNT_CIPHER_FINGERPRINT_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+	for k, v := range overrides {
+		t.Setenv(k, v)
+	}
+}
+
+func TestAccountCipher_FallbackToLegacyKey(t *testing.T) {
+	cipherEnv(t, map[string]string{"BANK_ACCOUNT_ENCRYPTION_KEY": b64key(7)})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	ac := cfg.AccountCipher()
+	if !ac.Configured() {
+		t.Fatal("expected cipher to be configured from legacy key")
+	}
+	if ac.ActiveVersion() != "v1" {
+		t.Fatalf("active version = %q, want v1", ac.ActiveVersion())
+	}
+	if got := ac.Keys(); len(got) != 1 || got["v1"] != b64key(7) {
+		t.Fatalf("keys = %v, want single v1 legacy key", got)
+	}
+}
+
+func TestAccountCipher_MultiKey(t *testing.T) {
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       "v1:" + b64key(1) + ",v2:" + b64key(2),
+		"ACCOUNT_CIPHER_ACTIVE_KEY": "v2",
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	ac := cfg.AccountCipher()
+	if ac.ActiveVersion() != "v2" {
+		t.Fatalf("active version = %q, want v2", ac.ActiveVersion())
+	}
+	keys := ac.Keys()
+	if keys["v1"] != b64key(1) || keys["v2"] != b64key(2) {
+		t.Fatalf("keys = %v", keys)
+	}
+}
+
+func TestAccountCipher_ActiveMissingFails(t *testing.T) {
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       "v1:" + b64key(1) + ",v2:" + b64key(2),
+		"ACCOUNT_CIPHER_ACTIVE_KEY": "v3",
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when active version is not in the key set")
+	}
+}
+
+func TestAccountCipher_RequiresActiveWhenKeysSet(t *testing.T) {
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS": "v1:" + b64key(1),
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when ACCOUNT_CIPHER_ACTIVE_KEY is missing")
+	}
+}
+
+func TestAccountCipher_MalformedPairFails(t *testing.T) {
+	cipherEnv(t, map[string]string{
+		"ACCOUNT_CIPHER_KEYS":       "v1",
+		"ACCOUNT_CIPHER_ACTIVE_KEY": "v1",
+	})
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error for malformed ACCOUNT_CIPHER_KEYS entry")
+	}
+}

--- a/apps/api/internal/crypto/account_cipher.go
+++ b/apps/api/internal/crypto/account_cipher.go
@@ -30,6 +30,10 @@ var (
 	ErrActiveKeyMissing   = errors.New("active key version is not present in the key set")
 	ErrUnknownKeyVersion  = errors.New("no key registered for the ciphertext key version")
 	ErrEmptyKeyVersion    = errors.New("key version must not be empty")
+	// ErrFingerprintKeyRequired is returned when no v1 key and no explicit
+	// fingerprint pepper are provided. Defaulting the pepper to the active key
+	// would let it change on every rotation and break blind-index uniqueness.
+	ErrFingerprintKeyRequired = errors.New("a fingerprint key is required when no v1 key is configured")
 )
 
 // CipherEnvelope pairs stored ciphertext with the key version that produced it.
@@ -65,8 +69,9 @@ func NewAccountCipher(keyB64 string) (*AccountCipher, error) {
 //   - keysB64 maps a version label (e.g. "v1", "v2") to a base64-encoded 32-byte key.
 //   - activeVersion selects the key used for new encryptions; it must exist in keysB64.
 //   - fingerprintKeyB64 is the stable pepper for uniqueness fingerprints. When empty
-//     it defaults to the LegacyKeyVersion key if present, otherwise the active key,
-//     which preserves fingerprints written before a rotation.
+//     it defaults to the LegacyKeyVersion (v1) key, preserving fingerprints written
+//     before a rotation. If neither a pepper nor a v1 key is present, construction
+//     fails with ErrFingerprintKeyRequired rather than tracking the active key.
 func NewAccountCipherWithKeys(activeVersion string, keysB64 map[string]string, fingerprintKeyB64 string) (*AccountCipher, error) {
 	activeVersion = strings.TrimSpace(activeVersion)
 	if len(keysB64) == 0 {
@@ -99,7 +104,7 @@ func NewAccountCipherWithKeys(activeVersion string, keysB64 map[string]string, f
 		return nil, ErrActiveKeyMissing
 	}
 
-	fpKey, err := resolveFingerprintKey(fingerprintKeyB64, activeVersion, rawByVersion)
+	fpKey, err := resolveFingerprintKey(fingerprintKeyB64, rawByVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +166,7 @@ func (c *AccountCipher) Fingerprint(normalizedAccount string) string {
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 }
 
-func resolveFingerprintKey(b64, activeVersion string, rawByVersion map[string][]byte) ([]byte, error) {
+func resolveFingerprintKey(b64 string, rawByVersion map[string][]byte) ([]byte, error) {
 	if strings.TrimSpace(b64) != "" {
 		raw, err := decodeKey(b64)
 		if err != nil {
@@ -172,7 +177,7 @@ func resolveFingerprintKey(b64, activeVersion string, rawByVersion map[string][]
 	if raw, ok := rawByVersion[LegacyKeyVersion]; ok {
 		return raw, nil
 	}
-	return rawByVersion[activeVersion], nil
+	return nil, ErrFingerprintKeyRequired
 }
 
 func decodeKey(b64 string) ([]byte, error) {

--- a/apps/api/internal/crypto/account_cipher.go
+++ b/apps/api/internal/crypto/account_cipher.go
@@ -13,28 +13,181 @@ import (
 	"strings"
 )
 
-var (
-	ErrInvalidKey       = errors.New("encryption key must be 32 bytes (base64-encoded)")
-	ErrCiphertextTooShort = errors.New("ciphertext is too short")
+const (
+	// LegacyKeyVersion labels ciphertext written before key versioning existed.
+	// The migration that introduces the key_version column defaults existing
+	// rows to this value, and the single-key constructor registers its key under
+	// this version so historical data keeps decrypting after the upgrade.
+	LegacyKeyVersion = "v1"
+
+	keyLen = 32
 )
 
-// AccountCipher encrypts and decrypts sensitive account numbers at rest.
-type AccountCipher struct {
-	aead cipher.AEAD
-	mac  []byte
+var (
+	ErrInvalidKey         = errors.New("encryption key must be 32 bytes (base64-encoded)")
+	ErrCiphertextTooShort = errors.New("ciphertext is too short")
+	ErrNoKeys             = errors.New("no encryption keys configured")
+	ErrActiveKeyMissing   = errors.New("active key version is not present in the key set")
+	ErrUnknownKeyVersion  = errors.New("no key registered for the ciphertext key version")
+	ErrEmptyKeyVersion    = errors.New("key version must not be empty")
+)
+
+// CipherEnvelope pairs stored ciphertext with the key version that produced it.
+// Persisting the version alongside the bytes is what makes non-destructive key
+// rotation possible: any historical version can still be resolved for
+// decryption while new writes use the active key.
+type CipherEnvelope struct {
+	KeyVersion string
+	Ciphertext []byte
 }
 
-// NewAccountCipher builds a cipher from a base64-encoded 32-byte key.
+// AccountCipher encrypts and decrypts sensitive account numbers at rest using a
+// set of versioned AES-256-GCM keys. New data is sealed with the active key;
+// any registered key version can decrypt. Uniqueness fingerprints use a stable
+// key that is independent of the active encryption key, so blind-index lookups
+// keep matching across a rotation.
+type AccountCipher struct {
+	keys           map[string]cipher.AEAD
+	activeVersion  string
+	fingerprintKey []byte
+}
+
+// NewAccountCipher builds a single-key cipher from a base64-encoded 32-byte key.
+// The key is registered under LegacyKeyVersion and used for both encryption and
+// fingerprints. Retained for backward compatibility with single-key
+// deployments and callers that predate multi-key rotation.
 func NewAccountCipher(keyB64 string) (*AccountCipher, error) {
-	keyB64 = strings.TrimSpace(keyB64)
-	if keyB64 == "" {
-		return nil, ErrInvalidKey
+	return NewAccountCipherWithKeys(LegacyKeyVersion, map[string]string{LegacyKeyVersion: keyB64}, "")
+}
+
+// NewAccountCipherWithKeys builds a multi-version cipher.
+//
+//   - keysB64 maps a version label (e.g. "v1", "v2") to a base64-encoded 32-byte key.
+//   - activeVersion selects the key used for new encryptions; it must exist in keysB64.
+//   - fingerprintKeyB64 is the stable pepper for uniqueness fingerprints. When empty
+//     it defaults to the LegacyKeyVersion key if present, otherwise the active key,
+//     which preserves fingerprints written before a rotation.
+func NewAccountCipherWithKeys(activeVersion string, keysB64 map[string]string, fingerprintKeyB64 string) (*AccountCipher, error) {
+	activeVersion = strings.TrimSpace(activeVersion)
+	if len(keysB64) == 0 {
+		return nil, ErrNoKeys
 	}
-	key, err := base64.StdEncoding.DecodeString(keyB64)
-	if err != nil || len(key) != 32 {
-		return nil, ErrInvalidKey
+	if activeVersion == "" {
+		return nil, ErrEmptyKeyVersion
 	}
 
+	keys := make(map[string]cipher.AEAD, len(keysB64))
+	rawByVersion := make(map[string][]byte, len(keysB64))
+	for version, b64 := range keysB64 {
+		version = strings.TrimSpace(version)
+		if version == "" {
+			return nil, ErrEmptyKeyVersion
+		}
+		raw, err := decodeKey(b64)
+		if err != nil {
+			return nil, fmt.Errorf("key %q: %w", version, err)
+		}
+		aead, err := newAEAD(raw)
+		if err != nil {
+			return nil, fmt.Errorf("key %q: %w", version, err)
+		}
+		keys[version] = aead
+		rawByVersion[version] = raw
+	}
+
+	if _, ok := keys[activeVersion]; !ok {
+		return nil, ErrActiveKeyMissing
+	}
+
+	fpKey, err := resolveFingerprintKey(fingerprintKeyB64, activeVersion, rawByVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AccountCipher{
+		keys:           keys,
+		activeVersion:  activeVersion,
+		fingerprintKey: fpKey,
+	}, nil
+}
+
+// ActiveVersion returns the key version used for new encryptions.
+func (c *AccountCipher) ActiveVersion() string {
+	return c.activeVersion
+}
+
+// Encrypt seals plaintext with the active key and tags the result with the
+// active key version so it can be resolved for decryption later.
+func (c *AccountCipher) Encrypt(plaintext string) (CipherEnvelope, error) {
+	aead := c.keys[c.activeVersion]
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return CipherEnvelope{}, err
+	}
+	sealed := aead.Seal(nonce, nonce, []byte(plaintext), nil)
+	return CipherEnvelope{KeyVersion: c.activeVersion, Ciphertext: sealed}, nil
+}
+
+// Decrypt resolves the key for env.KeyVersion and reverses Encrypt. It returns
+// ErrUnknownKeyVersion when no key is registered for the ciphertext's version,
+// which is the signal that a required legacy key was dropped too early.
+func (c *AccountCipher) Decrypt(env CipherEnvelope) (string, error) {
+	version := strings.TrimSpace(env.KeyVersion)
+	if version == "" {
+		return "", ErrEmptyKeyVersion
+	}
+	aead, ok := c.keys[version]
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrUnknownKeyVersion, version)
+	}
+	if len(env.Ciphertext) < aead.NonceSize() {
+		return "", ErrCiphertextTooShort
+	}
+	nonce := env.Ciphertext[:aead.NonceSize()]
+	body := env.Ciphertext[aead.NonceSize():]
+	plain, err := aead.Open(nil, nonce, body, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+// Fingerprint returns a stable HMAC for uniqueness checks without decryption.
+// It is keyed independently of the active encryption key so that rows created
+// before and after a rotation continue to collide on the same account number.
+func (c *AccountCipher) Fingerprint(normalizedAccount string) string {
+	mac := hmac.New(sha256.New, c.fingerprintKey)
+	_, _ = mac.Write([]byte(normalizedAccount))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func resolveFingerprintKey(b64, activeVersion string, rawByVersion map[string][]byte) ([]byte, error) {
+	if strings.TrimSpace(b64) != "" {
+		raw, err := decodeKey(b64)
+		if err != nil {
+			return nil, fmt.Errorf("fingerprint key: %w", err)
+		}
+		return raw, nil
+	}
+	if raw, ok := rawByVersion[LegacyKeyVersion]; ok {
+		return raw, nil
+	}
+	return rawByVersion[activeVersion], nil
+}
+
+func decodeKey(b64 string) ([]byte, error) {
+	b64 = strings.TrimSpace(b64)
+	if b64 == "" {
+		return nil, ErrInvalidKey
+	}
+	key, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil || len(key) != keyLen {
+		return nil, ErrInvalidKey
+	}
+	return key, nil
+}
+
+func newAEAD(key []byte) (cipher.AEAD, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("aes cipher: %w", err)
@@ -43,39 +196,5 @@ func NewAccountCipher(keyB64 string) (*AccountCipher, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gcm: %w", err)
 	}
-
-	return &AccountCipher{
-		aead: aead,
-		mac:  key,
-	}, nil
-}
-
-// Encrypt returns nonce || ciphertext for storage.
-func (c *AccountCipher) Encrypt(plaintext string) ([]byte, error) {
-	nonce := make([]byte, c.aead.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
-	return c.aead.Seal(nonce, nonce, []byte(plaintext), nil), nil
-}
-
-// Decrypt reverses Encrypt.
-func (c *AccountCipher) Decrypt(blob []byte) (string, error) {
-	if len(blob) < c.aead.NonceSize() {
-		return "", ErrCiphertextTooShort
-	}
-	nonce := blob[:c.aead.NonceSize()]
-	ciphertext := blob[c.aead.NonceSize():]
-	plain, err := c.aead.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return "", err
-	}
-	return string(plain), nil
-}
-
-// Fingerprint returns a stable HMAC for uniqueness checks without decryption.
-func (c *AccountCipher) Fingerprint(normalizedAccount string) string {
-	mac := hmac.New(sha256.New, c.mac)
-	_, _ = mac.Write([]byte(normalizedAccount))
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return aead, nil
 }

--- a/apps/api/internal/crypto/account_cipher_test.go
+++ b/apps/api/internal/crypto/account_cipher_test.go
@@ -1,0 +1,162 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func key(b byte) string {
+	raw := make([]byte, keyLen)
+	for i := range raw {
+		raw[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func TestNewAccountCipher_RejectsBadKey(t *testing.T) {
+	cases := map[string]string{
+		"empty":        "",
+		"not base64":   "not-base64!!",
+		"wrong length": base64.StdEncoding.EncodeToString(make([]byte, 16)),
+	}
+	for name, k := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewAccountCipher(k); !errors.Is(err, ErrInvalidKey) {
+				t.Fatalf("want ErrInvalidKey, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEncrypt_UsesActiveVersion(t *testing.T) {
+	c, err := NewAccountCipherWithKeys("v2", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	env, err := c.Encrypt("0123456789")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if env.KeyVersion != "v2" {
+		t.Fatalf("want active version v2, got %q", env.KeyVersion)
+	}
+	if c.ActiveVersion() != "v2" {
+		t.Fatalf("ActiveVersion = %q", c.ActiveVersion())
+	}
+}
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	c, err := NewAccountCipher(key(0))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	env, err := c.Encrypt("0123456789")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if env.KeyVersion != LegacyKeyVersion {
+		t.Fatalf("single key should use %q, got %q", LegacyKeyVersion, env.KeyVersion)
+	}
+	got, err := c.Decrypt(env)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if got != "0123456789" {
+		t.Fatalf("round trip mismatch: %q", got)
+	}
+}
+
+func TestDecrypt_CrossVersion(t *testing.T) {
+	// A row sealed by the v1 single-key cipher must still decrypt after a v2 key
+	// is added and made active.
+	v1, err := NewAccountCipher(key(1))
+	if err != nil {
+		t.Fatalf("v1 cipher: %v", err)
+	}
+	legacyEnv, err := v1.Encrypt("9876543210")
+	if err != nil {
+		t.Fatalf("v1 encrypt: %v", err)
+	}
+
+	multi, err := NewAccountCipherWithKeys("v2", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("multi cipher: %v", err)
+	}
+	got, err := multi.Decrypt(legacyEnv)
+	if err != nil {
+		t.Fatalf("cross-version decrypt: %v", err)
+	}
+	if got != "9876543210" {
+		t.Fatalf("cross-version mismatch: %q", got)
+	}
+}
+
+func TestDecrypt_UnknownVersionFails(t *testing.T) {
+	c, err := NewAccountCipherWithKeys("v2", map[string]string{"v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	_, err = c.Decrypt(CipherEnvelope{KeyVersion: "v1", Ciphertext: []byte("whatever-bytes-here-not-real")})
+	if !errors.Is(err, ErrUnknownKeyVersion) {
+		t.Fatalf("want ErrUnknownKeyVersion, got %v", err)
+	}
+}
+
+func TestDecrypt_EmptyVersionFails(t *testing.T) {
+	c, err := NewAccountCipher(key(0))
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	if _, err := c.Decrypt(CipherEnvelope{Ciphertext: []byte("x")}); !errors.Is(err, ErrEmptyKeyVersion) {
+		t.Fatalf("want ErrEmptyKeyVersion, got %v", err)
+	}
+}
+
+func TestNewAccountCipherWithKeys_ActiveMustExist(t *testing.T) {
+	_, err := NewAccountCipherWithKeys("v3", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if !errors.Is(err, ErrActiveKeyMissing) {
+		t.Fatalf("want ErrActiveKeyMissing, got %v", err)
+	}
+}
+
+func TestFingerprint_StableAcrossActiveKey(t *testing.T) {
+	// The fingerprint defaults to the v1 key. Changing the active key from v1 to
+	// v2 must not change fingerprints, or the uniqueness index would break.
+	fpV1, err := NewAccountCipherWithKeys("v1", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("cipher v1 active: %v", err)
+	}
+	fpV2, err := NewAccountCipherWithKeys("v2", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("cipher v2 active: %v", err)
+	}
+	single, err := NewAccountCipher(key(1))
+	if err != nil {
+		t.Fatalf("single cipher: %v", err)
+	}
+
+	const acct = "0123456789|058"
+	a, b, s := fpV1.Fingerprint(acct), fpV2.Fingerprint(acct), single.Fingerprint(acct)
+	if a != b || a != s {
+		t.Fatalf("fingerprints diverged: v1active=%q v2active=%q single=%q", a, b, s)
+	}
+	if strings.TrimSpace(a) == "" {
+		t.Fatal("fingerprint is empty")
+	}
+}
+
+func TestFingerprint_ExplicitPepperOverrides(t *testing.T) {
+	def, err := NewAccountCipherWithKeys("v1", map[string]string{"v1": key(1)}, "")
+	if err != nil {
+		t.Fatalf("default cipher: %v", err)
+	}
+	pep, err := NewAccountCipherWithKeys("v1", map[string]string{"v1": key(1)}, key(9))
+	if err != nil {
+		t.Fatalf("peppered cipher: %v", err)
+	}
+	if def.Fingerprint("x") == pep.Fingerprint("x") {
+		t.Fatal("explicit fingerprint key should change the fingerprint")
+	}
+}

--- a/apps/api/internal/crypto/account_cipher_test.go
+++ b/apps/api/internal/crypto/account_cipher_test.go
@@ -94,13 +94,40 @@ func TestDecrypt_CrossVersion(t *testing.T) {
 }
 
 func TestDecrypt_UnknownVersionFails(t *testing.T) {
-	c, err := NewAccountCipherWithKeys("v2", map[string]string{"v2": key(2)}, "")
+	// v2-only key set has no v1, so an explicit fingerprint pepper is required.
+	c, err := NewAccountCipherWithKeys("v2", map[string]string{"v2": key(2)}, key(9))
 	if err != nil {
 		t.Fatalf("cipher: %v", err)
 	}
 	_, err = c.Decrypt(CipherEnvelope{KeyVersion: "v1", Ciphertext: []byte("whatever-bytes-here-not-real")})
 	if !errors.Is(err, ErrUnknownKeyVersion) {
 		t.Fatalf("want ErrUnknownKeyVersion, got %v", err)
+	}
+}
+
+func TestNewAccountCipherWithKeys_RequiresPepperWithoutV1(t *testing.T) {
+	// No v1 and no explicit pepper must fail closed rather than defaulting the
+	// fingerprint key to the (rotatable) active key.
+	if _, err := NewAccountCipherWithKeys("v2", map[string]string{"v2": key(2), "v3": key(3)}, ""); !errors.Is(err, ErrFingerprintKeyRequired) {
+		t.Fatalf("want ErrFingerprintKeyRequired, got %v", err)
+	}
+}
+
+func TestFingerprint_StableAcrossActiveKey_NoV1(t *testing.T) {
+	// With an explicit pepper and no v1, rotating the active key from v2 to v3
+	// must not change the fingerprint.
+	keys := map[string]string{"v2": key(2), "v3": key(3)}
+	fpV2, err := NewAccountCipherWithKeys("v2", keys, key(9))
+	if err != nil {
+		t.Fatalf("cipher v2 active: %v", err)
+	}
+	fpV3, err := NewAccountCipherWithKeys("v3", keys, key(9))
+	if err != nil {
+		t.Fatalf("cipher v3 active: %v", err)
+	}
+	const acct = "0123456789|058"
+	if fpV2.Fingerprint(acct) != fpV3.Fingerprint(acct) {
+		t.Fatal("fingerprint changed across active-key rotation without v1")
 	}
 }
 

--- a/apps/api/internal/domain/bankaccount/model.go
+++ b/apps/api/internal/domain/bankaccount/model.go
@@ -83,11 +83,13 @@ type UpdateInput struct {
 	BankName     *string
 }
 
-// Repository persists encrypted bank accounts.
+// Repository persists encrypted bank accounts. The encrypted account number is
+// stored alongside the key version that sealed it so keys can be rotated
+// without rewriting historical rows.
 type Repository interface {
-	Create(ctx context.Context, account BankAccount, encryptedNumber []byte, fingerprint string) (BankAccount, error)
+	Create(ctx context.Context, account BankAccount, encryptedNumber []byte, fingerprint, keyVersion string) (BankAccount, error)
 	ListByUser(ctx context.Context, userID uuid.UUID) ([]BankAccount, error)
-	GetByID(ctx context.Context, id uuid.UUID) (BankAccount, []byte, error)
+	GetByID(ctx context.Context, id uuid.UUID) (account BankAccount, encryptedNumber []byte, keyVersion string, err error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	ClearDefaultForCurrency(ctx context.Context, userID uuid.UUID, currency string) error
 	SetDefault(ctx context.Context, id uuid.UUID, userID uuid.UUID) error

--- a/apps/api/internal/repository/postgres/bank_account_repository.go
+++ b/apps/api/internal/repository/postgres/bank_account_repository.go
@@ -26,7 +26,7 @@ func (r *BankAccountRepository) Create(
 	ctx context.Context,
 	account bankaccount.BankAccount,
 	encryptedNumber []byte,
-	fingerprint string,
+	fingerprint, keyVersion string,
 ) (bankaccount.BankAccount, error) {
 	last4 := account.AccountNumber
 	if len(last4) > 4 {
@@ -37,8 +37,8 @@ func (r *BankAccountRepository) Create(
 		INSERT INTO bank_accounts (
 			id, user_id, bank_name, bank_code,
 			account_number_encrypted, account_number_fingerprint, account_last4,
-			account_name, currency, country, is_default, verified_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			account_name, currency, country, is_default, verified_at, key_version
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
 		RETURNING created_at
 	`
 
@@ -57,6 +57,7 @@ func (r *BankAccountRepository) Create(
 		strings.ToUpper(account.Country),
 		account.IsDefault,
 		account.VerifiedAt,
+		keyVersion,
 	).Scan(&account.CreatedAt)
 	if err != nil {
 		return bankaccount.BankAccount{}, mapBankAccountError(err)

--- a/apps/api/internal/repository/postgres/bank_account_repository.go
+++ b/apps/api/internal/repository/postgres/bank_account_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/bankaccount"
+	"github.com/suncrestlabs/nester/apps/api/internal/rotation"
 )
 
 type BankAccountRepository struct {
@@ -116,7 +117,7 @@ func (r *BankAccountRepository) ListByUser(ctx context.Context, userID uuid.UUID
 	return out, rows.Err()
 }
 
-func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, error) {
+func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, string, error) {
 	var (
 		uid, bankName, bankCode string
 		encrypted               []byte
@@ -124,17 +125,18 @@ func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bank
 		isDefault               bool
 		verifiedAt              sql.NullTime
 		createdAt               time.Time
+		keyVersion              string
 	)
 	err := r.db.QueryRowContext(ctx, `
 		SELECT user_id, bank_name, COALESCE(bank_code, ''), account_number_encrypted,
-		       account_name, currency, country, is_default, verified_at, created_at
+		       account_name, currency, country, is_default, verified_at, created_at, key_version
 		FROM bank_accounts WHERE id = $1
 	`, id.String()).Scan(
 		&uid, &bankName, &bankCode, &encrypted,
-		&accountName, &currency, &country, &isDefault, &verifiedAt, &createdAt,
+		&accountName, &currency, &country, &isDefault, &verifiedAt, &createdAt, &keyVersion,
 	)
 	if err != nil {
-		return bankaccount.BankAccount{}, nil, mapBankAccountError(err)
+		return bankaccount.BankAccount{}, nil, "", mapBankAccountError(err)
 	}
 	parsedUser, _ := uuid.Parse(uid)
 	var verified *time.Time
@@ -152,7 +154,72 @@ func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bank
 		IsDefault:     isDefault,
 		VerifiedAt:    verified,
 		CreatedAt:     createdAt,
-	}, encrypted, nil
+	}, encrypted, keyVersion, nil
+}
+
+// CountPending reports how many stored rows are not on activeVersion. It backs
+// the rotation tool's progress reporting and satisfies rotation.Store.
+func (r *BankAccountRepository) CountPending(ctx context.Context, activeVersion string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM bank_accounts WHERE key_version <> $1`, activeVersion).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("bank account repository: count pending rotation: %w", err)
+	}
+	return n, nil
+}
+
+// ScanPending returns up to limit rows whose key version is not activeVersion,
+// ordered by id for stable paging. It satisfies rotation.Store.
+func (r *BankAccountRepository) ScanPending(ctx context.Context, activeVersion string, limit int) ([]rotation.EncryptedRow, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, account_number_encrypted, key_version
+		FROM bank_accounts
+		WHERE key_version <> $1
+		ORDER BY id
+		LIMIT $2
+	`, activeVersion, limit)
+	if err != nil {
+		return nil, fmt.Errorf("bank account repository: scan pending rotation: %w", err)
+	}
+	defer rows.Close()
+
+	var out []rotation.EncryptedRow
+	for rows.Next() {
+		var (
+			id         string
+			encrypted  []byte
+			keyVersion string
+		)
+		if err := rows.Scan(&id, &encrypted, &keyVersion); err != nil {
+			return nil, err
+		}
+		parsedID, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("bank account repository: parse id: %w", err)
+		}
+		out = append(out, rotation.EncryptedRow{ID: parsedID, Ciphertext: encrypted, KeyVersion: keyVersion})
+	}
+	return out, rows.Err()
+}
+
+// UpdateCipher atomically replaces a row's ciphertext and key version. It leaves
+// account_number_fingerprint untouched so the uniqueness index is unaffected by
+// rotation. It satisfies rotation.Store.
+func (r *BankAccountRepository) UpdateCipher(ctx context.Context, id uuid.UUID, ciphertext []byte, keyVersion string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE bank_accounts
+		SET account_number_encrypted = $2, key_version = $3
+		WHERE id = $1
+	`, id.String(), ciphertext, keyVersion)
+	if err != nil {
+		return fmt.Errorf("bank account repository: update cipher: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return bankaccount.ErrNotFound
+	}
+	return nil
 }
 
 func (r *BankAccountRepository) Delete(ctx context.Context, id uuid.UUID) error {

--- a/apps/api/internal/rotation/rotation.go
+++ b/apps/api/internal/rotation/rotation.go
@@ -1,0 +1,145 @@
+// Package rotation re-encrypts stored account ciphertext under the active key
+// version. It is the migration engine behind envelope key rotation: legacy rows
+// are decrypted with their recorded key version and re-sealed with the active
+// key, one committed row at a time so the process is idempotent and resumable.
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+)
+
+// EncryptedRow is a single stored ciphertext awaiting rotation.
+type EncryptedRow struct {
+	ID         uuid.UUID
+	Ciphertext []byte
+	KeyVersion string
+}
+
+// Store is the persistence surface the rotator needs. It deliberately exposes
+// only the operations required for a safe, resumable rotation and nothing that
+// would return plaintext.
+type Store interface {
+	// CountPending reports how many rows are not yet on activeVersion.
+	CountPending(ctx context.Context, activeVersion string) (int, error)
+	// ScanPending returns up to limit rows whose key version is not activeVersion.
+	ScanPending(ctx context.Context, activeVersion string, limit int) ([]EncryptedRow, error)
+	// UpdateCipher atomically replaces a single row's ciphertext and key version.
+	UpdateCipher(ctx context.Context, id uuid.UUID, ciphertext []byte, keyVersion string) error
+}
+
+// Cipher is the subset of *crypto.AccountCipher the rotator relies on.
+type Cipher interface {
+	ActiveVersion() string
+	Encrypt(plaintext string) (crypto.CipherEnvelope, error)
+	Decrypt(env crypto.CipherEnvelope) (string, error)
+}
+
+// Stats summarizes a rotation run.
+type Stats struct {
+	// Pending is the count of rows needing rotation observed at the start.
+	Pending int
+	// Rotated is the number of rows successfully re-encrypted this run.
+	Rotated int
+}
+
+// Options configures a rotation run.
+type Options struct {
+	// BatchSize bounds how many rows are loaded and re-encrypted per iteration.
+	BatchSize int
+	// Logger receives progress logs. Only counts and row IDs are logged — never
+	// plaintext, keys, or ciphertext.
+	Logger *slog.Logger
+}
+
+const defaultBatchSize = 500
+
+// Rotator re-encrypts pending rows under the cipher's active key version.
+type Rotator struct {
+	store  Store
+	cipher Cipher
+}
+
+// NewRotator constructs a Rotator over the given store and cipher.
+func NewRotator(store Store, cipher Cipher) *Rotator {
+	return &Rotator{store: store, cipher: cipher}
+}
+
+// Run rotates every row not already on the active key version.
+//
+//   - Idempotent: a second run finds no pending rows and does nothing.
+//   - Resumable: each row is committed as it is rotated, so an interrupted run
+//     leaves completed rows on the active version and a re-run continues with the
+//     remainder.
+//   - Safe: rows are processed in bounded batches, and any decrypt/update error
+//     stops the run (surfacing only the row ID and version) rather than looping.
+func (r *Rotator) Run(ctx context.Context, opts Options) (Stats, error) {
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	active := r.cipher.ActiveVersion()
+
+	pending, err := r.store.CountPending(ctx, active)
+	if err != nil {
+		return Stats{}, fmt.Errorf("count pending: %w", err)
+	}
+	stats := Stats{Pending: pending}
+	logger.Info("key rotation starting",
+		"active_version", active, "pending", pending, "batch_size", batchSize)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		batch, err := r.store.ScanPending(ctx, active, batchSize)
+		if err != nil {
+			return stats, fmt.Errorf("scan pending: %w", err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, row := range batch {
+			if err := r.rotateRow(ctx, row, active); err != nil {
+				return stats, err
+			}
+			stats.Rotated++
+		}
+		logger.Info("key rotation progress", "rotated", stats.Rotated, "pending", stats.Pending)
+	}
+
+	logger.Info("key rotation complete", "rotated", stats.Rotated, "active_version", active)
+	return stats, nil
+}
+
+func (r *Rotator) rotateRow(ctx context.Context, row EncryptedRow, active string) error {
+	// Belt-and-suspenders: ScanPending already filters these out, but never
+	// re-encrypt a row that is already current.
+	if row.KeyVersion == active {
+		return nil
+	}
+	plaintext, err := r.cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: row.KeyVersion, Ciphertext: row.Ciphertext})
+	if err != nil {
+		// The error intentionally carries only safe identifiers (row ID and key
+		// version) — never the ciphertext or plaintext.
+		return fmt.Errorf("decrypt row %s (version %s): %w", row.ID, row.KeyVersion, err)
+	}
+	env, err := r.cipher.Encrypt(plaintext)
+	if err != nil {
+		return fmt.Errorf("re-encrypt row %s: %w", row.ID, err)
+	}
+	if err := r.store.UpdateCipher(ctx, row.ID, env.Ciphertext, env.KeyVersion); err != nil {
+		return fmt.Errorf("update row %s: %w", row.ID, err)
+	}
+	return nil
+}

--- a/apps/api/internal/rotation/rotation_test.go
+++ b/apps/api/internal/rotation/rotation_test.go
@@ -1,0 +1,229 @@
+package rotation_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/rotation"
+)
+
+func key(b byte) string {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// memStore is an in-memory rotation.Store. failAfter, when > 0, makes
+// UpdateCipher return an error once that many updates have succeeded, simulating
+// an interrupted run.
+type memStore struct {
+	rows      map[uuid.UUID]rotation.EncryptedRow
+	updates   int
+	failAfter int
+}
+
+func newMemStore() *memStore {
+	return &memStore{rows: make(map[uuid.UUID]rotation.EncryptedRow)}
+}
+
+func (m *memStore) put(row rotation.EncryptedRow) {
+	m.rows[row.ID] = row
+}
+
+func (m *memStore) CountPending(_ context.Context, active string) (int, error) {
+	n := 0
+	for _, r := range m.rows {
+		if r.KeyVersion != active {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *memStore) ScanPending(_ context.Context, active string, limit int) ([]rotation.EncryptedRow, error) {
+	var pending []rotation.EncryptedRow
+	for _, r := range m.rows {
+		if r.KeyVersion != active {
+			pending = append(pending, r)
+		}
+	}
+	// Deterministic order for test stability.
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].ID.String() < pending[j].ID.String()
+	})
+	if len(pending) > limit {
+		pending = pending[:limit]
+	}
+	return pending, nil
+}
+
+var errInjected = errors.New("injected update failure")
+
+func (m *memStore) UpdateCipher(_ context.Context, id uuid.UUID, ciphertext []byte, keyVersion string) error {
+	if m.failAfter > 0 && m.updates >= m.failAfter {
+		return errInjected
+	}
+	m.rows[id] = rotation.EncryptedRow{ID: id, Ciphertext: ciphertext, KeyVersion: keyVersion}
+	m.updates++
+	return nil
+}
+
+// seedLegacyRows encrypts n account numbers with the v1 single-key cipher and
+// stores them, returning the plaintext keyed by row ID for later verification.
+func seedLegacyRows(t *testing.T, store *memStore, n int) map[uuid.UUID]string {
+	t.Helper()
+	v1, err := crypto.NewAccountCipher(key(1))
+	if err != nil {
+		t.Fatalf("v1 cipher: %v", err)
+	}
+	want := make(map[uuid.UUID]string, n)
+	for i := 0; i < n; i++ {
+		id := uuid.New()
+		plain := "acct-" + id.String()[:8]
+		env, err := v1.Encrypt(plain)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		store.put(rotation.EncryptedRow{ID: id, Ciphertext: env.Ciphertext, KeyVersion: env.KeyVersion})
+		want[id] = plain
+	}
+	return want
+}
+
+func multiCipher(t *testing.T) *crypto.AccountCipher {
+	t.Helper()
+	c, err := crypto.NewAccountCipherWithKeys("v2", map[string]string{"v1": key(1), "v2": key(2)}, "")
+	if err != nil {
+		t.Fatalf("multi cipher: %v", err)
+	}
+	return c
+}
+
+func TestRotator_ReencryptsToActive(t *testing.T) {
+	store := newMemStore()
+	want := seedLegacyRows(t, store, 5)
+	cipher := multiCipher(t)
+
+	stats, err := rotator(store, cipher).Run(context.Background(), rotation.Options{BatchSize: 2})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Pending != 5 || stats.Rotated != 5 {
+		t.Fatalf("stats = %+v, want pending=5 rotated=5", stats)
+	}
+
+	for id, plain := range want {
+		row := store.rows[id]
+		if row.KeyVersion != "v2" {
+			t.Fatalf("row %s version = %q, want v2", id, row.KeyVersion)
+		}
+		got, err := cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: row.KeyVersion, Ciphertext: row.Ciphertext})
+		if err != nil {
+			t.Fatalf("decrypt rotated row: %v", err)
+		}
+		if got != plain {
+			t.Fatalf("row %s plaintext = %q, want %q", id, got, plain)
+		}
+	}
+}
+
+func TestRotator_Idempotent(t *testing.T) {
+	store := newMemStore()
+	seedLegacyRows(t, store, 4)
+	cipher := multiCipher(t)
+
+	if _, err := rotator(store, cipher).Run(context.Background(), rotation.Options{BatchSize: 3}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	second, err := rotator(store, cipher).Run(context.Background(), rotation.Options{BatchSize: 3})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second.Pending != 0 || second.Rotated != 0 {
+		t.Fatalf("second run stats = %+v, want zero work", second)
+	}
+}
+
+func TestRotator_ResumableAfterInterrupt(t *testing.T) {
+	store := newMemStore()
+	want := seedLegacyRows(t, store, 6)
+	store.failAfter = 4 // fail partway through
+	cipher := multiCipher(t)
+
+	// First run is interrupted by the injected failure.
+	if _, err := rotator(store, cipher).Run(context.Background(), rotation.Options{BatchSize: 10}); !errors.Is(err, errInjected) {
+		t.Fatalf("want injected error, got %v", err)
+	}
+
+	// Some rows rotated, some remain — the run made partial, durable progress.
+	remaining, _ := store.CountPending(context.Background(), "v2")
+	if remaining == 0 || remaining == 6 {
+		t.Fatalf("expected partial progress, got %d pending of 6", remaining)
+	}
+
+	// Clear the fault and resume; the run must complete without redoing work
+	// destructively or losing data.
+	store.failAfter = 0
+	if _, err := rotator(store, cipher).Run(context.Background(), rotation.Options{BatchSize: 10}); err != nil {
+		t.Fatalf("resume run: %v", err)
+	}
+
+	done, _ := store.CountPending(context.Background(), "v2")
+	if done != 0 {
+		t.Fatalf("expected all rows rotated after resume, %d still pending", done)
+	}
+	for id, plain := range want {
+		row := store.rows[id]
+		got, err := cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: row.KeyVersion, Ciphertext: row.Ciphertext})
+		if err != nil {
+			t.Fatalf("decrypt row %s: %v", id, err)
+		}
+		if got != plain {
+			t.Fatalf("row %s data corrupted: got %q want %q", id, got, plain)
+		}
+	}
+}
+
+func TestRotator_LegacyDataReadableBeforeAndAfter(t *testing.T) {
+	store := newMemStore()
+	want := seedLegacyRows(t, store, 3)
+	cipher := multiCipher(t)
+
+	// Before rotation: rows are on v1 and must already decrypt via the multi-key
+	// cipher (v1 retained for decryption).
+	for id, plain := range want {
+		row := store.rows[id]
+		got, err := cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: row.KeyVersion, Ciphertext: row.Ciphertext})
+		if err != nil || got != plain {
+			t.Fatalf("pre-rotation decrypt of %s: got %q err %v", id, got, err)
+		}
+	}
+
+	if _, err := rotator(store, cipher).Run(context.Background(), rotation.Options{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// After rotation: same plaintext, now on the active version.
+	for id, plain := range want {
+		row := store.rows[id]
+		if row.KeyVersion != "v2" {
+			t.Fatalf("row %s not rotated", id)
+		}
+		got, err := cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: row.KeyVersion, Ciphertext: row.Ciphertext})
+		if err != nil || got != plain {
+			t.Fatalf("post-rotation decrypt of %s: got %q err %v", id, got, err)
+		}
+	}
+}
+
+func rotator(store rotation.Store, cipher rotation.Cipher) *rotation.Rotator {
+	return rotation.NewRotator(store, cipher)
+}

--- a/apps/api/internal/service/bankaccount_service.go
+++ b/apps/api/internal/service/bankaccount_service.go
@@ -58,7 +58,7 @@ func (s *BankAccountService) Add(ctx context.Context, userID uuid.UUID, input ba
 		}
 	}
 
-	encrypted, err := s.cipher.Encrypt(normalized.AccountNumber)
+	envelope, err := s.cipher.Encrypt(normalized.AccountNumber)
 	if err != nil {
 		return bankaccount.PublicView{}, err
 	}
@@ -83,7 +83,7 @@ func (s *BankAccountService) Add(ctx context.Context, userID uuid.UUID, input ba
 		}
 	}
 
-	created, err := s.repo.Create(ctx, model, encrypted, fingerprint)
+	created, err := s.repo.Create(ctx, model, envelope.Ciphertext, fingerprint, envelope.KeyVersion)
 	if err != nil {
 		return bankaccount.PublicView{}, err
 	}

--- a/apps/api/internal/service/bankaccount_service.go
+++ b/apps/api/internal/service/bankaccount_service.go
@@ -111,7 +111,7 @@ func (s *BankAccountService) SetDefault(ctx context.Context, userID, accountID u
 	if userID == uuid.Nil || accountID == uuid.Nil {
 		return bankaccount.PublicView{}, bankaccount.ErrInvalidInput
 	}
-	account, _, err := s.repo.GetByID(ctx, accountID)
+	account, _, _, err := s.repo.GetByID(ctx, accountID)
 	if err != nil {
 		return bankaccount.PublicView{}, err
 	}
@@ -145,7 +145,7 @@ func (s *BankAccountService) Remove(ctx context.Context, userID, accountID uuid.
 	if userID == uuid.Nil || accountID == uuid.Nil {
 		return bankaccount.ErrInvalidInput
 	}
-	account, _, err := s.repo.GetByID(ctx, accountID)
+	account, _, _, err := s.repo.GetByID(ctx, accountID)
 	if err != nil {
 		return err
 	}
@@ -163,14 +163,14 @@ func (s *BankAccountService) ResolveForSettlement(
 	if s.cipher == nil {
 		return bankaccount.BankAccount{}, bankaccount.ErrEncryptionUnavailable
 	}
-	account, encrypted, err := s.repo.GetByID(ctx, accountID)
+	account, encrypted, keyVersion, err := s.repo.GetByID(ctx, accountID)
 	if err != nil {
 		return bankaccount.BankAccount{}, err
 	}
 	if account.UserID != userID {
 		return bankaccount.BankAccount{}, bankaccount.ErrForbidden
 	}
-	plain, err := s.cipher.Decrypt(encrypted)
+	plain, err := s.cipher.Decrypt(crypto.CipherEnvelope{KeyVersion: keyVersion, Ciphertext: encrypted})
 	if err != nil {
 		return bankaccount.BankAccount{}, err
 	}

--- a/apps/api/internal/service/bankaccount_service_test.go
+++ b/apps/api/internal/service/bankaccount_service_test.go
@@ -183,3 +183,75 @@ func TestBankAccountService_DuplicateRejected(t *testing.T) {
 		t.Fatalf("expected duplicate error, got %v", err)
 	}
 }
+
+func b64Key(b byte) string {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// multiCipher builds a v1(all-zero)+v2 cipher. v1 matches testCipher's key so a
+// row written by testCipher decrypts here after v2 is added.
+func multiCipher(t *testing.T, active string) *crypto.AccountCipher {
+	t.Helper()
+	c, err := crypto.NewAccountCipherWithKeys(active, map[string]string{
+		"v1": b64Key(0),
+		"v2": b64Key(2),
+	}, "")
+	if err != nil {
+		t.Fatalf("multi cipher: %v", err)
+	}
+	return c
+}
+
+// New writes must be sealed with the active key version.
+func TestBankAccountService_NewWritesUseActiveKey(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemBankAccountRepo()
+	svc := service.NewBankAccountService(repo, multiCipher(t, "v2"), nil)
+
+	created, err := svc.Add(ctx, userID, bankaccount.AddInput{
+		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
+		AccountName: "A", Currency: "NGN", Country: "NG",
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if got := repo.byID[created.ID].keyVersion; got != "v2" {
+		t.Fatalf("stored key version = %q, want active v2", got)
+	}
+}
+
+// A row written under v1 must still decrypt after v2 is introduced and made
+// active — the cross-version guarantee at the service boundary.
+func TestBankAccountService_LegacyRowDecryptsAfterKeyAdded(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemBankAccountRepo()
+
+	// Write with the single-key (v1) cipher.
+	legacySvc := service.NewBankAccountService(repo, testCipher(t), nil)
+	created, err := legacySvc.Add(ctx, userID, bankaccount.AddInput{
+		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
+		AccountName: "A", Currency: "NGN", Country: "NG",
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if got := repo.byID[created.ID].keyVersion; got != "v1" {
+		t.Fatalf("stored key version = %q, want v1", got)
+	}
+
+	// Swap to the multi-key cipher (v2 active, v1 retained) and read back.
+	rotatedSvc := service.NewBankAccountService(repo, multiCipher(t, "v2"), nil)
+	account, err := rotatedSvc.ResolveForSettlement(ctx, userID, created.ID)
+	if err != nil {
+		t.Fatalf("resolve after key add: %v", err)
+	}
+	if account.AccountNumber != "0123456789" {
+		t.Fatalf("decrypted account = %q, want 0123456789", account.AccountNumber)
+	}
+}

--- a/apps/api/internal/service/bankaccount_service_test.go
+++ b/apps/api/internal/service/bankaccount_service_test.go
@@ -206,52 +206,61 @@ func multiCipher(t *testing.T, active string) *crypto.AccountCipher {
 	return c
 }
 
-// New writes must be sealed with the active key version.
-func TestBankAccountService_NewWritesUseActiveKey(t *testing.T) {
-	ctx := context.Background()
-	userID := uuid.New()
-	repo := newMemBankAccountRepo()
-	svc := service.NewBankAccountService(repo, multiCipher(t, "v2"), nil)
+// TestBankAccountService_KeyVersioning covers, per scenario: the key version a
+// new write is stored under, and that the row is still decryptable through the
+// (possibly rotated) cipher the reader is configured with.
+func TestBankAccountService_KeyVersioning(t *testing.T) {
+	const accountNumber = "0123456789"
 
-	created, err := svc.Add(ctx, userID, bankaccount.AddInput{
-		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
-		AccountName: "A", Currency: "NGN", Country: "NG",
-	})
-	if err != nil {
-		t.Fatalf("add: %v", err)
-	}
-	if got := repo.byID[created.ID].keyVersion; got != "v2" {
-		t.Fatalf("stored key version = %q, want active v2", got)
-	}
-}
-
-// A row written under v1 must still decrypt after v2 is introduced and made
-// active — the cross-version guarantee at the service boundary.
-func TestBankAccountService_LegacyRowDecryptsAfterKeyAdded(t *testing.T) {
-	ctx := context.Background()
-	userID := uuid.New()
-	repo := newMemBankAccountRepo()
-
-	// Write with the single-key (v1) cipher.
-	legacySvc := service.NewBankAccountService(repo, testCipher(t), nil)
-	created, err := legacySvc.Add(ctx, userID, bankaccount.AddInput{
-		BankName: "GTBank", BankCode: "058", AccountNumber: "0123456789",
-		AccountName: "A", Currency: "NGN", Country: "NG",
-	})
-	if err != nil {
-		t.Fatalf("add: %v", err)
-	}
-	if got := repo.byID[created.ID].keyVersion; got != "v1" {
-		t.Fatalf("stored key version = %q, want v1", got)
+	cases := []struct {
+		name        string
+		writeCipher func(*testing.T) *crypto.AccountCipher
+		readCipher  func(*testing.T) *crypto.AccountCipher // nil = reuse writeCipher
+		wantStored  string
+	}{
+		{
+			name:        "new writes use active key",
+			writeCipher: func(t *testing.T) *crypto.AccountCipher { return multiCipher(t, "v2") },
+			wantStored:  "v2",
+		},
+		{
+			name:        "legacy v1 row decrypts after v2 added and made active",
+			writeCipher: func(t *testing.T) *crypto.AccountCipher { return testCipher(t) },
+			readCipher:  func(t *testing.T) *crypto.AccountCipher { return multiCipher(t, "v2") },
+			wantStored:  "v1",
+		},
 	}
 
-	// Swap to the multi-key cipher (v2 active, v1 retained) and read back.
-	rotatedSvc := service.NewBankAccountService(repo, multiCipher(t, "v2"), nil)
-	account, err := rotatedSvc.ResolveForSettlement(ctx, userID, created.ID)
-	if err != nil {
-		t.Fatalf("resolve after key add: %v", err)
-	}
-	if account.AccountNumber != "0123456789" {
-		t.Fatalf("decrypted account = %q, want 0123456789", account.AccountNumber)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			userID := uuid.New()
+			repo := newMemBankAccountRepo()
+
+			created, err := service.NewBankAccountService(repo, tc.writeCipher(t), nil).
+				Add(ctx, userID, bankaccount.AddInput{
+					BankName: "GTBank", BankCode: "058", AccountNumber: accountNumber,
+					AccountName: "A", Currency: "NGN", Country: "NG",
+				})
+			if err != nil {
+				t.Fatalf("add: %v", err)
+			}
+			if got := repo.byID[created.ID].keyVersion; got != tc.wantStored {
+				t.Fatalf("stored key version = %q, want %q", got, tc.wantStored)
+			}
+
+			readCipher := tc.writeCipher
+			if tc.readCipher != nil {
+				readCipher = tc.readCipher
+			}
+			account, err := service.NewBankAccountService(repo, readCipher(t), nil).
+				ResolveForSettlement(ctx, userID, created.ID)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if account.AccountNumber != accountNumber {
+				t.Fatalf("decrypted account = %q, want %q", account.AccountNumber, accountNumber)
+			}
+		})
 	}
 }

--- a/apps/api/internal/service/bankaccount_service_test.go
+++ b/apps/api/internal/service/bankaccount_service_test.go
@@ -18,23 +18,24 @@ type memBankAccountRepo struct {
 }
 
 type storedAccount struct {
-	account   bankaccount.BankAccount
-	encrypted []byte
-	print     string
+	account    bankaccount.BankAccount
+	encrypted  []byte
+	print      string
+	keyVersion string
 }
 
 func newMemBankAccountRepo() *memBankAccountRepo {
 	return &memBankAccountRepo{byID: make(map[uuid.UUID]storedAccount)}
 }
 
-func (m *memBankAccountRepo) Create(_ context.Context, account bankaccount.BankAccount, encrypted []byte, fingerprint string) (bankaccount.BankAccount, error) {
+func (m *memBankAccountRepo) Create(_ context.Context, account bankaccount.BankAccount, encrypted []byte, fingerprint, keyVersion string) (bankaccount.BankAccount, error) {
 	for _, s := range m.byID {
 		if s.account.UserID == account.UserID && s.print == fingerprint {
 			return bankaccount.BankAccount{}, bankaccount.ErrDuplicateAccount
 		}
 	}
 	account.CreatedAt = time.Now().UTC()
-	m.byID[account.ID] = storedAccount{account: account, encrypted: encrypted, print: fingerprint}
+	m.byID[account.ID] = storedAccount{account: account, encrypted: encrypted, print: fingerprint, keyVersion: keyVersion}
 	return account, nil
 }
 
@@ -48,12 +49,12 @@ func (m *memBankAccountRepo) ListByUser(_ context.Context, userID uuid.UUID) ([]
 	return out, nil
 }
 
-func (m *memBankAccountRepo) GetByID(_ context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, error) {
+func (m *memBankAccountRepo) GetByID(_ context.Context, id uuid.UUID) (bankaccount.BankAccount, []byte, string, error) {
 	s, ok := m.byID[id]
 	if !ok {
-		return bankaccount.BankAccount{}, nil, bankaccount.ErrNotFound
+		return bankaccount.BankAccount{}, nil, "", bankaccount.ErrNotFound
 	}
-	return s.account, s.encrypted, nil
+	return s.account, s.encrypted, s.keyVersion, nil
 }
 
 func (m *memBankAccountRepo) Delete(_ context.Context, id uuid.UUID) error {

--- a/apps/api/migrations/057_add_bank_account_key_version.down.sql
+++ b/apps/api/migrations/057_add_bank_account_key_version.down.sql
@@ -1,2 +1,13 @@
-DROP INDEX IF EXISTS idx_bank_accounts_key_version;
+-- Rollback safety: key_version is the ONLY mapping from a ciphertext to the key
+-- that sealed it. Dropping it once any row has been rotated to a non-v1 key
+-- would leave those ciphertexts undecryptable. Abort rather than lose data.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM bank_accounts WHERE key_version <> 'v1') THEN
+        RAISE EXCEPTION
+            'cannot drop key_version: % row(s) are encrypted with a non-v1 key; re-key them to v1 before rolling back',
+            (SELECT COUNT(*) FROM bank_accounts WHERE key_version <> 'v1');
+    END IF;
+END $$;
+
 ALTER TABLE bank_accounts DROP COLUMN IF EXISTS key_version;

--- a/apps/api/migrations/057_add_bank_account_key_version.down.sql
+++ b/apps/api/migrations/057_add_bank_account_key_version.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_bank_accounts_key_version;
+ALTER TABLE bank_accounts DROP COLUMN IF EXISTS key_version;

--- a/apps/api/migrations/057_add_bank_account_key_version.up.sql
+++ b/apps/api/migrations/057_add_bank_account_key_version.up.sql
@@ -2,9 +2,8 @@
 -- can be rotated without rewriting historical rows. Rows created before key
 -- versioning were sealed with the original (v1) key, so the column defaults to
 -- 'v1' and existing data keeps decrypting after this migration is applied.
+--
+-- The supporting index is created separately (migration 058) with CREATE INDEX
+-- CONCURRENTLY so a large bank_accounts table is not write-locked during deploy.
 ALTER TABLE bank_accounts
     ADD COLUMN key_version VARCHAR(32) NOT NULL DEFAULT 'v1';
-
--- Lets the rotation tool cheaply find rows that are not yet on the active key
--- version (WHERE key_version <> $active).
-CREATE INDEX idx_bank_accounts_key_version ON bank_accounts (key_version);

--- a/apps/api/migrations/057_add_bank_account_key_version.up.sql
+++ b/apps/api/migrations/057_add_bank_account_key_version.up.sql
@@ -1,0 +1,10 @@
+-- Records which encryption key version sealed account_number_encrypted so keys
+-- can be rotated without rewriting historical rows. Rows created before key
+-- versioning were sealed with the original (v1) key, so the column defaults to
+-- 'v1' and existing data keeps decrypting after this migration is applied.
+ALTER TABLE bank_accounts
+    ADD COLUMN key_version VARCHAR(32) NOT NULL DEFAULT 'v1';
+
+-- Lets the rotation tool cheaply find rows that are not yet on the active key
+-- version (WHERE key_version <> $active).
+CREATE INDEX idx_bank_accounts_key_version ON bank_accounts (key_version);

--- a/apps/api/migrations/058_add_bank_account_key_version_index.down.sql
+++ b/apps/api/migrations/058_add_bank_account_key_version_index.down.sql
@@ -1,0 +1,3 @@
+-- Drop CONCURRENTLY to avoid a write lock; must be the sole statement and run
+-- outside a transaction.
+DROP INDEX CONCURRENTLY IF EXISTS idx_bank_accounts_key_version;

--- a/apps/api/migrations/058_add_bank_account_key_version_index.up.sql
+++ b/apps/api/migrations/058_add_bank_account_key_version_index.up.sql
@@ -1,0 +1,6 @@
+-- Index used by the rotation tool to find rows not yet on the active key
+-- version (WHERE key_version <> $active). Built CONCURRENTLY so it does not
+-- take a write lock on bank_accounts during deploy. This statement must run
+-- outside a transaction; keep it the sole statement in this migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bank_accounts_key_version
+    ON bank_accounts (key_version);

--- a/docs/security/key-rotation.md
+++ b/docs/security/key-rotation.md
@@ -51,12 +51,14 @@ detection would break. Rotation therefore **never** recomputes fingerprints.
 When `ACCOUNT_CIPHER_FINGERPRINT_KEY` is empty the pepper defaults to the `v1`
 key. That default is only available **while a `v1` key is configured** — a key
 set that has no `v1` (e.g. after `v1` is dropped, or a set that starts at `v2`)
-**must** set `ACCOUNT_CIPHER_FINGERPRINT_KEY` explicitly, or startup fails with
-`ErrFingerprintKeyRequired`. This is deliberate: without a pinned pepper the
-fingerprint key would fall back to the active key and shift on every rotation
-(e.g. `v2`→`v3`), silently breaking blind-index uniqueness. Treat the fingerprint
-key as long-lived and rotate it only with a dedicated, fingerprint-recomputing
-migration (out of scope here).
+**must** set `ACCOUNT_CIPHER_FINGERPRINT_KEY` explicitly. There is **no** fallback
+to the active key; a v1-less set without an explicit pepper is rejected — config
+loading fails at startup (`config.Load`), and, as a defense-in-depth safety net
+for any direct constructor caller, the cipher independently returns
+`ErrFingerprintKeyRequired`. This is deliberate: a pepper derived from the active
+key would shift on every rotation (e.g. `v2`→`v3`) and silently break blind-index
+uniqueness. Treat the fingerprint key as long-lived and rotate it only with a
+dedicated, fingerprint-recomputing migration (out of scope here).
 
 ## Configuration (ENV)
 

--- a/docs/security/key-rotation.md
+++ b/docs/security/key-rotation.md
@@ -1,0 +1,143 @@
+# Account Cipher — Key Versioning & Rotation
+
+Saved bank account numbers are encrypted at rest with **AES-256-GCM**. Each
+stored row records the **key version** that sealed it, which lets us rotate
+encryption keys without rewriting or risking historical data.
+
+- Code: [`apps/api/internal/crypto/account_cipher.go`](../../apps/api/internal/crypto/account_cipher.go)
+- Rotation core: [`apps/api/internal/rotation/`](../../apps/api/internal/rotation/)
+- Rotation tool: [`apps/api/cmd/rotate_keys/`](../../apps/api/cmd/rotate_keys/)
+- Migration: `apps/api/migrations/057_add_bank_account_key_version.up.sql`
+
+## Model
+
+```
+ciphertext = AES-256-GCM(nonce, plaintext, key[active_version])
+stored     = { account_number_encrypted: nonce||ciphertext,
+               key_version:               active_version }
+```
+
+Every ciphertext is paired with the version of the key that produced it (a
+`CipherEnvelope`). The stored bytes are exactly `nonce || ciphertext`; the
+version lives in its own `bank_accounts.key_version` column. Because the bytes
+are unchanged from the single-key format, the migration that adds the column
+defaults existing rows to `v1` and **no historical row needs to be rewritten to
+keep decrypting.**
+
+| Concept          | Purpose                                             |
+| ---------------- | --------------------------------------------------- |
+| Key version      | Labels which key encrypted a given row              |
+| Active key       | The one version used to encrypt **new** writes      |
+| Legacy key(s)    | Retained **only** to decrypt un-rotated rows        |
+| Fingerprint key  | Stable pepper for the uniqueness index (see below)  |
+| Rotation tool    | Re-encrypts legacy rows onto the active key         |
+
+### Encryption / decryption
+
+- **Encrypt** → seal with the active key, tag with the active version.
+- **Decrypt** → look up the key for the row's recorded version and open.
+- A row whose version has **no** registered key fails with
+  `ErrUnknownKeyVersion` — the signal that a still-needed legacy key was dropped
+  too early. It never silently returns wrong data.
+
+### Fingerprint (uniqueness) key
+
+The `account_number_fingerprint` blind index (used to reject duplicate accounts)
+is an HMAC keyed by a **stable pepper**, independent of the active encryption
+key. This is deliberate: if the fingerprint key changed on every rotation, rows
+written before and after a rotation would no longer collide and duplicate
+detection would break. Rotation therefore **never** recomputes fingerprints.
+
+By default the pepper is the `v1` key. Override it with
+`ACCOUNT_CIPHER_FINGERPRINT_KEY` if you intend to eventually drop `v1`. Treat
+the fingerprint key as long-lived and rotate it only with a dedicated,
+fingerprint-recomputing migration (out of scope here).
+
+## Configuration (ENV)
+
+Preferred multi-key form:
+
+```bash
+# Comma-separated "version:base64key" pairs. Each key is 32 raw bytes, base64.
+#   openssl rand -base64 32
+ACCOUNT_CIPHER_KEYS=v1:<base64-32B>,v2:<base64-32B>
+
+# Which version seals new writes. Must be one of the versions above.
+ACCOUNT_CIPHER_ACTIVE_KEY=v2
+
+# Optional. Stable pepper for the uniqueness fingerprint. Defaults to the v1 key.
+ACCOUNT_CIPHER_FINGERPRINT_KEY=
+```
+
+Legacy single-key fallback (used only when `ACCOUNT_CIPHER_KEYS` is unset; the
+key is registered as `v1`):
+
+```bash
+BANK_ACCOUNT_ENCRYPTION_KEY=<base64-32B>
+```
+
+Rules enforced at startup:
+
+- `ACCOUNT_CIPHER_ACTIVE_KEY` is required when `ACCOUNT_CIPHER_KEYS` is set and
+  must name one of the listed versions.
+- Every key must decode to exactly 32 bytes.
+- Keys are **never** logged.
+
+## Rotation runbook
+
+Rotate to a new key **without downtime and without losing decryptability**:
+
+1. **Add the new key** alongside the current one, keeping the old one active:
+   ```bash
+   ACCOUNT_CIPHER_KEYS=v1:<old>,v2:<new>
+   ACCOUNT_CIPHER_ACTIVE_KEY=v1        # still v1 for now
+   ```
+   Deploy. Nothing changes yet, but `v2` is now available for decryption.
+
+2. **Promote the new key to active** so new writes use it:
+   ```bash
+   ACCOUNT_CIPHER_ACTIVE_KEY=v2
+   ```
+
+3. **Deploy.** From here, new rows are written as `v2`; old rows remain `v1` and
+   still decrypt because `v1` is still listed.
+
+4. **Run the rotation tool** to re-encrypt the `v1` backlog onto `v2`:
+   ```bash
+   cd apps/api
+   go run ./cmd/rotate_keys                 # or: go run ./cmd/rotate_keys -batch-size=1000
+   ```
+   The tool:
+   - is **idempotent** — re-running finds nothing left to do;
+   - is **resumable** — each row is committed as it is rotated, so an interrupted
+     run just continues from the remainder next time;
+   - is **safe** — bounded batches, per-row commits, and it aborts (rather than
+     looping) on any decrypt/update error;
+   - logs only **counts and row IDs** — never plaintext, keys, or ciphertext.
+
+   Verify zero remain:
+   ```sql
+   SELECT key_version, COUNT(*) FROM bank_accounts GROUP BY key_version;
+   -- expect only: v2 | <n>
+   ```
+
+5. **Remove the old key — only after** step 4 reports everything on `v2` and the
+   query above shows no `v1` rows:
+   ```bash
+   ACCOUNT_CIPHER_KEYS=v2:<new>
+   ACCOUNT_CIPHER_ACTIVE_KEY=v2
+   # If you had been relying on v1 as the fingerprint pepper, pin it explicitly
+   # first so duplicate detection stays stable:
+   ACCOUNT_CIPHER_FINGERPRINT_KEY=<old v1 key>
+   ```
+   Deploy. Dropping `v1` before every row is rotated would make those rows
+   undecryptable (`ErrUnknownKeyVersion`) — do not skip the verification.
+
+## Operational notes
+
+- **Back up the database** before a rotation run, as with any bulk write.
+- Keys should come from a secrets manager, not source control. The format is
+  KMS-friendly: swapping `AccountCipher` for envelope data keys wrapped by a KMS
+  KEK is a localized change behind the same `Encrypt`/`Decrypt` interface.
+- The rotation tool reads the same config as the API, so run it from an
+  environment that has both the old and new keys present.

--- a/docs/security/key-rotation.md
+++ b/docs/security/key-rotation.md
@@ -48,10 +48,15 @@ key. This is deliberate: if the fingerprint key changed on every rotation, rows
 written before and after a rotation would no longer collide and duplicate
 detection would break. Rotation therefore **never** recomputes fingerprints.
 
-By default the pepper is the `v1` key. Override it with
-`ACCOUNT_CIPHER_FINGERPRINT_KEY` if you intend to eventually drop `v1`. Treat
-the fingerprint key as long-lived and rotate it only with a dedicated,
-fingerprint-recomputing migration (out of scope here).
+When `ACCOUNT_CIPHER_FINGERPRINT_KEY` is empty the pepper defaults to the `v1`
+key. That default is only available **while a `v1` key is configured** — a key
+set that has no `v1` (e.g. after `v1` is dropped, or a set that starts at `v2`)
+**must** set `ACCOUNT_CIPHER_FINGERPRINT_KEY` explicitly, or startup fails with
+`ErrFingerprintKeyRequired`. This is deliberate: without a pinned pepper the
+fingerprint key would fall back to the active key and shift on every rotation
+(e.g. `v2`→`v3`), silently breaking blind-index uniqueness. Treat the fingerprint
+key as long-lived and rotate it only with a dedicated, fingerprint-recomputing
+migration (out of scope here).
 
 ## Configuration (ENV)
 
@@ -65,7 +70,8 @@ ACCOUNT_CIPHER_KEYS=v1:<base64-32B>,v2:<base64-32B>
 # Which version seals new writes. Must be one of the versions above.
 ACCOUNT_CIPHER_ACTIVE_KEY=v2
 
-# Optional. Stable pepper for the uniqueness fingerprint. Defaults to the v1 key.
+# Stable pepper for the uniqueness fingerprint. Defaults to the v1 key when empty;
+# REQUIRED (startup fails otherwise) if the key set has no v1.
 ACCOUNT_CIPHER_FINGERPRINT_KEY=
 ```
 


### PR DESCRIPTION
## Envelope encryption + key versioning + rotation tooling for the account cipher

Introduces non-destructive key rotation for encrypted bank account numbers. New
writes are sealed with an **active** key; every configured key **version** stays
available for decryption; a **rotation tool** migrates old rows onto the active
key — with zero rewrite of existing data required to keep it readable.

### How it works
- Each ciphertext is paired with the key version that produced it (`CipherEnvelope`).
  The stored bytes remain exactly `nonce || ciphertext`; the version lives in a
  new `bank_accounts.key_version` column that **defaults existing rows to `v1`**.
- `AccountCipher` is now multi-version (AES-256-GCM). `Encrypt` seals with the
  active key and tags the version; `Decrypt` resolves the key by the row's
  version and fails closed with `ErrUnknownKeyVersion` if a still-needed legacy
  key was dropped too early.
- The uniqueness **fingerprint** is keyed by a stable pepper (defaults to the v1
  key, overridable via `ACCOUNT_CIPHER_FINGERPRINT_KEY`) so the blind-index and
  duplicate detection survive a rotation. Rotation never recomputes fingerprints.

### Configuration
```
ACCOUNT_CIPHER_KEYS=v1:<base64-32B>,v2:<base64-32B>   # version:key pairs
ACCOUNT_CIPHER_ACTIVE_KEY=v2                           # seals new writes
ACCOUNT_CIPHER_FINGERPRINT_KEY=                        # optional stable pepper
```
Falls back to the legacy single `BANK_ACCOUNT_ENCRYPTION_KEY` (registered as v1)
when `ACCOUNT_CIPHER_KEYS` is unset, so existing deployments keep working.

### Rotation tool
`go run ./cmd/rotate_keys [-batch-size=500] [-timeout=0]`
- **Idempotent** — a second run finds nothing to do.
- **Resumable** — each row is committed as it is rotated; an interrupted run
  continues from the remainder.
- **Safe** — bounded batches, per-row commits, aborts (never loops) on error.
- Logs only counts and row IDs — **never** plaintext, keys, or ciphertext.

Full model, env format, and the 5-step operational runbook:
`docs/security/key-rotation.md`.

### Changes
- `internal/crypto/account_cipher.go` — versioned envelope cipher (backward-compatible constructor retained)
- `internal/config` — `ACCOUNT_CIPHER_KEYS` / `ACCOUNT_CIPHER_ACTIVE_KEY` / `ACCOUNT_CIPHER_FINGERPRINT_KEY` parsing + validation
- `migrations/057_*` — `key_version` column (+index), defaulting existing rows to `v1`
- `internal/domain/bankaccount` + `repository/postgres` — thread key version through Create/GetByID; rotation `Store` methods
- `internal/rotation` — idempotent/resumable rotation engine
- `internal/service/bankaccount_service.go` — seal with active key, decrypt by stored version
- `cmd/rotate_keys` — rotation CLI; `cmd/api` — multi-key wiring
- `.env.example` + `docs/security/key-rotation.md`

### Tests
- crypto: active-key encrypt, cross-version decrypt, unknown-version failure, fingerprint stability
- config: multi-key parsing, legacy fallback, validation errors
- rotation: re-encrypt-to-active, idempotency, resume-after-interrupt with no data loss
- service: new writes use active key; a v1 row still decrypts after v2 is added

### Acceptance criteria
- [x] Ciphertext carries key version
- [x] Multi-key config supported
- [x] Old data decrypts after rotation
- [x] Rotation tool works, idempotent + resumable
- [x] New data uses the active key
- [x] Migration applied safely (existing rows default to v1)
- [x] Documentation complete
- [x] Tests validate cross-version decrypt

> Local: `go build ./...` and unit tests pass (race + integration run in CI, which needs a DB). No issue auto-link added — say the word and I'll add `Closes #<n>`.

Closes #796 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned AES-GCM encryption for stored bank account numbers using a per-row key version.
  * Introduced a `rotate_keys` tool to re-encrypt legacy records to the currently active key version.
  * Updated database schema to track `bank_accounts.key_version` and added an index to support rotation.
* **Bug Fixes**
  * Improved validation and startup/config failures when encryption key versions are misconfigured.
  * Ensures older, previously encrypted data remains decryptable.
* **Documentation**
  * Added security guidance and a key-rotation runbook, including required configuration and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->