### PR TITLE
Feat/tokenised vault standard 809

### DIFF
--- a/packages/contracts/contracts/vault/src/conversion.rs
+++ b/packages/contracts/contracts/vault/src/conversion.rs
@@ -1,0 +1,178 @@
+//! Pure tokenised-vault conversion arithmetic.
+//!
+//! # Rounding policy
+//!
+//! * Conversions determining what a user **receives** round down.
+//! * Conversions determining what a user **pays** round up.
+//! * Every remainder therefore favours the vault, never the user.
+//!
+//! This rule is security-critical: rounding in the user's favour can allow
+//! repeated small operations to inflate shares or drain underlying assets.
+
+use nester_common::ContractError;
+
+/// Computes `floor(x * y / denominator)` without constructing the potentially
+/// overflowing intermediate product `x * y`.
+pub fn mul_div_down(x: i128, y: i128, denominator: i128) -> Result<i128, ContractError> {
+    mul_div(x, y, denominator).map(|(quotient, _)| quotient)
+}
+
+/// Computes `ceil(x * y / denominator)` without constructing the potentially
+/// overflowing intermediate product `x * y`.
+pub fn mul_div_up(x: i128, y: i128, denominator: i128) -> Result<i128, ContractError> {
+    let (quotient, remainder) = mul_div(x, y, denominator)?;
+    if remainder == 0 {
+        Ok(quotient)
+    } else {
+        quotient
+            .checked_add(1)
+            .ok_or(ContractError::ArithmeticOverflow)
+    }
+}
+
+/// Shares received for an asset amount.
+pub fn assets_to_shares_down(
+    assets: i128,
+    total_assets: i128,
+    total_shares: i128,
+) -> Result<i128, ContractError> {
+    validate_conversion_inputs(assets, total_assets, total_shares)?;
+    if total_shares == 0 {
+        return Ok(assets);
+    }
+    // A live supply backed by zero assets is insolvent. Issuing shares 1:1 in
+    // this state would let a new depositor recapitalise existing holders and
+    // receive an incorrect ownership fraction.
+    if total_assets == 0 {
+        return Err(ContractError::InvalidOperation);
+    }
+    mul_div_down(assets, total_shares, total_assets)
+}
+
+/// Shares a user must pay for an exact asset amount.
+pub fn assets_to_shares_up(
+    assets: i128,
+    total_assets: i128,
+    total_shares: i128,
+) -> Result<i128, ContractError> {
+    validate_conversion_inputs(assets, total_assets, total_shares)?;
+    if total_shares == 0 {
+        return Ok(assets);
+    }
+    if total_assets == 0 {
+        return Err(ContractError::InvalidOperation);
+    }
+    mul_div_up(assets, total_shares, total_assets)
+}
+
+/// Assets received for a share amount.
+pub fn shares_to_assets_down(
+    shares: i128,
+    total_assets: i128,
+    total_shares: i128,
+) -> Result<i128, ContractError> {
+    validate_conversion_inputs(shares, total_assets, total_shares)?;
+    if total_shares == 0 {
+        return Ok(shares);
+    }
+    mul_div_down(shares, total_assets, total_shares)
+}
+
+/// Assets a user must pay for an exact share amount.
+pub fn shares_to_assets_up(
+    shares: i128,
+    total_assets: i128,
+    total_shares: i128,
+) -> Result<i128, ContractError> {
+    validate_conversion_inputs(shares, total_assets, total_shares)?;
+    if total_shares == 0 {
+        return Ok(shares);
+    }
+    mul_div_up(shares, total_assets, total_shares)
+}
+
+fn validate_conversion_inputs(
+    amount: i128,
+    total_assets: i128,
+    total_shares: i128,
+) -> Result<(), ContractError> {
+    if amount < 0 || total_assets < 0 || total_shares < 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+    Ok(())
+}
+
+/// Binary long multiplication represented as `(quotient, remainder)` modulo
+/// `denominator`. This keeps every intermediate within `i128` while preserving
+/// the exact mathematical result.
+fn mul_div(x: i128, y: i128, denominator: i128) -> Result<(i128, i128), ContractError> {
+    if x < 0 || y < 0 || denominator <= 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+    if x == 0 || y == 0 {
+        return Ok((0, 0));
+    }
+
+    let mut bits = x;
+    let mut part_q = y / denominator;
+    let mut part_r = y % denominator;
+    let mut result_q = 0_i128;
+    let mut result_r = 0_i128;
+
+    while bits != 0 {
+        if bits & 1 == 1 {
+            result_q = result_q
+                .checked_add(part_q)
+                .ok_or(ContractError::ArithmeticOverflow)?;
+            if result_r >= denominator - part_r {
+                result_r -= denominator - part_r;
+                result_q = result_q
+                    .checked_add(1)
+                    .ok_or(ContractError::ArithmeticOverflow)?;
+            } else {
+                result_r += part_r;
+            }
+        }
+
+        bits >>= 1;
+        if bits == 0 {
+            break;
+        }
+
+        part_q = part_q
+            .checked_mul(2)
+            .ok_or(ContractError::ArithmeticOverflow)?;
+        if part_r >= denominator - part_r {
+            part_r -= denominator - part_r;
+            part_q = part_q
+                .checked_add(1)
+                .ok_or(ContractError::ArithmeticOverflow)?;
+        } else {
+            part_r += part_r;
+        }
+    }
+
+    Ok((result_q, result_r))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_mul_div_handles_product_larger_than_i128() {
+        assert_eq!(mul_div_down(i128::MAX, i128::MAX, i128::MAX), Ok(i128::MAX));
+    }
+
+    #[test]
+    fn insolvent_live_supply_never_uses_bootstrap_rate() {
+        assert_eq!(
+            assets_to_shares_down(100, 0, 50),
+            Err(ContractError::InvalidOperation)
+        );
+        assert_eq!(
+            assets_to_shares_up(100, 0, 50),
+            Err(ContractError::InvalidOperation)
+        );
+    }
+}

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod breaker;
+pub mod conversion;
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, panic_with_error, symbol_short, token, Address, BytesN, Env,
@@ -613,6 +614,68 @@ fn get_total_assets(env: &Env) -> i128 {
 
 fn set_total_assets(env: &Env, amount: i128) {
     env.storage().instance().set(&DataKey::TotalAssets, &amount);
+}
+
+/// Assets backing shares after already-accrued vault fees.
+fn get_net_total_assets(env: &Env) -> i128 {
+    get_total_assets(env).saturating_sub(get_accrued_fees(env))
+}
+
+/// Remaining assets that can be withdrawn without crossing the configured
+/// rolling circuit-breaker threshold. This helper is read-only and deliberately
+/// uses saturating arithmetic so `max_*` queries never fail.
+fn circuit_breaker_headroom(env: &Env) -> i128 {
+    let Some(config) = env
+        .storage()
+        .instance()
+        .get::<_, CircuitBreakerConfig>(&DataKey::CircuitBreakerConfig)
+    else {
+        return 0;
+    };
+
+    let threshold = nester_common::fees::mul_div(
+        get_total_assets(env),
+        config.threshold_bps as i128,
+        10_000,
+    )
+    .unwrap_or(0);
+    // A zero threshold disables the check in `check_circuit_breaker`.
+    if threshold == 0 {
+        return i128::MAX;
+    }
+
+    let window_start = env
+        .ledger()
+        .timestamp()
+        .saturating_sub(config.window_seconds);
+    let history: Vec<WithdrawalEntry> = env
+        .storage()
+        .instance()
+        .get(&DataKey::WithdrawalHistory)
+        .unwrap_or(Vec::new(env));
+    let mut used = 0_i128;
+    for entry in history.iter() {
+        if entry.timestamp >= window_start && entry.sum > 0 {
+            used = used.saturating_add(entry.sum);
+        }
+    }
+    threshold.saturating_sub(used)
+}
+
+/// Maximum gross assets the holder can presently redeem. Unlike the mutating
+/// withdrawal path this function never panics.
+fn max_withdrawable_assets(env: &Env, user: &Address) -> i128 {
+    if !env.storage().instance().has(&DataKey::Token) || is_paused(env) {
+        return 0;
+    }
+
+    let shares = get_shares(env, user);
+    let total_shares = vault_token_client(env).total_supply();
+    let total_assets = get_net_total_assets(env);
+    let holder_assets =
+        conversion::shares_to_assets_down(shares, total_assets, total_shares).unwrap_or(0);
+    let liquid = get_vault_liquid_reserves(env).saturating_sub(get_liquid_reserved(env));
+    holder_assets.min(liquid).min(circuit_breaker_headroom(env))
 }
 
 fn sync_vault_token_total_assets(env: &Env) {
@@ -2650,6 +2713,16 @@ impl VaultContract {
         user.require_auth();
         accrue_management_fee(&env);
 
+        // Validate the exchange-rate state before moving funds. In particular,
+        // a live share supply backed by zero assets is insolvent and must not
+        // fall back to the bootstrap 1:1 rate.
+        let _validated_conversion = conversion::assets_to_shares_down(
+            amount,
+            get_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or_else(|e| panic_with_error!(&env, e));
+
         let token_address = self::VaultContract::get_token(env.clone());
         let contract_address = env.current_contract_address();
 
@@ -3311,7 +3384,12 @@ impl VaultContract {
         if amount <= 0 {
             panic_with_error!(&env, ContractError::InvalidAmount);
         }
-        vault_token_client(&env).shares_for_deposit(&amount)
+        conversion::assets_to_shares_down(
+            amount,
+            get_net_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or_else(|e| panic_with_error!(&env, e))
     }
 
     /// Returns the **gross**, pre-fee asset value of `shares` (the raw
@@ -3331,7 +3409,85 @@ impl VaultContract {
         if shares <= 0 {
             panic_with_error!(&env, ContractError::InvalidAmount);
         }
-        vault_token_client(&env).amount_for_shares(&shares)
+        conversion::shares_to_assets_down(
+            shares,
+            get_net_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or_else(|e| panic_with_error!(&env, e))
+    }
+
+    /// Convert assets to shares at the current exchange rate. Since this is the
+    /// amount the caller would receive, a non-zero remainder rounds down.
+    pub fn convert_to_shares(env: Env, assets: i128) -> i128 {
+        require_initialized(&env);
+        conversion::assets_to_shares_down(
+            assets,
+            get_net_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or_else(|e| panic_with_error!(&env, e))
+    }
+
+    /// Convert shares to assets at the current exchange rate. Since this is the
+    /// amount the caller would receive, a non-zero remainder rounds down.
+    pub fn convert_to_assets(env: Env, shares: i128) -> i128 {
+        require_initialized(&env);
+        conversion::shares_to_assets_down(
+            shares,
+            get_net_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or_else(|e| panic_with_error!(&env, e))
+    }
+
+    /// Total underlying assets currently backing outstanding shares.
+    pub fn total_assets(env: Env) -> i128 {
+        require_initialized(&env);
+        get_net_total_assets(&env)
+    }
+
+    /// Maximum assets accepted by one deposit. Returns zero rather than
+    /// reverting when deposits are unavailable.
+    pub fn max_deposit(env: Env, _user: Address) -> i128 {
+        if !env.storage().instance().has(&DataKey::Token) || is_paused(&env) {
+            return 0;
+        }
+        let cap: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxDeposit)
+            .unwrap_or(i128::MAX);
+        if cap <= 0 {
+            return 0;
+        }
+        // Refuse deposits in the insolvent live-supply state.
+        let total_shares = vault_token_client(&env).total_supply();
+        if total_shares > 0 && get_net_total_assets(&env) == 0 {
+            return 0;
+        }
+        cap
+    }
+
+    /// Maximum gross assets currently withdrawable by `user`.
+    pub fn max_withdraw(env: Env, user: Address) -> i128 {
+        max_withdrawable_assets(&env, &user)
+    }
+
+    /// Maximum shares currently redeemable by `user`.
+    pub fn max_redeem(env: Env, user: Address) -> i128 {
+        let max_assets = max_withdrawable_assets(&env, &user);
+        if max_assets == 0 {
+            return 0;
+        }
+        let balance = get_shares(&env, &user);
+        conversion::assets_to_shares_down(
+            max_assets,
+            get_net_total_assets(&env),
+            vault_token_client(&env).total_supply(),
+        )
+        .unwrap_or(0)
+        .min(balance)
     }
 
     /// Returns the amount the caller actually receives after all fees —

--- a/packages/contracts/libs/common/src/lib.rs
+++ b/packages/contracts/libs/common/src/lib.rs
@@ -16,7 +16,22 @@ pub use storage::*;
 pub use upgrade::*;
 
 
-use soroban_sdk::contracttype;
+use soroban_sdk::{contractclient, contracttype, Address, Env};
+
+/// Standard read-only surface exposed by a Nester tokenised vault.
+///
+/// Implementations must return zero from `max_*` when the requested action is
+/// currently unavailable. Integrators can therefore probe limits without
+/// handling a contract failure.
+#[contractclient(name = "TokenisedVaultClient")]
+pub trait TokenisedVault {
+    fn convert_to_shares(env: Env, assets: i128) -> i128;
+    fn convert_to_assets(env: Env, shares: i128) -> i128;
+    fn total_assets(env: Env) -> i128;
+    fn max_deposit(env: Env, user: Address) -> i128;
+    fn max_withdraw(env: Env, user: Address) -> i128;
+    fn max_redeem(env: Env, user: Address) -> i128;
+}
 
 /// Lifecycle status of a yield source.
 #[contracttype]

--- a/packages/contracts/tests/integration/src/integration/mod.rs
+++ b/packages/contracts/tests/integration/src/integration/mod.rs
@@ -18,6 +18,7 @@ pub mod adversarial_tests;
 pub mod circuit_breaker_tests;
 pub mod fee_tests;
 pub mod lifecycle_tests;
+pub mod share_price_tests;
 
 extern crate std;
 

--- a/packages/contracts/tests/integration/src/integration/share_price_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/share_price_tests.rs
@@ -1,6 +1,11 @@
 //! Integration tests for share price edge cases.
 #![cfg(test)]
 
+use nester_common::ContractError;
+use vault_contract::conversion::{
+    assets_to_shares_down, assets_to_shares_up, shares_to_assets_down, shares_to_assets_up,
+};
+
 /// Deposit after yield reported results in share price > 1:1.
 #[test]
 fn test_deposit_after_yield_share_price_above_one() {
@@ -22,5 +27,40 @@ fn test_minimum_deposit_one_unit() {
 /// Zero-share edge case: calculated shares round to zero should revert.
 #[test]
 fn test_zero_share_edge_case_reverts() {
-    assert!(true, "placeholder: zero share edge case reverts");
+    assert_eq!(
+        assets_to_shares_down(1, 10_000, 1),
+        Ok(0),
+        "a received-share conversion must round down"
+    );
+}
+
+/// Assets -> shares uses floor for receipts and ceiling for exact-asset
+/// payments when the division has a non-zero remainder.
+#[test]
+fn test_assets_to_shares_rounds_in_both_directions() {
+    // 10 assets * 3 shares / 7 assets = 4 remainder 2.
+    assert_eq!(assets_to_shares_down(10, 7, 3), Ok(4));
+    assert_eq!(assets_to_shares_up(10, 7, 3), Ok(5));
+}
+
+/// Shares -> assets uses floor for receipts and ceiling for exact-share
+/// payments when the division has a non-zero remainder.
+#[test]
+fn test_shares_to_assets_rounds_in_both_directions() {
+    // 10 shares * 7 assets / 3 shares = 23 remainder 1.
+    assert_eq!(shares_to_assets_down(10, 7, 3), Ok(23));
+    assert_eq!(shares_to_assets_up(10, 7, 3), Ok(24));
+}
+
+/// A non-zero supply with no backing is insolvent, not a bootstrap state.
+#[test]
+fn test_zero_assets_with_live_supply_rejects_new_share_conversion() {
+    assert_eq!(
+        assets_to_shares_down(10, 0, 3),
+        Err(ContractError::InvalidOperation)
+    );
+    assert_eq!(
+        assets_to_shares_up(10, 0, 3),
+        Err(ContractError::InvalidOperation)
+    );
 }


### PR DESCRIPTION
Closes #809 — Stage 1 of a staged implementation (conversion & 
limits only). Token hardening, transfer-sync/reentrancy, lock 
semantics, backend indexing, and documentation are separate follow-up 
stages, not included here.

## Problem
No standard tokenised-vault interface exists on Nester's vault. This 
stage adds the conversion/limit surface (convert_to_shares, 
convert_to_assets, total_assets, max_deposit, max_withdraw, max_redeem) 
with explicit, tested rounding rules — the foundation the later stages 
build on.

## Changes
- New packages/contracts/contracts/vault/src/conversion.rs — pure, 
  Soroban-environment-free arithmetic module:
  - mul_div_down / mul_div_up using checked quotient/remainder 
    decomposition (avoids the unchecked x*y overflow present in the 
    existing shares_for_deposit_math/amount_for_shares_math).
  - assets_to_shares_down/up, shares_to_assets_down/up.
  - Explicitly distinguishes bootstrap (total_shares == 0 → 1:1) from 
    insolvency (total_assets == 0 with total_shares > 0 → returns 
    ContractError::InvalidOperation). This fixes an existing bug where 
    an insolvent-but-live vault would silently mint shares 1:1 — a 
    known share-inflation exploit vector.
- vault/src/lib.rs — new TokenisedVault entrypoints. max_deposit/
  max_withdraw/max_redeem return zero (never revert) when the action is 
  impossible, per the interface contract integrators depend on.
- libs/common/src/lib.rs — shared TokenisedVault trait definition.
- tests/integration — added non-zero-remainder rounding tests in both 
  directions. Also fixed: share_price_tests.rs existed but was never 
  declared in integration/mod.rs, so it had never actually been 
  compiled or run before this change.

## Rounding rule (documented in conversion.rs)
- Value a user receives rounds down.
- Value a user must pay rounds up.
- Every remainder favors the vault, never the user.

## Verification
- cargo check -p vault-contract -j 1: passed.
- Test execution blocked locally by a Windows GNU linker limitation 
  (export ordinal too large: 66278) — unrelated to code correctness. 
  Full test run needs to happen via CI or a non-Windows-GNU environment 
  before merge confidence.
- git diff --check: clean. No unrelated formatter/CRLF churn included.
- Scope confirmed: only conversion/limit logic touched. No token, 
  transfer-sync, lock, backend, or documentation changes in this stage.

## Open items for maintainer / next stage
Two pre-existing security issues were found during investigation, 
unrelated to #809's literal scope:
1. vault_token's burn_from is not vault-restricted — any address with 
   sufficient allowance can burn, not just the vault.
2. Negative amounts are not consistently rejected across transfer/burn 
   paths, which can invert balance movements.
Recommend deciding whether these are fixed as part of a later stage of 
this PR series or filed as separate security issues — flagging now so 
they aren't lost.

## Files changed
- packages/contracts/contracts/vault/src/conversion.rs (new)
- packages/contracts/contracts/vault/src/lib.rs
- packages/contracts/libs/common/src/lib.rs
- packages/contracts/tests/integration/src/integration/mod.rs
- packages/contracts/tests/integration/src/integration/share_price_tests.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned bank-account encryption, supporting safer key rotation while preserving access to existing records.
  * Added resumable account-encryption rotation tooling.
  * Added distributed and route-specific rate limiting, including trusted proxy support.
  * Improved vault asset/share conversions with explicit rounding and insolvency safeguards.
  * Added read-only vault conversion and limit queries.

* **Documentation**
  * Added security guidance and operational instructions for encryption key management and rotation.

* **Bug Fixes**
  * Strengthened authorization checks and error handling across contract operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->