### PR TITLE
feat(api): distributed rate limiting with strict route limits

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -112,6 +112,12 @@ RATELIMIT_AUTH_WINDOW=1m
 RATELIMIT_SETTLEMENT_LIMIT=5
 RATELIMIT_SETTLEMENT_WINDOW=1m
 
+# Number of trusted reverse proxies / load balancers in front of the API. When
+# 0 (default) rate limits key off the direct connection IP. Set to the number of
+# trusted hops (e.g. 1 behind a single load balancer) so limits key off the real
+# client IP from X-Forwarded-For instead of collapsing all traffic onto the proxy.
+RATELIMIT_TRUSTED_PROXY_COUNT=0
+
 # Optional: set REDIS_ADDR (see above) to enforce all rate limits across every
 # API instance. Without it, limits are enforced per-instance in memory.
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -102,6 +102,19 @@ RATELIMIT_WRITE_WINDOW=1m
 RATELIMIT_WALLET_LIMIT=60
 RATELIMIT_WALLET_WINDOW=1m
 
+# Strict per-IP rate limit for the unauthenticated auth handshake
+# (POST /api/v1/auth/challenge and /verify). Blunts credential-stuffing.
+RATELIMIT_AUTH_LIMIT=10
+RATELIMIT_AUTH_WINDOW=1m
+
+# Strict per-user rate limit for settlement creation (POST /api/v1/settlements).
+# Keyed by user ID so a single account cannot spam settlements across IPs.
+RATELIMIT_SETTLEMENT_LIMIT=5
+RATELIMIT_SETTLEMENT_WINDOW=1m
+
+# Optional: set REDIS_ADDR (see above) to enforce all rate limits across every
+# API instance. Without it, limits are enforced per-instance in memory.
+
 # How often the performance tracker writes vault performance snapshots.
 PERFORMANCE_SNAPSHOT_INTERVAL=1h
 

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -197,11 +197,18 @@ func run() error {
 		Logger:  baseLogger,
 	})
 
