### PR TITLE
Add time-series rollup store

### DIFF
--- a/apps/api/internal/timeseries/aggregation.go
+++ b/apps/api/internal/timeseries/aggregation.go
@@ -1,0 +1,93 @@
+package timeseries
+
+import (
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func Aggregate(points []Point, resolution Resolution) ([]RollupPoint, error) {
+	if len(points) == 0 {
+		return nil, nil
+	}
+
+	type keyedPoint struct {
+		point       Point
+		seriesKey   string
+		bucketStart time.Time
+	}
+
+	keyed := make([]keyedPoint, 0, len(points))
+	for _, point := range points {
+		seriesKey, err := point.Series.Key()
+		if err != nil {
+			return nil, err
+		}
+		bucket, err := BucketStart(point.ObservedAt, resolution)
+		if err != nil {
+			return nil, err
+		}
+		keyed = append(keyed, keyedPoint{
+			point:       point,
+			seriesKey:   seriesKey,
+			bucketStart: bucket,
+		})
+	}
+
+	sort.Slice(keyed, func(i, j int) bool {
+		if keyed[i].seriesKey != keyed[j].seriesKey {
+			return keyed[i].seriesKey < keyed[j].seriesKey
+		}
+		if !keyed[i].bucketStart.Equal(keyed[j].bucketStart) {
+			return keyed[i].bucketStart.Before(keyed[j].bucketStart)
+		}
+		return keyed[i].point.ObservedAt.Before(keyed[j].point.ObservedAt)
+	})
+
+	var out []RollupPoint
+	var current *RollupPoint
+	var sum decimal.Decimal
+	var currentKey string
+	for _, item := range keyed {
+		groupKey := item.seriesKey + "|" + item.bucketStart.Format(time.RFC3339Nano)
+		if current == nil || groupKey != currentKey {
+			if current != nil {
+				current.Average = sum.Div(decimal.NewFromInt(current.Count))
+				out = append(out, *current)
+			}
+			currentKey = groupKey
+			sum = decimal.Zero
+			current = &RollupPoint{
+				SeriesKey:   item.seriesKey,
+				Metric:      item.point.Series.Metric,
+				EntityType:  item.point.Series.EntityType,
+				EntityID:    item.point.Series.EntityID,
+				Resolution:  resolution,
+				BucketStart: item.bucketStart,
+				Open:        item.point.Value,
+				High:        item.point.Value,
+				Low:         item.point.Value,
+				Close:       item.point.Value,
+				Last:        item.point.Value,
+			}
+		}
+
+		if item.point.Value.GreaterThan(current.High) {
+			current.High = item.point.Value
+		}
+		if item.point.Value.LessThan(current.Low) {
+			current.Low = item.point.Value
+		}
+		current.Close = item.point.Value
+		current.Last = item.point.Value
+		current.Count++
+		sum = sum.Add(item.point.Value)
+	}
+
+	if current != nil {
+		current.Average = sum.Div(decimal.NewFromInt(current.Count))
+		out = append(out, *current)
+	}
+	return out, nil
+}

--- a/apps/api/internal/timeseries/model.go
+++ b/apps/api/internal/timeseries/model.go
@@ -1,0 +1,151 @@
+// Package timeseries stores high-volume metric history and downsampled rollups
+// for APY, TVL, and portfolio charting.
+package timeseries
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type Metric string
+
+const (
+	MetricAPY       Metric = "apy"
+	MetricTVL       Metric = "tvl"
+	MetricPortfolio Metric = "portfolio"
+)
+
+type Resolution string
+
+const (
+	ResolutionRaw    Resolution = "raw"
+	ResolutionMinute Resolution = "minute"
+	ResolutionHour   Resolution = "hour"
+	ResolutionDay    Resolution = "day"
+)
+
+var ErrInvalidSeries = errors.New("timeseries: invalid series")
+
+type SeriesRef struct {
+	Metric     Metric
+	EntityType string
+	EntityID   string
+	Dimensions map[string]string
+}
+
+func (s SeriesRef) Key() (string, error) {
+	if s.Metric == "" || s.EntityType == "" || s.EntityID == "" {
+		return "", ErrInvalidSeries
+	}
+
+	parts := []string{string(s.Metric), s.EntityType, s.EntityID}
+	if len(s.Dimensions) > 0 {
+		keys := make([]string, 0, len(s.Dimensions))
+		for key := range s.Dimensions {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			parts = append(parts, key+"="+s.Dimensions[key])
+		}
+	}
+	return strings.Join(parts, ":"), nil
+}
+
+type Point struct {
+	Series     SeriesRef
+	ObservedAt time.Time
+	Value      decimal.Decimal
+}
+
+type RollupPoint struct {
+	SeriesKey   string
+	Metric      Metric
+	EntityType  string
+	EntityID    string
+	Resolution  Resolution
+	BucketStart time.Time
+	Open        decimal.Decimal
+	High        decimal.Decimal
+	Low         decimal.Decimal
+	Close       decimal.Decimal
+	Average     decimal.Decimal
+	Last        decimal.Decimal
+	Count       int64
+}
+
+type QueryRequest struct {
+	Series              SeriesRef
+	From                time.Time
+	To                  time.Time
+	MaxPoints           int
+	PreferredResolution Resolution
+}
+
+type QueryResult struct {
+	Resolution Resolution
+	Points     []RollupPoint
+}
+
+type RetentionPolicy struct {
+	RawMaxAge    time.Duration
+	MinuteMaxAge time.Duration
+	HourMaxAge   time.Duration
+}
+
+func ValidResolution(resolution Resolution) bool {
+	switch resolution {
+	case ResolutionRaw, ResolutionMinute, ResolutionHour, ResolutionDay:
+		return true
+	default:
+		return false
+	}
+}
+
+func BucketStart(t time.Time, resolution Resolution) (time.Time, error) {
+	t = t.UTC()
+	switch resolution {
+	case ResolutionRaw:
+		return t, nil
+	case ResolutionMinute:
+		return t.Truncate(time.Minute), nil
+	case ResolutionHour:
+		return t.Truncate(time.Hour), nil
+	case ResolutionDay:
+		y, m, d := t.Date()
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC), nil
+	default:
+		return time.Time{}, fmt.Errorf("timeseries: invalid resolution %q", resolution)
+	}
+}
+
+func SelectTier(req QueryRequest, now time.Time) Resolution {
+	if req.PreferredResolution != "" && ValidResolution(req.PreferredResolution) {
+		return req.PreferredResolution
+	}
+
+	maxPoints := req.MaxPoints
+	if maxPoints <= 0 {
+		maxPoints = 500
+	}
+
+	duration := req.To.Sub(req.From)
+	if duration <= 0 {
+		return ResolutionRaw
+	}
+	if !req.From.Before(now.UTC().Add(-24*time.Hour)) && duration <= time.Duration(maxPoints)*time.Minute {
+		return ResolutionRaw
+	}
+	if duration <= time.Duration(maxPoints)*time.Minute {
+		return ResolutionMinute
+	}
+	if duration <= time.Duration(maxPoints)*time.Hour {
+		return ResolutionHour
+	}
+	return ResolutionDay
+}

