### PR TITLE
feat(api): savings goal archive-on-delete, amount/name validation, yield cache warming

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -393,6 +393,19 @@ func run() error {
 
 	// Yield opportunities (DeFiLlama Stellar pools)
 	yieldSvc := service.NewYieldService("")
+	// Warm the Stellar yield cache in the background so the first user request
+	// doesn't pay the DeFiLlama round-trip (#667). Failure is non-fatal: the
+	// lazy-load path still works.
+	go func() {
+		warmCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		start := time.Now()
+		if pools, err := yieldSvc.WarmCache(warmCtx); err != nil {
+			baseLogger.Warn("yield cache warm failed", "error", err)
+		} else {
+			baseLogger.Info("yield cache warmed", "chain", "Stellar", "pools", pools, "duration_ms", time.Since(start).Milliseconds())
+		}
+	}()
 	yieldBookmarkSvc := service.NewYieldBookmarkService(db, yieldSvc)
 	protocolTVLRepo := postgres.NewProtocolTVLRepository(db)
 	yieldHandler := handler.NewYieldHandler(yieldSvc, yieldBookmarkSvc)

--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -24,7 +24,15 @@ var (
 	// ErrGoalArchived is returned when an operation is not allowed on an archived goal
 	// (e.g. adding a new contribution schedule).
 	ErrGoalArchived = errors.New("savings goal is archived")
+	// ErrInvalidAmount is returned when a goal's target amount is zero, negative,
+	// or below MinTargetAmount (#692). Defined here so handlers don't have to
+	// import the vault domain to classify amount validation failures.
+	ErrInvalidAmount = errors.New("invalid target amount")
 )
+
+// MinTargetAmount is the smallest meaningful goal target (#692). Values above
+// zero but below this (e.g. 0.000000001) are rejected as no-op goals.
+var MinTargetAmount = decimal.RequireFromString("0.01")
 
 const (
 	GoalStatusActive    = "active"

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -585,6 +585,8 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "vault does not belong to you"))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	case errors.Is(err, savingsgoal.ErrInvalidAmount):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:
 		logpkg.FromContext(r.Context()).Error("savings goal handler failed", "error", err.Error())
 		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -159,8 +159,16 @@ func (r *SavingsGoalRepository) Update(ctx context.Context, goal *savingsgoal.Sa
 	return nil
 }
 