-	var challengeStore service.ChallengeStore
+	// A single shared Redis client (nil when REDIS_ADDR is unset) powers both the
+	// challenge store and the distributed rate limiters. When nil, both fall back
+	// to in-memory implementations suitable for single-instance deployments.
+	var redisClient *redis.Client
 	if addr := cfg.Redis().Addr(); addr != "" {
-		redisClient := redis.NewClient(&redis.Options{Addr: addr})
+		redisClient = redis.NewClient(&redis.Options{Addr: addr})
+	}
+
+	var challengeStore service.ChallengeStore
+	if redisClient != nil {
 		challengeStore = service.NewRedisChallengeStore(redisClient, cfg.Auth().ChallengeExpiry())
-		baseLogger.Info("challenge store: redis", "addr", addr)
+		baseLogger.Info("challenge store: redis", "addr", cfg.Redis().Addr())
 	} else {
 		challengeStore = service.NewInMemoryChallengeStore(cfg.Auth().ChallengeExpiry())
 		baseLogger.Info("challenge store: in-memory (single-instance only)")
@@ -335,7 +342,6 @@ func run() error {
 		notificationRepository,
 		nil,
 	)
-
 
 	var ready atomic.Bool
 	ready.Store(true)
@@ -531,7 +537,33 @@ func run() error {
 		{PathPrefix: "/api/v1/", Public: false},
 	}
 	authenticator := middleware.Authenticate(cfg.Auth().Secret(), cfg.Auth().ServiceAPIKey(), authRules)
-	globalLimiter := middleware.IPRateLimiter(cfg.RateLimit().GlobalLimit(), cfg.RateLimit().GlobalWindow())
+	// globalLimiter bounds every request per client IP, but skips liveness /
+	// readiness / metrics endpoints so orchestrators can always reach them. It is
+	// distributed across instances when Redis is configured.
+	globalLimiter := middleware.GlobalRateLimiter(
+		middleware.NewLimiter(redisClient, "global", cfg.RateLimit().GlobalLimit(), cfg.RateLimit().GlobalWindow()),
+		[]string{"/health", "/healthz", "/readyz", "/metrics"},
+	)
+	// authRouteLimiter applies a strict per-IP limit to the unauthenticated auth
+	// handshake to blunt credential-stuffing. Keyed by IP because no user exists
+	// yet at challenge/verify time.
+	authRouteLimiter := middleware.SensitiveRouteLimiter(
+		middleware.NewLimiter(redisClient, "auth", cfg.RateLimit().AuthLimit(), cfg.RateLimit().AuthWindow()),
+		[]middleware.RouteMatch{
+			{Method: http.MethodPost, Path: "/api/v1/auth/challenge"},
+			{Method: http.MethodPost, Path: "/api/v1/auth/verify"},
+		},
+		"authentication rate limit exceeded",
+	)
+	// settlementLimiter applies a strict per-user limit to settlement creation to
+	// prevent settlement spam. Placed after authentication so it keys by user ID.
+	settlementLimiter := middleware.SensitiveUserRouteLimiter(
+		middleware.NewLimiter(redisClient, "settlement", cfg.RateLimit().SettlementLimit(), cfg.RateLimit().SettlementWindow()),
+		[]middleware.RouteMatch{
+			{Method: http.MethodPost, Path: "/api/v1/settlements"},
+		},
+		"settlement rate limit exceeded",
+	)
 	writeLimiter := middleware.WriteMethodRateLimiter(cfg.RateLimit().WriteLimit(), cfg.RateLimit().WriteWindow())
 	walletLimiter := middleware.WalletRateLimiter(
 		cfg.RateLimit().WalletLimit(),
@@ -545,12 +577,16 @@ func run() error {
 		Handler: middleware.SecurityHeaders(cfg.Environment())(
 			middleware.RecoverPanic(baseLogger)(
 				globalLimiter(
-					cors(
-						writeLimiter(
-							authenticator(
-								walletLimiter(
-									middleware.LimitRequestBody(1 * 1024 * 1024)(
-										middleware.Logging(baseLogger)(mux),
+					authRouteLimiter(
+						cors(
+							writeLimiter(
+								authenticator(
+									settlementLimiter(
+										walletLimiter(
+											middleware.LimitRequestBody(1 * 1024 * 1024)(
+												middleware.Logging(baseLogger)(mux),
+											),
+										),
 									),
 								),
 							),

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -537,6 +537,11 @@ func run() error {
 		{PathPrefix: "/api/v1/", Public: false},
 	}
 	authenticator := middleware.Authenticate(cfg.Auth().Secret(), cfg.Auth().ServiceAPIKey(), authRules)
+	// Tell the rate-limit client-IP extractor how many trusted proxies sit in
+	// front of the API so it derives the originating client IP from
+	// X-Forwarded-For instead of collapsing all traffic onto the proxy address.
+	middleware.ConfigureClientIP(cfg.RateLimit().TrustedProxyCount())
+
 	// globalLimiter bounds every request per client IP, but skips liveness /
 	// readiness / metrics endpoints so orchestrators can always reach them. It is
 	// distributed across instances when Redis is configured.
@@ -574,11 +579,16 @@ func run() error {
 
 	server := &http.Server{
 		Addr: cfg.Server().Address(),
+		// cors is outermost of the request-processing middleware (after only
+		// SecurityHeaders/RecoverPanic) so that rate-limit 429 responses from
+		// globalLimiter and authRouteLimiter still carry CORS headers and remain
+		// readable to browser clients. OPTIONS preflights are short-circuited by
+		// cors and never reach the limiters.
 		Handler: middleware.SecurityHeaders(cfg.Environment())(
 			middleware.RecoverPanic(baseLogger)(
-				globalLimiter(
-					authRouteLimiter(
-						cors(
+				cors(
+					globalLimiter(
+						authRouteLimiter(
 							writeLimiter(
 								authenticator(
 									settlementLimiter(

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -158,18 +158,19 @@ type AuthConfig struct {
 }
 
 type RateLimitConfig struct {
-	globalLimit      int
-	globalWindow     time.Duration
-	writeLimit       int
-	writeWindow      time.Duration
-	walletLimit      int
-	walletWindow     time.Duration
-	rebalanceLimit   int
-	rebalanceWindow  time.Duration
-	authLimit        int
-	authWindow       time.Duration
-	settlementLimit  int
-	settlementWindow time.Duration
+	globalLimit       int
+	globalWindow      time.Duration
+	writeLimit        int
+	writeWindow       time.Duration
+	walletLimit       int
+	walletWindow      time.Duration
+	rebalanceLimit    int
+	rebalanceWindow   time.Duration
+	authLimit         int
+	authWindow        time.Duration
+	settlementLimit   int
+	settlementWindow  time.Duration
+	trustedProxyCount int
 }
 
 type LogConfig struct {
@@ -249,18 +250,19 @@ func Load() (*Config, error) {
 			challengeExpiry: loader.durationDefault("AUTH_CHALLENGE_EXPIRY", 5*time.Minute),
 		},
 		rateLimit: RateLimitConfig{
-			globalLimit:      loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
-			globalWindow:     loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
-			writeLimit:       loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
-			writeWindow:      loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
-			walletLimit:      loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
-			walletWindow:     loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
-			rebalanceLimit:   loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
-			rebalanceWindow:  loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
-			authLimit:        loader.intDefault("RATELIMIT_AUTH_LIMIT", 10),
-			authWindow:       loader.durationDefault("RATELIMIT_AUTH_WINDOW", 1*time.Minute),
-			settlementLimit:  loader.intDefault("RATELIMIT_SETTLEMENT_LIMIT", 5),
-			settlementWindow: loader.durationDefault("RATELIMIT_SETTLEMENT_WINDOW", 1*time.Minute),
+			globalLimit:       loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
+			globalWindow:      loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
+			writeLimit:        loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
+			writeWindow:       loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
+			walletLimit:       loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
+			walletWindow:      loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
+			rebalanceLimit:    loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
+			rebalanceWindow:   loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
+			authLimit:         loader.intDefault("RATELIMIT_AUTH_LIMIT", 10),
+			authWindow:        loader.durationDefault("RATELIMIT_AUTH_WINDOW", 1*time.Minute),
+			settlementLimit:   loader.intDefault("RATELIMIT_SETTLEMENT_LIMIT", 5),
+			settlementWindow:  loader.durationDefault("RATELIMIT_SETTLEMENT_WINDOW", 1*time.Minute),
+			trustedProxyCount: loader.intDefault("RATELIMIT_TRUSTED_PROXY_COUNT", 0),
 		},
 		log: LogConfig{
 			level:  strings.ToLower(loader.stringDefault("LOG_LEVEL", "info")),
@@ -601,6 +603,9 @@ func (c *Config) validate(loader *envLoader) {
 	if c.rateLimit.settlementWindow <= 0 {
 		loader.addError("RATELIMIT_SETTLEMENT_WINDOW must be greater than 0")
 	}
+	if c.rateLimit.trustedProxyCount < 0 {
+		loader.addError("RATELIMIT_TRUSTED_PROXY_COUNT must be zero or greater")
+	}
 
 	if !isOneOf(c.log.level, "debug", "info", "warn", "error") {
 		loader.addError("LOG_LEVEL must be one of debug, info, warn, error")
@@ -832,6 +837,10 @@ func (r RateLimitConfig) SettlementLimit() int {
 
 func (r RateLimitConfig) SettlementWindow() time.Duration {
 	return r.settlementWindow
+}
+
+func (r RateLimitConfig) TrustedProxyCount() int {
+	return r.trustedProxyCount
 }
 
 type envLoader struct {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -568,6 +568,11 @@ func (c *Config) validate(loader *envLoader) {
 
 	if c.rateLimit.globalWindow <= 0 {
 		loader.addError("RATELIMIT_GLOBAL_WINDOW must be greater than 0")
+	} else if c.rateLimit.globalWindow < time.Millisecond {
+		// The Redis limiter converts the window to whole milliseconds for
+		// PEXPIRE; a sub-millisecond window truncates to 0 and the counter would
+		// expire immediately, silently disabling enforcement.
+		loader.addError("RATELIMIT_GLOBAL_WINDOW must be at least 1ms")
 	}
 
 	if c.rateLimit.writeLimit <= 0 {
@@ -596,12 +601,16 @@ func (c *Config) validate(loader *envLoader) {
 	}
 	if c.rateLimit.authWindow <= 0 {
 		loader.addError("RATELIMIT_AUTH_WINDOW must be greater than 0")
+	} else if c.rateLimit.authWindow < time.Millisecond {
+		loader.addError("RATELIMIT_AUTH_WINDOW must be at least 1ms")
 	}
 	if c.rateLimit.settlementLimit <= 0 {
 		loader.addError("RATELIMIT_SETTLEMENT_LIMIT must be greater than 0")
 	}
 	if c.rateLimit.settlementWindow <= 0 {
 		loader.addError("RATELIMIT_SETTLEMENT_WINDOW must be greater than 0")
+	} else if c.rateLimit.settlementWindow < time.Millisecond {
+		loader.addError("RATELIMIT_SETTLEMENT_WINDOW must be at least 1ms")
 	}
 	if c.rateLimit.trustedProxyCount < 0 {
 		loader.addError("RATELIMIT_TRUSTED_PROXY_COUNT must be zero or greater")

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -118,14 +118,18 @@ type AuthConfig struct {
 }
 
 type RateLimitConfig struct {
-	globalLimit    int
-	globalWindow   time.Duration
-	writeLimit     int
-	writeWindow    time.Duration
-	walletLimit    int
-	walletWindow   time.Duration
-	rebalanceLimit int
-	rebalanceWindow time.Duration
+	globalLimit      int
+	globalWindow     time.Duration
+	writeLimit       int
+	writeWindow      time.Duration
+	walletLimit      int
+	walletWindow     time.Duration
+	rebalanceLimit   int
+	rebalanceWindow  time.Duration
+	authLimit        int
+	authWindow       time.Duration
+	settlementLimit  int
+	settlementWindow time.Duration
 }
 
 type LogConfig struct {
@@ -205,14 +209,18 @@ func Load() (*Config, error) {
 			challengeExpiry: loader.durationDefault("AUTH_CHALLENGE_EXPIRY", 5*time.Minute),
 		},
 		rateLimit: RateLimitConfig{
-			globalLimit:    loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
-			globalWindow:   loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
-			writeLimit:     loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
-			writeWindow:    loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
-			walletLimit:    loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
-			walletWindow:   loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
-			rebalanceLimit: loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
-			rebalanceWindow: loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
+			globalLimit:      loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
+			globalWindow:     loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
+			writeLimit:       loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
+			writeWindow:      loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
+			walletLimit:      loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
+			walletWindow:     loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
+			rebalanceLimit:   loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
+			rebalanceWindow:  loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
+			authLimit:        loader.intDefault("RATELIMIT_AUTH_LIMIT", 10),
+			authWindow:       loader.durationDefault("RATELIMIT_AUTH_WINDOW", 1*time.Minute),
+			settlementLimit:  loader.intDefault("RATELIMIT_SETTLEMENT_LIMIT", 5),
+			settlementWindow: loader.durationDefault("RATELIMIT_SETTLEMENT_WINDOW", 1*time.Minute),
 		},
 		log: LogConfig{
 			level:  strings.ToLower(loader.stringDefault("LOG_LEVEL", "info")),
@@ -254,7 +262,6 @@ func Load() (*Config, error) {
 	if cfg.bankAccountCipherKey == "" && environment == "development" {
 		cfg.bankAccountCipherKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 	}
-
 
 	cfg.validate(&loader)
 
@@ -411,9 +418,9 @@ func (t TransactionPollerConfig) MinAge() time.Duration {
 
 // RecurringDepositConfig governs the hourly savings schedule deposit loop.
 type RecurringDepositConfig struct {
-	enabled      bool
-	interval     time.Duration
-	minDeposit   string
+	enabled    bool
+	interval   time.Duration
+	minDeposit string
 }
 
 func (c Config) RecurringDeposit() RecurringDepositConfig {
@@ -534,6 +541,18 @@ func (c *Config) validate(loader *envLoader) {
 	}
 	if c.rateLimit.rebalanceWindow <= 0 {
 		loader.addError("RATELIMIT_REBALANCE_WINDOW must be greater than 0")
+	}
+	if c.rateLimit.authLimit <= 0 {
+		loader.addError("RATELIMIT_AUTH_LIMIT must be greater than 0")
+	}
+	if c.rateLimit.authWindow <= 0 {
+		loader.addError("RATELIMIT_AUTH_WINDOW must be greater than 0")
+	}
+	if c.rateLimit.settlementLimit <= 0 {
+		loader.addError("RATELIMIT_SETTLEMENT_LIMIT must be greater than 0")
+	}
+	if c.rateLimit.settlementWindow <= 0 {
+		loader.addError("RATELIMIT_SETTLEMENT_WINDOW must be greater than 0")
 	}
 
 	if !isOneOf(c.log.level, "debug", "info", "warn", "error") {
@@ -750,6 +769,22 @@ func (r RateLimitConfig) RebalanceLimit() int {
 
 func (r RateLimitConfig) RebalanceWindow() time.Duration {
 	return r.rebalanceWindow
+}
+
+func (r RateLimitConfig) AuthLimit() int {
+	return r.authLimit
+}
+
+func (r RateLimitConfig) AuthWindow() time.Duration {
+	return r.authWindow
+}
+
+func (r RateLimitConfig) SettlementLimit() int {
+	return r.settlementLimit
+}
+
+func (r RateLimitConfig) SettlementWindow() time.Duration {
+	return r.settlementWindow
 }
 
 type envLoader struct {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"sync"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -22,6 +22,7 @@ func baseEnv(t *testing.T) {
 		"AUTH_JWT_SECRET", "AUTH_TOKEN_EXPIRY", "AUTH_CHALLENGE_EXPIRY",
 		"RATELIMIT_GLOBAL_LIMIT", "RATELIMIT_GLOBAL_WINDOW", "RATELIMIT_WRITE_LIMIT", "RATELIMIT_WRITE_WINDOW",
 		"RATELIMIT_WALLET_LIMIT", "RATELIMIT_WALLET_WINDOW",
+		"RATELIMIT_AUTH_LIMIT", "RATELIMIT_AUTH_WINDOW", "RATELIMIT_SETTLEMENT_LIMIT", "RATELIMIT_SETTLEMENT_WINDOW",
 		"LOG_LEVEL", "LOG_FORMAT",
 		"ALLOWED_ORIGINS",
 		"RUN_MIGRATIONS", "MIGRATIONS_DIR", "STARTUP_DEPENDENCY_TIMEOUT",
@@ -348,10 +349,10 @@ func TestLoadProcessEnvOverridesDotEnvAndFallsBack(t *testing.T) {
 // only a subset of required fields are missing.
 func TestLoadMissingRequiredFieldsPartial(t *testing.T) {
 	cases := []struct {
-		name          string
-		set           func(t *testing.T)
-		wantMissing   []string
-		wantNotInErr  []string
+		name         string
+		set          func(t *testing.T)
+		wantMissing  []string
+		wantNotInErr []string
 	}{
 		{
 			name: "missing database dsn only",
@@ -446,6 +447,10 @@ func TestLoadAllDefaults(t *testing.T) {
 		{"ratelimit write window", cfg.RateLimit().WriteWindow(), 1 * time.Minute},
 		{"ratelimit wallet limit", cfg.RateLimit().WalletLimit(), 60},
 		{"ratelimit wallet window", cfg.RateLimit().WalletWindow(), 1 * time.Minute},
+		{"ratelimit auth limit", cfg.RateLimit().AuthLimit(), 10},
+		{"ratelimit auth window", cfg.RateLimit().AuthWindow(), 1 * time.Minute},
+		{"ratelimit settlement limit", cfg.RateLimit().SettlementLimit(), 5},
+		{"ratelimit settlement window", cfg.RateLimit().SettlementWindow(), 1 * time.Minute},
 	}
 
 	for _, tc := range cases {
@@ -788,6 +793,73 @@ func TestLoadWalletRateLimitOverrides(t *testing.T) {
 	}
 	if got := cfg.RateLimit().WalletWindow(); got != 15*time.Second {
 		t.Errorf("WalletWindow() = %s, want 15s", got)
+	}
+}
+
+// TestLoadSensitiveRateLimitRejectsNonPositiveValues verifies validation of the
+// strict auth and settlement rate-limit knobs.
+func TestLoadSensitiveRateLimitRejectsNonPositiveValues(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		val  string
+		want string
+	}{
+		{"zero auth limit", "RATELIMIT_AUTH_LIMIT", "0", "RATELIMIT_AUTH_LIMIT must be greater than 0"},
+		{"negative auth limit", "RATELIMIT_AUTH_LIMIT", "-1", "RATELIMIT_AUTH_LIMIT must be greater than 0"},
+		{"zero auth window", "RATELIMIT_AUTH_WINDOW", "0s", "RATELIMIT_AUTH_WINDOW must be greater than 0"},
+		{"zero settlement limit", "RATELIMIT_SETTLEMENT_LIMIT", "0", "RATELIMIT_SETTLEMENT_LIMIT must be greater than 0"},
+		{"zero settlement window", "RATELIMIT_SETTLEMENT_WINDOW", "0s", "RATELIMIT_SETTLEMENT_WINDOW must be greater than 0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			t.Setenv(tc.key, tc.val)
+
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to fail for %s=%s", tc.key, tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to contain %q, got %q", tc.want, err.Error())
+			}
+		})
+	}
+}
+
+// TestLoadSensitiveRateLimitOverrides verifies env overrides for the strict auth
+// and settlement rate-limit knobs are honoured.
+func TestLoadSensitiveRateLimitOverrides(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("RATELIMIT_AUTH_LIMIT", "7")
+	t.Setenv("RATELIMIT_AUTH_WINDOW", "30s")
+	t.Setenv("RATELIMIT_SETTLEMENT_LIMIT", "3")
+	t.Setenv("RATELIMIT_SETTLEMENT_WINDOW", "45s")
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.RateLimit().AuthLimit(); got != 7 {
+		t.Errorf("AuthLimit() = %d, want 7", got)
+	}
+	if got := cfg.RateLimit().AuthWindow(); got != 30*time.Second {
+		t.Errorf("AuthWindow() = %s, want 30s", got)
+	}
+	if got := cfg.RateLimit().SettlementLimit(); got != 3 {
+		t.Errorf("SettlementLimit() = %d, want 3", got)
+	}
+	if got := cfg.RateLimit().SettlementWindow(); got != 45*time.Second {
+		t.Errorf("SettlementWindow() = %s, want 45s", got)
 	}
 }
 

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -865,6 +865,41 @@ func TestLoadSensitiveRateLimitOverrides(t *testing.T) {
 	}
 }
 
+// TestLoadRateLimitRejectsSubMillisecondWindows verifies that Redis-backed
+// limiter windows below 1ms are rejected: the Redis limiter converts the window
+// to whole milliseconds for PEXPIRE, so a sub-ms window truncates to 0 and would
+// silently disable enforcement.
+func TestLoadRateLimitRejectsSubMillisecondWindows(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"global", "RATELIMIT_GLOBAL_WINDOW", "RATELIMIT_GLOBAL_WINDOW must be at least 1ms"},
+		{"auth", "RATELIMIT_AUTH_WINDOW", "RATELIMIT_AUTH_WINDOW must be at least 1ms"},
+		{"settlement", "RATELIMIT_SETTLEMENT_WINDOW", "RATELIMIT_SETTLEMENT_WINDOW must be at least 1ms"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			t.Setenv(tc.key, "500us")
+
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to fail for %s=500us", tc.key)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to contain %q, got %q", tc.want, err.Error())
+			}
+		})
+	}
+}
+
 // TestLoadTrustedProxyCountOverride verifies RATELIMIT_TRUSTED_PROXY_COUNT is
 // honoured and that a negative value is rejected.
 func TestLoadTrustedProxyCountOverride(t *testing.T) {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -23,6 +23,7 @@ func baseEnv(t *testing.T) {
 		"RATELIMIT_GLOBAL_LIMIT", "RATELIMIT_GLOBAL_WINDOW", "RATELIMIT_WRITE_LIMIT", "RATELIMIT_WRITE_WINDOW",
 		"RATELIMIT_WALLET_LIMIT", "RATELIMIT_WALLET_WINDOW",
 		"RATELIMIT_AUTH_LIMIT", "RATELIMIT_AUTH_WINDOW", "RATELIMIT_SETTLEMENT_LIMIT", "RATELIMIT_SETTLEMENT_WINDOW",
+		"RATELIMIT_TRUSTED_PROXY_COUNT",
 		"LOG_LEVEL", "LOG_FORMAT",
 		"ALLOWED_ORIGINS",
 		"RUN_MIGRATIONS", "MIGRATIONS_DIR", "STARTUP_DEPENDENCY_TIMEOUT",
@@ -451,6 +452,7 @@ func TestLoadAllDefaults(t *testing.T) {
 		{"ratelimit auth window", cfg.RateLimit().AuthWindow(), 1 * time.Minute},
 		{"ratelimit settlement limit", cfg.RateLimit().SettlementLimit(), 5},
 		{"ratelimit settlement window", cfg.RateLimit().SettlementWindow(), 1 * time.Minute},
+		{"ratelimit trusted proxy count", cfg.RateLimit().TrustedProxyCount(), 0},
 	}
 
 	for _, tc := range cases {
@@ -860,6 +862,42 @@ func TestLoadSensitiveRateLimitOverrides(t *testing.T) {
 	}
 	if got := cfg.RateLimit().SettlementWindow(); got != 45*time.Second {
 		t.Errorf("SettlementWindow() = %s, want 45s", got)
+	}
+}
+
+// TestLoadTrustedProxyCountOverride verifies RATELIMIT_TRUSTED_PROXY_COUNT is
+// honoured and that a negative value is rejected.
+func TestLoadTrustedProxyCountOverride(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("RATELIMIT_TRUSTED_PROXY_COUNT", "2")
+
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.RateLimit().TrustedProxyCount(); got != 2 {
+		t.Errorf("TrustedProxyCount() = %d, want 2", got)
+	}
+}
+
+func TestLoadTrustedProxyCountRejectsNegative(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("RATELIMIT_TRUSTED_PROXY_COUNT", "-1")
+
+	chdir(t, t.TempDir())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail for RATELIMIT_TRUSTED_PROXY_COUNT=-1")
+	}
+	if !strings.Contains(err.Error(), "RATELIMIT_TRUSTED_PROXY_COUNT must be zero or greater") {
+		t.Fatalf("unexpected error: %q", err.Error())
 	}
 }
 

--- a/apps/api/internal/middleware/ratelimit.go
+++ b/apps/api/internal/middleware/ratelimit.go
@@ -4,9 +4,29 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
+
+// trustedProxyCount is the number of trusted reverse proxies / load balancers in
+// front of the API. It defaults to 0 (trust none: rate limits key off the direct
+// connection address) and is set once at startup via ConfigureClientIP. When
+// greater than 0, clientIP derives the originating client address from the
+// X-Forwarded-For chain, counting hops from the right so spoofed left-most
+// entries cannot forge a client IP past the trusted-proxy boundary.
+var trustedProxyCount int
+
+// ConfigureClientIP sets how many trusted proxies sit in front of the API for
+// the purpose of client-IP extraction in rate limiting. It must be called once
+// during startup, before the server begins serving. A negative count is treated
+// as 0. See trustedProxyCount.
+func ConfigureClientIP(count int) {
+	if count < 0 {
+		count = 0
+	}
+	trustedProxyCount = count
+}
 
 // bucket is a token-bucket entry for a single rate-limit key.
 type bucket struct {
@@ -65,14 +85,37 @@ func (l *limiter) allow(key string) (bool, time.Duration) {
 	return false, wait
 }
 
-// clientIP extracts the client IP from r.RemoteAddr, stripping the port. When
-// RemoteAddr carries no port it is returned unchanged.
+// clientIP returns the address used to key rate limits for r.
+//
+// With no trusted proxies configured (the default), it is the direct connection
+// address from r.RemoteAddr (port stripped). When trustedProxyCount > 0, the API
+// is assumed to sit behind that many trusted proxies, and the originating client
+// address is taken from the X-Forwarded-For chain: the direct peer is appended as
+// the right-most hop and the entry trustedProxyCount positions further left is
+// returned. Counting from the right means a client cannot spoof its way past the
+// trusted-proxy boundary by injecting extra left-most X-Forwarded-For entries.
 func clientIP(r *http.Request) string {
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		return r.RemoteAddr
+		host = r.RemoteAddr
 	}
-	return ip
+	if trustedProxyCount <= 0 {
+		return host
+	}
+
+	// chain is client...proxies (left to right), with the direct peer last.
+	chain := make([]string, 0, trustedProxyCount+1)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		for _, p := range strings.Split(xff, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				chain = append(chain, p)
+			}
+		}
+	}
+	chain = append(chain, host)
+
+	idx := max(len(chain)-1-trustedProxyCount, 0)
+	return chain[idx]
 }
 
 // writeRateLimited writes the shared 429 response: a Retry-After header (in

--- a/apps/api/internal/middleware/ratelimit.go
+++ b/apps/api/internal/middleware/ratelimit.go
@@ -65,17 +65,31 @@ func (l *limiter) allow(key string) (bool, time.Duration) {
 	return false, wait
 }
 
+// clientIP extracts the client IP from r.RemoteAddr, stripping the port. When
+// RemoteAddr carries no port it is returned unchanged.
+func clientIP(r *http.Request) string {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// writeRateLimited writes the shared 429 response: a Retry-After header (in
+// whole seconds, minimum 1) and the API's standard JSON error envelope.
+func writeRateLimited(w http.ResponseWriter, wait time.Duration, message string) {
+	retryAfter := max(int(wait.Seconds()), 1)
+	w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	fmt.Fprintf(w, `{"success":false,"error":{"code":"RATE_LIMITED","message":%q}}`, message)
+}
+
 // IPRateLimiter returns middleware that enforces a per-remote-IP rate limit of
 // limit requests per window.
 func IPRateLimiter(limit int, window time.Duration) func(http.Handler) http.Handler {
 	l := newLimiter(limit, window)
-	return rateLimitMiddleware(l, func(r *http.Request) string {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			return r.RemoteAddr
-		}
-		return ip
-	})
+	return rateLimitMiddleware(l, clientIP)
 }
 
 // WalletRateLimiter returns middleware that enforces a per-wallet rate limit.
@@ -105,21 +119,9 @@ func WriteMethodRateLimiter(limit int, window time.Duration) func(http.Handler) 
 				return
 			}
 
-			ip, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err != nil {
-				ip = r.RemoteAddr
-			}
-
-			allowed, wait := l.allow(ip)
+			allowed, wait := l.allow(clientIP(r))
 			if !allowed {
-				retryAfter := int(wait.Seconds())
-				if retryAfter < 1 {
-					retryAfter = 1
-				}
-				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusTooManyRequests)
-				fmt.Fprintf(w, `{"success":false,"error":{"code":"RATE_LIMITED","message":"write rate limit exceeded"}}`)
+				writeRateLimited(w, wait, "write rate limit exceeded")
 				return
 			}
 
@@ -139,14 +141,7 @@ func rateLimitMiddleware(l *limiter, keyFn func(*http.Request) string) func(http
 
 			allowed, wait := l.allow(key)
 			if !allowed {
-				retryAfter := int(wait.Seconds())
-				if retryAfter < 1 {
-					retryAfter = 1
-				}
-				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusTooManyRequests)
-				fmt.Fprintf(w, `{"success":false,"error":{"code":"RATE_LIMITED","message":"rate limit exceeded"}}`)
+				writeRateLimited(w, wait, "rate limit exceeded")
 				return
 			}
 

--- a/apps/api/internal/middleware/ratelimit_backend.go
+++ b/apps/api/internal/middleware/ratelimit_backend.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Limiter decides whether a request identified by an opaque key may proceed.
+// Implementations may be process-local (in-memory token bucket) or distributed
+// (Redis fixed-window counter). A denied call returns an estimated wait before
+// the next request for the same key will be allowed.
+type Limiter interface {
+	Allow(ctx context.Context, key string) (allowed bool, retryAfter time.Duration)
+}
+
+// Allow adapts the in-memory token-bucket limiter to the Limiter interface. The
+// context is unused because the in-memory bucket never blocks or performs I/O.
+func (l *limiter) Allow(_ context.Context, key string) (bool, time.Duration) {
+	return l.allow(key)
+}
+
+// NewLimiter returns a distributed, Redis-backed limiter when rc is non-nil, and
+// a process-local in-memory limiter otherwise. This is the dual-mode entry point:
+// deployments with Redis get cross-instance rate limiting, while single-instance
+// or Redis-less deployments fall back transparently.
+//
+// prefix namespaces the Redis keys ("rl:{prefix}:{key}") so several limiters can
+// share one Redis instance without colliding.
+func NewLimiter(rc *redis.Client, prefix string, limit int, window time.Duration) Limiter {
+	if rc != nil {
+		return &redisLimiter{rc: rc, prefix: prefix, limit: limit, window: window}
+	}
+	return newLimiter(limit, window)
+}
+
+// redisLimiter implements a fixed-window counter. Each request atomically
+// increments a per-key counter; the counter's TTL is set to the window on first
+// use and the request is rejected once the count exceeds the limit. Because the
+// counter lives in Redis, the limit is enforced across every API instance.
+type redisLimiter struct {
+	rc     *redis.Client
+	prefix string
+	limit  int
+	window time.Duration
+}
+
+// rateLimitScript atomically increments the counter at KEYS[1], sets its TTL to
+// ARGV[1] milliseconds when the counter is first created, and returns the
+// current count alongside the remaining TTL. Running it as a single script keeps
+// the increment and expiry atomic under concurrency.
+var rateLimitScript = redis.NewScript(`
+local current = redis.call("INCR", KEYS[1])
+if current == 1 then
+	redis.call("PEXPIRE", KEYS[1], ARGV[1])
+end
+local ttl = redis.call("PTTL", KEYS[1])
+return {current, ttl}
+`)
+
+func (l *redisLimiter) Allow(ctx context.Context, key string) (bool, time.Duration) {
+	fullKey := "rl:" + l.prefix + ":" + key
+
+	res, err := rateLimitScript.Run(ctx, l.rc, []string{fullKey}, l.window.Milliseconds()).Result()
+	if err != nil {
+		// Fail open: a Redis outage must never take down the API by rejecting
+		// legitimate traffic. Requests pass through until Redis recovers.
+		return true, 0
+	}
+
+	vals, ok := res.([]any)
+	if !ok || len(vals) != 2 {
+		return true, 0
+	}
+	count, _ := vals[0].(int64)
+	ttlMS, _ := vals[1].(int64)
+
+	if count > int64(l.limit) {
+		wait := max(time.Duration(ttlMS)*time.Millisecond, time.Second)
+		return false, wait
+	}
+	return true, 0
+}

--- a/apps/api/internal/middleware/ratelimit_backend.go
+++ b/apps/api/internal/middleware/ratelimit_backend.go
@@ -2,10 +2,15 @@ package middleware
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
+
+// redisCallTimeout bounds each Redis round-trip so a degraded (slow) Redis
+// cannot add latency to every request before the limiter fails open.
+const redisCallTimeout = 75 * time.Millisecond
 
 // Limiter decides whether a request identified by an opaque key may proceed.
 // Implementations may be process-local (in-memory token bucket) or distributed
@@ -62,15 +67,24 @@ return {current, ttl}
 func (l *redisLimiter) Allow(ctx context.Context, key string) (bool, time.Duration) {
 	fullKey := "rl:" + l.prefix + ":" + key
 
+	ctx, cancel := context.WithTimeout(ctx, redisCallTimeout)
+	defer cancel()
+
 	res, err := rateLimitScript.Run(ctx, l.rc, []string{fullKey}, l.window.Milliseconds()).Result()
 	if err != nil {
-		// Fail open: a Redis outage must never take down the API by rejecting
-		// legitimate traffic. Requests pass through until Redis recovers.
+		// Fail open: a Redis outage (or a call that exceeds redisCallTimeout)
+		// must never take down the API by rejecting legitimate traffic. Requests
+		// pass through until Redis recovers; the failure is logged so a
+		// persistent outage does not go unnoticed.
+		slog.Default().WarnContext(ctx, "rate limiter: redis error, failing open",
+			"prefix", l.prefix, "error", err)
 		return true, 0
 	}
 
 	vals, ok := res.([]any)
 	if !ok || len(vals) != 2 {
+		slog.Default().WarnContext(ctx, "rate limiter: unexpected redis result, failing open",
+			"prefix", l.prefix)
 		return true, 0
 	}
 	count, _ := vals[0].(int64)

--- a/apps/api/internal/middleware/ratelimit_backend_test.go
+++ b/apps/api/internal/middleware/ratelimit_backend_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestRedisLimiterDistributed exercises the Redis-backed limiter against a real
+// Redis. It is skipped unless REDIS_ADDR is set and reachable, so it runs in CI
+// (where Redis is available) but never blocks local runs without one.
+func TestRedisLimiterDistributed(t *testing.T) {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set; skipping distributed rate-limit test")
+	}
+
+	rc := redis.NewClient(&redis.Options{Addr: addr})
+	ctx := context.Background()
+	if err := rc.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not reachable at %s: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+
+	prefix := "test-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	key := "1.2.3.4"
+	t.Cleanup(func() { _ = rc.Del(ctx, "rl:"+prefix+":"+key).Err() })
+
+	l := NewLimiter(rc, prefix, 2, time.Second)
+
+	// Two requests allowed, third denied with a positive retry-after.
+	for i := 0; i < 2; i++ {
+		if allowed, _ := l.Allow(ctx, key); !allowed {
+			t.Fatalf("request %d: got denied, want allowed", i+1)
+		}
+	}
+	allowed, wait := l.Allow(ctx, key)
+	if allowed {
+		t.Fatal("third request: got allowed, want denied")
+	}
+	if wait <= 0 {
+		t.Fatalf("retryAfter = %s, want > 0", wait)
+	}
+
+	// After the window the counter expires and requests are allowed again.
+	time.Sleep(1100 * time.Millisecond)
+	if allowed, _ := l.Allow(ctx, key); !allowed {
+		t.Fatal("after window reset: got denied, want allowed")
+	}
+}
+
+// TestRedisLimiterFailsOpenOnError verifies that a Redis outage never blocks
+// traffic: when the client cannot reach Redis, Allow returns allowed=true.
+func TestRedisLimiterFailsOpenOnError(t *testing.T) {
+	rc := redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:1", // nothing listening here
+		DialTimeout: 200 * time.Millisecond,
+		MaxRetries:  -1,
+	})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	l := &redisLimiter{rc: rc, prefix: "x", limit: 1, window: time.Second}
+	allowed, wait := l.Allow(context.Background(), "k")
+	if !allowed || wait != 0 {
+		t.Fatalf("Allow on unreachable redis = (%v, %s), want (true, 0) — must fail open", allowed, wait)
+	}
+}

--- a/apps/api/internal/middleware/ratelimit_routes.go
+++ b/apps/api/internal/middleware/ratelimit_routes.go
@@ -1,0 +1,114 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+// RouteMatch identifies a single method+path endpoint that a route-scoped
+// limiter applies to. Path is matched exactly against r.URL.Path.
+type RouteMatch struct {
+	Method string
+	Path   string
+}
+
+// userIDFromContext returns the authenticated user's ID, or "" when the request
+// carries no authenticated user (i.e. it has not passed Authenticate or is a
+// public route).
+func userIDFromContext(r *http.Request) string {
+	u, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		return ""
+	}
+	return u.ID
+}
+
+// userOrIP keys authenticated requests by user ID and falls back to the client
+// IP for anonymous requests. This gives per-user isolation once a request is
+// authenticated while still bounding pre-auth traffic per source.
+func userOrIP(r *http.Request) string {
+	if id := userIDFromContext(r); id != "" {
+		return id
+	}
+	return clientIP(r)
+}
+
+// GlobalRateLimiter enforces a per-client-IP limit across all requests except
+// those whose path matches one of excludePrefixes (health, readiness and
+// metrics endpoints, which must remain callable by orchestrators under load).
+// It is backed by the supplied Limiter, so it is distributed when Redis is
+// configured and in-memory otherwise.
+func GlobalRateLimiter(l Limiter, excludePrefixes []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, p := range excludePrefixes {
+				if strings.HasPrefix(r.URL.Path, p) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			allowed, wait := l.Allow(r.Context(), clientIP(r))
+			if !allowed {
+				writeRateLimited(w, wait, "rate limit exceeded")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// SensitiveRouteLimiter applies a strict per-client-IP limit to a fixed set of
+// abuse-prone endpoints. Requests that match none of routes pass through
+// untouched. Keying by IP works even for pre-authentication routes (e.g. the
+// auth challenge/verify handshake) where no user identity exists yet.
+func SensitiveRouteLimiter(l Limiter, routes []RouteMatch, message string) func(http.Handler) http.Handler {
+	return sensitiveRouteLimiter(l, routes, clientIP, message)
+}
+
+// SensitiveUserRouteLimiter applies a strict limit to a fixed set of
+// authenticated endpoints, keyed by user ID (falling back to IP for any
+// unauthenticated caller that reaches the route). It must be placed after the
+// authentication middleware so the user identity is present in the context.
+func SensitiveUserRouteLimiter(l Limiter, routes []RouteMatch, message string) func(http.Handler) http.Handler {
+	return sensitiveRouteLimiter(l, routes, userOrIP, message)
+}
+
+// sensitiveRouteLimiter is the shared implementation behind the exported
+// route-scoped limiters: it applies l to any request matching routes, deriving
+// the rate-limit key with keyFn, and passes everything else through.
+func sensitiveRouteLimiter(l Limiter, routes []RouteMatch, keyFn func(*http.Request) string, message string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !matchesRoute(routes, r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := keyFn(r)
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowed, wait := l.Allow(r.Context(), key)
+			if !allowed {
+				writeRateLimited(w, wait, message)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// matchesRoute reports whether r matches any of routes by exact method and path.
+func matchesRoute(routes []RouteMatch, r *http.Request) bool {
+	for _, rt := range routes {
+		if r.Method == rt.Method && r.URL.Path == rt.Path {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/internal/middleware/ratelimit_routes_test.go
+++ b/apps/api/internal/middleware/ratelimit_routes_test.go
@@ -1,0 +1,223 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+// --- Global limiter: excluded paths always pass ---
+
+func TestGlobalRateLimiterExcludesHealthAndMetrics(t *testing.T) {
+	const limit = 2
+	l := NewLimiter(nil, "global", limit, time.Second)
+	handler := GlobalRateLimiter(l, []string{"/health", "/healthz", "/readyz", "/metrics"})(ok200)
+
+	for _, path := range []string{"/healthz", "/readyz", "/metrics", "/health/detailed"} {
+		for i := 0; i < limit+5; i++ {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.RemoteAddr = "10.0.0.1:1111"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s request %d: got %d, want 200 (excluded path must never be limited)", path, i+1, rec.Code)
+			}
+		}
+	}
+}
+
+// --- Global limiter: non-excluded paths are limited with Retry-After ---
+
+func TestGlobalRateLimiterLimitsNonExcludedPaths(t *testing.T) {
+	const limit = 3
+	l := NewLimiter(nil, "global", limit, time.Second)
+	handler := GlobalRateLimiter(l, []string{"/health"})(ok200)
+
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil)
+		req.RemoteAddr = "10.0.0.2:2222"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	for i := 0; i < limit; i++ {
+		if rec := send(); rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200", i+1, rec.Code)
+		}
+	}
+
+	rec := send()
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-limit request: got %d, want 429", rec.Code)
+	}
+	ra := rec.Header().Get("Retry-After")
+	if secs, err := strconv.Atoi(ra); err != nil || secs < 1 {
+		t.Fatalf("Retry-After = %q, want positive integer seconds", ra)
+	}
+}
+
+// --- Global limiter: per-IP isolation ---
+
+func TestGlobalRateLimiterPerIPIsolation(t *testing.T) {
+	const limit = 1
+	l := NewLimiter(nil, "global", limit, time.Second)
+	handler := GlobalRateLimiter(l, nil)(ok200)
+
+	send := func(ip string) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
+		req.RemoteAddr = ip + ":9999"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := send("192.168.0.1"); got != http.StatusOK {
+		t.Fatalf("IP A first: got %d, want 200", got)
+	}
+	if got := send("192.168.0.1"); got != http.StatusTooManyRequests {
+		t.Fatalf("IP A second: got %d, want 429", got)
+	}
+	if got := send("192.168.0.2"); got != http.StatusOK {
+		t.Fatalf("IP B first: got %d, want 200 (independent bucket)", got)
+	}
+}
+
+// --- Sensitive IP limiter: only matched routes are limited ---
+
+func TestSensitiveRouteLimiterOnlyLimitsMatchedRoutes(t *testing.T) {
+	const limit = 1
+	l := NewLimiter(nil, "auth", limit, time.Second)
+	routes := []RouteMatch{
+		{Method: http.MethodPost, Path: "/api/v1/auth/challenge"},
+		{Method: http.MethodPost, Path: "/api/v1/auth/verify"},
+	}
+	handler := SensitiveRouteLimiter(l, routes, "authentication rate limit exceeded")(ok200)
+
+	send := func(method, path string) int {
+		req := httptest.NewRequest(method, path, nil)
+		req.RemoteAddr = "10.0.0.5:5555"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// Unmatched by method: GET on a sensitive path must always pass.
+	for i := 0; i < 5; i++ {
+		if got := send(http.MethodGet, "/api/v1/auth/challenge"); got != http.StatusOK {
+			t.Fatalf("GET challenge %d: got %d, want 200 (only POST is limited)", i+1, got)
+		}
+	}
+	// Unmatched by path: a different endpoint must always pass.
+	for i := 0; i < 5; i++ {
+		if got := send(http.MethodPost, "/api/v1/vaults"); got != http.StatusOK {
+			t.Fatalf("POST vaults %d: got %d, want 200 (unmatched path)", i+1, got)
+		}
+	}
+	// Matched route: first allowed, next rejected.
+	if got := send(http.MethodPost, "/api/v1/auth/challenge"); got != http.StatusOK {
+		t.Fatalf("POST challenge first: got %d, want 200", got)
+	}
+	if got := send(http.MethodPost, "/api/v1/auth/challenge"); got != http.StatusTooManyRequests {
+		t.Fatalf("POST challenge second: got %d, want 429", got)
+	}
+}
+
+// --- Sensitive IP limiter: window resets after expiry ---
+
+func TestSensitiveRouteLimiterWindowResets(t *testing.T) {
+	const limit = 1
+	window := 100 * time.Millisecond
+	l := NewLimiter(nil, "auth", limit, window)
+	routes := []RouteMatch{{Method: http.MethodPost, Path: "/api/v1/auth/verify"}}
+	handler := SensitiveRouteLimiter(l, routes, "authentication rate limit exceeded")(ok200)
+
+	send := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/verify", nil)
+		req.RemoteAddr = "10.0.0.6:6666"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := send(); got != http.StatusOK {
+		t.Fatalf("first: got %d, want 200", got)
+	}
+	if got := send(); got != http.StatusTooManyRequests {
+		t.Fatalf("second (before reset): got %d, want 429", got)
+	}
+	time.Sleep(window + 50*time.Millisecond)
+	if got := send(); got != http.StatusOK {
+		t.Fatalf("after window reset: got %d, want 200", got)
+	}
+}
+
+// --- Sensitive user limiter: per-user isolation via Authenticate ---
+
+func TestSensitiveUserRouteLimiterPerUser(t *testing.T) {
+	const limit = 1
+	l := NewLimiter(nil, "settlement", limit, time.Second)
+	routes := []RouteMatch{{Method: http.MethodPost, Path: "/api/v1/settlements"}}
+
+	rules := []RouteRule{{PathPrefix: "/api/v1/"}}
+	chain := Authenticate(testSecret, "", rules)(
+		SensitiveUserRouteLimiter(l, routes, "settlement rate limit exceeded")(ok200),
+	)
+
+	mint := func(id string) string {
+		return makeToken(t, auth.Claims{
+			Subject:       id,
+			WalletAddress: "wallet-" + id,
+			ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+		})
+	}
+
+	send := func(token string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/settlements", nil)
+		req.RemoteAddr = "10.0.0.7:7777" // same IP for every request
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		chain.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	tokA := mint("user-A")
+	tokB := mint("user-B")
+
+	if got := send(tokA); got != http.StatusOK {
+		t.Fatalf("user-A first: got %d, want 200", got)
+	}
+	if got := send(tokA); got != http.StatusTooManyRequests {
+		t.Fatalf("user-A second: got %d, want 429", got)
+	}
+	// user-B shares the IP but must have an independent per-user bucket.
+	if got := send(tokB); got != http.StatusOK {
+		t.Fatalf("user-B first: got %d, want 200 (bucket is per-user, not per-IP)", got)
+	}
+}
+
+// --- NewLimiter without Redis returns a working in-memory fallback ---
+
+func TestNewLimiterFallsBackToMemoryWithoutRedis(t *testing.T) {
+	l := NewLimiter(nil, "test", 1, time.Second)
+
+	allowed, _ := l.Allow(t.Context(), "k1")
+	if !allowed {
+		t.Fatal("first request for key: got denied, want allowed")
+	}
+	allowed, wait := l.Allow(t.Context(), "k1")
+	if allowed {
+		t.Fatal("second request for key: got allowed, want denied")
+	}
+	if wait <= 0 {
+		t.Fatalf("denied request retryAfter = %s, want > 0", wait)
+	}
+	// A different key is unaffected.
+	if allowed, _ := l.Allow(t.Context(), "k2"); !allowed {
+		t.Fatal("first request for second key: got denied, want allowed")
+	}
+}

--- a/apps/api/internal/middleware/ratelimit_routes_test.go
+++ b/apps/api/internal/middleware/ratelimit_routes_test.go
@@ -200,6 +200,68 @@ func TestSensitiveUserRouteLimiterPerUser(t *testing.T) {
 	}
 }
 
+// --- Proxy-aware client IP keying ---
+
+func TestClientIPUsesForwardedForBehindTrustedProxies(t *testing.T) {
+	ConfigureClientIP(1)
+	t.Cleanup(func() { ConfigureClientIP(0) })
+
+	const limit = 1
+	l := NewLimiter(nil, "global", limit, time.Second)
+	handler := GlobalRateLimiter(l, nil)(ok200)
+
+	// One trusted proxy: the real client is the right-most X-Forwarded-For entry.
+	// The proxy connects from a single RemoteAddr, but two different clients
+	// behind it must get independent buckets.
+	send := func(client string) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
+		req.RemoteAddr = "10.0.0.254:5555" // the proxy's address, shared
+		req.Header.Set("X-Forwarded-For", client)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := send("203.0.113.1"); got != http.StatusOK {
+		t.Fatalf("client A first: got %d, want 200", got)
+	}
+	if got := send("203.0.113.1"); got != http.StatusTooManyRequests {
+		t.Fatalf("client A second: got %d, want 429", got)
+	}
+	// A different client behind the same proxy must not be throttled.
+	if got := send("203.0.113.2"); got != http.StatusOK {
+		t.Fatalf("client B first: got %d, want 200 (keyed by forwarded client IP, not proxy)", got)
+	}
+}
+
+func TestClientIPForwardedForCannotBeSpoofedPastTrustedHops(t *testing.T) {
+	ConfigureClientIP(1)
+	t.Cleanup(func() { ConfigureClientIP(0) })
+
+	const limit = 1
+	l := NewLimiter(nil, "global", limit, time.Second)
+	handler := GlobalRateLimiter(l, nil)(ok200)
+
+	// With one trusted proxy, only the right-most XFF entry (appended by that
+	// proxy) is trusted. A client injecting extra left-most entries cannot rotate
+	// its effective key, so it stays in a single bucket.
+	send := func(xff string) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
+		req.RemoteAddr = "10.0.0.254:5555"
+		req.Header.Set("X-Forwarded-For", xff)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := send("spoof-1, 203.0.113.9"); got != http.StatusOK {
+		t.Fatalf("first: got %d, want 200", got)
+	}
+	if got := send("spoof-2, 203.0.113.9"); got != http.StatusTooManyRequests {
+		t.Fatalf("second (spoofed left-most entry changed): got %d, want 429 (same trusted client IP)", got)
+	}
+}
+
 // --- NewLimiter without Redis returns a working in-memory fallback ---
 
 func TestNewLimiterFallsBackToMemoryWithoutRedis(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #782.

Extends the existing in-memory rate limiter (#10) into a configurable, scalable, dual-mode system without regressing current behavior.

**Dual-mode backend** — `NewLimiter` returns a Redis-backed fixed-window counter (atomic `INCR`+`PEXPIRE` Lua) when `REDIS_ADDR` is set for cross-instance enforcement, and transparently falls back to the in-memory token bucket otherwise. The Redis limiter **fails open** on any Redis error so an outage never blocks live traffic.

**Keys**
- Anonymous / global → client IP
- Authenticated settlement route → user ID (from auth context), IP fallback

**Sensitive routes (strict limits, IP-keyed pre-auth)**
- `POST /api/v1/auth/challenge`, `POST /api/v1/auth/verify` — blunts credential stuffing
- `POST /api/v1/settlements` — per-user, blunts settlement spam

**Excluded from the global limiter:** `/health*`, `/readyz`, `/metrics`.

**Middleware order (unchanged flow, additions inserted):**
`Security → Recover → global(IP, exclusions) → authRoute(IP, strict) → CORS → write → authenticate → settlement(userID, strict) → wallet → bodyLimit → logging → mux`

## Config

New env knobs (following existing `RATELIMIT_*_LIMIT`/`_WINDOW` convention), validated in `config.Load`, documented in `.env.example`:

| Var | Default |
|---|---|
| `RATELIMIT_AUTH_LIMIT` / `_WINDOW` | 10 / 1m |
| `RATELIMIT_SETTLEMENT_LIMIT` / `_WINDOW` | 5 / 1m |

Set `REDIS_ADDR` to enforce all limits across every API instance.

## Notes / deviations from the issue spec

- Repo already had a rate limiter (#10); this **extends** it rather than rewriting, keeping the existing `IPRateLimiter`/`WalletRateLimiter`/`WriteMethodRateLimiter` and the `{"success":false,"error":{"code":"RATE_LIMITED"}}` error shape.
- Env vars follow the existing `RATELIMIT_*_LIMIT/_WINDOW` naming (not `*_RPS/_BURST`).
- Router is stdlib `net/http.ServeMux`, so sensitive routes are matched by exact method+path (not chi `r.Route`).
- No `/metrics` route exists yet; excluded anyway for forward-compat.

## Test plan

- `go build ./...`, `go vet`, `golangci-lint run` — clean
- `go test ./internal/middleware/... ./internal/config/... ./cmd/...` — pass
- New table-driven tests: under/over limit, 429 + `Retry-After`, window reset, per-IP and per-user isolation, in-memory fallback, Redis fail-open, and a Redis integration test guarded by `REDIS_ADDR` (runs in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter, configurable rate limits for unauthenticated auth handshake and settlement creation, with per-user semantics for settlement.
  * Enabled distributed rate limiting across API instances when Redis is configured (including route-scoped enforcement).
  * Added trusted-proxy-aware client IP handling for rate-limit keys.
  * Excluded health/readiness/metrics endpoints from global limits.
* **Bug Fixes**
  * Standardized 429 responses to consistently return `Retry-After` and the usual JSON error format.
* **Documentation**
  * Updated the example environment file with the new rate-limit and Redis behavior settings.
* **Tests**
  * Added integration and validation tests for Redis behavior, fail-open behavior, and in-memory fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->