### PR TITLE
feat(contracts): reentrancy and cross-contract call guard framework (#811)

### DIFF
--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -699,6 +699,7 @@ name = "nester-test-utils"
 version = "0.1.0"
 dependencies = [
  "allocation-strategy-contract",
+ "nester-access-control",
  "nester-common",
  "soroban-sdk",
  "treasury-contract",

--- a/packages/contracts/TESTING.md
+++ b/packages/contracts/TESTING.md
@@ -95,8 +95,42 @@ and `h.strategy()`.
 | Module | Purpose |
 |--------|---------|
 | `env` | `setup_test_env()` — creates a default `Env` |
-| `assertions` | `assert_error`, `assert_ok`, `assert_eq_balance` helpers |
+| `assertions` | `assert_error`, `assert_ok`, `assert_eq_balance`, `assert_reentrancy_blocked` helpers |
 | `harness` | `NesterHarness` — full-protocol deployment harness for integration tests |
+| `hostile` | Reentrant token, strategy, and yield-source mocks for adversarial tests |
+
+---
+
+## Reentrancy guard resource cost
+
+The shared reentrancy guard uses Soroban temporary storage so the lock is scoped to the current transaction and clears automatically on revert.
+
+Measured in-process via `env.budget().reset_tracker()` around guarded `deposit` and `withdraw` calls in `vault` unit tests (`measure_reentrancy_guard_resource_cost_on_deposit_and_withdraw`). Run:
+
+```bash
+cargo test -p vault-contract measure_reentrancy_guard_resource_cost -- --nocapture
+```
+
+Record the printed CPU instruction and memory byte totals below when validating guard overhead. Native Rust test execution underestimates WASM costs; treat these as relative baselines.
+
+| Operation | CPU instructions | Memory bytes |
+|-----------|------------------|--------------|
+| `deposit` (with guard) | 2,285,474 | 249,857 |
+| `withdraw` (with guard) | 3,153,289 | 357,906 |
+
+---
+
+## Adversarial integration tests
+
+`tests/integration/src/integration/adversarial_tests.rs` exercises hostile mocks from `libs/test_utils/src/hostile.rs`:
+
+| Scenario | What it validates |
+|----------|-------------------|
+| `reentrant_token_during_deposit_is_blocked` | Token transfer hook cannot re-enter via `withdraw` |
+| `reentrant_strategy_during_rebalance_is_blocked` | Strategy callback cannot re-enter during rebalance |
+| `reentrant_yield_source_during_harvest_is_blocked` | External fee sink cannot re-enter during harvest |
+| `unregistered_callee_is_rejected` | Callee allowlist blocks unknown cross-contract targets |
+| `nested_emergency_queue_processing_does_not_double_guard` | Legitimate internal nesting via unguarded variants |
 
 ---
 

--- a/packages/contracts/contracts/allocation_strategy/src/lib.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/lib.rs
@@ -7,7 +7,8 @@ use soroban_sdk::{
 
 use nester_access_control::{AccessControl, Role};
 use nester_common::{
-    emit_event, fees::mul_div, ContractError, ProtocolType, SourceStatus, BASIS_POINT_SCALE,
+    emit_event, fees::mul_div, CalleeAllowlist, ContractError, ProtocolType, SourceStatus,
+    with_reentrancy_guard, BASIS_POINT_SCALE,
 };
 
 const STRATEGY: Symbol = symbol_short!("STRATEGY");
@@ -52,6 +53,7 @@ impl<'a> RegistryClient<'a> {
     }
 
     fn get_active_sources(&self) -> Vec<RegistrySource> {
+        CalleeAllowlist::assert_allowed(self.env, self.contract_id);
         self.env.invoke_contract(
             self.contract_id,
             &Symbol::new(self.env, "get_active_sources"),
@@ -146,6 +148,7 @@ impl AllocationStrategyContract {
         env.storage()
             .instance()
             .set(&DataKey::RegistryId, &registry_id);
+        CalleeAllowlist::register(&env, &registry_id);
         env.storage()
             .instance()
             .set(&DataKey::VaultType, &vault_type);
@@ -223,6 +226,10 @@ impl AllocationStrategyContract {
     }
 
     pub fn set_weights(env: Env, caller: Address, weights: Vec<AllocationWeight>) {
+        with_reentrancy_guard(env, |env| Self::set_weights_internal(env, caller, weights));
+    }
+
+    fn set_weights_internal(env: Env, caller: Address, weights: Vec<AllocationWeight>) {
         caller.require_auth();
         require_admin_or_operator(&env, &caller);
 
@@ -339,7 +346,7 @@ impl AllocationStrategyContract {
         target_weights: Vec<AllocationWeight>,
     ) -> bool {
         let threshold = Self::get_strategy_params(env).rebalance_threshold_bps;
-        let mut seen = Vec::new(&current_weights.env());
+        let mut seen = Vec::new(current_weights.env());
 
         for weight in current_weights.iter() {
             if !contains_symbol(&seen, &weight.source_id) {
@@ -513,9 +520,9 @@ impl AllocationStrategyContract {
             if let Some(idx) = max_idx {
                 let remainder = total_to_redistribute - distributed;
                 if remainder != 0 {
-                    let mut d = deltas.get(idx as u32).unwrap();
+                    let mut d = deltas.get(idx).unwrap();
                     d.delta += remainder;
-                    deltas.set(idx as u32, d);
+                    deltas.set(idx, d);
                 }
             }
         } else if total_to_redistribute > 0 {
@@ -667,9 +674,7 @@ fn suggest_weights_from_sources(env: &Env, sources: Vec<RegistrySource>) -> Vec<
 
 fn source_score(source: &RegistrySource) -> i128 {
     let raw_risk = source.risk_rating;
-    let clamped_risk = if raw_risk == 0 {
-        MAX_RISK_RATING
-    } else if raw_risk > MAX_RISK_RATING {
+    let clamped_risk = if raw_risk == 0 || raw_risk > MAX_RISK_RATING {
         MAX_RISK_RATING
     } else {
         raw_risk
@@ -841,7 +846,7 @@ fn even_distribution(env: &Env, count: usize) -> Vec<u32> {
 }
 
 fn proportional_with_cap(env: &Env, scores: &Vec<i128>, max_weight_bps: u32) -> Vec<u32> {
-    if scores.len() == 0 {
+    if scores.is_empty() {
         return Vec::new(env);
     }
 
@@ -993,7 +998,7 @@ fn compute_weights(env: &Env, apys: Vec<SourceApy>) -> Vec<AllocationWeight> {
         }
     }
 
-    if eligible_indices.len() > 0 {
+    if !eligible_indices.is_empty() {
         let computed = match vault_type {
             VaultType::DeFi500 => even_distribution(env, eligible_indices.len() as usize),
             _ => proportional_with_cap(env, &scores, params.max_weight_bps),
@@ -1020,7 +1025,7 @@ fn persist_allocations(env: &Env, total_amount: i128, weights: &Vec<AllocationWe
 fn allocation_amounts(weights: &Vec<AllocationWeight>, total_amount: i128) -> Vec<(Symbol, i128)> {
     let scale = BASIS_POINT_SCALE as i128;
     let env = weights.env();
-    let mut out = Vec::new(&env);
+    let mut out = Vec::new(env);
     let mut total_allocated = 0_i128;
     let mut max_index = None;
     let mut max_weight = 0_u32;
@@ -1033,7 +1038,7 @@ fn allocation_amounts(weights: &Vec<AllocationWeight>, total_amount: i128) -> Ve
         total_allocated += amount;
         if weight.weight_bps > max_weight {
             max_weight = weight.weight_bps;
-            max_index = Some(index as usize);
+            max_index = Some(index);
         }
         out.push_back((weight.source_id, amount));
     }
@@ -1077,6 +1082,7 @@ fn lookup_weight(weights: &Vec<AllocationWeight>, target: &Symbol) -> u32 {
 }
 
 fn registry_has_source(env: &Env, registry_id: &Address, source_id: &Symbol) -> bool {
+    CalleeAllowlist::assert_allowed(env, registry_id);
     env.invoke_contract(
         registry_id,
         &Symbol::new(env, "has_source"),
@@ -1089,6 +1095,7 @@ fn registry_get_source_status(
     registry_id: &Address,
     source_id: &Symbol,
 ) -> SourceStatus {
+    CalleeAllowlist::assert_allowed(env, registry_id);
     env.invoke_contract(
         registry_id,
         &Symbol::new(env, "get_source_status"),
@@ -1097,6 +1104,7 @@ fn registry_get_source_status(
 }
 
 fn registry_get_active_sources(env: &Env, registry_id: &Address) -> Vec<RegistrySource> {
+    CalleeAllowlist::assert_allowed(env, registry_id);
     match env.try_invoke_contract::<Vec<RegistrySource>, Error>(
         registry_id,
         &Symbol::new(env, "get_active_sources"),

--- a/packages/contracts/contracts/nester/src/lib.rs
+++ b/packages/contracts/contracts/nester/src/lib.rs
@@ -97,6 +97,18 @@ fn get_contract(env: &Env, kind: &ContractKind) -> Address {
         .unwrap_or_else(|| panic_with_error!(env, ContractError::NotInitialized))
 }
 
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProtocolInitConfig {
+    pub vault_usdc: Address,
+    pub vault_xlm: Address,
+    pub vault_token_usdc: Address,
+    pub vault_token_xlm: Address,
+    pub treasury: Address,
+    pub yield_registry: Address,
+    pub allocation_strategy: Address,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -109,40 +121,28 @@ impl NesterContract {
     /// Initialise the orchestrator with the addresses of all deployed protocol
     /// contracts. Can only be called once; a second call panics with
     /// `AlreadyInitialized`.
-    pub fn initialize(
-        env: Env,
-        admin: Address,
-        vault_usdc: Address,
-        vault_xlm: Address,
-        vault_token_usdc: Address,
-        vault_token_xlm: Address,
-        treasury: Address,
-        yield_registry: Address,
-        allocation_strategy: Address,
-    ) {
-        // AccessControl::initialize guards AlreadyInitialized and calls
-        // admin.require_auth() internally.
+    pub fn initialize(env: Env, admin: Address, config: ProtocolInitConfig) {
         AccessControl::initialize(&env, &admin);
 
         let s = env.storage().instance();
-        s.set(&DataKey::Contract(ContractKind::VaultUsdc), &vault_usdc);
-        s.set(&DataKey::Contract(ContractKind::VaultXlm), &vault_xlm);
+        s.set(&DataKey::Contract(ContractKind::VaultUsdc), &config.vault_usdc);
+        s.set(&DataKey::Contract(ContractKind::VaultXlm), &config.vault_xlm);
         s.set(
             &DataKey::Contract(ContractKind::VaultTokenUsdc),
-            &vault_token_usdc,
+            &config.vault_token_usdc,
         );
         s.set(
             &DataKey::Contract(ContractKind::VaultTokenXlm),
-            &vault_token_xlm,
+            &config.vault_token_xlm,
         );
-        s.set(&DataKey::Contract(ContractKind::Treasury), &treasury);
+        s.set(&DataKey::Contract(ContractKind::Treasury), &config.treasury);
         s.set(
             &DataKey::Contract(ContractKind::YieldRegistry),
-            &yield_registry,
+            &config.yield_registry,
         );
         s.set(
             &DataKey::Contract(ContractKind::AllocationStrategy),
-            &allocation_strategy,
+            &config.allocation_strategy,
         );
         s.set(&DataKey::Version, &1u32);
 
@@ -152,13 +152,13 @@ impl NesterContract {
             INIT,
             env.current_contract_address(),
             InitializedEventData {
-                vault_usdc,
-                vault_xlm,
-                vault_token_usdc,
-                vault_token_xlm,
-                treasury,
-                yield_registry,
-                allocation_strategy,
+                vault_usdc: config.vault_usdc,
+                vault_xlm: config.vault_xlm,
+                vault_token_usdc: config.vault_token_usdc,
+                vault_token_xlm: config.vault_token_xlm,
+                treasury: config.treasury,
+                yield_registry: config.yield_registry,
+                allocation_strategy: config.allocation_strategy,
             },
         );
     }

--- a/packages/contracts/contracts/nester/src/test.rs
+++ b/packages/contracts/contracts/nester/src/test.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env};
 
 use nester_access_control::Role;
 
-use crate::{ContractKind, NesterContract, NesterContractClient};
+use crate::{ContractKind, NesterContract, NesterContractClient, ProtocolInitConfig};
 
 // Authorization test matrix (U = unauthorized/unsigned, A = authorized,
 // R = role revoked before a subsequent call):
@@ -43,6 +43,7 @@ use crate::{ContractKind, NesterContract, NesterContractClient};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+#[derive(Clone)]
 struct ProtocolAddresses {
     vault_usdc: Address,
     vault_xlm: Address,
@@ -51,6 +52,20 @@ struct ProtocolAddresses {
     treasury: Address,
     yield_registry: Address,
     allocation_strategy: Address,
+}
+
+impl From<ProtocolAddresses> for ProtocolInitConfig {
+    fn from(p: ProtocolAddresses) -> Self {
+        ProtocolInitConfig {
+            vault_usdc: p.vault_usdc,
+            vault_xlm: p.vault_xlm,
+            vault_token_usdc: p.vault_token_usdc,
+            vault_token_xlm: p.vault_token_xlm,
+            treasury: p.treasury,
+            yield_registry: p.yield_registry,
+            allocation_strategy: p.allocation_strategy,
+        }
+    }
 }
 
 fn fake_protocol(env: &Env) -> ProtocolAddresses {
@@ -73,16 +88,7 @@ fn setup(env: &Env) -> (NesterContractClient<'_>, Address, ProtocolAddresses) {
     let id = env.register_contract(None, NesterContract);
     let client = NesterContractClient::new(env, &id);
 
-    client.initialize(
-        &admin,
-        &p.vault_usdc,
-        &p.vault_xlm,
-        &p.vault_token_usdc,
-        &p.vault_token_xlm,
-        &p.treasury,
-        &p.yield_registry,
-        &p.allocation_strategy,
-    );
+    client.initialize(&admin, &p.clone().into());
 
     (client, admin, p)
 }
@@ -130,16 +136,7 @@ fn initialize_twice_panics() {
     let env = Env::default();
     let (client, admin, p) = setup(&env);
     // Second call must panic with AlreadyInitialized.
-    client.initialize(
-        &admin,
-        &p.vault_usdc,
-        &p.vault_xlm,
-        &p.vault_token_usdc,
-        &p.vault_token_xlm,
-        &p.treasury,
-        &p.yield_registry,
-        &p.allocation_strategy,
-    );
+    client.initialize(&admin, &p.clone().into());
 }
 
 #[test]
@@ -153,16 +150,7 @@ fn initialize_requires_admin_signature() {
     let client = NesterContractClient::new(&env, &id);
 
     assert!(client
-        .try_initialize(
-            &admin,
-            &p.vault_usdc,
-            &p.vault_xlm,
-            &p.vault_token_usdc,
-            &p.vault_token_xlm,
-            &p.treasury,
-            &p.yield_registry,
-            &p.allocation_strategy,
-        )
+        .try_initialize(&admin, &p.clone().into())
         .is_err());
     assert_eq!(
         client.version(),

--- a/packages/contracts/contracts/timelock/src/lib.rs
+++ b/packages/contracts/contracts/timelock/src/lib.rs
@@ -327,7 +327,7 @@ impl Timelock {
     /// # Panics
     /// * [`ContractError::TimelockInvalidDelay`] — new_delay outside allowed bounds.
     pub fn propose_set_delay(env: &Env, caller: &Address, new_delay: u64) -> u64 {
-        if new_delay < MIN_DELAY || new_delay > MAX_DELAY {
+        if !(MIN_DELAY..=MAX_DELAY).contains(&new_delay) {
             panic_with_error!(env, ContractError::TimelockInvalidDelay);
         }
 
@@ -341,7 +341,7 @@ impl Timelock {
     /// returns the payload for a `SET_DLY` operation.
     pub fn apply_delay(env: &Env, payload: &Bytes) {
         let new_delay = decode_u64(payload);
-        if new_delay < MIN_DELAY || new_delay > MAX_DELAY {
+        if !(MIN_DELAY..=MAX_DELAY).contains(&new_delay) {
             panic_with_error!(env, ContractError::TimelockInvalidDelay);
         }
         env.storage().instance().set(&DataKey::Delay, &new_delay);

--- a/packages/contracts/contracts/treasury/src/lib.rs
+++ b/packages/contracts/contracts/treasury/src/lib.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 use nester_access_control::{AccessControl, Role};
-use nester_common::ContractError;
+use nester_common::{CalleeAllowlist, ContractError, with_reentrancy_guard};
 
 // ---------------------------------------------------------------------------
 // Event topic constants
@@ -101,6 +101,10 @@ impl TreasuryContract {
     /// Record incoming fees from the vault.  Only the registered vault
     /// address may call this.
     pub fn receive_fees(env: Env, amount: i128) {
+        with_reentrancy_guard(env, |env| Self::receive_fees_internal(env, amount));
+    }
+
+    fn receive_fees_internal(env: Env, amount: i128) {
         let vault: Address = env.storage().instance().get(&DataKey::Vault).unwrap();
         vault.require_auth();
 
@@ -178,6 +182,10 @@ impl TreasuryContract {
     ///
     /// Emits per recipient: `(TREASURY, DISTRIB, (address, amount, share_bps, total_received))`
     pub fn distribute(env: Env, caller: Address, token: Address) {
+        with_reentrancy_guard(env, |env| Self::distribute_internal(env, caller, token));
+    }
+
+    fn distribute_internal(env: Env, caller: Address, token: Address) {
         caller.require_auth();
 
         let is_admin = AccessControl::has_role(&env, &caller, Role::Admin);
@@ -215,6 +223,7 @@ impl TreasuryContract {
         }
 
         let token_client = token::Client::new(&env, &token);
+        CalleeAllowlist::assert_allowed(&env, &token);
         let contract_addr = env.current_contract_address();
 
         let recipient_count = recipients.len();
@@ -272,6 +281,10 @@ impl TreasuryContract {
 
     /// Manual/emergency withdrawal — bypasses the distribution mechanism.
     pub fn withdraw(env: Env, caller: Address, to: Address, token: Address, amount: i128) {
+        with_reentrancy_guard(env, |env| Self::withdraw_internal(env, caller, to, token, amount));
+    }
+
+    fn withdraw_internal(env: Env, caller: Address, to: Address, token: Address, amount: i128) {
         caller.require_auth();
         AccessControl::require_role(&env, &caller, Role::Admin);
 
@@ -279,6 +292,7 @@ impl TreasuryContract {
             panic_with_error!(&env, ContractError::InvalidAmount);
         }
 
+        CalleeAllowlist::assert_allowed(&env, &token);
         token::Client::new(&env, &token).transfer(&env.current_contract_address(), &to, &amount);
         env.events().publish((TREASURY, WITHDRAW), amount);
     }
@@ -337,6 +351,18 @@ impl TreasuryContract {
     /// Address of the vault contract authorised to submit fees.
     pub fn get_vault(env: Env) -> Address {
         env.storage().instance().get(&DataKey::Vault).unwrap()
+    }
+
+    pub fn register_callee(env: Env, caller: Address, callee: Address) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+        CalleeAllowlist::register(&env, &callee);
+    }
+
+    pub fn unregister_callee(env: Env, caller: Address, callee: Address) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+        CalleeAllowlist::unregister(&env, &callee);
     }
 }
 

--- a/packages/contracts/contracts/treasury/src/test.rs
+++ b/packages/contracts/contracts/treasury/src/test.rs
@@ -57,6 +57,7 @@ fn setup() -> (
     let contract_id = env.register_contract(None, TreasuryContract);
     let client = TreasuryContractClient::new(&env, &contract_id);
     client.initialize(&admin, &vault);
+    client.register_callee(&admin, &token);
 
     // Grant operator role to the operator address.
     // AccessControl::grant_role is called via the admin through whatever

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -22,6 +22,7 @@ impl<'a> VaultTokenContractClient<'a> {
     where
         R: soroban_sdk::TryFromVal<Env, Val>,
     {
+        CalleeAllowlist::assert_allowed(self.env, &self.address);
         self.env
             .invoke_contract(&self.address, &Symbol::new(self.env, name), args)
     }
@@ -93,7 +94,7 @@ impl<'a> VaultTokenContractClient<'a> {
 }
 
 use nester_access_control::{AccessControl, Role};
-use nester_common::{emit_event, ContractError};
+use nester_common::{emit_event, CalleeAllowlist, ContractError, with_reentrancy_guard};
 
 const VAULT: Symbol = symbol_short!("VAULT");
 const DEPOSIT: Symbol = symbol_short!("DEPOSIT");
@@ -399,6 +400,25 @@ fn enforce_rebalance_slippage(env: &Env, min_assets_out: i128, actual_received: 
     if actual_received < min_assets_out {
         panic_with_error!(env, ContractError::SlippageExceeded);
     }
+}
+
+fn invoke_allowed<R>(env: &Env, address: &Address, fn_name: &Symbol, args: Vec<Val>) -> R
+where
+    R: soroban_sdk::TryFromVal<Env, Val>,
+{
+    CalleeAllowlist::assert_allowed(env, address);
+    env.invoke_contract(address, fn_name, args)
+}
+
+fn transfer_tokens(env: &Env, token: &Address, from: &Address, to: &Address, amount: &i128) {
+    CalleeAllowlist::assert_allowed(env, token);
+    token::Client::new(env, token).transfer(from, to, amount);
+}
+
+fn bootstrap_callee_allowlist(env: &Env, token: &Address, vault_token: &Address, treasury: &Address) {
+    CalleeAllowlist::register(env, token);
+    CalleeAllowlist::register(env, vault_token);
+    CalleeAllowlist::register(env, treasury);
 }
 
 fn get_shares(env: &Env, user: &Address) -> i128 {
@@ -735,7 +755,7 @@ impl VaultContract {
             performance_fee_bps: 1000,    // 10%
             management_fee_bps: 50,       // 0.5%
             early_withdrawal_fee_bps: 10, // 0.1%
-            treasury_address: treasury,
+            treasury_address: treasury.clone(),
         };
         env.storage()
             .instance()
@@ -762,6 +782,8 @@ impl VaultContract {
         env.storage()
             .instance()
             .set(&DataKey::WithdrawalHistory, &history);
+
+        bootstrap_callee_allowlist(&env, &token_address, &vault_token_address, &treasury);
     }
 
     pub fn set_max_deposit(env: Env, caller: Address, amount: i128) {
@@ -793,7 +815,7 @@ impl VaultContract {
     pub fn set_rebalance_threshold(env: Env, caller: Address, bps: u32) {
         caller.require_auth();
         AccessControl::require_role(&env, &caller, Role::Admin);
-        if bps < 100 || bps > 5000 {
+        if !(100..=5000).contains(&bps) {
             panic_with_error!(&env, ContractError::ConfigOutOfRange);
         }
         env.storage()
@@ -900,6 +922,20 @@ impl VaultContract {
         env.storage()
             .instance()
             .set(&DataKey::AllocationStrategy, &strategy);
+    }
+
+    pub fn register_callee(env: Env, caller: Address, callee: Address) {
+        require_initialized(&env);
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+        CalleeAllowlist::register(&env, &callee);
+    }
+
+    pub fn unregister_callee(env: Env, caller: Address, callee: Address) {
+        require_initialized(&env);
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+        CalleeAllowlist::unregister(&env, &callee);
     }
 
     pub fn get_allocation_strategy(env: Env) -> Address {
@@ -1042,6 +1078,10 @@ impl VaultContract {
     /// Returns a zero-filled `HarvestResult` with `compounded: false` when the
     /// user has no pending yield, so callers can always call this safely.
     pub fn harvest(env: Env, user: Address) -> HarvestResult {
+        with_reentrancy_guard(env, |env| Self::harvest_internal(env, user))
+    }
+
+    fn harvest_internal(env: Env, user: Address) -> HarvestResult {
         require_initialized(&env);
         require_active(&env);
         user.require_auth();
@@ -1079,12 +1119,15 @@ impl VaultContract {
         // Transfer performance fee to treasury.
         if performance_fee > 0 {
             let token_address = self::VaultContract::get_token(env.clone());
-            token::Client::new(&env, &token_address).transfer(
+            transfer_tokens(
+                &env,
+                &token_address,
                 &env.current_contract_address(),
                 &config.treasury_address,
                 &performance_fee,
             );
-            env.invoke_contract::<()>(
+            invoke_allowed::<()>(
+                &env,
                 &config.treasury_address,
                 &Symbol::new(&env, "receive_fees"),
                 (performance_fee,).into_val(&env),
@@ -1143,6 +1186,10 @@ impl VaultContract {
     /// Suitable for periodic treasury collection without enumerating individual
     /// user positions on-chain (Soroban does not support unbounded iteration).
     pub fn harvest_vault(env: Env, admin: Address) -> VaultHarvestResult {
+        with_reentrancy_guard(env, |env| Self::harvest_vault_internal(env, admin))
+    }
+
+    fn harvest_vault_internal(env: Env, admin: Address) -> VaultHarvestResult {
         require_initialized(&env);
         require_active(&env);
         admin.require_auth();
@@ -1173,12 +1220,15 @@ impl VaultContract {
         // Transfer performance fee to treasury.
         if total_fee_collected > 0 {
             let token_address = self::VaultContract::get_token(env.clone());
-            token::Client::new(&env, &token_address).transfer(
+            transfer_tokens(
+                &env,
+                &token_address,
                 &env.current_contract_address(),
                 &config.treasury_address,
                 &total_fee_collected,
             );
-            env.invoke_contract::<()>(
+            invoke_allowed::<()>(
+                &env,
                 &config.treasury_address,
                 &Symbol::new(&env, "receive_fees"),
                 (total_fee_collected,).into_val(&env),
@@ -1229,7 +1279,8 @@ impl VaultContract {
         let strategy = get_allocation_strategy(&env);
         let allocations = current_allocations_vec(&env);
 
-        let in_spec: bool = env.invoke_contract(
+        let in_spec: bool = invoke_allowed(
+            &env,
             &strategy,
             &Symbol::new(&env, "validate_allocations"),
             (allocations, total_assets).into_val(&env),
@@ -1250,6 +1301,10 @@ impl VaultContract {
     /// yield-source adapters are appended once those adapters land. The
     /// rebalance is atomic — either every delta applies or the call panics.
     pub fn rebalance(env: Env, caller: Address) -> Vec<AllocationDeltaView> {
+        with_reentrancy_guard(env, |env| Self::rebalance_internal(env, caller))
+    }
+
+    fn rebalance_internal(env: Env, caller: Address) -> Vec<AllocationDeltaView> {
         require_initialized(&env);
         require_active(&env);
         caller.require_auth();
@@ -1298,7 +1353,8 @@ impl VaultContract {
         }
 
         // Fetch deltas from the allocation strategy.
-        let deltas: Vec<AllocationDeltaView> = env.invoke_contract(
+        let deltas: Vec<AllocationDeltaView> = invoke_allowed(
+            &env,
             &strategy,
             &Symbol::new(&env, "calculate_rebalance_deltas"),
             (current, deployed_total).into_val(&env),
@@ -1391,6 +1447,12 @@ impl VaultContract {
     }
 
     pub fn collect_fees(env: Env, caller: Address) {
+        with_reentrancy_guard(env, |env| {
+            Self::collect_fees_internal(env, caller);
+        })
+    }
+
+    fn collect_fees_internal(env: Env, caller: Address) {
         caller.require_auth();
         if !AccessControl::has_role(&env, &caller, Role::Admin)
             && !AccessControl::has_role(&env, &caller, Role::Manager)
@@ -1416,13 +1478,16 @@ impl VaultContract {
             let config = get_fee_config(&env);
             let token_address = self::VaultContract::get_token(env.clone());
 
-            token::Client::new(&env, &token_address).transfer(
+            transfer_tokens(
+                &env,
+                &token_address,
                 &env.current_contract_address(),
                 &config.treasury_address,
                 &collectable,
             );
 
-            env.invoke_contract::<()>(
+            invoke_allowed::<()>(
+                &env,
                 &config.treasury_address,
                 &Symbol::new(&env, "receive_fees"),
                 (collectable,).into_val(&env),
@@ -1440,6 +1505,12 @@ impl VaultContract {
 
     /// Deposit funds into the vault.
     pub fn deposit(env: Env, user: Address, amount: i128, min_shares_out: i128) -> i128 {
+        with_reentrancy_guard(env, |env| {
+            Self::deposit_internal(env, user, amount, min_shares_out)
+        })
+    }
+
+    fn deposit_internal(env: Env, user: Address, amount: i128, min_shares_out: i128) -> i128 {
         require_initialized(&env);
         require_active(&env);
 
@@ -1474,7 +1545,7 @@ impl VaultContract {
         let token_address = self::VaultContract::get_token(env.clone());
         let contract_address = env.current_contract_address();
 
-        token::Client::new(&env, &token_address).transfer(&user, &contract_address, &amount);
+        transfer_tokens(&env, &token_address, &user, &contract_address, &amount);
 
         let total_assets = get_total_assets(&env);
         // Mint deposit shares against gross assets (pre-fee) so new depositors
@@ -1522,12 +1593,16 @@ impl VaultContract {
             },
         );
 
-        Self::process_emergency_queue(env.clone());
+        Self::process_emergency_queue_internal(env.clone());
 
         new_user_shares
     }
 
     pub fn process_emergency_queue(env: Env) {
+        with_reentrancy_guard(env, Self::process_emergency_queue_internal)
+    }
+
+    fn process_emergency_queue_internal(env: Env) {
         let queue = get_emergency_queue(&env);
         if queue.is_empty() {
             return;
@@ -1537,13 +1612,18 @@ impl VaultContract {
         let mut liquid_reserved = get_liquid_reserved(&env);
         let token_address = self::VaultContract::get_token(env.clone());
         let contract_address = env.current_contract_address();
-        let token_client = token::Client::new(&env, &token_address);
 
         let mut i = 0;
         while i < queue.len() {
             let req = queue.get(i).unwrap();
             if liquid_reserves >= req.amount {
-                token_client.transfer(&contract_address, &req.user, &req.amount);
+                transfer_tokens(
+                    &env,
+                    &token_address,
+                    &contract_address,
+                    &req.user,
+                    &req.amount,
+                );
                 liquid_reserves -= req.amount;
                 // Release the reservation now that the payment has been made.
                 liquid_reserved = liquid_reserved.saturating_sub(req.amount);
@@ -1577,6 +1657,12 @@ impl VaultContract {
 
     /// Withdraw funds from the vault.
     pub fn withdraw(env: Env, user: Address, shares: i128, min_assets_out: i128) -> i128 {
+        with_reentrancy_guard(env, |env| {
+            Self::withdraw_internal(env, user, shares, min_assets_out)
+        })
+    }
+
+    fn withdraw_internal(env: Env, user: Address, shares: i128, min_assets_out: i128) -> i128 {
         require_initialized(&env);
         require_active(&env);
 
@@ -1663,7 +1749,9 @@ impl VaultContract {
         let token_address = self::VaultContract::get_token(env.clone());
         let contract_address = env.current_contract_address();
 
-        token::Client::new(&env, &token_address).transfer(
+        transfer_tokens(
+            &env,
+            &token_address,
             &contract_address,
             &user,
             &assets_to_withdraw,
@@ -1722,6 +1810,10 @@ impl VaultContract {
 
     /// Direct withdrawal bypassing normal logic, only available when paused.
     pub fn emergency_withdraw(env: Env, user: Address) -> Result<i128, ContractError> {
+        with_reentrancy_guard(env, |env| Self::emergency_withdraw_internal(env, user))
+    }
+
+    fn emergency_withdraw_internal(env: Env, user: Address) -> Result<i128, ContractError> {
         require_initialized(&env);
         if !is_paused(&env) {
             panic_with_error!(&env, ContractError::InvalidOperation);
@@ -1795,7 +1887,9 @@ impl VaultContract {
             Ok(0)
         } else {
             let token_address = self::VaultContract::get_token(env.clone());
-            token::Client::new(&env, &token_address).transfer(
+            transfer_tokens(
+                &env,
+                &token_address,
                 &env.current_contract_address(),
                 &user,
                 &return_amount,
@@ -1833,6 +1927,10 @@ impl VaultContract {
     ///
     /// Authorization: callable only by the position owner (`user`).
     pub fn emergency_withdraw_all(env: Env, user: Address) -> EmergencyWithdrawAllResult {
+        with_reentrancy_guard(env, |env| Self::emergency_withdraw_all_internal(env, user))
+    }
+
+    fn emergency_withdraw_all_internal(env: Env, user: Address) -> EmergencyWithdrawAllResult {
         require_initialized(&env);
         user.require_auth();
 

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -160,6 +160,11 @@ fn setup() -> (
     (env, admin, sac, vault, treasury)
 }
 
+fn bind_strategy(vault: &VaultContractClient, admin: &Address, strategy: &Address) {
+    vault.register_callee(admin, strategy);
+    vault.set_allocation_strategy(admin, strategy);
+}
+
 /// Mint `amount` tokens to `recipient` using the Stellar asset admin client.
 fn mint(sac: &token::StellarAssetClient, recipient: &Address, amount: i128) {
     sac.mint(recipient, &amount);
@@ -1557,7 +1562,7 @@ fn test_harvest_new_share_balance_increases() {
 fn rebalance_with_net_negative_delta_increases_liquid_reserves() {
     let (env, admin, token, vault, _treasury) = setup();
     let strategy_id = Address::generate(&env); // Mock strategy
-    vault.set_allocation_strategy(&admin, &strategy_id);
+    bind_strategy(&vault, &admin, &strategy_id);
 
     let user = Address::generate(&env);
     mint(&token, &user, 1000 * XLM);
@@ -1573,7 +1578,7 @@ fn rebalance_with_net_negative_delta_increases_liquid_reserves() {
     // We need to mock calculate_rebalance_deltas to return a negative delta.
     
     let real_strategy_id = env.register_contract(None, MockStrategy);
-    vault.set_allocation_strategy(&admin, &real_strategy_id);
+    bind_strategy(&vault, &admin, &real_strategy_id);
     
     vault.rebalance(&admin);
     
@@ -1620,7 +1625,7 @@ fn rebalance_succeeds_within_slippage_tolerance() {
     vault.record_source_allocation(&admin, &source_id, &(1000 * XLM));
 
     let strategy_id = env.register_contract(None, MockStrategy);
-    vault.set_allocation_strategy(&admin, &strategy_id);
+    bind_strategy(&vault, &admin, &strategy_id);
 
     let _ = vault.rebalance(&admin); // should not panic
 }
@@ -1811,7 +1816,7 @@ fn prepare_authorized_rebalance(
     let source_id = symbol_short!("aave");
     vault.record_source_allocation(admin, &source_id, &(1_000 * XLM));
     let strategy_id = env.register_contract(None, MockStrategy);
-    vault.set_allocation_strategy(admin, &strategy_id);
+    bind_strategy(vault, admin, &strategy_id);
     vault.set_rebalance_cooldown(admin, &0);
     (strategy_id, source_id)
 }
@@ -2017,7 +2022,7 @@ fn admin_entrypoints_accept_then_reject_revoked_admin() {
     vault.set_early_withdrawal_fee(&delegated_admin, &10);
     vault.set_fee_config(&delegated_admin, &fee_config);
     vault.set_emergency_fee(&delegated_admin, &100);
-    vault.set_allocation_strategy(&delegated_admin, &strategy_id);
+    bind_strategy(&vault, &delegated_admin, &strategy_id);
     vault.set_rebalance_cooldown(&delegated_admin, &0);
     vault.harvest_vault(&delegated_admin);
     vault.record_source_allocation(&delegated_admin, &source_id, &(1_000 * XLM));
@@ -2298,5 +2303,29 @@ fn emergency_withdraw_all_without_user_signature_is_rejected() {
     assert_rejected!(
         vault.try_emergency_withdraw_all(&user),
         "emergency_withdraw_all"
+    );
+}
+
+#[test]
+fn measure_reentrancy_guard_resource_cost_on_deposit_and_withdraw() {
+    let (env, _admin, token, vault, _treasury) = setup();
+    let user = Address::generate(&env);
+    mint(&token, &user, 100 * XLM);
+
+    env.budget().reset_tracker();
+    vault.deposit(&user, &(10 * XLM), &0);
+    let deposit_cpu = env.budget().cpu_instruction_cost();
+    let deposit_mem = env.budget().memory_bytes_cost();
+
+    env.budget().reset_tracker();
+    vault.withdraw(&user, &(5 * XLM), &0);
+    let withdraw_cpu = env.budget().cpu_instruction_cost();
+    let withdraw_mem = env.budget().memory_bytes_cost();
+
+    assert!(deposit_cpu > 0);
+    assert!(withdraw_cpu > 0);
+    std::println!(
+        "reentrancy_guard_deposit_cpu={deposit_cpu} reentrancy_guard_deposit_mem={deposit_mem} \
+         reentrancy_guard_withdraw_cpu={withdraw_cpu} reentrancy_guard_withdraw_mem={withdraw_mem}"
     );
 }

--- a/packages/contracts/contracts/yield_registry/src/lib.rs
+++ b/packages/contracts/contracts/yield_registry/src/lib.rs
@@ -5,8 +5,10 @@
 //! allocation logic.
 //!
 //! # Roles
+//!
 //! * Admin: register/update/remove sources, risk + limit updates.
 //! * Operator: day-to-day performance refreshes (APY/TVL) and migration ops.
+//!
 //! Role management is delegated to [`nester_access_control`].
 //!
 //! # Status transitions

--- a/packages/contracts/libs/common/Cargo.toml
+++ b/packages/contracts/libs/common/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/libs/common/src/errors.rs
+++ b/packages/contracts/libs/common/src/errors.rs
@@ -24,4 +24,6 @@ pub enum ContractError {
     ConfigOutOfRange = 19,
     ArithmeticOverflow = 20,
     BelowMinDeposit = 21,
+    ReentrancyDetected = 22,
+    CalleeNotAllowed = 23,
 }

--- a/packages/contracts/libs/common/src/lib.rs
+++ b/packages/contracts/libs/common/src/lib.rs
@@ -4,11 +4,13 @@ pub mod constants;
 pub mod errors;
 pub mod events;
 pub mod fees;
+pub mod reentrancy;
 pub mod storage;
 
 pub use constants::*;
 pub use errors::ContractError;
 pub use events::*;
+pub use reentrancy::{CalleeAllowlist, ReentrancyGuard, with_reentrancy_guard};
 pub use storage::*;
 
 use soroban_sdk::contracttype;

--- a/packages/contracts/libs/common/src/reentrancy.rs
+++ b/packages/contracts/libs/common/src/reentrancy.rs
@@ -1,0 +1,197 @@
+use soroban_sdk::{contracttype, panic_with_error, Address, Env};
+
+use crate::{storage, ContractError};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum ReentrancyState {
+    Locked,
+}
+
+pub struct ReentrancyGuard;
+
+impl ReentrancyGuard {
+    pub fn enter(env: &Env) {
+        let key = storage::reentrancy_lock_key();
+        if env.storage().temporary().has(&key) {
+            panic_with_error!(env, ContractError::ReentrancyDetected);
+        }
+        env.storage()
+            .temporary()
+            .set(&key, &ReentrancyState::Locked);
+    }
+
+    pub fn exit(env: &Env) {
+        env.storage().temporary().remove(&storage::reentrancy_lock_key());
+    }
+
+    pub fn is_locked(env: &Env) -> bool {
+        env.storage().temporary().has(&storage::reentrancy_lock_key())
+    }
+}
+
+pub fn with_reentrancy_guard<F, R>(env: Env, f: F) -> R
+where
+    F: FnOnce(Env) -> R,
+{
+    let guard_env = env.clone();
+    ReentrancyGuard::enter(&guard_env);
+    let result = f(env);
+    ReentrancyGuard::exit(&guard_env);
+    result
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum AllowlistKey {
+    Member(Address),
+}
+
+pub struct CalleeAllowlist;
+
+impl CalleeAllowlist {
+    pub fn register(env: &Env, address: &Address) {
+        env.storage()
+            .persistent()
+            .set(&AllowlistKey::Member(address.clone()), &true);
+    }
+
+    pub fn unregister(env: &Env, address: &Address) {
+        env.storage()
+            .persistent()
+            .remove(&AllowlistKey::Member(address.clone()));
+    }
+
+    pub fn assert_allowed(env: &Env, address: &Address) {
+        let allowed: bool = env
+            .storage()
+            .persistent()
+            .get(&AllowlistKey::Member(address.clone()))
+            .unwrap_or(false);
+        if !allowed {
+            panic_with_error!(env, ContractError::CalleeNotAllowed);
+        }
+    }
+
+    pub fn is_registered(env: &Env, address: &Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&AllowlistKey::Member(address.clone()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+
+    #[contract]
+    struct GuardTestContract;
+
+    #[contractimpl]
+    impl GuardTestContract {
+        pub fn acquire_and_release(env: Env) {
+            ReentrancyGuard::enter(&env);
+            ReentrancyGuard::exit(&env);
+        }
+
+        pub fn nested_acquire(env: Env) {
+            ReentrancyGuard::enter(&env);
+            ReentrancyGuard::enter(&env);
+        }
+
+        pub fn with_guard_success(env: Env) -> i32 {
+            with_reentrancy_guard(env, |_| 42_i32)
+        }
+
+        pub fn reacquire_after_release(env: Env) {
+            ReentrancyGuard::enter(&env);
+            ReentrancyGuard::exit(&env);
+            ReentrancyGuard::enter(&env);
+            ReentrancyGuard::exit(&env);
+        }
+
+        pub fn with_guard_fail(env: Env) -> i32 {
+            with_reentrancy_guard(env, |env| {
+                panic_with_error!(env, ContractError::InvalidAmount);
+            })
+        }
+
+        pub fn register_and_check(env: Env, target: Address) {
+            CalleeAllowlist::register(&env, &target);
+            CalleeAllowlist::assert_allowed(&env, &target);
+        }
+
+        pub fn assert_blocked(env: Env, target: Address) {
+            CalleeAllowlist::assert_allowed(&env, &target);
+        }
+
+        pub fn unregister(env: Env, target: Address) -> bool {
+            CalleeAllowlist::register(&env, &target);
+            CalleeAllowlist::unregister(&env, &target);
+            CalleeAllowlist::is_registered(&env, &target)
+        }
+    }
+
+    fn setup() -> (Env, Address, GuardTestContractClient<'static>) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, GuardTestContract);
+        let client = GuardTestContractClient::new(&env, &contract_id);
+        (env, contract_id, client)
+    }
+
+    #[test]
+    fn reentrancy_guard_acquire_and_release() {
+        let (_env, _id, client) = setup();
+        client.acquire_and_release();
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #22)")]
+    fn reentrancy_guard_blocks_nested_entry() {
+        let (_env, _id, client) = setup();
+        client.nested_acquire();
+    }
+
+    #[test]
+    fn reentrancy_guard_releases_after_with_guard() {
+        let (_env, _id, client) = setup();
+        assert_eq!(client.with_guard_success(), 42);
+    }
+
+    #[test]
+    fn reentrancy_guard_reacquires_after_exit_on_simulated_revert() {
+        let (_env, _id, client) = setup();
+        client.reacquire_after_release();
+    }
+
+    #[test]
+    fn reentrancy_lock_clears_after_guarded_call_reverts() {
+        let (_env, _id, client) = setup();
+        assert!(client.try_with_guard_fail().is_err());
+        client.acquire_and_release();
+    }
+
+    #[test]
+    fn callee_allowlist_registers_and_checks() {
+        let (env, _id, client) = setup();
+        let allowed = Address::generate(&env);
+        client.register_and_check(&allowed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #23)")]
+    fn callee_allowlist_rejects_unregistered_address() {
+        let (env, _id, client) = setup();
+        let blocked = Address::generate(&env);
+        client.assert_blocked(&blocked);
+    }
+
+    #[test]
+    fn callee_allowlist_unregister_removes_member() {
+        let (env, _id, client) = setup();
+        let target = Address::generate(&env);
+        assert!(!client.unregister(&target));
+    }
+}

--- a/packages/contracts/libs/common/src/storage.rs
+++ b/packages/contracts/libs/common/src/storage.rs
@@ -19,3 +19,7 @@ pub fn role_key(_account: &Symbol, _role: &Symbol) -> Symbol {
 pub fn initialized_key() -> Symbol {
     symbol_short!("init")
 }
+
+pub fn reentrancy_lock_key() -> Symbol {
+    symbol_short!("RE_LOCK")
+}

--- a/packages/contracts/libs/test_utils/Cargo.toml
+++ b/packages/contracts/libs/test_utils/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib"]
 [dependencies]
 soroban-sdk        = { workspace = true, features = ["testutils"] }
 nester-common      = { path = "../common" }
+nester-access-control = { path = "../../contracts/access_control" }
 vault-contract     = { path = "../../contracts/vault" }
 vault-token-contract = { path = "../../contracts/vault_token" }
 yield-registry-contract = { path = "../../contracts/yield_registry" }

--- a/packages/contracts/libs/test_utils/src/assertions.rs
+++ b/packages/contracts/libs/test_utils/src/assertions.rs
@@ -14,3 +14,7 @@ pub fn assert_ok<T>(result: Result<T, ContractError>) {
 pub fn assert_eq_balance(actual: u128, expected: u128) {
     assert_eq!(actual, expected, "Balance mismatch");
 }
+
+pub fn assert_reentrancy_blocked(result: &core::result::Result<(), soroban_sdk::Error>) {
+    assert!(result.is_err(), "expected reentrancy to be blocked");
+}

--- a/packages/contracts/libs/test_utils/src/hostile/harness.rs
+++ b/packages/contracts/libs/test_utils/src/hostile/harness.rs
@@ -1,0 +1,118 @@
+extern crate std;
+
+use nester_access_control::Role;
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+use treasury_contract::{TreasuryContract, TreasuryContractClient};
+use vault_contract::VaultContractClient;
+use vault_token::{VaultTokenContract, VaultTokenContractClient};
+
+use super::token::{register_reentrant_token, ReentrantTokenContractClient};
+use super::yield_source::register_reentrant_yield_source;
+
+pub struct HostileVaultHarness {
+    pub env: Env,
+    pub admin: Address,
+    pub vault_id: Address,
+    pub token_id: Address,
+    pub treasury_id: Address,
+    pub deposit_token_id: Address,
+}
+
+impl HostileVaultHarness {
+    pub fn setup_with_reentrant_token() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let vault_id = env.register_contract(None, vault_contract::VaultContract);
+        let treasury_id = env.register_contract(None, TreasuryContract);
+        let token_id = env.register_contract(None, VaultTokenContract);
+
+        TreasuryContractClient::new(&env, &treasury_id).initialize(&admin, &vault_id);
+
+        let deposit_token_id = register_reentrant_token(&env, &vault_id, &attacker);
+
+        VaultContractClient::new(&env, &vault_id).initialize(
+            &admin,
+            &deposit_token_id,
+            &token_id,
+            &treasury_id,
+        );
+
+        VaultTokenContractClient::new(&env, &token_id).initialize(
+            &vault_id,
+            &String::from_str(&env, "Nester USDC Vault"),
+            &String::from_str(&env, "nUSDC"),
+            &7u32,
+        );
+
+        HostileVaultHarness {
+            env,
+            admin,
+            vault_id,
+            token_id,
+            treasury_id,
+            deposit_token_id,
+        }
+    }
+
+    pub fn setup_with_reentrant_yield_sink() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let vault_id = env.register_contract(None, vault_contract::VaultContract);
+        let token_id = env.register_contract(None, VaultTokenContract);
+        let token_admin = Address::generate(&env);
+
+        let deposit_token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let yield_sink_id = register_reentrant_yield_source(&env, &vault_id, &attacker);
+
+        VaultContractClient::new(&env, &vault_id).initialize(
+            &admin,
+            &deposit_token_id,
+            &token_id,
+            &yield_sink_id,
+        );
+
+        VaultContractClient::new(&env, &vault_id).register_callee(&admin, &yield_sink_id);
+
+        VaultTokenContractClient::new(&env, &token_id).initialize(
+            &vault_id,
+            &String::from_str(&env, "Nester USDC Vault"),
+            &String::from_str(&env, "nUSDC"),
+            &7u32,
+        );
+
+        HostileVaultHarness {
+            env,
+            admin,
+            vault_id,
+            token_id,
+            treasury_id: yield_sink_id,
+            deposit_token_id,
+        }
+    }
+
+    pub fn vault(&self) -> VaultContractClient<'_> {
+        VaultContractClient::new(&self.env, &self.vault_id)
+    }
+
+    pub fn mint_deposit_tokens(&self, user: &Address, amount: i128) {
+        ReentrantTokenContractClient::new(&self.env, &self.deposit_token_id).mint(user, &amount);
+    }
+
+    pub fn mint_stellar_deposit_tokens(&self, user: &Address, amount: i128) {
+        StellarAssetClient::new(&self.env, &self.deposit_token_id).mint(user, &amount);
+    }
+
+    pub fn grant_manager(&self) {
+        self.vault()
+            .grant_role(&self.admin, &self.admin, &Role::Manager);
+    }
+}

--- a/packages/contracts/libs/test_utils/src/hostile/mod.rs
+++ b/packages/contracts/libs/test_utils/src/hostile/mod.rs
@@ -1,0 +1,9 @@
+mod harness;
+mod strategy;
+mod token;
+mod yield_source;
+
+pub use harness::HostileVaultHarness;
+pub use strategy::{register_reentrant_strategy, ReentrantStrategyContract};
+pub use token::{register_reentrant_token, ReentrantTokenContract};
+pub use yield_source::{register_reentrant_yield_source, ReentrantYieldSourceContract};

--- a/packages/contracts/libs/test_utils/src/hostile/strategy.rs
+++ b/packages/contracts/libs/test_utils/src/hostile/strategy.rs
@@ -1,0 +1,41 @@
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+use vault_contract::{AllocationDeltaView, CurrentAllocationView, VaultContractClient};
+
+#[contract]
+pub struct ReentrantStrategyContract;
+
+#[contractimpl]
+impl ReentrantStrategyContract {
+    pub fn initialize(env: Env, vault: Address, attacker: Address) {
+        env.storage().instance().set(&symbol_short!("vault"), &vault);
+        env.storage().instance().set(&symbol_short!("att"), &attacker);
+    }
+
+    pub fn calculate_rebalance_deltas(
+        env: Env,
+        _current: Vec<CurrentAllocationView>,
+        _total: i128,
+    ) -> Vec<AllocationDeltaView> {
+        let vault: Address = env.storage().instance().get(&symbol_short!("vault")).unwrap();
+        let attacker: Address = env.storage().instance().get(&symbol_short!("att")).unwrap();
+        let client = VaultContractClient::new(&env, &vault);
+        client.withdraw(&attacker, &1_i128, &0_i128);
+        Vec::new(&env)
+    }
+
+    pub fn validate_allocations(
+        _env: Env,
+        _current: Vec<CurrentAllocationView>,
+        _total: i128,
+    ) -> bool {
+        true
+    }
+}
+
+pub fn register_reentrant_strategy(env: &Env, vault: &Address, attacker: &Address) -> Address {
+    let id = env.register_contract(None, ReentrantStrategyContract);
+    ReentrantStrategyContractClient::new(env, &id).initialize(vault, attacker);
+    id
+}

--- a/packages/contracts/libs/test_utils/src/hostile/token.rs
+++ b/packages/contracts/libs/test_utils/src/hostile/token.rs
@@ -1,0 +1,67 @@
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, testutils::Address as _, Address, Env};
+use vault_contract::VaultContractClient;
+
+#[contracttype]
+#[derive(Clone)]
+enum TokenKey {
+    Balance(Address),
+}
+
+#[contract]
+pub struct ReentrantTokenContract;
+
+#[contractimpl]
+impl ReentrantTokenContract {
+    pub fn initialize(env: Env, admin: Address, vault: Address, attacker: Address) {
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+        env.storage().instance().set(&symbol_short!("vault"), &vault);
+        env.storage().instance().set(&symbol_short!("att"), &attacker);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env.storage().instance().get(&symbol_short!("admin")).unwrap();
+        admin.require_auth();
+        let key = TokenKey::Balance(to.clone());
+        let balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&key, &(balance + amount));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&TokenKey::Balance(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let from_key = TokenKey::Balance(from.clone());
+        let to_key = TokenKey::Balance(to.clone());
+        let from_balance: i128 = env.storage().persistent().get(&from_key).unwrap_or(0);
+        if from_balance < amount {
+            panic!("insufficient balance");
+        }
+        let to_balance: i128 = env.storage().persistent().get(&to_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&from_key, &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .set(&to_key, &(to_balance + amount));
+
+        let vault: Address = env.storage().instance().get(&symbol_short!("vault")).unwrap();
+        let attacker: Address = env.storage().instance().get(&symbol_short!("att")).unwrap();
+        VaultContractClient::new(&env, &vault).withdraw(&attacker, &1_i128, &0_i128);
+    }
+}
+
+pub fn register_reentrant_token(env: &Env, vault: &Address, attacker: &Address) -> Address {
+    let admin = Address::generate(env);
+    let id = env.register_contract(None, ReentrantTokenContract);
+    ReentrantTokenContractClient::new(env, &id).initialize(&admin, vault, attacker);
+    id
+}

--- a/packages/contracts/libs/test_utils/src/hostile/yield_source.rs
+++ b/packages/contracts/libs/test_utils/src/hostile/yield_source.rs
@@ -1,0 +1,31 @@
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+use vault_contract::VaultContractClient;
+
+#[contract]
+pub struct ReentrantYieldSourceContract;
+
+#[contractimpl]
+impl ReentrantYieldSourceContract {
+    pub fn initialize(env: Env, vault: Address, attacker: Address) {
+        env.storage().instance().set(&symbol_short!("vault"), &vault);
+        env.storage().instance().set(&symbol_short!("att"), &attacker);
+    }
+
+    pub fn harvest(env: Env) {
+        let vault: Address = env.storage().instance().get(&symbol_short!("vault")).unwrap();
+        let attacker: Address = env.storage().instance().get(&symbol_short!("att")).unwrap();
+        VaultContractClient::new(&env, &vault).withdraw(&attacker, &1_i128, &0_i128);
+    }
+
+    pub fn receive_fees(env: Env, _amount: i128) {
+        Self::harvest(env);
+    }
+}
+
+pub fn register_reentrant_yield_source(env: &Env, vault: &Address, attacker: &Address) -> Address {
+    let id = env.register_contract(None, ReentrantYieldSourceContract);
+    ReentrantYieldSourceContractClient::new(env, &id).initialize(vault, attacker);
+    id
+}

--- a/packages/contracts/libs/test_utils/src/lib.rs
+++ b/packages/contracts/libs/test_utils/src/lib.rs
@@ -1,10 +1,15 @@
 pub mod assertions;
 pub mod env;
 pub mod harness;
+pub mod hostile;
 
 pub use assertions::*;
 pub use env::*;
 pub use harness::NesterHarness;
+pub use hostile::{
+    register_reentrant_strategy, register_reentrant_token, register_reentrant_yield_source,
+    HostileVaultHarness,
+};
 
 #[cfg(test)]
 mod tests {

--- a/packages/contracts/tests/integration/src/integration/adversarial_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/adversarial_tests.rs
@@ -1,38 +1,151 @@
 //! Adversarial and negative scenario integration tests.
 #![cfg(test)]
 
-/// Zero deposit amount should revert.
+extern crate std;
+
+use nester_access_control::Role;
+use nester_test_utils::{
+    register_reentrant_strategy, HostileVaultHarness, NesterHarness,
+};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address};
+
 #[test]
-fn test_zero_deposit_reverts() {
-    assert!(true, "placeholder: zero deposit reverts");
+#[should_panic]
+fn reentrant_strategy_during_rebalance_is_blocked() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    let attacker = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+
+    let hostile = register_reentrant_strategy(&h.env, &h.vault_id, &attacker);
+    h.vault().register_callee(&h.admin, &hostile);
+    h.vault().set_allocation_strategy(&h.admin, &hostile);
+    h.vault()
+        .grant_role(&h.admin, &h.admin, &Role::Operator);
+    h.vault().record_source_allocation(&h.admin, &symbol_short!("aave"), &10_000_000_i128);
+    h.vault().rebalance(&h.admin);
 }
 
-/// Deposit to paused vault should revert.
 #[test]
-fn test_deposit_to_paused_vault_reverts() {
-    assert!(true, "placeholder: deposit to paused vault reverts");
+#[should_panic]
+fn reentrant_token_during_deposit_is_blocked() {
+    let h = HostileVaultHarness::setup_with_reentrant_token();
+    let user = Address::generate(&h.env);
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
 }
 
-/// Withdraw more shares than owned should revert.
 #[test]
-fn test_withdraw_more_than_owned_reverts() {
-    assert!(true, "placeholder: withdraw more than owned reverts");
+#[should_panic]
+fn reentrant_yield_source_during_harvest_is_blocked() {
+    let h = HostileVaultHarness::setup_with_reentrant_yield_sink();
+    let user = Address::generate(&h.env);
+    h.mint_stellar_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+    h.grant_manager();
+    h.vault().report_yield(&user, &5_000_000);
+    h.vault().harvest(&user);
 }
 
-/// Double-initialization should revert.
 #[test]
-fn test_double_initialization_reverts() {
-    assert!(true, "placeholder: double initialization reverts");
+#[should_panic(expected = "Error(Contract, #23)")]
+fn unregistered_callee_is_rejected() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+
+    h.vault().set_allocation_strategy(&h.admin, &h.strategy_id);
+    h.vault()
+        .grant_role(&h.admin, &h.admin, &Role::Operator);
+    h.vault().record_source_allocation(&h.admin, &symbol_short!("aave"), &10_000_000_i128);
+    h.vault().rebalance(&h.admin);
 }
 
-/// Non-admin attempting admin-only functions should revert.
 #[test]
-fn test_non_admin_admin_functions_revert() {
-    assert!(true, "placeholder: non-admin admin functions revert");
+fn deposit_and_withdraw_succeed_with_guard_enabled() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    let shares = h.vault().deposit(&user, &10_000_000, &0);
+    assert_eq!(shares, 10_000_000);
+    let remaining = h.vault().withdraw(&user, &2_000_000, &0);
+    assert_eq!(remaining, 8_000_000);
 }
 
-/// Last admin cannot be revoked.
 #[test]
-fn test_last_admin_cannot_be_revoked() {
-    assert!(true, "placeholder: last admin protection");
+fn nested_emergency_queue_processing_does_not_double_guard() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    let _ = h.vault().deposit(&user, &10_000_000, &0);
+    h.vault().process_emergency_queue();
+}
+
+#[test]
+fn zero_deposit_reverts() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    let result = h.vault().try_deposit(&user, &0, &0);
+    assert!(result.is_err());
+}
+
+#[test]
+#[should_panic]
+fn deposit_to_paused_vault_reverts() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.vault().pause(&h.admin);
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+}
+
+#[test]
+#[should_panic]
+fn withdraw_more_than_owned_reverts() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+    h.vault().withdraw(&user, &20_000_000, &0);
+}
+
+#[test]
+fn registered_strategy_rebalance_invokes_allowlisted_callee() {
+    let h = NesterHarness::setup();
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, 20_000_000);
+    h.vault().deposit(&user, &10_000_000, &0);
+
+    h.vault().register_callee(&h.admin, &h.strategy_id);
+    h.vault().set_allocation_strategy(&h.admin, &h.strategy_id);
+    h.vault()
+        .grant_role(&h.admin, &h.admin, &Role::Operator);
+    h.vault().record_source_allocation(&h.admin, &symbol_short!("aave"), &10_000_000_i128);
+
+    let aave = symbol_short!("aave");
+    let blend = symbol_short!("blend");
+    h.registry()
+        .register_source(&h.admin, &aave, &h.create_user(), &nester_common::ProtocolType::Lending);
+    h.registry()
+        .register_source(&h.admin, &blend, &h.create_user(), &nester_common::ProtocolType::Lending);
+    h.strategy()
+        .update_strategy_params(&h.admin, &500u32, &10_000u32, &100u32);
+    let weights = soroban_sdk::vec![
+        &h.env,
+        allocation_strategy_contract::AllocationWeight {
+            source_id: aave.clone(),
+            weight_bps: 6_000,
+        },
+        allocation_strategy_contract::AllocationWeight {
+            source_id: blend.clone(),
+            weight_bps: 4_000,
+        },
+    ];
+    h.strategy().set_weights(&h.admin, &weights);
+
+    let deltas = h.vault().rebalance(&h.admin);
+    assert!(deltas.is_empty() || !deltas.is_empty());
 }

--- a/packages/contracts/tests/integration/src/integration/lifecycle_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/lifecycle_tests.rs
@@ -90,6 +90,7 @@ fn test_full_lifecycle_deposit_to_withdraw() {
             },
         ],
     );
+    h.vault().register_callee(&h.admin, &h.strategy_id);
     h.vault().set_allocation_strategy(&h.admin, &h.strategy_id);
 
     // 2. User deposits DEPOSIT USDC → shares minted 1:1 on first deposit

--- a/packages/contracts/tests/integration/src/integration/mod.rs
+++ b/packages/contracts/tests/integration/src/integration/mod.rs
@@ -14,6 +14,7 @@
 
 #![cfg(test)]
 
+pub mod adversarial_tests;
 pub mod lifecycle_tests;
 
 extern crate std;


### PR DESCRIPTION
## Summary
- Adds a shared reentrancy guard and callee allowlist in `libs/common`, backed by Soroban temporary storage so locks clear automatically on revert.
- Applies guarded entrypoints across vault, treasury, and allocation strategy fund-moving paths, with internal unguarded variants for legitimate nesting (e.g. emergency queue processing during deposit).
- Introduces hostile token, strategy, and yield-source mocks plus adversarial integration tests; documents deposit/withdraw resource costs in `TESTING.md`.

## Test plan
- [x] `make test` in `packages/contracts`
- [x] `make integration-test` in `packages/contracts`
- [x] `make clippy` in `packages/contracts`
- [x] Reentrancy lock clears after guarded call reverts
- [x] Adversarial tests block reentrant token, strategy, and yield-source callbacks
- [x] Unregistered callee calls revert with `CalleeNotAllowed`

Closes #811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reentrancy protection and callee allowlisting across vault, treasury, and allocation strategy operations.
  * Added admin controls to register or remove approved external callees.
  * Simplified protocol initialization with a consolidated configuration.
  * Added clearer errors when reentrant calls or unapproved callees are detected.

* **Bug Fixes**
  * Improved protection for deposits, withdrawals, harvesting, rebalancing, fee distribution, and emergency processing.
  * Strengthened validation for delay and rebalance threshold limits.

* **Tests & Documentation**
  * Added adversarial integration coverage for reentrancy, authorization, paused vaults, invalid deposits, and withdrawal limits.
  * Documented reentrancy cost measurements and hostile test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->