--- a/apps/api/internal/timeseries/model_test.go
+++ b/apps/api/internal/timeseries/model_test.go
@@ -1,0 +1,96 @@
+package timeseries
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestSeriesRefKeySortsDimensions(t *testing.T) {
+	key, err := (SeriesRef{
+		Metric:     MetricAPY,
+		EntityType: "vault",
+		EntityID:   "v1",
+		Dimensions: map[string]string{"period": "7d", "source": "blend"},
+	}).Key()
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	if key != "apy:vault:v1:period=7d:source=blend" {
+		t.Fatalf("Key() = %q", key)
+	}
+}
+
+func TestAggregateComputesOHLCAndAverage(t *testing.T) {
+	series := SeriesRef{Metric: MetricTVL, EntityType: "vault", EntityID: "v1"}
+	base := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	points := []Point{
+		{Series: series, ObservedAt: base.Add(40 * time.Second), Value: decimal.RequireFromString("12")},
+		{Series: series, ObservedAt: base.Add(10 * time.Second), Value: decimal.RequireFromString("10")},
+		{Series: series, ObservedAt: base.Add(50 * time.Second), Value: decimal.RequireFromString("8")},
+	}
+
+	rollups, err := Aggregate(points, ResolutionMinute)
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+	if len(rollups) != 1 {
+		t.Fatalf("len(rollups) = %d, want 1", len(rollups))
+	}
+	got := rollups[0]
+	assertDecimal(t, "open", got.Open, "10")
+	assertDecimal(t, "high", got.High, "12")
+	assertDecimal(t, "low", got.Low, "8")
+	assertDecimal(t, "close", got.Close, "8")
+	assertDecimal(t, "average", got.Average, "10")
+	assertDecimal(t, "last", got.Last, "8")
+	if got.Count != 3 {
+		t.Fatalf("Count = %d, want 3", got.Count)
+	}
+}
+
+func TestSelectTier(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		req  QueryRequest
+		want Resolution
+	}{
+		{
+			name: "recent narrow range uses raw",
+			req:  QueryRequest{From: now.Add(-2 * time.Hour), To: now, MaxPoints: 180},
+			want: ResolutionRaw,
+		},
+		{
+			name: "multi day range uses hour rollup",
+			req:  QueryRequest{From: now.Add(-48 * time.Hour), To: now, MaxPoints: 100},
+			want: ResolutionHour,
+		},
+		{
+			name: "wide range uses day rollup",
+			req:  QueryRequest{From: now.Add(-180 * 24 * time.Hour), To: now, MaxPoints: 100},
+			want: ResolutionDay,
+		},
+		{
+			name: "preferred resolution wins",
+			req:  QueryRequest{From: now.Add(-180 * 24 * time.Hour), To: now, PreferredResolution: ResolutionMinute},
+			want: ResolutionMinute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SelectTier(tt.req, now); got != tt.want {
+				t.Fatalf("SelectTier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertDecimal(t *testing.T, name string, got decimal.Decimal, want string) {
+	t.Helper()
+	if !got.Equal(decimal.RequireFromString(want)) {
+		t.Fatalf("%s = %s, want %s", name, got.String(), want)
+	}
+}

--- a/apps/api/internal/timeseries/rollup_job.go
+++ b/apps/api/internal/timeseries/rollup_job.go
@@ -1,0 +1,77 @@
+package timeseries
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type Store interface {
+	Rollup(ctx context.Context, resolution Resolution, from, to time.Time) error
+	Checkpoint(ctx context.Context, resolution Resolution) (time.Time, bool, error)
+	SetCheckpoint(ctx context.Context, resolution Resolution, processedUntil time.Time) error
+	SafeDeleteRawBefore(ctx context.Context, before time.Time) (int64, error)
+}
+
+type RollupJobConfig struct {
+	Lookback     time.Duration
+	RawRetention time.Duration
+	Now          func() time.Time
+}
+
+type RollupJob struct {
+	store Store
+	cfg   RollupJobConfig
+}
+
+func NewRollupJob(store Store, cfg RollupJobConfig) *RollupJob {
+	if cfg.Lookback <= 0 {
+		cfg.Lookback = 24 * time.Hour
+	}
+	if cfg.RawRetention <= 0 {
+		cfg.RawRetention = 30 * 24 * time.Hour
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	return &RollupJob{store: store, cfg: cfg}
+}
+
+func (j *RollupJob) RunOnce(ctx context.Context) error {
+	now := j.cfg.Now().UTC()
+	if err := j.runResolution(ctx, ResolutionMinute, now.Truncate(time.Minute)); err != nil {
+		return err
+	}
+	if err := j.runResolution(ctx, ResolutionHour, now.Truncate(time.Hour)); err != nil {
+		return err
+	}
+	if err := j.runResolution(ctx, ResolutionDay, dayStart(now)); err != nil {
+		return err
+	}
+	if _, err := j.store.SafeDeleteRawBefore(ctx, now.Add(-j.cfg.RawRetention)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j *RollupJob) runResolution(ctx context.Context, resolution Resolution, to time.Time) error {
+	from, ok, err := j.store.Checkpoint(ctx, resolution)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		from = to.Add(-j.cfg.Lookback)
+	}
+	if !from.Before(to) {
+		return nil
+	}
+	if err := j.store.Rollup(ctx, resolution, from, to); err != nil {
+		return fmt.Errorf("timeseries: run %s rollup: %w", resolution, err)
+	}
+	return j.store.SetCheckpoint(ctx, resolution, to)
+}
+
+func dayStart(t time.Time) time.Time {
+	y, m, d := t.UTC().Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}

--- a/apps/api/internal/timeseries/rollup_job_test.go
+++ b/apps/api/internal/timeseries/rollup_job_test.go
@@ -1,0 +1,64 @@
+package timeseries
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type fakeStore struct {
+	checkpoints map[Resolution]time.Time
+	rollups     []Resolution
+	deletedAt   time.Time
+}
+
+func (s *fakeStore) Rollup(ctx context.Context, resolution Resolution, from, to time.Time) error {
+	s.rollups = append(s.rollups, resolution)
+	return nil
+}
+
+func (s *fakeStore) Checkpoint(ctx context.Context, resolution Resolution) (time.Time, bool, error) {
+	v, ok := s.checkpoints[resolution]
+	return v, ok, nil
+}
+
+func (s *fakeStore) SetCheckpoint(ctx context.Context, resolution Resolution, processedUntil time.Time) error {
+	s.checkpoints[resolution] = processedUntil
+	return nil
+}
+
+func (s *fakeStore) SafeDeleteRawBefore(ctx context.Context, before time.Time) (int64, error) {
+	s.deletedAt = before
+	return 1, nil
+}
+
+func TestRollupJobResumesFromCheckpointAndRetainsAfterRollup(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 34, 56, 0, time.UTC)
+	store := &fakeStore{
+		checkpoints: map[Resolution]time.Time{
+			ResolutionMinute: now.Add(-2 * time.Hour),
+		},
+	}
+	job := NewRollupJob(store, RollupJobConfig{
+		Lookback:     6 * time.Hour,
+		RawRetention: 7 * 24 * time.Hour,
+		Now:          func() time.Time { return now },
+	})
+
+	if err := job.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+
+	if len(store.rollups) != 3 {
+		t.Fatalf("rollups = %v, want three resolutions", store.rollups)
+	}
+	if got := store.checkpoints[ResolutionMinute]; !got.Equal(now.Truncate(time.Minute)) {
+		t.Fatalf("minute checkpoint = %s", got)
+	}
+	if store.deletedAt.IsZero() {
+		t.Fatal("SafeDeleteRawBefore was not called")
+	}
+	if !store.deletedAt.Equal(now.Add(-7 * 24 * time.Hour)) {
+		t.Fatalf("deletedAt = %s", store.deletedAt)
+	}
+}

--- a/apps/api/internal/timeseries/store.go
+++ b/apps/api/internal/timeseries/store.go
@@ -1,0 +1,341 @@
+package timeseries
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type PostgresStore struct {
+	db *sql.DB
+}
+
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+func (s *PostgresStore) Ingest(ctx context.Context, point Point) error {
+	seriesKey, err := point.Series.Key()
+	if err != nil {
+		return err
+	}
+	if point.ObservedAt.IsZero() {
+		point.ObservedAt = time.Now().UTC()
+	}
+	dimensions := []byte("{}")
+	if point.Series.Dimensions != nil {
+		encoded, err := json.Marshal(point.Series.Dimensions)
+		if err != nil {
+			return fmt.Errorf("timeseries: encode dimensions: %w", err)
+		}
+		dimensions = encoded
+	}
+
+	const stmt = `
+		INSERT INTO timeseries_raw
+			(series_key, metric, entity_type, entity_id, observed_at, value, dimensions)
+		VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7::jsonb, '{}'::jsonb))
+		ON CONFLICT (series_key, observed_at)
+		DO UPDATE SET
+			value = EXCLUDED.value,
+			dimensions = EXCLUDED.dimensions,
+			created_at = NOW()
+	`
+	if _, err := s.db.ExecContext(ctx, stmt,
+		seriesKey,
+		string(point.Series.Metric),
+		point.Series.EntityType,
+		point.Series.EntityID,
+		point.ObservedAt.UTC(),
+		point.Value.String(),
+		string(dimensions),
+	); err != nil {
+		return fmt.Errorf("timeseries: ingest: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) Query(ctx context.Context, req QueryRequest) (QueryResult, error) {
+	seriesKey, err := req.Series.Key()
+	if err != nil {
+		return QueryResult{}, err
+	}
+	resolution := SelectTier(req, time.Now().UTC())
+	if !ValidResolution(resolution) {
+		return QueryResult{}, fmt.Errorf("timeseries: invalid query resolution %q", resolution)
+	}
+
+	if resolution == ResolutionRaw {
+		return s.queryRaw(ctx, seriesKey, req)
+	}
+	return s.queryRollup(ctx, seriesKey, req, resolution)
+}
+
+func (s *PostgresStore) Rollup(ctx context.Context, resolution Resolution, from, to time.Time) error {
+	if !ValidResolution(resolution) || resolution == ResolutionRaw {
+		return fmt.Errorf("timeseries: invalid rollup resolution %q", resolution)
+	}
+	if !from.Before(to) {
+		return nil
+	}
+
+	stmt, args := rollupStatement(resolution, from.UTC(), to.UTC())
+	if _, err := s.db.ExecContext(ctx, stmt, args...); err != nil {
+		return fmt.Errorf("timeseries: rollup %s: %w", resolution, err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) SafeDeleteRawBefore(ctx context.Context, before time.Time) (int64, error) {
+	const stmt = `
+		DELETE FROM timeseries_raw raw
+		WHERE raw.observed_at < $1
+		  AND EXISTS (
+			SELECT 1
+			FROM timeseries_rollups rollup
+			WHERE rollup.series_key = raw.series_key
+			  AND rollup.resolution = 'minute'
+			  AND rollup.bucket_start = date_trunc('minute', raw.observed_at)
+		  )
+	`
+	result, err := s.db.ExecContext(ctx, stmt, before.UTC())
+	if err != nil {
+		return 0, fmt.Errorf("timeseries: safe raw retention: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("timeseries: raw retention rows affected: %w", err)
+	}
+	return deleted, nil
+}
+
+func (s *PostgresStore) Checkpoint(ctx context.Context, resolution Resolution) (time.Time, bool, error) {
+	const stmt = `
+		SELECT processed_until
+		FROM timeseries_rollup_checkpoints
+		WHERE resolution = $1
+	`
+	var processedUntil time.Time
+	if err := s.db.QueryRowContext(ctx, stmt, string(resolution)).Scan(&processedUntil); err != nil {
+		if err == sql.ErrNoRows {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, fmt.Errorf("timeseries: read checkpoint: %w", err)
+	}
+	return processedUntil.UTC(), true, nil
+}
+
+func (s *PostgresStore) SetCheckpoint(ctx context.Context, resolution Resolution, processedUntil time.Time) error {
+	const stmt = `
+		INSERT INTO timeseries_rollup_checkpoints (resolution, processed_until, updated_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (resolution)
+		DO UPDATE SET
+			processed_until = GREATEST(timeseries_rollup_checkpoints.processed_until, EXCLUDED.processed_until),
+			updated_at = NOW()
+	`
+	if _, err := s.db.ExecContext(ctx, stmt, string(resolution), processedUntil.UTC()); err != nil {
+		return fmt.Errorf("timeseries: set checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) queryRaw(ctx context.Context, seriesKey string, req QueryRequest) (QueryResult, error) {
+	const stmt = `
+		SELECT observed_at, value::text
+		FROM timeseries_raw
+		WHERE series_key = $1
+		  AND observed_at >= $2
+		  AND observed_at < $3
+		ORDER BY observed_at ASC
+	`
+	rows, err := s.db.QueryContext(ctx, stmt, seriesKey, req.From.UTC(), req.To.UTC())
+	if err != nil {
+		return QueryResult{}, fmt.Errorf("timeseries: query raw: %w", err)
+	}
+	defer rows.Close()
+
+	result := QueryResult{Resolution: ResolutionRaw}
+	for rows.Next() {
+		var bucket time.Time
+		var valueText string
+		if err := rows.Scan(&bucket, &valueText); err != nil {
+			return QueryResult{}, err
+		}
+		value, err := decimal.NewFromString(valueText)
+		if err != nil {
+			return QueryResult{}, fmt.Errorf("timeseries: parse raw value: %w", err)
+		}
+		result.Points = append(result.Points, RollupPoint{
+			SeriesKey:   seriesKey,
+			Resolution:  ResolutionRaw,
+			BucketStart: bucket.UTC(),
+			Open:        value,
+			High:        value,
+			Low:         value,
+			Close:       value,
+			Average:     value,
+			Last:        value,
+			Count:       1,
+		})
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) queryRollup(ctx context.Context, seriesKey string, req QueryRequest, resolution Resolution) (QueryResult, error) {
+	const stmt = `
+		SELECT
+			series_key, metric, entity_type, entity_id, bucket_start,
+			open::text, high::text, low::text, close::text, average::text, last::text, point_count
+		FROM timeseries_rollups
+		WHERE series_key = $1
+		  AND resolution = $2
+		  AND bucket_start >= $3
+		  AND bucket_start < $4
+		ORDER BY bucket_start ASC
+	`
+	rows, err := s.db.QueryContext(ctx, stmt, seriesKey, string(resolution), req.From.UTC(), req.To.UTC())
+	if err != nil {
+		return QueryResult{}, fmt.Errorf("timeseries: query rollups: %w", err)
+	}
+	defer rows.Close()
+
+	result := QueryResult{Resolution: resolution}
+	for rows.Next() {
+		point, err := scanRollup(rows, resolution)
+		if err != nil {
+			return QueryResult{}, err
+		}
+		result.Points = append(result.Points, point)
+	}
+	return result, rows.Err()
+}
+
+func scanRollup(rows *sql.Rows, resolution Resolution) (RollupPoint, error) {
+	var point RollupPoint
+	var metric, openText, highText, lowText, closeText, averageText, lastText string
+	if err := rows.Scan(
+		&point.SeriesKey,
+		&metric,
+		&point.EntityType,
+		&point.EntityID,
+		&point.BucketStart,
+		&openText,
+		&highText,
+		&lowText,
+		&closeText,
+		&averageText,
+		&lastText,
+		&point.Count,
+	); err != nil {
+		return RollupPoint{}, err
+	}
+
+	values := []*decimal.Decimal{&point.Open, &point.High, &point.Low, &point.Close, &point.Average, &point.Last}
+	for i, text := range []string{openText, highText, lowText, closeText, averageText, lastText} {
+		value, err := decimal.NewFromString(text)
+		if err != nil {
+			return RollupPoint{}, fmt.Errorf("timeseries: parse rollup value: %w", err)
+		}
+		*values[i] = value
+	}
+	point.Metric = Metric(metric)
+	point.Resolution = resolution
+	point.BucketStart = point.BucketStart.UTC()
+	return point, nil
+}
+
+func rollupStatement(resolution Resolution, from, to time.Time) (string, []any) {
+	switch resolution {
+	case ResolutionMinute:
+		return `
+			WITH source AS (
+				SELECT
+					series_key, metric, entity_type, entity_id,
+					date_trunc('minute', observed_at) AS bucket_start,
+					observed_at AS point_at,
+					value
+				FROM timeseries_raw
+				WHERE observed_at >= $1 AND observed_at < $2
+			),
+			aggregated AS (
+				SELECT
+					series_key, metric, entity_type, entity_id, bucket_start,
+					(array_agg(value ORDER BY point_at ASC))[1] AS open,
+					MAX(value) AS high,
+					MIN(value) AS low,
+					(array_agg(value ORDER BY point_at DESC))[1] AS close,
+					AVG(value) AS average,
+					(array_agg(value ORDER BY point_at DESC))[1] AS last,
+					COUNT(*) AS point_count
+				FROM source
+				GROUP BY series_key, metric, entity_type, entity_id, bucket_start
+			)
+			INSERT INTO timeseries_rollups
+				(series_key, metric, entity_type, entity_id, resolution, bucket_start, open, high, low, close, average, last, point_count)
+			SELECT series_key, metric, entity_type, entity_id, 'minute', bucket_start, open, high, low, close, average, last, point_count
+			FROM aggregated
+			ON CONFLICT (series_key, resolution, bucket_start)
+			DO UPDATE SET
+				open = EXCLUDED.open,
+				high = EXCLUDED.high,
+				low = EXCLUDED.low,
+				close = EXCLUDED.close,
+				average = EXCLUDED.average,
+				last = EXCLUDED.last,
+				point_count = EXCLUDED.point_count,
+				updated_at = NOW()
+		`, []any{from, to}
+	case ResolutionHour:
+		return rollupFromRollupsStatement("hour", "minute"), []any{from, to}
+	default:
+		return rollupFromRollupsStatement("day", "hour"), []any{from, to}
+	}
+}
+
+func rollupFromRollupsStatement(targetUnit, sourceResolution string) string {
+	return fmt.Sprintf(`
+		WITH source AS (
+			SELECT
+				series_key, metric, entity_type, entity_id,
+				date_trunc('%s', bucket_start) AS bucket_start,
+				bucket_start AS point_at,
+				open, high, low, close, average, last, point_count
+			FROM timeseries_rollups
+			WHERE resolution = '%s'
+			  AND bucket_start >= $1
+			  AND bucket_start < $2
+		),
+		aggregated AS (
+			SELECT
+				series_key, metric, entity_type, entity_id, bucket_start,
+				(array_agg(open ORDER BY point_at ASC))[1] AS open,
+				MAX(high) AS high,
+				MIN(low) AS low,
+				(array_agg(close ORDER BY point_at DESC))[1] AS close,
+				SUM(average * point_count) / NULLIF(SUM(point_count), 0) AS average,
+				(array_agg(last ORDER BY point_at DESC))[1] AS last,
+				SUM(point_count) AS point_count
+			FROM source
+			GROUP BY series_key, metric, entity_type, entity_id, bucket_start
+		)
+		INSERT INTO timeseries_rollups
+			(series_key, metric, entity_type, entity_id, resolution, bucket_start, open, high, low, close, average, last, point_count)
+		SELECT series_key, metric, entity_type, entity_id, '%s', bucket_start, open, high, low, close, average, last, point_count
+		FROM aggregated
+		ON CONFLICT (series_key, resolution, bucket_start)
+		DO UPDATE SET
+			open = EXCLUDED.open,
+			high = EXCLUDED.high,
+			low = EXCLUDED.low,
+			close = EXCLUDED.close,
+			average = EXCLUDED.average,
+			last = EXCLUDED.last,
+			point_count = EXCLUDED.point_count,
+			updated_at = NOW()
+	`, targetUnit, sourceResolution, targetUnit)
+}

--- a/apps/api/migrations/060_create_timeseries_store.down.sql
+++ b/apps/api/migrations/060_create_timeseries_store.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS timeseries_rollup_checkpoints;
+DROP TABLE IF EXISTS timeseries_rollups;
+DROP TABLE IF EXISTS timeseries_raw_default;
+DROP TABLE IF EXISTS timeseries_raw;

--- a/apps/api/migrations/060_create_timeseries_store.up.sql
+++ b/apps/api/migrations/060_create_timeseries_store.up.sql
@@ -1,0 +1,51 @@
+-- Unified time-series store for APY, TVL, and portfolio history.
+-- Existing snapshot tables remain in place; producers can backfill and dual-write
+-- into this store without breaking current API responses.
+CREATE TABLE IF NOT EXISTS timeseries_raw (
+    series_key   TEXT        NOT NULL,
+    metric       TEXT        NOT NULL CHECK (metric IN ('apy', 'tvl', 'portfolio')),
+    entity_type  TEXT        NOT NULL,
+    entity_id    TEXT        NOT NULL,
+    observed_at  TIMESTAMPTZ NOT NULL,
+    value        NUMERIC(38, 18) NOT NULL,
+    dimensions   JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (series_key, observed_at)
+) PARTITION BY RANGE (observed_at);
+
+CREATE TABLE IF NOT EXISTS timeseries_raw_default
+    PARTITION OF timeseries_raw DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_timeseries_raw_series_observed_at
+    ON timeseries_raw (series_key, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_timeseries_raw_metric_entity_time
+    ON timeseries_raw (metric, entity_type, entity_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS timeseries_rollups (
+    series_key   TEXT        NOT NULL,
+    metric       TEXT        NOT NULL CHECK (metric IN ('apy', 'tvl', 'portfolio')),
+    entity_type  TEXT        NOT NULL,
+    entity_id    TEXT        NOT NULL,
+    resolution   TEXT        NOT NULL CHECK (resolution IN ('minute', 'hour', 'day')),
+    bucket_start TIMESTAMPTZ NOT NULL,
+    open         NUMERIC(38, 18) NOT NULL,
+    high         NUMERIC(38, 18) NOT NULL,
+    low          NUMERIC(38, 18) NOT NULL,
+    close        NUMERIC(38, 18) NOT NULL,
+    average      NUMERIC(38, 18) NOT NULL,
+    last         NUMERIC(38, 18) NOT NULL,
+    point_count  BIGINT      NOT NULL CHECK (point_count > 0),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (series_key, resolution, bucket_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_timeseries_rollups_metric_entity_time
+    ON timeseries_rollups (metric, entity_type, entity_id, resolution, bucket_start DESC);
+
+CREATE TABLE IF NOT EXISTS timeseries_rollup_checkpoints (
+    resolution      TEXT        PRIMARY KEY CHECK (resolution IN ('minute', 'hour', 'day')),
+    processed_until TIMESTAMPTZ NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Summary
- Adds a unified API time-series foundation for APY, TVL, and portfolio history with partition-ready raw storage, minute/hour/day rollups, resumable checkpoints, safe raw retention, and automatic query tier selection.

Issue
- Closes #833

Changes
- Added `internal/timeseries` models for metrics, series identifiers, points, rollups, query requests, and retention policy.
- Added deterministic in-memory aggregation helpers for OHLC/average/last/count rollups.
- Added a Postgres-backed store for idempotent raw ingestion, rollup upserts, checkpoint tracking, safe raw retention, and tiered queries.
- Added a resumable rollup job that advances minute, hour, and day checkpoints before running raw retention.
- Added migration `060_create_timeseries_store` for `timeseries_raw`, `timeseries_rollups`, and `timeseries_rollup_checkpoints`.
- Added unit coverage for stable series keys, rollup correctness, query-tier selection, and rollup checkpoint/retention ordering.

Validation
- Ran `git diff --check`.
- `go test ./internal/timeseries` was not run locally because Go is not installed on this machine.
- Attempted Docker-based Go validation, but Docker Desktop engine is not running (`dockerDesktopLinuxEngine` pipe unavailable).

Notes
- This keeps the existing snapshot tables and API paths intact so current data and migration paths are preserved while the new time-series store is introduced for incremental producer/handler adoption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-series storage for APY, TVL, and portfolio history.
  * Added ingestion and querying of raw and aggregated time-series data.
  * Added automatic resolution selection based on query range and point limits.
  * Added minute, hourly, and daily rollups with OHLC, average, latest value, and count metrics.
  * Added scheduled rollup processing with checkpoint recovery and safe raw-data retention cleanup.
  * Added database schema and migration support for time-series data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->