+// Delete soft-archives the goal instead of destroying the row (#685): it
+// stamps archived_at and moves the goal to the archived status. Already
+// archived goals are not matched, so a repeat DELETE surfaces as
+// ErrGoalNotFound (404) and no row is ever permanently removed via this path.
 func (r *SavingsGoalRepository) Delete(ctx context.Context, id, userID uuid.UUID) error {
-	res, err := r.db.ExecContext(ctx, `DELETE FROM savings_goals WHERE id = $1 AND user_id = $2`, id, userID)
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET archived_at = NOW(), status = 'archived', updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND status <> 'archived'
+	`, id, userID)
 	if err != nil {
 		return err
 	}

--- a/apps/api/internal/repository/postgres/savings_goal_repository_test.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository_test.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+const softDeleteQuery = `
+		UPDATE savings_goals
+		SET archived_at = NOW(), status = 'archived', updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND status <> 'archived'
+	`
+
+func TestSavingsGoalDeleteSoftArchivesRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+	userID := uuid.New()
+
+	mock.ExpectExec(regexp.QuoteMeta(softDeleteQuery)).
+		WithArgs(goalID, userID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repository.Delete(context.Background(), goalID, userID); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSavingsGoalDeleteAlreadyArchivedReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+	userID := uuid.New()
+
+	// The status <> 'archived' guard means an already-archived (or missing)
+	// goal matches zero rows.
+	mock.ExpectExec(regexp.QuoteMeta(softDeleteQuery)).
+		WithArgs(goalID, userID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repository.Delete(context.Background(), goalID, userID)
+	if !errors.Is(err, savingsgoal.ErrGoalNotFound) {
+		t.Fatalf("Delete() error = %v, want ErrGoalNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -103,6 +103,9 @@ func (s *SavingsGoalService) Create(ctx context.Context, userID uuid.UUID, in Cr
 	}
 	desc := strings.TrimSpace(in.Description)
 	name := strings.TrimSpace(in.Name)
+	if err := validateGoalName(name); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
 	if name == "" && desc != "" {
 		runes := []rune(desc)
 		if len(runes) > 50 {
@@ -270,7 +273,11 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 		goal.Category = category
 	}
 	if in.Name != nil {
-		goal.Name = strings.TrimSpace(*in.Name)
+		name := strings.TrimSpace(*in.Name)
+		if err := validateGoalName(name); err != nil {
+			return savingsgoal.SavingsGoal{}, err
+		}
+		goal.Name = name
 	}
 	if in.Emoji != nil {
 		e := strings.TrimSpace(*in.Emoji)
@@ -917,9 +924,23 @@ func (s *SavingsGoalService) DepositSplit(ctx context.Context, userID uuid.UUID,
 // meaningless for a savings goal, so creation requires at least 24h (#686).
 const MinDeadlineLeadTime = 24 * time.Hour
 
+// MaxGoalNameLength caps the goal name to the savings_goals.name column width
+// (VARCHAR(100)); validating here returns a 400 instead of a DB error (#681).
+const MaxGoalNameLength = 100
+
+func validateGoalName(name string) error {
+	if len([]rune(name)) > MaxGoalNameLength {
+		return fmt.Errorf("%w: name must be at most %d characters", savingsgoal.ErrInvalidGoal, MaxGoalNameLength)
+	}
+	return nil
+}
+
 func validateSavingsGoalInput(target decimal.Decimal, currency string) error {
 	if !target.IsPositive() {
-		return fmt.Errorf("%w: target_amount must be positive", savingsgoal.ErrInvalidGoal)
+		return fmt.Errorf("%w: target_amount must be greater than zero", savingsgoal.ErrInvalidAmount)
+	}
+	if target.LessThan(savingsgoal.MinTargetAmount) {
+		return fmt.Errorf("%w: target_amount must be at least %s", savingsgoal.ErrInvalidAmount, savingsgoal.MinTargetAmount)
 	}
 	currency = strings.TrimSpace(currency)
 	if currency == "" {

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -1332,3 +1332,122 @@ func TestSavingsGoalService_NoVaultFallsBackToSum(t *testing.T) {
 		t.Fatalf("current_amount = %s, want 450 (sum-all fallback)", goal.CurrentAmount)
 	}
 }
+
+func TestSavingsGoalService_Create_RejectsZeroAndNegativeTarget(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil, nil)
+
+	for _, amount := range []decimal.Decimal{
+		decimal.Zero,
+		decimal.NewFromInt(-100),
+	} {
+		_, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+			TargetAmount: amount,
+			Currency:     "USDC",
+			Deadline:     testDeadline(),
+		})
+		if !errors.Is(err, savingsgoal.ErrInvalidAmount) {
+			t.Errorf("Create(target=%s) error = %v, want ErrInvalidAmount", amount, err)
+		}
+	}
+}
+
+func TestSavingsGoalService_Create_RejectsTargetBelowMinimum(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil, nil)
+
+	_, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.RequireFromString("0.001"),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+	})
+	if !errors.Is(err, savingsgoal.ErrInvalidAmount) {
+		t.Fatalf("Create(target=0.001) error = %v, want ErrInvalidAmount", err)
+	}
+
+	// The minimum itself is accepted.
+	if _, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: savingsgoal.MinTargetAmount,
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+	}); err != nil {
+		t.Fatalf("Create(target=0.01) error = %v, want nil", err)
+	}
+}
+
+func TestSavingsGoalService_Update_RejectsZeroTarget(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	zero := decimal.Zero
+	_, err = svc.Update(ctx, userID, goal.ID, UpdateSavingsGoalInput{TargetAmount: &zero})
+	if !errors.Is(err, savingsgoal.ErrInvalidAmount) {
+		t.Fatalf("Update(target=0) error = %v, want ErrInvalidAmount", err)
+	}
+}
+
+func TestSavingsGoalService_Create_RejectsOverlongName(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	svc := NewSavingsGoalService(newMemorySavingsGoalRepo(), nil, nil)
+
+	_, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         strings.Repeat("n", MaxGoalNameLength+1),
+	})
+	if !errors.Is(err, savingsgoal.ErrInvalidGoal) {
+		t.Fatalf("Create(101-char name) error = %v, want ErrInvalidGoal", err)
+	}
+
+	// Exactly the maximum is accepted.
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         strings.Repeat("n", MaxGoalNameLength),
+	})
+	if err != nil {
+		t.Fatalf("Create(100-char name) error = %v, want nil", err)
+	}
+	if len([]rune(goal.Name)) != MaxGoalNameLength {
+		t.Fatalf("name length = %d, want %d", len([]rune(goal.Name)), MaxGoalNameLength)
+	}
+}
+
+func TestSavingsGoalService_Update_RejectsOverlongName(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	long := strings.Repeat("n", MaxGoalNameLength+1)
+	_, err = svc.Update(ctx, userID, goal.ID, UpdateSavingsGoalInput{Name: &long})
+	if !errors.Is(err, savingsgoal.ErrInvalidGoal) {
+		t.Fatalf("Update(101-char name) error = %v, want ErrInvalidGoal", err)
+	}
+}

--- a/apps/api/internal/service/yield_service.go
+++ b/apps/api/internal/service/yield_service.go
@@ -177,6 +177,18 @@ func (s *YieldService) GetYieldOpportunities(ctx context.Context, chain string, 
 	return nil, fetchErr
 }
 
+// WarmCache pre-populates the Stellar yield cache so the first request after a
+// cold start doesn't pay the full DeFiLlama round-trip (#667). It returns the
+// number of pools cached. Failures are non-fatal: callers log and rely on the
+// lazy-load path.
+func (s *YieldService) WarmCache(ctx context.Context) (int, error) {
+	resp, err := s.GetYieldOpportunities(ctx, "Stellar", 100)
+	if err != nil {
+		return 0, err
+	}
+	return len(resp.Pools), nil
+}
+
 // GetYieldOpportunitiesByTier returns up to `limit` opportunities on `chain`
 // whose risk score falls in `tier` ("low"|"medium"|"high"). An empty tier means
 // "all tiers" and behaves exactly like GetYieldOpportunities.

--- a/apps/api/internal/service/yield_service_test.go
+++ b/apps/api/internal/service/yield_service_test.go
@@ -154,3 +154,49 @@ func TestYieldService_TVLFilter(t *testing.T) {
 func TestYieldService_RiskScore(t *testing.T) {
     t.Skip("Skipping until #662 (Risk score) is merged")
 }
+
+func TestYieldService_WarmCachePopulatesCache(t *testing.T) {
+    var hitCount int32
+    payload := `{"status":"success","data":[{"pool":"1","chain":"Stellar","apy":5.0,"tvlUsd":100000},{"pool":"2","chain":"Stellar","apy":3.0,"tvlUsd":200000}]}`
+    ts := newMockDeFiLlamaServer(t, http.StatusOK, payload, &hitCount)
+    defer ts.Close()
+
+    svc := NewYieldService(ts.URL)
+    ctx := context.Background()
+
+    pools, err := svc.WarmCache(ctx)
+    if err != nil {
+        t.Fatalf("WarmCache() error = %v", err)
+    }
+    if pools != 2 {
+        t.Errorf("WarmCache() pools = %d, want 2", pools)
+    }
+
+    // The warmed cache serves the same chain/limit key without another upstream call.
+    if _, err := svc.GetYieldOpportunities(ctx, "Stellar", 100); err != nil {
+        t.Fatalf("GetYieldOpportunities() after warm error = %v", err)
+    }
+    if atomic.LoadInt32(&hitCount) != 1 {
+        t.Errorf("expected exactly 1 HTTP call after warm, got %d", hitCount)
+    }
+}
+
+func TestYieldService_WarmCacheFailureIsNonFatal(t *testing.T) {
+    ts := newMockDeFiLlamaServer(t, http.StatusInternalServerError, "", nil)
+    defer ts.Close()
+
+    svc := NewYieldService(ts.URL)
+    pools, err := svc.WarmCache(context.Background())
+    if err == nil {
+        t.Fatal("WarmCache() error = nil, want upstream error")
+    }
+    if pools != 0 {
+        t.Errorf("WarmCache() pools = %d, want 0 on failure", pools)
+    }
+
+    // A failed warm leaves no cache entry: the lazy path still surfaces the
+    // upstream error rather than serving stale/empty data.
+    if _, err := svc.GetYieldOpportunities(context.Background(), "Stellar", 100); err == nil {
+        t.Error("GetYieldOpportunities() after failed warm = nil error, want upstream error")
+    }
+}

--- a/apps/api/migrations/059_add_savings_goal_archived_at.down.sql
+++ b/apps/api/migrations/059_add_savings_goal_archived_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE savings_goals
+    DROP COLUMN IF EXISTS archived_at;

--- a/apps/api/migrations/059_add_savings_goal_archived_at.up.sql
+++ b/apps/api/migrations/059_add_savings_goal_archived_at.up.sql
@@ -1,0 +1,6 @@
+-- DELETE /savings-goals/{id} now soft-archives instead of destroying the row
+-- (#685). archived_at records when the goal was archived via deletion; goals
+-- archived through the status endpoint before this migration keep a NULL
+-- archived_at.
+ALTER TABLE savings_goals
+    ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ NULL;


### PR DESCRIPTION
## Summary
Hardens the savings-goal API (soft-delete instead of destructive DELETE, proper 400s for invalid target amounts, server-side name length cap) and warms the DeFiLlama Stellar yield cache at startup so the first request doesn't pay the cold-start round-trip.
## Related Issues
Closes #667
Closes #685
Closes #692
Closes #681

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
## Changes Made
- **#685 — soft-delete savings goals**: migration `059_add_savings_goal_archived_at` adds a nullable `archived_at TIMESTAMPTZ`. `SavingsGoalRepository.Delete` now runs an `UPDATE … SET archived_at = NOW(), status = 'archived'` guarded by `status <> 'archived'` instead of a `DELETE`, so: the HTTP handler still returns `204` with an unchanged response shape; repeating the DELETE (or deleting an already-archived goal) matches zero rows and surfaces as `404` via `ErrGoalNotFound`; no row is ever permanently removed through the API. Archived goals were already excluded from the default list and reachable via `?status=archived` / `include_archived=true`, so listing needed no changes.
- **#692 — target amount validation**: adds `savingsgoal.ErrInvalidAmount` and `savingsgoal.MinTargetAmount` (0.01) to the savings-goal domain (previously the amount check wrapped the generic `ErrInvalidGoal`; nothing imported the vault error, but there was no distinct amount error and no minimum). `validateSavingsGoalInput` — used by both create and update — now rejects zero/negative amounts and amounts below 0.01 with `ErrInvalidAmount`, and the handler maps it to `400` with the standard `ValidationErr` shape (previously unmapped errors risked `500`).
- **#681 — name length cap**: `Create` and `Update` now validate the trimmed goal name against the `VARCHAR(100)` column width and return `400` instead of letting Postgres reject the insert with a `500`. Note: the name column, model field, repository plumbing, and PATCH support already landed via #738 (migration 045), including a deliberate fallback that derives the name from the description. The remaining acceptance criterion — reject creates with no name with a 400 — directly contradicts that fallback and the existing handler/service tests that create goals without names, so this PR implements the uncontested trim + 100-char cap and leaves the "name required on create" decision to maintainers.
- **#667 — yield cache warming**: `YieldService.WarmCache(ctx)` fetches Stellar pools (limit 100, the max) through the normal cached path and returns the pool count. `cmd/api/main.go` launches it in a goroutine after service construction with a 20-second bounded context; success logs `yield cache warmed` with chain/pools/duration_ms, failure logs a warning and the API continues serving via the lazy-load path.
## Testing Done
- `go build ./...` and `go test ./...` in `apps/api`: 26 packages, all passing.
- New tests: sqlmock tests asserting DELETE issues the soft-archive UPDATE and maps zero rows to `ErrGoalNotFound` (#685); service tests for target 0, -100, 0.001 (rejected) and 0.01 (accepted) on create, and 0 on update (#692); 100 vs 101-char name on create and update (#681); WarmCache populates the cache (exactly one upstream HTTP call across warm + subsequent request) and failure is non-fatal with the lazy path intact (#667).
## Screenshots
N/A (API-only).
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [ ] Documentation updated if needed
- [x] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications (N/A)