### PR TITLE
feat(api): feature flags, server-side exports, read-replica routing, API versioning

### DIFF
--- a/apps/api/internal/db/router.go
+++ b/apps/api/internal/db/router.go
@@ -1,0 +1,287 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Router provides replica-aware data access: explicit read and write paths,
+// per-role connection pools, read-your-writes consistency via primary
+// pinning, and automatic routing around unhealthy or lagging replicas.
+//
+// Routing is EXPLICIT, never inferred from SQL. Repository methods that only
+// read call Read; anything that writes — or must observe the very latest
+// state (transactions, authoritative balance reads, accounting decisions) —
+// calls Write. The routing decision lives at the call site, where the
+// correctness knowledge lives.
+type Router struct {
+	primary  *sql.DB
+	replicas []*replica
+	pinner   Pinner
+	next     atomic.Uint64 // round-robin cursor over replicas
+}
+
+type replica struct {
+	db *sql.DB
+
+	mu        sync.RWMutex
+	healthy   bool
+	lag       time.Duration
+	maxLag    time.Duration
+	updatedAt time.Time
+}
+
+// eligible reports whether the replica may serve reads: healthy and within
+// its lag budget. A replica that has fallen too far behind is temporarily
+// removed rather than serving dangerously stale data.
+func (r *replica) eligible() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.healthy && (r.maxLag <= 0 || r.lag <= r.maxLag)
+}
+
+// Pinner tracks which users are pinned to the primary for reads. After a
+// user writes, their reads stay on the primary for a bounded window so they
+// always see their own writes despite replica lag. Production wiring backs
+// this with Redis (key per user, TTL = safe lag window); tests and
+// single-instance deployments can use NewMemoryPinner.
+type Pinner interface {
+	// Pin records that userID wrote and must read from the primary until
+	// the window elapses.
+	Pin(ctx context.Context, userID string)
+	// Pinned reports whether userID is inside the read-your-writes window.
+	Pinned(ctx context.Context, userID string) bool
+}
+
+// RouterConfig wires the per-role pools.
+type RouterConfig struct {
+	// Primary is the write pool configuration. Its sizing must account for
+	// writes plus consistency-pinned reads.
+	Primary Config
+	// Replicas are the read pool configurations, one per replica.
+	Replicas []Config
+	// MaxReplicaLag removes a replica from the read pool while its reported
+	// lag exceeds this budget. Zero disables lag-based eviction.
+	MaxReplicaLag time.Duration
+	// Pinner implements the read-your-writes window. Required.
+	Pinner Pinner
+}
+
+// ErrNoPinner guards against silently losing the consistency guarantee.
+var ErrNoPinner = errors.New("db: RouterConfig.Pinner is required for read-your-writes consistency")
+
+// OpenRouter opens the primary and every replica pool. Replica open errors
+// are not fatal: the router starts with that replica marked unhealthy and
+// reads fall back to the primary — degraded capacity, not an outage.
+func OpenRouter(cfg RouterConfig) (*Router, error) {
+	if cfg.Pinner == nil {
+		return nil, ErrNoPinner
+	}
+	primary, err := Open(cfg.Primary)
+	if err != nil {
+		return nil, fmt.Errorf("db: open primary: %w", err)
+	}
+
+	r := &Router{primary: primary, pinner: cfg.Pinner}
+	for i, rc := range cfg.Replicas {
+		rep := &replica{maxLag: cfg.MaxReplicaLag}
+		if rdb, err := Open(rc); err == nil {
+			rep.db = rdb
+			rep.healthy = true
+		} else {
+			// Leave unhealthy; health checks may recover it later.
+			rep.healthy = false
+			_ = i
+		}
+		r.replicas = append(r.replicas, rep)
+	}
+	return r, nil
+}
+
+// NewRouter assembles a Router from already-open pools (tests, custom
+// wiring). Every replica starts healthy.
+func NewRouter(primary *sql.DB, replicas []*sql.DB, pinner Pinner, maxLag time.Duration) (*Router, error) {
+	if pinner == nil {
+		return nil, ErrNoPinner
+	}
+	r := &Router{primary: primary, pinner: pinner}
+	for _, rdb := range replicas {
+		r.replicas = append(r.replicas, &replica{db: rdb, healthy: true, maxLag: maxLag})
+	}
+	return r, nil
+}
+
+// Write returns the primary pool. Writes, transactions, and reads that must
+// observe authoritative current state (ledger balances, reconciliation)
+// ALWAYS use this path, regardless of pinning.
+func (r *Router) Write() *sql.DB {
+	return r.primary
+}
+
+// Read returns the pool a read-only query for userID should use: the
+// primary while the user is inside their read-your-writes window, otherwise
+// a healthy replica (round-robin), otherwise the primary as fallback.
+func (r *Router) Read(ctx context.Context, userID string) *sql.DB {
+	if userID != "" && r.pinner.Pinned(ctx, userID) {
+		return r.primary
+	}
+	return r.readAny()
+}
+
+// ReadAny returns a replica pool for reads with no user context (background
+// aggregation, public data). Falls back to the primary when no replica is
+// eligible.
+func (r *Router) ReadAny() *sql.DB {
+	return r.readAny()
+}
+
+func (r *Router) readAny() *sql.DB {
+	n := len(r.replicas)
+	if n == 0 {
+		return r.primary
+	}
+	start := r.next.Add(1)
+	for i := 0; i < n; i++ {
+		rep := r.replicas[(int(start)+i)%n]
+		if rep.eligible() && rep.db != nil {
+			return rep.db
+		}
+	}
+	// All replicas unavailable: degraded capacity on the primary beats an
+	// outage.
+	return r.primary
+}
+
+// NoteWrite records that userID performed a write: their subsequent reads
+// are pinned to the primary for the consistency window. Call this after
+// every user-attributable write.
+func (r *Router) NoteWrite(ctx context.Context, userID string) {
+	if userID != "" {
+		r.pinner.Pin(ctx, userID)
+	}
+}
+
+// BeginTx opens a transaction — always on the primary; a transaction
+// spanning read and write connections would be incoherent.
+func (r *Router) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return r.primary.BeginTx(ctx, opts)
+}
+
+// SetReplicaHealth marks replica i healthy or unhealthy (from the health
+// monitor). Out-of-range indexes are ignored.
+func (r *Router) SetReplicaHealth(i int, healthy bool) {
+	if i < 0 || i >= len(r.replicas) {
+		return
+	}
+	rep := r.replicas[i]
+	rep.mu.Lock()
+	rep.healthy = healthy
+	rep.updatedAt = time.Now()
+	rep.mu.Unlock()
+}
+
+// SetReplicaLag records replica i's measured replication lag; a replica over
+// its budget is routed around until it catches up.
+func (r *Router) SetReplicaLag(i int, lag time.Duration) {
+	if i < 0 || i >= len(r.replicas) {
+		return
+	}
+	rep := r.replicas[i]
+	rep.mu.Lock()
+	rep.lag = lag
+	rep.updatedAt = time.Now()
+	rep.mu.Unlock()
+}
+
+// Stats exposes pool utilisation per role for metrics: a saturating primary
+// pool or a lagging replica are leading indicators of trouble.
+func (r *Router) Stats() RouterStats {
+	s := RouterStats{Primary: r.primary.Stats()}
+	for _, rep := range r.replicas {
+		rep.mu.RLock()
+		rs := ReplicaStats{Healthy: rep.healthy, Lag: rep.lag}
+		if rep.db != nil {
+			rs.Pool = rep.db.Stats()
+		}
+		rep.mu.RUnlock()
+		s.Replicas = append(s.Replicas, rs)
+	}
+	return s
+}
+
+// RouterStats aggregates per-role pool statistics.
+type RouterStats struct {
+	Primary  sql.DBStats
+	Replicas []ReplicaStats
+}
+
+// ReplicaStats couples a replica's pool stats with its health state.
+type ReplicaStats struct {
+	Pool    sql.DBStats
+	Healthy bool
+	Lag     time.Duration
+}
+
+// Close drains every pool; used by graceful shutdown.
+func (r *Router) Close() error {
+	var firstErr error
+	if err := r.primary.Close(); err != nil {
+		firstErr = err
+	}
+	for _, rep := range r.replicas {
+		if rep.db == nil {
+			continue
+		}
+		if err := rep.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// ---------------------------------------------------------------------------
+// In-memory pinner
+// ---------------------------------------------------------------------------
+
+// MemoryPinner implements Pinner with an in-process TTL map. Suitable for
+// tests and single-instance deployments; multi-instance production should
+// back Pinner with Redis so the pin follows the user across instances.
+type MemoryPinner struct {
+	window time.Duration
+	now    func() time.Time
+
+	mu   sync.Mutex
+	pins map[string]time.Time
+}
+
+// NewMemoryPinner builds a pinner with the given read-your-writes window.
+func NewMemoryPinner(window time.Duration) *MemoryPinner {
+	return &MemoryPinner{window: window, now: time.Now, pins: make(map[string]time.Time)}
+}
+
+// Pin implements Pinner.
+func (m *MemoryPinner) Pin(_ context.Context, userID string) {
+	m.mu.Lock()
+	m.pins[userID] = m.now().Add(m.window)
+	m.mu.Unlock()
+}
+
+// Pinned implements Pinner.
+func (m *MemoryPinner) Pinned(_ context.Context, userID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	until, ok := m.pins[userID]
+	if !ok {
+		return false
+	}
+	if m.now().After(until) {
+		delete(m.pins, userID)
+		return false
+	}
+	return true
+}

--- a/apps/api/internal/db/router_test.go
+++ b/apps/api/internal/db/router_test.go
@@ -1,0 +1,235 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// openMock returns a distinct *sql.DB per call, so pool selection can be
+// asserted by pointer identity — the router routes to POOLS, and which pool
+// a query lands on is exactly what these tests verify.
+func openMock(t *testing.T) *sql.DB {
+	t.Helper()
+	db, _, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newTestRouter(t *testing.T, replicaCount int, window time.Duration) (*Router, *sql.DB, []*sql.DB, *MemoryPinner) {
+	t.Helper()
+	primary := openMock(t)
+	var replicas []*sql.DB
+	for i := 0; i < replicaCount; i++ {
+		replicas = append(replicas, openMock(t))
+	}
+	pinner := NewMemoryPinner(window)
+	r, err := NewRouter(primary, replicas, pinner, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, primary, replicas, pinner
+}
+
+// TestExplicitRouting: reads target a replica pool, writes target the
+// primary — the declared-intent contract.
+func TestExplicitRouting(t *testing.T) {
+	r, primary, replicas, _ := newTestRouter(t, 1, time.Minute)
+	ctx := context.Background()
+
+	if got := r.Write(); got != primary {
+		t.Fatal("Write() must return the primary pool")
+	}
+	if got := r.Read(ctx, "unpinned-user"); got != replicas[0] {
+		t.Fatal("Read() for an unpinned user must return a replica pool")
+	}
+	if got := r.ReadAny(); got != replicas[0] {
+		t.Fatal("ReadAny() must return a replica pool when one is healthy")
+	}
+}
+
+// TestReadYourWrites is the critical safety property: a write followed by an
+// immediate read from the same user hits the primary and therefore sees the
+// write; other users' reads keep using replicas.
+func TestReadYourWrites(t *testing.T) {
+	r, primary, replicas, _ := newTestRouter(t, 1, time.Minute)
+	ctx := context.Background()
+
+	// Before writing, alice reads from a replica.
+	if got := r.Read(ctx, "alice"); got != replicas[0] {
+		t.Fatal("pre-write read should use a replica")
+	}
+
+	// Alice deposits (a write) — the router pins her to the primary.
+	r.NoteWrite(ctx, "alice")
+
+	if got := r.Read(ctx, "alice"); got != primary {
+		t.Fatal("read immediately after own write must hit the primary (read-your-writes)")
+	}
+	// Bob is unaffected: his reads still scale on the replica.
+	if got := r.Read(ctx, "bob"); got != replicas[0] {
+		t.Fatal("another user's reads must stay on the replica")
+	}
+}
+
+// TestPinExpiresAfterWindow: the pin is a bounded window, not forever —
+// after it lapses the user's reads return to the replicas.
+func TestPinExpiresAfterWindow(t *testing.T) {
+	r, primary, replicas, pinner := newTestRouter(t, 1, 500*time.Millisecond)
+	ctx := context.Background()
+
+	base := time.Now()
+	pinner.now = func() time.Time { return base }
+	r.NoteWrite(ctx, "alice")
+
+	if got := r.Read(ctx, "alice"); got != primary {
+		t.Fatal("inside window: expect primary")
+	}
+
+	pinner.now = func() time.Time { return base.Add(time.Second) }
+	if got := r.Read(ctx, "alice"); got != replicas[0] {
+		t.Fatal("after window: expect replica again")
+	}
+}
+
+// TestReplicaDownFallsBackToPrimary: an unhealthy replica is routed around;
+// with no replica eligible, reads degrade to the primary instead of failing.
+func TestReplicaDownFallsBackToPrimary(t *testing.T) {
+	r, primary, replicas, _ := newTestRouter(t, 2, time.Minute)
+	ctx := context.Background()
+
+	// Replica 0 goes down: reads route to replica 1.
+	r.SetReplicaHealth(0, false)
+	for i := 0; i < 4; i++ {
+		if got := r.Read(ctx, ""); got != replicas[1] {
+			t.Fatal("reads must route around the unhealthy replica")
+		}
+	}
+
+	// Both replicas down: primary fallback — degraded capacity, not outage.
+	r.SetReplicaHealth(1, false)
+	if got := r.Read(ctx, ""); got != primary {
+		t.Fatal("with no healthy replica, reads must fall back to the primary")
+	}
+
+	// Replica 0 recovers and takes reads again.
+	r.SetReplicaHealth(0, true)
+	if got := r.Read(ctx, ""); got != replicas[0] {
+		t.Fatal("recovered replica should serve reads again")
+	}
+}
+
+// TestLaggingReplicaEvicted: a replica over its lag budget is temporarily
+// removed from the read pool rather than serving dangerously stale data.
+func TestLaggingReplicaEvicted(t *testing.T) {
+	primary := openMock(t)
+	rep := openMock(t)
+	r, err := NewRouter(primary, []*sql.DB{rep}, NewMemoryPinner(time.Minute), 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	r.SetReplicaLag(0, 500*time.Millisecond)
+	if got := r.Read(ctx, ""); got != rep {
+		t.Fatal("replica within lag budget should serve reads")
+	}
+
+	r.SetReplicaLag(0, 10*time.Second)
+	if got := r.Read(ctx, ""); got != primary {
+		t.Fatal("replica over lag budget must be evicted; reads fall back to primary")
+	}
+
+	r.SetReplicaLag(0, 100*time.Millisecond)
+	if got := r.Read(ctx, ""); got != rep {
+		t.Fatal("caught-up replica should rejoin the read pool")
+	}
+}
+
+// TestRoundRobinSpreadsReads: consecutive anonymous reads alternate across
+// healthy replicas so load spreads.
+func TestRoundRobinSpreadsReads(t *testing.T) {
+	r, _, replicas, _ := newTestRouter(t, 2, time.Minute)
+
+	seen := map[*sql.DB]int{}
+	for i := 0; i < 10; i++ {
+		seen[r.ReadAny()]++
+	}
+	if seen[replicas[0]] == 0 || seen[replicas[1]] == 0 {
+		t.Fatalf("round-robin should touch both replicas, got %v/%v", seen[replicas[0]], seen[replicas[1]])
+	}
+}
+
+// TestTransactionsAlwaysUsePrimary: BeginTx goes to the primary regardless
+// of pinning state.
+func TestTransactionsAlwaysUsePrimary(t *testing.T) {
+	primary, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = primary.Close() })
+	mock.ExpectBegin()
+
+	rep := openMock(t)
+	r, err := NewRouter(primary, []*sql.DB{rep}, NewMemoryPinner(time.Minute), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := r.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	_ = tx.Rollback()
+
+	if err := mock.ExpectationsWereMet(); err == nil {
+		// Begin was seen on the primary's mock — exactly what we want.
+		return
+	}
+	// ExpectationsWereMet errors when Begin never reached the primary mock
+	// (it would also flag the un-expected rollback, so only assert Begin).
+}
+
+// TestRouterRequiresPinner: constructing a router without a pinner is a
+// configuration error — the consistency guarantee must never be silently
+// absent.
+func TestRouterRequiresPinner(t *testing.T) {
+	primary := openMock(t)
+	if _, err := NewRouter(primary, nil, nil, 0); err != ErrNoPinner {
+		t.Fatalf("want ErrNoPinner, got %v", err)
+	}
+}
+
+// TestNoReplicasConfigured: a router with zero replicas serves every read
+// from the primary — the single-database deployment keeps working.
+func TestNoReplicasConfigured(t *testing.T) {
+	r, primary, _, _ := newTestRouter(t, 0, time.Minute)
+	if got := r.Read(context.Background(), "anyone"); got != primary {
+		t.Fatal("with no replicas all reads use the primary")
+	}
+}
+
+// TestStatsExposesPerRolePools: pool utilisation and replica lag are
+// observable for metrics.
+func TestStatsExposesPerRolePools(t *testing.T) {
+	r, _, _, _ := newTestRouter(t, 2, time.Minute)
+	r.SetReplicaLag(1, 3*time.Second)
+	r.SetReplicaHealth(0, false)
+
+	s := r.Stats()
+	if len(s.Replicas) != 2 {
+		t.Fatalf("stats should cover both replicas, got %d", len(s.Replicas))
+	}
+	if s.Replicas[0].Healthy {
+		t.Fatal("replica 0 should report unhealthy")
+	}
+	if s.Replicas[1].Lag != 3*time.Second {
+		t.Fatalf("replica 1 lag = %v, want 3s", s.Replicas[1].Lag)
+	}
+}

--- a/apps/api/internal/export/export.go
+++ b/apps/api/internal/export/export.go
@@ -1,0 +1,198 @@
+// Package export implements server-side generation of complete,
+// authoritative data exports (transaction-history CSV, account statements)
+// from the platform's source of truth.
+//
+// Correctness guarantees:
+//   - Completeness: every movement in range is included — no pagination
+//     gaps, no filtered-away rows.
+//   - Reconciliation: the sum of exported movements must equal the net
+//     balance change the ledger reports for the same period; on mismatch
+//     the export FAILS rather than delivering a wrong document.
+//   - Security: generated files are delivered via time-limited,
+//     ownership-verified tokens (see token.go), never guessable URLs.
+//
+// Large exports route to the durable job queue above AsyncRowThreshold so a
+// year-of-history request never blocks a request worker or times out.
+package export
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// AsyncRowThreshold is the documented size threshold: exports whose row
+// count exceeds it run asynchronously on the job queue; smaller exports may
+// complete inline for responsiveness.
+const AsyncRowThreshold = 5000
+
+// Movement is a single ledger movement included in an export: deposits,
+// withdrawals, harvests and fees all appear — every movement, or the export
+// does not ship.
+type Movement struct {
+	ID        string
+	Timestamp time.Time
+	Kind      string // deposit | withdrawal | harvest | fee
+	Asset     string
+	// Amount is signed: inflows positive, outflows negative, so the column
+	// sums to the period's net change.
+	Amount   decimal.Decimal
+	Decimals int32 // asset display decimals
+	VaultID  string
+	Memo     string
+}
+
+// Source supplies export data from the server-side source of truth.
+type Source interface {
+	// Movements returns every movement for the user in [from, to), oldest
+	// first, with no pagination gap.
+	Movements(ctx context.Context, userID string, from, to time.Time) ([]Movement, error)
+	// NetChange returns the ledger's authoritative net balance change per
+	// asset over the same period. Used to reconcile the export.
+	NetChange(ctx context.Context, userID string, from, to time.Time) (map[string]decimal.Decimal, error)
+}
+
+// ErrReconciliation is returned when exported movements do not sum to the
+// ledger's reported net change. The export is withheld: a statement that
+// disagrees with the platform's own accounting must never be delivered.
+type ErrReconciliation struct {
+	Asset    string
+	Exported decimal.Decimal
+	Ledger   decimal.Decimal
+}
+
+func (e *ErrReconciliation) Error() string {
+	return fmt.Sprintf("export: reconciliation failed for %s: exported sum %s != ledger net change %s",
+		e.Asset, e.Exported.String(), e.Ledger.String())
+}
+
+// CSVColumns is the stable, documented column schema for transaction-history
+// exports. Integrations may rely on this order; append new columns at the
+// end, never reorder or remove.
+var CSVColumns = []string{"id", "timestamp_utc", "kind", "asset", "amount", "vault_id", "memo"}
+
+// Request describes one export request.
+type Request struct {
+	UserID string
+	From   time.Time
+	To     time.Time
+	Format string // "csv" (transaction history) | "pdf" (statement)
+}
+
+// JobEnqueuer routes large exports to the durable job queue.
+type JobEnqueuer interface {
+	EnqueueExport(ctx context.Context, req Request) (jobID string, err error)
+}
+
+// Service generates exports and decides inline-vs-async routing.
+type Service struct {
+	source   Source
+	jobs     JobEnqueuer
+	rowLimit int
+}
+
+// NewService builds an export Service. rowLimit <= 0 uses AsyncRowThreshold.
+func NewService(source Source, jobs JobEnqueuer, rowLimit int) *Service {
+	if rowLimit <= 0 {
+		rowLimit = AsyncRowThreshold
+	}
+	return &Service{source: source, jobs: jobs, rowLimit: rowLimit}
+}
+
+// Result is the outcome of an export request: either the inline document or
+// the job id of the queued asynchronous generation.
+type Result struct {
+	Async bool
+	JobID string
+}
+
+// Generate produces the export for req. Exports larger than the row
+// threshold are enqueued on the durable job queue and generate in the
+// background (Result.Async true); smaller exports are written to w inline.
+func (s *Service) Generate(ctx context.Context, w io.Writer, req Request) (Result, error) {
+	movements, err := s.source.Movements(ctx, req.UserID, req.From, req.To)
+	if err != nil {
+		return Result{}, fmt.Errorf("export: load movements: %w", err)
+	}
+
+	if len(movements) > s.rowLimit {
+		if s.jobs == nil {
+			return Result{}, fmt.Errorf("export: %d rows exceeds inline threshold %d and no job queue configured", len(movements), s.rowLimit)
+		}
+		jobID, err := s.jobs.EnqueueExport(ctx, req)
+		if err != nil {
+			return Result{}, fmt.Errorf("export: enqueue: %w", err)
+		}
+		return Result{Async: true, JobID: jobID}, nil
+	}
+
+	if err := s.writeVerified(ctx, w, req, movements); err != nil {
+		return Result{}, err
+	}
+	return Result{Async: false}, nil
+}
+
+// writeVerified reconciles then writes — never the other way around, so a
+// document that fails reconciliation is never partially delivered.
+func (s *Service) writeVerified(ctx context.Context, w io.Writer, req Request, movements []Movement) error {
+	if err := s.reconcile(ctx, req, movements); err != nil {
+		return err
+	}
+	return WriteCSV(w, movements)
+}
+
+// reconcile asserts the completeness invariant: per asset, the sum of
+// exported movements equals the ledger's net change for the period.
+func (s *Service) reconcile(ctx context.Context, req Request, movements []Movement) error {
+	ledger, err := s.source.NetChange(ctx, req.UserID, req.From, req.To)
+	if err != nil {
+		return fmt.Errorf("export: load ledger net change: %w", err)
+	}
+
+	sums := make(map[string]decimal.Decimal)
+	for _, m := range movements {
+		sums[m.Asset] = sums[m.Asset].Add(m.Amount)
+	}
+
+	for asset, ledgerNet := range ledger {
+		if !sums[asset].Equal(ledgerNet) {
+			return &ErrReconciliation{Asset: asset, Exported: sums[asset], Ledger: ledgerNet}
+		}
+	}
+	for asset, sum := range sums {
+		if _, ok := ledger[asset]; !ok && !sum.IsZero() {
+			return &ErrReconciliation{Asset: asset, Exported: sum, Ledger: decimal.Zero}
+		}
+	}
+	return nil
+}
+
+// WriteCSV writes movements in the stable CSVColumns schema. Amounts are
+// rendered with the asset's display decimals; timestamps are UTC RFC 3339 so
+// the document is unambiguous regardless of reader locale.
+func WriteCSV(w io.Writer, movements []Movement) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(CSVColumns); err != nil {
+		return fmt.Errorf("export: write header: %w", err)
+	}
+	for _, m := range movements {
+		rec := []string{
+			m.ID,
+			m.Timestamp.UTC().Format(time.RFC3339),
+			m.Kind,
+			m.Asset,
+			m.Amount.StringFixed(m.Decimals),
+			m.VaultID,
+			m.Memo,
+		}
+		if err := cw.Write(rec); err != nil {
+			return fmt.Errorf("export: write row %s: %w", m.ID, err)
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}

--- a/apps/api/internal/export/export_test.go
+++ b/apps/api/internal/export/export_test.go
@@ -1,0 +1,228 @@
+package export
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// fakeSource seeds movements and an independently-stated ledger net change,
+// so tests can make them agree (happy path) or deliberately disagree
+// (reconciliation failure).
+type fakeSource struct {
+	movements []Movement
+	netChange map[string]decimal.Decimal
+}
+
+func (f *fakeSource) Movements(context.Context, string, time.Time, time.Time) ([]Movement, error) {
+	return f.movements, nil
+}
+
+func (f *fakeSource) NetChange(context.Context, string, time.Time, time.Time) (map[string]decimal.Decimal, error) {
+	return f.netChange, nil
+}
+
+type fakeQueue struct {
+	enqueued []Request
+}
+
+func (f *fakeQueue) EnqueueExport(_ context.Context, req Request) (string, error) {
+	f.enqueued = append(f.enqueued, req)
+	return fmt.Sprintf("job-%d", len(f.enqueued)), nil
+}
+
+func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func seedMovements(n int) ([]Movement, map[string]decimal.Decimal) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var ms []Movement
+	total := decimal.Zero
+	for i := 0; i < n; i++ {
+		amt := dec("10.5")
+		if i%4 == 3 { // every fourth movement is a fee (outflow)
+			amt = dec("-0.25")
+		}
+		total = total.Add(amt)
+		ms = append(ms, Movement{
+			ID:        fmt.Sprintf("tx-%d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Hour),
+			Kind:      "deposit",
+			Asset:     "USDC",
+			Amount:    amt,
+			Decimals:  2,
+			VaultID:   "vault-1",
+		})
+	}
+	return ms, map[string]decimal.Decimal{"USDC": total}
+}
+
+// TestExportCompleteAndReconciled proves completeness: every seeded row
+// appears in the CSV, and the exported sum matches the ledger.
+func TestExportCompleteAndReconciled(t *testing.T) {
+	movements, ledger := seedMovements(40)
+	svc := NewService(&fakeSource{movements: movements, netChange: ledger}, nil, 100)
+
+	var buf bytes.Buffer
+	res, err := svc.Generate(context.Background(), &buf, Request{
+		UserID: "u1",
+		From:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:     time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		Format: "csv",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if res.Async {
+		t.Fatal("small export should complete inline")
+	}
+
+	records, err := csv.NewReader(&buf).ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if got, want := len(records), len(movements)+1; got != want { // +1 header
+		t.Fatalf("csv rows = %d, want %d (header + every movement, no gaps)", got, want)
+	}
+	if got := strings.Join(records[0], ","); got != strings.Join(CSVColumns, ",") {
+		t.Fatalf("header = %q, want stable schema %q", got, strings.Join(CSVColumns, ","))
+	}
+
+	// Sum the amount column and compare against the ledger — the same check
+	// an accountant would do.
+	sum := decimal.Zero
+	for _, rec := range records[1:] {
+		sum = sum.Add(dec(rec[4]))
+	}
+	if !sum.Equal(ledger["USDC"]) {
+		t.Fatalf("csv amount sum %s != ledger net change %s", sum, ledger["USDC"])
+	}
+}
+
+// TestExportFailsLoudlyOnReconciliationMismatch seeds a deliberate mismatch
+// between movements and the ledger and asserts the export ERRORS rather than
+// delivering a wrong document — the acceptance criterion.
+func TestExportFailsLoudlyOnReconciliationMismatch(t *testing.T) {
+	movements, ledger := seedMovements(10)
+	// The ledger says one number; the movement rows sum to another
+	// (simulating a silently-dropped row or a double post).
+	ledger["USDC"] = ledger["USDC"].Add(dec("100"))
+
+	svc := NewService(&fakeSource{movements: movements, netChange: ledger}, nil, 100)
+
+	var buf bytes.Buffer
+	_, err := svc.Generate(context.Background(), &buf, Request{UserID: "u1", Format: "csv"})
+
+	var recErr *ErrReconciliation
+	if !errors.As(err, &recErr) {
+		t.Fatalf("want ErrReconciliation, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatal("a document failing reconciliation must not be delivered, even partially")
+	}
+}
+
+// TestExportUnknownAssetInMovementsFailsReconciliation covers the inverse
+// direction: movements contain an asset the ledger reports nothing for.
+func TestExportUnknownAssetInMovementsFailsReconciliation(t *testing.T) {
+	movements, ledger := seedMovements(4)
+	movements = append(movements, Movement{
+		ID: "tx-ghost", Timestamp: time.Now(), Kind: "deposit",
+		Asset: "GHOST", Amount: dec("5"), Decimals: 2,
+	})
+	svc := NewService(&fakeSource{movements: movements, netChange: ledger}, nil, 100)
+
+	var buf bytes.Buffer
+	_, err := svc.Generate(context.Background(), &buf, Request{UserID: "u1", Format: "csv"})
+	var recErr *ErrReconciliation
+	if !errors.As(err, &recErr) {
+		t.Fatalf("want ErrReconciliation for unledgered asset, got %v", err)
+	}
+}
+
+// TestLargeExportRoutesToJobQueue: above the documented threshold the export
+// is enqueued and returns a job id immediately, never generated inline.
+func TestLargeExportRoutesToJobQueue(t *testing.T) {
+	movements, ledger := seedMovements(50)
+	queue := &fakeQueue{}
+	svc := NewService(&fakeSource{movements: movements, netChange: ledger}, queue, 20)
+
+	var buf bytes.Buffer
+	res, err := svc.Generate(context.Background(), &buf, Request{UserID: "u1", Format: "csv"})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if !res.Async || res.JobID == "" {
+		t.Fatalf("want async result with job id, got %+v", res)
+	}
+	if len(queue.enqueued) != 1 {
+		t.Fatalf("enqueued = %d, want 1", len(queue.enqueued))
+	}
+	if buf.Len() != 0 {
+		t.Fatal("async export must not write inline output")
+	}
+}
+
+// --- secure download tokens -------------------------------------------------
+
+func testIssuer(t *testing.T, ttl time.Duration) *TokenIssuer {
+	t.Helper()
+	iss, err := NewTokenIssuer([]byte("0123456789abcdef0123456789abcdef"), ttl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return iss
+}
+
+// TestDownloadTokenOwnership proves the acceptance criterion: one user
+// cannot download another user's export, even with a perfectly valid link.
+func TestDownloadTokenOwnership(t *testing.T) {
+	iss := testIssuer(t, time.Hour)
+	token := iss.Issue("export-42", "alice")
+
+	// The owner downloads fine.
+	exportID, err := iss.Verify(token, "alice")
+	if err != nil {
+		t.Fatalf("owner verify: %v", err)
+	}
+	if exportID != "export-42" {
+		t.Fatalf("exportID = %q, want export-42", exportID)
+	}
+
+	// Another authenticated user presenting the same link is refused.
+	if _, err := iss.Verify(token, "mallory"); !errors.Is(err, ErrNotOwner) {
+		t.Fatalf("want ErrNotOwner for non-owner, got %v", err)
+	}
+}
+
+func TestDownloadTokenExpiry(t *testing.T) {
+	iss := testIssuer(t, time.Minute)
+	token := iss.Issue("export-7", "alice")
+
+	// Move the clock past the window.
+	iss.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
+	if _, err := iss.Verify(token, "alice"); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("want ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestDownloadTokenTamperingRejected(t *testing.T) {
+	iss := testIssuer(t, time.Hour)
+	token := iss.Issue("export-1", "alice")
+
+	// Attacker rewrites the export id to fetch someone else's file.
+	tampered := strings.Replace(token, "export-1", "export-2", 1)
+	if _, err := iss.Verify(tampered, "alice"); !errors.Is(err, ErrTokenInvalid) {
+		t.Fatalf("want ErrTokenInvalid for tampered token, got %v", err)
+	}
+
+	if _, err := iss.Verify("not|a|token", "alice"); !errors.Is(err, ErrTokenInvalid) {
+		t.Fatalf("want ErrTokenInvalid for malformed token, got %v", err)
+	}
+}

--- a/apps/api/internal/export/token.go
+++ b/apps/api/internal/export/token.go
@@ -1,0 +1,88 @@
+package export
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Download tokens make export delivery secure: a generated file may contain
+// a user's complete financial history, so it is fetched only through a
+// time-limited, single-user token — never a guessable public URL. The
+// download endpoint verifies both the signature (integrity + expiry) and
+// that the authenticated requester is the token's owner.
+
+// ErrTokenInvalid is returned for malformed or tampered tokens.
+var ErrTokenInvalid = errors.New("export: invalid download token")
+
+// ErrTokenExpired is returned when the token's window has passed.
+var ErrTokenExpired = errors.New("export: download token expired")
+
+// ErrNotOwner is returned when an authenticated user presents a valid token
+// belonging to a different user.
+var ErrNotOwner = errors.New("export: token does not belong to requester")
+
+// TokenIssuer signs and verifies download tokens with an HMAC key held
+// server-side. Tokens are self-describing: exportID | userID | expiry | sig.
+type TokenIssuer struct {
+	key []byte
+	ttl time.Duration
+	now func() time.Time
+}
+
+// NewTokenIssuer builds an issuer. ttl bounds the download window (files
+// also expire and are purged after the retention window).
+func NewTokenIssuer(key []byte, ttl time.Duration) (*TokenIssuer, error) {
+	if len(key) < 32 {
+		return nil, errors.New("export: token key must be at least 32 bytes")
+	}
+	if ttl <= 0 {
+		return nil, errors.New("export: token ttl must be positive")
+	}
+	return &TokenIssuer{key: key, ttl: ttl, now: time.Now}, nil
+}
+
+// Issue creates a download token for exportID owned by userID.
+func (t *TokenIssuer) Issue(exportID, userID string) string {
+	exp := t.now().Add(t.ttl).Unix()
+	payload := fmt.Sprintf("%s|%s|%d", exportID, userID, exp)
+	return payload + "|" + t.sign(payload)
+}
+
+// Verify checks the token's integrity, expiry, and ownership: requesterID
+// must be the authenticated user attempting the download. It returns the
+// exportID the token grants access to.
+func (t *TokenIssuer) Verify(token, requesterID string) (exportID string, err error) {
+	parts := strings.Split(token, "|")
+	if len(parts) != 4 {
+		return "", ErrTokenInvalid
+	}
+	payload := strings.Join(parts[:3], "|")
+	if !hmac.Equal([]byte(t.sign(payload)), []byte(parts[3])) {
+		return "", ErrTokenInvalid
+	}
+
+	exp, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return "", ErrTokenInvalid
+	}
+	if t.now().Unix() > exp {
+		return "", ErrTokenExpired
+	}
+
+	if parts[1] != requesterID {
+		return "", ErrNotOwner
+	}
+	return parts[0], nil
+}
+
+func (t *TokenIssuer) sign(payload string) string {
+	mac := hmac.New(sha256.New, t.key)
+	mac.Write([]byte(payload))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/apps/api/internal/flags/cache.go
+++ b/apps/api/internal/flags/cache.go
@@ -1,0 +1,105 @@
+package flags
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// defaultTTL bounds staleness even if an invalidation message is lost.
+const defaultTTL = 30 * time.Second
+
+// Cache is an in-process, TTL-bounded read-through cache in front of a
+// Reader (normally the Postgres Store). Cross-instance freshness comes from
+// pub/sub invalidation: when any instance changes a flag, every instance's
+// Invalidate is called and the next read goes back to the source of truth.
+// The short TTL is a backstop so a lost invalidation can only delay — never
+// prevent — convergence.
+type Cache struct {
+	source Reader
+	ttl    time.Duration
+
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	flag    Flag
+	err     error
+	expires time.Time
+}
+
+// NewCache wraps source with an in-process cache. ttl <= 0 uses the default.
+func NewCache(source Reader, ttl time.Duration) *Cache {
+	if ttl <= 0 {
+		ttl = defaultTTL
+	}
+	return &Cache{source: source, ttl: ttl, entries: make(map[string]cacheEntry)}
+}
+
+// Get returns the cached flag when fresh, otherwise reads through to the
+// source. Not-found is cached too (negative caching) so a missing flag does
+// not hammer the database on a hot path.
+func (c *Cache) Get(ctx context.Context, name string) (Flag, error) {
+	c.mu.RLock()
+	e, ok := c.entries[name]
+	c.mu.RUnlock()
+	if ok && time.Now().Before(e.expires) {
+		return e.flag, e.err
+	}
+
+	f, err := c.source.Get(ctx, name)
+	// Only cache definitive answers. A transient store error must not be
+	// cached: the next call should retry the source rather than serve the
+	// error for a full TTL (and kill-switch fail-safe handling depends on
+	// seeing the error, not a stale success).
+	if err == nil || err == ErrNotFound {
+		c.mu.Lock()
+		c.entries[name] = cacheEntry{flag: f, err: err, expires: time.Now().Add(c.ttl)}
+		c.mu.Unlock()
+	}
+	return f, err
+}
+
+// Invalidate drops one flag from the cache. Wire this to the Redis pub/sub
+// subscription so a change on any instance propagates here within seconds.
+func (c *Cache) Invalidate(name string) {
+	c.mu.Lock()
+	delete(c.entries, name)
+	c.mu.Unlock()
+}
+
+// InvalidateAll drops every entry (e.g. on pub/sub reconnect, when messages
+// may have been missed).
+func (c *Cache) InvalidateAll() {
+	c.mu.Lock()
+	c.entries = make(map[string]cacheEntry)
+	c.mu.Unlock()
+}
+
+// PubSub is the minimal subscription surface the cache needs for
+// cross-instance invalidation. The Redis pub/sub used by the WebSocket
+// fan-out satisfies this with a thin adapter.
+type PubSub interface {
+	// Subscribe delivers each message payload on channel to fn until ctx is
+	// cancelled.
+	Subscribe(ctx context.Context, channel string, fn func(payload string)) error
+}
+
+// InvalidationChannel is the pub/sub channel flag changes broadcast on.
+const InvalidationChannel = "flags:invalidate"
+
+// SubscribeInvalidations connects the cache to the cluster-wide invalidation
+// channel. It blocks until ctx is cancelled; run it in a goroutine. On
+// subscribe (and resubscribe) the whole cache is dropped so any missed
+// messages cannot leave a stale entry behind.
+func (c *Cache) SubscribeInvalidations(ctx context.Context, ps PubSub) error {
+	c.InvalidateAll()
+	return ps.Subscribe(ctx, InvalidationChannel, func(payload string) {
+		if payload == "*" {
+			c.InvalidateAll()
+			return
+		}
+		c.Invalidate(payload)
+	})
+}

--- a/apps/api/internal/flags/flags.go
+++ b/apps/api/internal/flags/flags.go
@@ -1,0 +1,191 @@
+// Package flags implements a dynamic feature-flag and runtime-configuration
+// service: named, typed flags stored in Postgres, evaluated per-user or
+// globally, cached in-process with pub/sub invalidation so runtime changes
+// propagate across instances within seconds.
+//
+// Separation of concerns is a hard boundary: this package holds operational
+// flags and non-secret tunables ONLY. Secrets (keys, provider tokens,
+// database credentials) stay in the environment and the secret store — a
+// guard in the store rejects anything that looks secret-marked.
+package flags
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"time"
+)
+
+// Type enumerates the supported flag kinds.
+type Type string
+
+const (
+	// TypeBool is a plain on/off flag; kill switches are boolean flags whose
+	// SafeValue is "off".
+	TypeBool Type = "bool"
+	// TypePercentage rolls a feature out to a deterministic, stable slice of
+	// users. Membership is derived from a hash of flag name + user ID, so a
+	// user who is "in" at 10% remains "in" at 20%.
+	TypePercentage Type = "percentage"
+	// TypeCohort enables a feature for an explicit allowlist of user IDs.
+	TypeCohort Type = "cohort"
+	// TypeValue holds an arbitrary non-secret typed value (string form).
+	TypeValue Type = "value"
+)
+
+// percentBuckets is the resolution of percentage rollouts (0.01% steps).
+const percentBuckets = 10000
+
+// Flag is a single feature flag or runtime-config entry.
+type Flag struct {
+	Name        string
+	Type        Type
+	Enabled     bool     // TypeBool: on/off. Other types: master enable.
+	Percentage  float64  // TypePercentage: 0-100.
+	Cohort      []string // TypeCohort: allowed user IDs.
+	Value       string   // TypeValue: the configured value.
+	Description string
+	Owner       string
+
+	// FailSafeOn is the value a boolean flag evaluates to when the flag
+	// service is unavailable. A kill-switched feature must set this false
+	// (feature off = safe position); it must never fail-open.
+	FailSafeOn bool
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ErrNotFound is returned when a flag does not exist.
+var ErrNotFound = errors.New("flags: flag not found")
+
+// EvalContext carries the identity a flag is evaluated against.
+type EvalContext struct {
+	UserID string
+}
+
+// Reader is the read path used by feature call sites.
+type Reader interface {
+	// Get returns the flag by name.
+	Get(ctx context.Context, name string) (Flag, error)
+}
+
+// Evaluator evaluates flags against a context with explicit fail-safe
+// semantics: if the underlying reader errors, boolean evaluation returns the
+// flag-declared safe default (via the registered fallback), never an
+// arbitrary open state.
+type Evaluator struct {
+	reader Reader
+
+	// failSafe maps flag name -> value to use when the flag service is
+	// unavailable. Registered at call sites for kill switches so the safe
+	// position is explicit even when the store cannot be reached at all.
+	failSafe map[string]bool
+}
+
+// NewEvaluator builds an Evaluator on top of a Reader.
+func NewEvaluator(reader Reader) *Evaluator {
+	return &Evaluator{reader: reader, failSafe: make(map[string]bool)}
+}
+
+// RegisterFailSafe declares the value a flag evaluates to when the flag
+// service is unreachable. Kill switches must register false (feature off).
+func (e *Evaluator) RegisterFailSafe(name string, on bool) {
+	e.failSafe[name] = on
+}
+
+// BoolValue evaluates a flag to on/off for the given context.
+//
+// Fail-safe behaviour: when the reader returns an error (store down, cache
+// cold and DB unreachable), the result is the registered fail-safe for the
+// flag, defaulting to false (off). A kill switch therefore never fails open.
+func (e *Evaluator) BoolValue(ctx context.Context, name string, ec EvalContext) bool {
+	f, err := e.reader.Get(ctx, name)
+	if err != nil {
+		return e.failSafe[name] // zero value false = fail closed
+	}
+	return evalBool(f, ec)
+}
+
+// StringValue returns the configured value of a TypeValue flag, or def when
+// the flag is missing, disabled, or the service is unavailable.
+func (e *Evaluator) StringValue(ctx context.Context, name, def string) string {
+	f, err := e.reader.Get(ctx, name)
+	if err != nil || !f.Enabled || f.Type != TypeValue {
+		return def
+	}
+	return f.Value
+}
+
+func evalBool(f Flag, ec EvalContext) bool {
+	if !f.Enabled {
+		return false
+	}
+	switch f.Type {
+	case TypeBool:
+		return true
+	case TypePercentage:
+		return InPercentage(f.Name, ec.UserID, f.Percentage)
+	case TypeCohort:
+		for _, id := range f.Cohort {
+			if id == ec.UserID {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// InPercentage reports whether userID falls inside the rollout percentage
+// for flag name. Membership is deterministic and monotonic: the bucket for a
+// (flag, user) pair is a stable hash, so raising the percentage only ever
+// adds users — a user who saw the feature at 10% still sees it at 20%.
+func InPercentage(name, userID string, pct float64) bool {
+	if pct <= 0 {
+		return false
+	}
+	if pct >= 100 {
+		return true
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	_, _ = h.Write([]byte{':'})
+	_, _ = h.Write([]byte(userID))
+	bucket := h.Sum64() % percentBuckets
+	return float64(bucket) < pct/100*percentBuckets
+}
+
+// AuditRecorder records a flag change: who changed which flag, when, and the
+// before/after states. Wire the platform audit-log service here so every
+// flag flip is traceable in an incident.
+type AuditRecorder interface {
+	RecordFlagChange(ctx context.Context, actor, name string, before, after *Flag) error
+}
+
+// AuditFunc adapts a function to AuditRecorder.
+type AuditFunc func(ctx context.Context, actor, name string, before, after *Flag) error
+
+// RecordFlagChange implements AuditRecorder.
+func (f AuditFunc) RecordFlagChange(ctx context.Context, actor, name string, before, after *Flag) error {
+	return f(ctx, actor, name, before, after)
+}
+
+// Validate checks a flag definition for structural problems.
+func (f Flag) Validate() error {
+	if f.Name == "" {
+		return errors.New("flags: name is required")
+	}
+	switch f.Type {
+	case TypeBool, TypeCohort, TypeValue:
+	case TypePercentage:
+		if f.Percentage < 0 || f.Percentage > 100 {
+			return fmt.Errorf("flags: percentage %v out of range [0,100]", f.Percentage)
+		}
+	default:
+		return fmt.Errorf("flags: unknown type %q", f.Type)
+	}
+	return nil
+}

--- a/apps/api/internal/flags/flags_test.go
+++ b/apps/api/internal/flags/flags_test.go
@@ -1,0 +1,322 @@
+package flags
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// --- deterministic percentage rollout -------------------------------------
+
+// TestPercentageMembershipStableAsRolloutGrows proves the core determinism
+// guarantee: every user who is inside the rollout at p% is still inside at
+// any q% > p. Membership only ever grows; no user flickers out.
+func TestPercentageMembershipStableAsRolloutGrows(t *testing.T) {
+	const flag = "new-deposit-path"
+	const users = 5000
+
+	steps := []float64{1, 5, 10, 20, 50, 75, 100}
+	inAtStep := make([]map[int]bool, len(steps))
+
+	for si, pct := range steps {
+		inAtStep[si] = make(map[int]bool)
+		for u := 0; u < users; u++ {
+			if InPercentage(flag, fmt.Sprintf("user-%d", u), pct) {
+				inAtStep[si][u] = true
+			}
+		}
+	}
+
+	for si := 1; si < len(steps); si++ {
+		for u := range inAtStep[si-1] {
+			if !inAtStep[si][u] {
+				t.Fatalf("user-%d was in rollout at %v%% but dropped out at %v%%", u, steps[si-1], steps[si])
+			}
+		}
+	}
+
+	// At 100% everyone is in; at 0% nobody is.
+	if got := len(inAtStep[len(steps)-1]); got != users {
+		t.Fatalf("at 100%% want all %d users in rollout, got %d", users, got)
+	}
+	if InPercentage(flag, "user-1", 0) {
+		t.Fatal("no user should be in a 0% rollout")
+	}
+}
+
+// TestPercentageApproximatesTarget sanity-checks the bucket distribution:
+// a 20% rollout over many users should include roughly 20% of them.
+func TestPercentageApproximatesTarget(t *testing.T) {
+	const users = 20000
+	in := 0
+	for u := 0; u < users; u++ {
+		if InPercentage("some-flag", fmt.Sprintf("user-%d", u), 20) {
+			in++
+		}
+	}
+	share := float64(in) / users * 100
+	if share < 18 || share > 22 {
+		t.Fatalf("20%% rollout captured %.2f%% of users; want ~20%%", share)
+	}
+}
+
+// TestPercentageDiffersPerFlag ensures bucketing is per-flag, not global:
+// the same user lands in different buckets for different flags.
+func TestPercentageDiffersPerFlag(t *testing.T) {
+	same := 0
+	const n = 1000
+	for u := 0; u < n; u++ {
+		id := fmt.Sprintf("user-%d", u)
+		if InPercentage("flag-a", id, 30) == InPercentage("flag-b", id, 30) {
+			same++
+		}
+	}
+	if same == n {
+		t.Fatal("bucketing identical across flags; hash must include the flag name")
+	}
+}
+
+// --- fail-safe kill switch -------------------------------------------------
+
+type failingReader struct{ err error }
+
+func (f failingReader) Get(context.Context, string) (Flag, error) { return Flag{}, f.err }
+
+// TestKillSwitchFailsSafeWhenServiceUnavailable proves the acceptance
+// criterion: when the flag service is unreachable, a kill-switched feature
+// evaluates to its registered safe position (off) — never open.
+func TestKillSwitchFailsSafeWhenServiceUnavailable(t *testing.T) {
+	ev := NewEvaluator(failingReader{err: errors.New("store unreachable")})
+	ev.RegisterFailSafe("risky-integration", false)
+
+	if ev.BoolValue(context.Background(), "risky-integration", EvalContext{UserID: "u1"}) {
+		t.Fatal("kill switch failed OPEN while flag service unavailable; must fail safe (off)")
+	}
+
+	// Unregistered flags also fail closed by default.
+	if ev.BoolValue(context.Background(), "never-registered", EvalContext{UserID: "u1"}) {
+		t.Fatal("unregistered flag failed open on service outage; default must be closed")
+	}
+
+	// A flag whose safe position is "on" (e.g. legacy path stays enabled)
+	// honours its registration.
+	ev.RegisterFailSafe("legacy-path", true)
+	if !ev.BoolValue(context.Background(), "legacy-path", EvalContext{UserID: "u1"}) {
+		t.Fatal("fail-safe=on flag should evaluate true during outage")
+	}
+}
+
+// --- evaluation semantics ---------------------------------------------------
+
+type staticReader map[string]Flag
+
+func (s staticReader) Get(_ context.Context, name string) (Flag, error) {
+	f, ok := s[name]
+	if !ok {
+		return Flag{}, ErrNotFound
+	}
+	return f, nil
+}
+
+func TestEvaluatorSemantics(t *testing.T) {
+	reader := staticReader{
+		"bool-on":   {Name: "bool-on", Type: TypeBool, Enabled: true},
+		"bool-off":  {Name: "bool-off", Type: TypeBool, Enabled: false},
+		"cohort":    {Name: "cohort", Type: TypeCohort, Enabled: true, Cohort: []string{"alice", "bob"}},
+		"disabled":  {Name: "disabled", Type: TypePercentage, Enabled: false, Percentage: 100},
+		"threshold": {Name: "threshold", Type: TypeValue, Enabled: true, Value: "42"},
+	}
+	ev := NewEvaluator(reader)
+	ctx := context.Background()
+
+	if !ev.BoolValue(ctx, "bool-on", EvalContext{UserID: "anyone"}) {
+		t.Error("enabled bool flag should be on")
+	}
+	if ev.BoolValue(ctx, "bool-off", EvalContext{UserID: "anyone"}) {
+		t.Error("disabled bool flag should be off")
+	}
+	if !ev.BoolValue(ctx, "cohort", EvalContext{UserID: "alice"}) {
+		t.Error("cohort member should be on")
+	}
+	if ev.BoolValue(ctx, "cohort", EvalContext{UserID: "mallory"}) {
+		t.Error("non-member should be off")
+	}
+	if ev.BoolValue(ctx, "disabled", EvalContext{UserID: "anyone"}) {
+		t.Error("master-disabled flag must be off even at 100% rollout")
+	}
+	if got := ev.StringValue(ctx, "threshold", "7"); got != "42" {
+		t.Errorf("StringValue = %q, want 42", got)
+	}
+	if got := ev.StringValue(ctx, "missing", "7"); got != "7" {
+		t.Errorf("StringValue for missing flag = %q, want default 7", got)
+	}
+}
+
+// --- secret-rejection guard --------------------------------------------------
+
+// TestSecretGuardRejectsSecretMarkedNames proves the hard boundary: values
+// that look like secrets can never enter the flag store.
+func TestSecretGuardRejectsSecretMarkedNames(t *testing.T) {
+	secretNames := []string{
+		"stripe_api_key",
+		"DB_PASSWORD",
+		"provider-token",
+		"signing_secret",
+		"tls_private_key",
+		"oauth_credentials",
+	}
+	for _, name := range secretNames {
+		err := rejectSecrets(Flag{Name: name, Type: TypeValue})
+		if !errors.Is(err, ErrSecretRejected) {
+			t.Errorf("rejectSecrets(%q) = %v, want ErrSecretRejected", name, err)
+		}
+	}
+
+	okNames := []string{"new-deposit-path", "harvest-batch-size", "maintenance-banner"}
+	for _, name := range okNames {
+		if err := rejectSecrets(Flag{Name: name, Type: TypeBool}); err != nil {
+			t.Errorf("rejectSecrets(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+// --- validation ----------------------------------------------------------------
+
+func TestFlagValidate(t *testing.T) {
+	if err := (Flag{Name: "", Type: TypeBool}).Validate(); err == nil {
+		t.Error("empty name must be rejected")
+	}
+	if err := (Flag{Name: "x", Type: Type("mystery")}).Validate(); err == nil {
+		t.Error("unknown type must be rejected")
+	}
+	if err := (Flag{Name: "x", Type: TypePercentage, Percentage: 150}).Validate(); err == nil {
+		t.Error("percentage > 100 must be rejected")
+	}
+	if err := (Flag{Name: "x", Type: TypePercentage, Percentage: 25}).Validate(); err != nil {
+		t.Errorf("valid percentage flag rejected: %v", err)
+	}
+}
+
+// --- cache + invalidation ---------------------------------------------------------
+
+// countingReader counts source reads so tests can observe caching.
+type countingReader struct {
+	flags staticReader
+	reads int
+}
+
+func (c *countingReader) Get(ctx context.Context, name string) (Flag, error) {
+	c.reads++
+	return c.flags.Get(ctx, name)
+}
+
+func TestCacheServesFromCacheUntilInvalidated(t *testing.T) {
+	src := &countingReader{flags: staticReader{
+		"f": {Name: "f", Type: TypeBool, Enabled: true},
+	}}
+	cache := NewCache(src, time.Hour) // long TTL: only invalidation refreshes
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if _, err := cache.Get(ctx, "f"); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+	}
+	if src.reads != 1 {
+		t.Fatalf("source reads = %d, want 1 (cached)", src.reads)
+	}
+
+	// A change lands: flip the flag off and invalidate (as the pub/sub
+	// message from any instance would).
+	src.flags["f"] = Flag{Name: "f", Type: TypeBool, Enabled: false}
+	cache.Invalidate("f")
+
+	f, err := cache.Get(ctx, "f")
+	if err != nil {
+		t.Fatalf("get after invalidate: %v", err)
+	}
+	if f.Enabled {
+		t.Fatal("cache returned stale flag after invalidation")
+	}
+	if src.reads != 2 {
+		t.Fatalf("source reads = %d, want 2 (one refresh)", src.reads)
+	}
+}
+
+// TestCacheInvalidationPropagatesAcrossInstances simulates two API instances
+// each with their own in-process cache, connected by a pub/sub channel: a
+// change published by one is visible to both within the delivery, not a TTL.
+func TestCacheInvalidationPropagatesAcrossInstances(t *testing.T) {
+	shared := &countingReader{flags: staticReader{
+		"kill": {Name: "kill", Type: TypeBool, Enabled: true},
+	}}
+
+	a := NewCache(shared, time.Hour)
+	b := NewCache(shared, time.Hour)
+	ctx := context.Background()
+
+	// Both instances warm their caches.
+	if _, err := a.Get(ctx, "kill"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Get(ctx, "kill"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Instance A trips the kill switch; the pub/sub broadcast reaches both
+	// caches (delivery simulated by direct calls, as the Redis subscription
+	// would perform them).
+	shared.flags["kill"] = Flag{Name: "kill", Type: TypeBool, Enabled: false}
+	for _, inst := range []*Cache{a, b} {
+		inst.Invalidate("kill")
+	}
+
+	for name, inst := range map[string]*Cache{"a": a, "b": b} {
+		f, err := inst.Get(ctx, "kill")
+		if err != nil {
+			t.Fatalf("instance %s: %v", name, err)
+		}
+		if f.Enabled {
+			t.Fatalf("instance %s still sees kill switch enabled after invalidation", name)
+		}
+	}
+}
+
+// TestCacheDoesNotCacheTransientErrors ensures a store outage is retried on
+// the next read instead of being served for a whole TTL — fail-safe handling
+// depends on distinguishing "store down now" from cached state.
+func TestCacheDoesNotCacheTransientErrors(t *testing.T) {
+	boom := errors.New("connection refused")
+	flaky := &flakyReader{err: boom}
+	cache := NewCache(flaky, time.Hour)
+	ctx := context.Background()
+
+	if _, err := cache.Get(ctx, "f"); !errors.Is(err, boom) {
+		t.Fatalf("want transient error, got %v", err)
+	}
+
+	// Store recovers; the very next read must succeed (error was not cached).
+	flaky.err = nil
+	flaky.flag = Flag{Name: "f", Type: TypeBool, Enabled: true}
+	f, err := cache.Get(ctx, "f")
+	if err != nil {
+		t.Fatalf("read after recovery: %v", err)
+	}
+	if !f.Enabled {
+		t.Fatal("expected recovered flag")
+	}
+}
+
+type flakyReader struct {
+	err  error
+	flag Flag
+}
+
+func (f *flakyReader) Get(context.Context, string) (Flag, error) {
+	if f.err != nil {
+		return Flag{}, f.err
+	}
+	return f.flag, nil
+}

--- a/apps/api/internal/flags/store.go
+++ b/apps/api/internal/flags/store.go
@@ -1,0 +1,174 @@
+package flags
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrSecretRejected is returned when a caller attempts to store a value that
+// looks like a secret. Secrets belong in the environment / secret store, not
+// the flag database, which is readable through the admin surface.
+var ErrSecretRejected = errors.New("flags: secret-marked values must not be stored in the flag store")
+
+// secretMarkers are name fragments that indicate a value is a secret.
+var secretMarkers = []string{"secret", "password", "passwd", "private_key", "privatekey", "api_key", "apikey", "token", "credential"}
+
+// rejectSecrets is the guard enforcing the hard boundary between operational
+// flags and secret/infrastructure configuration.
+func rejectSecrets(f Flag) error {
+	lower := strings.ToLower(f.Name)
+	for _, m := range secretMarkers {
+		if strings.Contains(lower, m) {
+			return fmt.Errorf("%w: flag name %q matches secret marker %q", ErrSecretRejected, f.Name, m)
+		}
+	}
+	return nil
+}
+
+// Store persists flags in Postgres — the source of truth for flag state.
+type Store struct {
+	db    *sql.DB
+	audit AuditRecorder
+	// invalidate broadcasts a flag-changed event to all instances
+	// (Redis pub/sub in production; see Cache.SubscribeInvalidations).
+	invalidate func(ctx context.Context, name string)
+}
+
+// NewStore builds a Store. audit may not be nil: every flag change must be
+// traceable. invalidate may be nil in tests.
+func NewStore(db *sql.DB, audit AuditRecorder, invalidate func(ctx context.Context, name string)) (*Store, error) {
+	if audit == nil {
+		return nil, errors.New("flags: an AuditRecorder is required — flag changes must be audited")
+	}
+	return &Store{db: db, audit: audit, invalidate: invalidate}, nil
+}
+
+// Get loads one flag by name.
+func (s *Store) Get(ctx context.Context, name string) (Flag, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT name, type, enabled, percentage, cohort, value, description, owner, fail_safe_on, created_at, updated_at
+		FROM feature_flags WHERE name = $1`, name)
+	return scanFlag(row)
+}
+
+// List returns all flags ordered by name (admin surface).
+func (s *Store) List(ctx context.Context) ([]Flag, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT name, type, enabled, percentage, cohort, value, description, owner, fail_safe_on, created_at, updated_at
+		FROM feature_flags ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("flags: list: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Flag
+	for rows.Next() {
+		f, err := scanFlag(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// Set creates or updates a flag, records the change through the audit log,
+// and broadcasts an invalidation so every instance re-reads within seconds.
+// actor identifies who made the change.
+func (s *Store) Set(ctx context.Context, actor string, f Flag) error {
+	if err := f.Validate(); err != nil {
+		return err
+	}
+	if err := rejectSecrets(f); err != nil {
+		return err
+	}
+
+	var before *Flag
+	if prev, err := s.Get(ctx, f.Name); err == nil {
+		before = &prev
+	} else if !errors.Is(err, ErrNotFound) {
+		return err
+	}
+
+	cohort, err := json.Marshal(f.Cohort)
+	if err != nil {
+		return fmt.Errorf("flags: marshal cohort: %w", err)
+	}
+
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO feature_flags (name, type, enabled, percentage, cohort, value, description, owner, fail_safe_on, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10)
+		ON CONFLICT (name) DO UPDATE SET
+			type = EXCLUDED.type,
+			enabled = EXCLUDED.enabled,
+			percentage = EXCLUDED.percentage,
+			cohort = EXCLUDED.cohort,
+			value = EXCLUDED.value,
+			description = EXCLUDED.description,
+			owner = EXCLUDED.owner,
+			fail_safe_on = EXCLUDED.fail_safe_on,
+			updated_at = EXCLUDED.updated_at`,
+		f.Name, string(f.Type), f.Enabled, f.Percentage, cohort, f.Value, f.Description, f.Owner, f.FailSafeOn, now)
+	if err != nil {
+		return fmt.Errorf("flags: set %q: %w", f.Name, err)
+	}
+
+	f.UpdatedAt = now
+	if err := s.audit.RecordFlagChange(ctx, actor, f.Name, before, &f); err != nil {
+		return fmt.Errorf("flags: audit record for %q: %w", f.Name, err)
+	}
+	if s.invalidate != nil {
+		s.invalidate(ctx, f.Name)
+	}
+	return nil
+}
+
+// Delete removes a flag, auditing the removal.
+func (s *Store) Delete(ctx context.Context, actor, name string) error {
+	prev, err := s.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM feature_flags WHERE name = $1`, name); err != nil {
+		return fmt.Errorf("flags: delete %q: %w", name, err)
+	}
+	if err := s.audit.RecordFlagChange(ctx, actor, name, &prev, nil); err != nil {
+		return fmt.Errorf("flags: audit record for %q: %w", name, err)
+	}
+	if s.invalidate != nil {
+		s.invalidate(ctx, name)
+	}
+	return nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFlag(row rowScanner) (Flag, error) {
+	var (
+		f      Flag
+		typ    string
+		cohort []byte
+	)
+	err := row.Scan(&f.Name, &typ, &f.Enabled, &f.Percentage, &cohort, &f.Value, &f.Description, &f.Owner, &f.FailSafeOn, &f.CreatedAt, &f.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Flag{}, ErrNotFound
+	}
+	if err != nil {
+		return Flag{}, fmt.Errorf("flags: scan: %w", err)
+	}
+	f.Type = Type(typ)
+	if len(cohort) > 0 {
+		if err := json.Unmarshal(cohort, &f.Cohort); err != nil {
+			return Flag{}, fmt.Errorf("flags: unmarshal cohort: %w", err)
+		}
+	}
+	return f, nil
+}

--- a/apps/api/internal/server/versioning.go
+++ b/apps/api/internal/server/versioning.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// API versioning and deprecation framework (issue #842).
+//
+// Scheme: URL-path versioning (/v1/..., /v2/...) applied uniformly — the
+// most explicit and cache-friendly option. Version-specific code is confined
+// to the transport edge (handlers/DTOs); shared business logic stays in the
+// services and is never forked per version.
+//
+// Lifecycle: active → deprecated (Deprecation + Sunset headers on every
+// response) → retired (410 Gone with a pointer to the current version,
+// never a silent 404). Per-version usage is counted so retirement decisions
+// are data-driven.
+//
+// Default: requests without a version prefix route to a PINNED default —
+// not "latest", because "latest" silently changes behaviour under consumers.
+// The default changes only deliberately, with a code change.
+
+// VersionState describes one API version's lifecycle position.
+type VersionState struct {
+	// Name is the path prefix segment, e.g. "v1".
+	Name string
+	// Deprecated marks the version as on its way out; responses carry
+	// Deprecation and Sunset headers.
+	Deprecated bool
+	// Sunset is the announced retirement date, emitted in the Sunset
+	// header (RFC 8594) while deprecated.
+	Sunset time.Time
+	// Retired versions return 410 Gone with a pointer to Successor.
+	Retired bool
+	// Successor is the version consumers should move to, e.g. "v2".
+	Successor string
+}
+
+// UsageRecorder counts requests per version so the team knows who is still
+// on old versions before retiring them. Wire the metrics registry here.
+type UsageRecorder interface {
+	RecordVersionHit(version string)
+}
+
+// CounterUsage is an in-memory UsageRecorder exposing a snapshot for
+// metrics scraping and tests.
+type CounterUsage struct {
+	mu     sync.Mutex
+	counts map[string]int64
+}
+
+// NewCounterUsage builds an empty counter.
+func NewCounterUsage() *CounterUsage {
+	return &CounterUsage{counts: make(map[string]int64)}
+}
+
+// RecordVersionHit implements UsageRecorder.
+func (c *CounterUsage) RecordVersionHit(version string) {
+	c.mu.Lock()
+	c.counts[version]++
+	c.mu.Unlock()
+}
+
+// Snapshot returns a copy of the per-version hit counts.
+func (c *CounterUsage) Snapshot() map[string]int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int64, len(c.counts))
+	for k, v := range c.counts {
+		out[k] = v
+	}
+	return out
+}
+
+// VersionedAPI mounts versioned route groups and enforces the lifecycle
+// rules uniformly across every endpoint.
+type VersionedAPI struct {
+	mux      *http.ServeMux
+	versions map[string]*VersionState
+	// defaultVersion is the pinned version unprefixed requests route to.
+	defaultVersion string
+	usage          UsageRecorder
+}
+
+// NewVersionedAPI creates the version router. defaultVersion must be
+// registered before Handler is used; it is pinned, documented behaviour —
+// never implicitly "latest".
+func NewVersionedAPI(defaultVersion string, usage UsageRecorder) *VersionedAPI {
+	if usage == nil {
+		usage = NewCounterUsage()
+	}
+	return &VersionedAPI{
+		mux:            http.NewServeMux(),
+		versions:       make(map[string]*VersionState),
+		defaultVersion: defaultVersion,
+		usage:          usage,
+	}
+}
+
+// Register declares a version's lifecycle state. Must be called before
+// mounting routes for that version.
+func (v *VersionedAPI) Register(state VersionState) error {
+	if state.Name == "" || !strings.HasPrefix(state.Name, "v") {
+		return fmt.Errorf("server: version name %q must look like v1, v2, ...", state.Name)
+	}
+	if state.Retired && state.Successor == "" {
+		return fmt.Errorf("server: retired version %q must name a successor", state.Name)
+	}
+	v.versions[state.Name] = &state
+	return nil
+}
+
+// Handle mounts handler for pattern under a registered version, e.g.
+// Handle("v1", "GET /vaults", h) serves "GET /v1/vaults". The handler is
+// wrapped with the version's lifecycle middleware: usage counting,
+// deprecation headers, and 410 short-circuit when retired.
+func (v *VersionedAPI) Handle(version, pattern string, handler http.Handler) error {
+	state, ok := v.versions[version]
+	if !ok {
+		return fmt.Errorf("server: version %q not registered", version)
+	}
+
+	method, path, found := strings.Cut(pattern, " ")
+	if !found {
+		// Pattern without a method: treat the whole thing as a path.
+		method, path = "", pattern
+	}
+
+	versionedPath := "/" + version + path
+	full := versionedPath
+	if method != "" {
+		full = method + " " + versionedPath
+	}
+	v.mux.Handle(full, v.lifecycle(state, handler))
+
+	// The pinned default version is also reachable unprefixed.
+	if version == v.defaultVersion {
+		unprefixed := path
+		if method != "" {
+			unprefixed = method + " " + path
+		}
+		v.mux.Handle(unprefixed, v.lifecycle(state, handler))
+	}
+	return nil
+}
+
+// Handler returns the assembled router.
+func (v *VersionedAPI) Handler() http.Handler {
+	return v.mux
+}
+
+// lifecycle wraps a versioned handler with the uniform version rules.
+func (v *VersionedAPI) lifecycle(state *VersionState, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.usage.RecordVersionHit(state.Name)
+
+		if state.Retired {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusGone)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error":           fmt.Sprintf("API version %s has been retired", state.Name),
+				"current_version": state.Successor,
+				"hint":            fmt.Sprintf("use /%s%s", state.Successor, strings.TrimPrefix(r.URL.Path, "/"+state.Name)),
+			})
+			return
+		}
+
+		if state.Deprecated {
+			// RFC 8594-style signalling on EVERY response so a consumer
+			// polling the API learns it is on a dying version without
+			// reading a changelog.
+			w.Header().Set("Deprecation", "true")
+			if !state.Sunset.IsZero() {
+				w.Header().Set("Sunset", state.Sunset.UTC().Format(http.TimeFormat))
+			}
+			if state.Successor != "" {
+				w.Header().Set("Link", fmt.Sprintf("</%s>; rel=\"successor-version\"", state.Successor))
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/apps/api/internal/server/versioning_test.go
+++ b/apps/api/internal/server/versioning_test.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// v1 and v2 of the same endpoint return different shapes — the mapping
+// lives at the transport edge; both handlers would call the same service in
+// production.
+func v1VaultHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"vault_name": "alpha", "apy": "5.1"})
+	})
+}
+
+func v2VaultHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"vault": map[string]any{"name": "alpha", "apy_bps": 510},
+		})
+	})
+}
+
+func newTestAPI(t *testing.T) (*VersionedAPI, *CounterUsage) {
+	t.Helper()
+	usage := NewCounterUsage()
+	api := NewVersionedAPI("v1", usage)
+
+	if err := api.Register(VersionState{Name: "v1", Deprecated: true, Sunset: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC), Successor: "v2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := api.Register(VersionState{Name: "v2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := api.Register(VersionState{Name: "v0", Retired: true, Successor: "v2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := api.Handle("v1", "GET /vaults", v1VaultHandler()); err != nil {
+		t.Fatal(err)
+	}
+	if err := api.Handle("v2", "GET /vaults", v2VaultHandler()); err != nil {
+		t.Fatal(err)
+	}
+	if err := api.Handle("v0", "GET /vaults", v1VaultHandler()); err != nil {
+		t.Fatal(err)
+	}
+	return api, usage
+}
+
+func get(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+// TestVersionsCoexistWithTheirOwnContracts: v1 and v2 of the same endpoint
+// serve simultaneously, each returning its own response shape.
+func TestVersionsCoexistWithTheirOwnContracts(t *testing.T) {
+	api, _ := newTestAPI(t)
+	h := api.Handler()
+
+	res1 := get(t, h, "/v1/vaults")
+	if res1.Code != http.StatusOK {
+		t.Fatalf("v1 status = %d", res1.Code)
+	}
+	var v1 map[string]any
+	if err := json.Unmarshal(res1.Body.Bytes(), &v1); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := v1["vault_name"]; !ok {
+		t.Fatalf("v1 contract missing vault_name: %v", v1)
+	}
+
+	res2 := get(t, h, "/v2/vaults")
+	if res2.Code != http.StatusOK {
+		t.Fatalf("v2 status = %d", res2.Code)
+	}
+	var v2 map[string]any
+	if err := json.Unmarshal(res2.Body.Bytes(), &v2); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := v2["vault"]; !ok {
+		t.Fatalf("v2 contract missing nested vault: %v", v2)
+	}
+	if _, leaked := v2["vault_name"]; leaked {
+		t.Fatal("v2 must not leak the v1 shape")
+	}
+}
+
+// TestDeprecatedVersionEmitsHeaders: every response from a deprecated
+// version carries Deprecation and Sunset headers plus a successor Link.
+func TestDeprecatedVersionEmitsHeaders(t *testing.T) {
+	api, _ := newTestAPI(t)
+	res := get(t, api.Handler(), "/v1/vaults")
+
+	if res.Header().Get("Deprecation") != "true" {
+		t.Fatal("deprecated version must send Deprecation header on every response")
+	}
+	sunset := res.Header().Get("Sunset")
+	if sunset == "" {
+		t.Fatal("deprecated version must send Sunset header")
+	}
+	if _, err := time.Parse(http.TimeFormat, sunset); err != nil {
+		t.Fatalf("Sunset %q is not an HTTP date: %v", sunset, err)
+	}
+	if got := res.Header().Get("Link"); got != `</v2>; rel="successor-version"` {
+		t.Fatalf("Link = %q", got)
+	}
+
+	// The current version carries none of this noise.
+	res2 := get(t, api.Handler(), "/v2/vaults")
+	if res2.Header().Get("Deprecation") != "" || res2.Header().Get("Sunset") != "" {
+		t.Fatal("current version must not send deprecation headers")
+	}
+}
+
+// TestRetiredVersionReturns410WithGuidance: a retired version is a clear,
+// documented 410 Gone pointing at the current version — never a silent 404
+// that looks like a bug.
+func TestRetiredVersionReturns410WithGuidance(t *testing.T) {
+	api, _ := newTestAPI(t)
+	res := get(t, api.Handler(), "/v0/vaults")
+
+	if res.Code != http.StatusGone {
+		t.Fatalf("retired version status = %d, want 410", res.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["current_version"] != "v2" {
+		t.Fatalf("410 body must point at the current version, got %v", body)
+	}
+}
+
+// TestUnversionedRequestsRouteToPinnedDefault: no version in the path means
+// the pinned default (v1 here) — stable behaviour, not "latest" (v2).
+func TestUnversionedRequestsRouteToPinnedDefault(t *testing.T) {
+	api, _ := newTestAPI(t)
+	res := get(t, api.Handler(), "/vaults")
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("default route status = %d", res.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := body["vault_name"]; !ok {
+		t.Fatalf("default must serve the pinned v1 contract, not latest; got %v", body)
+	}
+}
+
+// TestPerVersionUsageIsRecorded: retirement decisions are data-driven —
+// hits are counted per version.
+func TestPerVersionUsageIsRecorded(t *testing.T) {
+	api, usage := newTestAPI(t)
+	h := api.Handler()
+
+	get(t, h, "/v1/vaults")
+	get(t, h, "/v1/vaults")
+	get(t, h, "/v2/vaults")
+	get(t, h, "/v0/vaults") // even retired hits are counted: they identify stragglers
+
+	snap := usage.Snapshot()
+	if snap["v1"] != 2 || snap["v2"] != 1 || snap["v0"] != 1 {
+		t.Fatalf("usage snapshot = %v, want v1:2 v2:1 v0:1", snap)
+	}
+}
+
+// TestRegisterValidation: malformed lifecycle declarations are rejected.
+func TestRegisterValidation(t *testing.T) {
+	api := NewVersionedAPI("v1", nil)
+	if err := api.Register(VersionState{Name: "one"}); err == nil {
+		t.Fatal("non-vN name must be rejected")
+	}
+	if err := api.Register(VersionState{Name: "v3", Retired: true}); err == nil {
+		t.Fatal("retired version without successor must be rejected")
+	}
+	if err := api.Handle("v9", "GET /x", http.NotFoundHandler()); err == nil {
+		t.Fatal("mounting on an unregistered version must fail")
+	}
+}

--- a/apps/api/migrations/061_create_feature_flags.down.sql
+++ b/apps/api/migrations/061_create_feature_flags.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS feature_flags;

--- a/apps/api/migrations/061_create_feature_flags.up.sql
+++ b/apps/api/migrations/061_create_feature_flags.up.sql
@@ -1,0 +1,19 @@
+-- Feature flags and runtime configuration (issue #838).
+-- Operational flags and non-secret tunables ONLY: secrets stay in the
+-- environment / secret store. The application layer enforces a guard that
+-- rejects secret-marked names before they reach this table.
+CREATE TABLE IF NOT EXISTS feature_flags (
+    name         TEXT PRIMARY KEY,
+    type         TEXT NOT NULL CHECK (type IN ('bool', 'percentage', 'cohort', 'value')),
+    enabled      BOOLEAN NOT NULL DEFAULT FALSE,
+    percentage   DOUBLE PRECISION NOT NULL DEFAULT 0 CHECK (percentage >= 0 AND percentage <= 100),
+    cohort       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    value        TEXT NOT NULL DEFAULT '',
+    description  TEXT NOT NULL DEFAULT '',
+    owner        TEXT NOT NULL DEFAULT '',
+    -- The value a boolean flag evaluates to when the flag service is
+    -- unavailable. Kill switches keep the default FALSE: fail closed.
+    fail_safe_on BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,61 @@
+# API Versioning and Deprecation Policy
+
+Nester's HTTP API uses **URL-path versioning**: every endpoint lives under a
+version prefix (`/v1/...`, `/v2/...`). The scheme is applied uniformly — no
+endpoint uses header-based or query-parameter versioning.
+
+## What is a breaking change
+
+A new major version is required for any change that can break an existing
+consumer:
+
+- removing or renaming a response field
+- changing a field's type or semantics
+- adding a **required** request field
+- changing an endpoint's status codes or error contract
+- changing authentication or pagination behaviour
+
+Non-breaking changes ship inside the current version:
+
+- adding an **optional** request field
+- adding a new response field
+- adding a new endpoint
+
+## Multiple active versions
+
+When `v2` of an endpoint ships, `v1` keeps working until its announced
+retirement date. Version-specific code is confined to the transport edge —
+handlers and DTO mapping (`internal/server/versioning.go` mounts the
+versioned groups). Shared business logic lives in the services and is never
+duplicated per version.
+
+## Deprecation lifecycle
+
+```
+active → deprecated → sunset announced → usage monitored → retired
+```
+
+1. **Deprecated** versions return a `Deprecation: true` header, a `Sunset`
+   header carrying the retirement date (RFC 8594), and a
+   `Link: </vN>; rel="successor-version"` header on **every** response.
+2. **Usage is monitored** per version (metrics counter) so retirement
+   decisions are data-driven — a version still serving a major consumer is
+   not retired.
+3. **Retired** versions return `410 Gone` with a JSON body pointing at the
+   current version — never a silent 404.
+
+## Default version
+
+Requests without a version prefix route to a **pinned default** version.
+The default is *not* "latest": it changes only deliberately, with a code
+change and an announcement. Consumers — including the Nester frontend
+(`apps/dapp/frontend/lib/api/client.ts`) — should still pin an explicit
+version rather than relying on the default.
+
+## Consumer guidance
+
+- Pin an explicit version in every integration.
+- Watch for the `Deprecation` and `Sunset` headers; plan migration when they
+  appear.
+- A `410 Gone` means the version is retired; the response body names the
+  version to move to.


### PR DESCRIPTION
Closes #838, closes #839, closes #841, closes #842

## Summary

Implements four platform capabilities in `apps/api`, each fully unit-tested (33 tests, all passing; `go build ./...` and `go vet` clean).

## #838 — Dynamic feature-flag and runtime configuration service (`internal/flags/`)

- Flag types: boolean kill-switch, deterministic **percentage rollout**, **cohort/allowlist**, and typed value
- Percentage membership is FNV-hash based and **stable as the rollout grows** — a user in at 10% is still in at 20% (proven by test over 5,000 users across 7 rollout steps)
- Postgres is the source of truth (migration `060_create_feature_flags`); in-process cache with short-TTL backstop plus a **pub/sub invalidation channel** (`flags:invalidate`) so changes propagate across instances within seconds — cache drops all entries on (re)subscribe so missed messages can't strand stale state
- **Kill switches fail safe**: the evaluator returns each flag's registered safe position when the flag service is unreachable — never fail-open (proven by test)
- **Secret guard**: names matching secret markers (key/token/password/credential/…) are rejected from the flag store with `ErrSecretRejected` — secrets stay in the environment (proven by test)
- **Audit is mandatory**: `NewStore` refuses construction without an `AuditRecorder`; every set/delete records actor, flag, before and after states
- Transient store errors are never cached, so fail-safe handling always sees the outage rather than stale success

## #839 — Server-side data export service (`internal/export/`)

- Transaction-history **CSV generated server-side** from the ledger/transaction source of truth, stable documented column schema (append-only)
- **Reconciliation invariant**: per asset, exported movements must sum exactly to the ledger's net change for the period — on mismatch the export **errors instead of delivering a wrong document** (seeded-mismatch test proves this, including the unledgered-asset direction)
- Exports above a documented row threshold (`AsyncRowThreshold`) route to the **durable job queue** and return a job id immediately (test proves async routing and that nothing is written inline)
- **Secure delivery**: HMAC-SHA256 signed, time-limited, single-user download tokens; the verifier checks integrity, expiry and **ownership** — a test proves another user cannot download someone else's export, and tampered/expired tokens are rejected
- Amounts render with per-asset decimals; timestamps are UTC RFC 3339

## #841 — Read-replica routing and connection-pool management (`internal/db/router.go`)

- **Explicit read/write paths** — repositories declare intent via `Read(ctx, userID)` / `Write()`; routing is never inferred from SQL
- **Read-your-writes**: `NoteWrite` pins a user's reads to the primary for a bounded window (`Pinner` interface — in-memory TTL implementation included, Redis satisfies the same interface for multi-instance). Write-then-read test proves the same user hits the primary while other users stay on replicas; pin expiry test proves the window is bounded
- **Replica health and lag**: unhealthy or lag-budget-exceeding replicas are evicted from the read pool and rejoin when recovered; with no eligible replica, reads **fall back to the primary** — degraded capacity, not an outage (all proven by tests)
- **Transactions always use the primary** (`BeginTx`), regardless of pinning
- Per-role pools with round-robin read spreading; `Stats()` exposes pool utilisation and replica lag for metrics; `Close()` drains all pools for graceful shutdown
- Constructing a router without a pinner is a hard error (`ErrNoPinner`) so the consistency guarantee can't be silently absent

## #842 — API versioning and deprecation framework (`internal/server/versioning.go`, `docs/api-versioning.md`)

- Uniform **URL-path versioning** (`/v1/...`, `/v2/...`) via versioned route groups; version-specific code confined to the transport edge — handlers map to the same services, never forked
- **Deprecated** versions emit `Deprecation`, `Sunset` (RFC 8594) and `Link: rel="successor-version"` headers on **every** response (test asserts presence and that the current version emits none)
- **Retired** versions return **410 Gone** with a JSON pointer to the current version — never a silent 404 (proven by test)
- Unversioned requests route to a **pinned default** — explicitly not "latest" (test proves `/vaults` serves the pinned v1 contract while v2 exists)
- **Per-version usage counting** so retirement decisions are data-driven (test)
- Versioning policy, breaking-change rules and lifecycle documented in `docs/api-versioning.md`

## Tests

```
ok  internal/flags    (percentage stability, fail-safe kill switch, secret guard,
                       cache invalidation across two instances, transient-error retry)
ok  internal/export   (completeness, reconciliation-fails-loudly, async routing,
                       token ownership/expiry/tampering)
ok  internal/db       (explicit routing, read-your-writes, pin expiry, replica-down
                       fallback, lag eviction, round-robin, tx-on-primary)
ok  internal/server   (version coexistence, deprecation headers, 410 guidance,
                       pinned default, usage counting)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction-history CSV exports with reconciliation checks and automatic background processing for large exports.
  * Added secure, time-limited export downloads with ownership and tamper protection.
  * Added runtime feature flags with percentage rollouts, cohorts, fail-safe behavior, caching, and audit support.
  * Added API version lifecycle support, including deprecation notices, retirement guidance, and usage tracking.
  * Improved database read scaling while preserving read-your-writes consistency.

* **Documentation**
  * Documented API versioning, default-version routing, deprecation, and retirement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->