### PR TITLE
Add reconciliation engine foundation

### DIFF
--- a/apps/api/internal/reconciliation/cadence.go
+++ b/apps/api/internal/reconciliation/cadence.go
@@ -1,0 +1,44 @@
+package reconciliation
+
+import "time"
+
+type CadenceConfig struct {
+	Balance     time.Duration
+	Transaction time.Duration
+	Invariant   time.Duration
+}
+
+func DefaultCadenceConfig() CadenceConfig {
+	return CadenceConfig{
+		Balance:     5 * time.Minute,
+		Transaction: 2 * time.Minute,
+		Invariant:   15 * time.Minute,
+	}
+}
+
+func (c CadenceConfig) CadenceFor(level Level) time.Duration {
+	defaults := DefaultCadenceConfig()
+	switch level {
+	case LevelBalance:
+		if c.Balance > 0 {
+			return c.Balance
+		}
+		return defaults.Balance
+	case LevelTransaction:
+		if c.Transaction > 0 {
+			return c.Transaction
+		}
+		return defaults.Transaction
+	case LevelInvariant:
+		if c.Invariant > 0 {
+			return c.Invariant
+		}
+		return defaults.Invariant
+	default:
+		return 0
+	}
+}
+
+func CheckpointKey(level Level, comparator string) string {
+	return "reconciliation:" + string(level) + ":" + comparator
+}

--- a/apps/api/internal/reconciliation/classifier.go
+++ b/apps/api/internal/reconciliation/classifier.go
@@ -1,0 +1,78 @@
+package reconciliation
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type Classifier struct {
+	DustTolerance     decimal.Decimal
+	WarningThreshold  decimal.Decimal
+	CriticalThreshold decimal.Decimal
+	StuckAfter        time.Duration
+}
+
+func NewClassifier(cfg Classifier) Classifier {
+	if cfg.DustTolerance.IsZero() {
+		cfg.DustTolerance = decimal.RequireFromString("0.000001")
+	}
+	if cfg.WarningThreshold.IsZero() {
+		cfg.WarningThreshold = decimal.RequireFromString("0.01")
+	}
+	if cfg.CriticalThreshold.IsZero() {
+		cfg.CriticalThreshold = decimal.RequireFromString("1")
+	}
+	if cfg.StuckAfter <= 0 {
+		cfg.StuckAfter = 30 * time.Minute
+	}
+	return cfg
+}
+
+func (c Classifier) Classify(input FindingInput, observedAt time.Time) Finding {
+	c = NewClassifier(c)
+	finding := Finding{
+		Level:           input.Level,
+		Type:            input.Type,
+		EntityType:      input.EntityType,
+		EntityID:        input.EntityID,
+		RecordedValue:   input.RecordedValue,
+		OnChainValue:    input.OnChainValue,
+		Tolerance:       c.DustTolerance,
+		ObservedAt:      observedAt.UTC(),
+		Details:         input.Details,
+		ResolutionState: ResolutionOpen,
+	}
+
+	if input.RecordedValue != nil && input.OnChainValue != nil {
+		diff := input.RecordedValue.Sub(*input.OnChainValue).Abs()
+		finding.Difference = &diff
+		finding.Severity = c.severityForDifference(diff)
+		return finding
+	}
+
+	if input.Type == TypeStuck && input.Age >= c.StuckAfter {
+		finding.Severity = SeverityWarning
+		return finding
+	}
+	if input.Type == TypeMissing || input.Type == TypeExtra {
+		finding.Severity = SeverityCritical
+		return finding
+	}
+
+	finding.Severity = SeverityInformational
+	return finding
+}
+
+func (c Classifier) severityForDifference(diff decimal.Decimal) Severity {
+	if diff.LessThanOrEqual(c.DustTolerance) {
+		return SeverityInformational
+	}
+	if diff.GreaterThanOrEqual(c.CriticalThreshold) {
+		return SeverityCritical
+	}
+	if diff.GreaterThanOrEqual(c.WarningThreshold) {
+		return SeverityWarning
+	}
+	return SeverityInformational
+}

--- a/apps/api/internal/reconciliation/classifier_test.go
+++ b/apps/api/internal/reconciliation/classifier_test.go
@@ -1,0 +1,70 @@
+package reconciliation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestClassifierClassifiesDustAsInformational(t *testing.T) {
+	classifier := NewClassifier(Classifier{
+		DustTolerance:     decimal.RequireFromString("0.01"),
+		WarningThreshold:  decimal.RequireFromString("1"),
+		CriticalThreshold: decimal.RequireFromString("100"),
+	})
+	recorded := decimal.RequireFromString("100.001")
+	onChain := decimal.RequireFromString("100.000")
+
+	finding := classifier.Classify(FindingInput{
+		Level:         LevelBalance,
+		Type:          TypeMismatch,
+		EntityType:    "vault",
+		EntityID:      "vault-1",
+		RecordedValue: &recorded,
+		OnChainValue:  &onChain,
+	}, time.Now())
+
+	if finding.Severity != SeverityInformational {
+		t.Fatalf("severity = %q, want informational", finding.Severity)
+	}
+}
+
+func TestClassifierClassifiesMaterialMismatchAsCritical(t *testing.T) {
+	classifier := NewClassifier(Classifier{
+		DustTolerance:     decimal.RequireFromString("0.01"),
+		WarningThreshold:  decimal.RequireFromString("1"),
+		CriticalThreshold: decimal.RequireFromString("100"),
+	})
+	recorded := decimal.RequireFromString("250")
+	onChain := decimal.RequireFromString("100")
+
+	finding := classifier.Classify(FindingInput{
+		Level:         LevelBalance,
+		Type:          TypeMismatch,
+		EntityType:    "vault",
+		EntityID:      "vault-1",
+		RecordedValue: &recorded,
+		OnChainValue:  &onChain,
+	}, time.Now())
+
+	if finding.Severity != SeverityCritical {
+		t.Fatalf("severity = %q, want critical", finding.Severity)
+	}
+}
+
+func TestClassifierClassifiesStuckTransaction(t *testing.T) {
+	classifier := NewClassifier(Classifier{StuckAfter: 30 * time.Minute})
+
+	finding := classifier.Classify(FindingInput{
+		Level:      LevelTransaction,
+		Type:       TypeStuck,
+		EntityType: "transaction",
+		EntityID:   "hash",
+		Age:        time.Hour,
+	}, time.Now())
+
+	if finding.Severity != SeverityWarning {
+		t.Fatalf("severity = %q, want warning", finding.Severity)
+	}
+}

--- a/apps/api/internal/reconciliation/comparators.go
+++ b/apps/api/internal/reconciliation/comparators.go
@@ -1,0 +1,152 @@
+package reconciliation
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+type VaultBalanceReader interface {
+	TotalAssets(ctx context.Context, contractAddress string) (decimal.Decimal, error)
+}
+
+type VaultLister interface {
+	ListVaults(ctx context.Context, filter vault.ListFilter) ([]vault.Vault, int, error)
+}
+
+type BalanceComparator struct {
+	Vaults     VaultLister
+	Chain      VaultBalanceReader
+	Classifier Classifier
+	Clock      func() time.Time
+}
+
+func (c BalanceComparator) Name() string { return "vault_balance" }
+func (c BalanceComparator) Level() Level { return LevelBalance }
+
+func (c BalanceComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
+	now := clock(c.Clock)
+	filter := vault.ListFilter{Status: string(vault.StatusActive), Limit: 500, Offset: 0}
+	vaults, _, err := c.Vaults.ListVaults(ctx, filter)
+	if err != nil {
+		return ComparisonResult{}, err
+	}
+
+	var findings []Finding
+	classifier := NewClassifier(c.Classifier)
+	checked := 0
+	for _, v := range vaults {
+		if scope.VaultID != uuid.Nil && v.ID != scope.VaultID {
+			continue
+		}
+		checked++
+		if v.ContractAddress == "" {
+			continue
+		}
+		onChain, err := c.Chain.TotalAssets(ctx, v.ContractAddress)
+		if err != nil {
+			return ComparisonResult{}, err
+		}
+		if !v.CurrentBalance.Equal(onChain) {
+			recorded := v.CurrentBalance
+			chain := onChain
+			findings = append(findings, classifier.Classify(FindingInput{
+				Level:         LevelBalance,
+				Type:          TypeMismatch,
+				EntityType:    "vault",
+				EntityID:      v.ID.String(),
+				RecordedValue: &recorded,
+				OnChainValue:  &chain,
+				Details: map[string]string{
+					"contract_address": v.ContractAddress,
+					"currency":         v.Currency,
+				},
+			}, now))
+		}
+	}
+	return ComparisonResult{Checked: checked, Findings: findings}, nil
+}
+
+type TransactionStatusReader interface {
+	Status(ctx context.Context, txHash string) (transaction.TransactionStatus, bool, error)
+}
+
+type PendingTransactionLister interface {
+	ListPendingOlderThan(ctx context.Context, cutoff time.Time) ([]transaction.Transaction, error)
+}
+
+type TransactionComparator struct {
+	Transactions PendingTransactionLister
+	Chain        TransactionStatusReader
+	Classifier   Classifier
+	PendingAfter  time.Duration
+	Clock        func() time.Time
+}
+
+func (c TransactionComparator) Name() string { return "transaction_status" }
+func (c TransactionComparator) Level() Level { return LevelTransaction }
+
+func (c TransactionComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
+	pendingAfter := c.PendingAfter
+	if pendingAfter <= 0 {
+		pendingAfter = 30 * time.Minute
+	}
+	now := clock(c.Clock)
+	pending, err := c.Transactions.ListPendingOlderThan(ctx, now.Add(-pendingAfter))
+	if err != nil {
+		return ComparisonResult{}, err
+	}
+
+	classifier := NewClassifier(c.Classifier)
+	var findings []Finding
+	for _, tx := range pending {
+		status, found, err := c.Chain.Status(ctx, tx.TxHash)
+		if err != nil {
+			return ComparisonResult{}, err
+		}
+		if found && status != transaction.StatusPending {
+			findings = append(findings, classifier.Classify(FindingInput{
+				Level:      LevelTransaction,
+				Type:       TypeStuck,
+				EntityType: "transaction",
+				EntityID:   tx.TxHash,
+				Age:        now.Sub(tx.CreatedAt),
+				Details: map[string]string{
+					"recorded_status": string(tx.Status),
+					"on_chain_status": string(status),
+				},
+			}, now))
+		}
+	}
+	return ComparisonResult{Checked: len(pending), Findings: findings}, nil
+}
+
+type InvariantCheck func(ctx context.Context, scope Scope, classifier Classifier, observedAt time.Time) (ComparisonResult, error)
+
+type InvariantComparator struct {
+	Check      InvariantCheck
+	Classifier Classifier
+	Clock      func() time.Time
+}
+
+func (c InvariantComparator) Name() string { return "protocol_invariant" }
+func (c InvariantComparator) Level() Level { return LevelInvariant }
+
+func (c InvariantComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
+	if c.Check == nil {
+		return ComparisonResult{}, nil
+	}
+	return c.Check(ctx, scope, NewClassifier(c.Classifier), clock(c.Clock))
+}
+
+func clock(now func() time.Time) time.Time {
+	if now == nil {
+		return time.Now().UTC()
+	}
+	return now().UTC()
+}

--- a/apps/api/internal/reconciliation/correction.go
+++ b/apps/api/internal/reconciliation/correction.go
@@ -1,0 +1,51 @@
+package reconciliation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+type TransactionStatusUpdater interface {
+	UpdateStatus(ctx context.Context, hash string, status transaction.TransactionStatus, confirmedAt *time.Time, errorReason string) (transaction.Transaction, error)
+}
+
+type CorrectionService struct {
+	repo         Repository
+	transactions TransactionStatusUpdater
+	clock        func() time.Time
+}
+
+func NewCorrectionService(repo Repository, transactions TransactionStatusUpdater) *CorrectionService {
+	return &CorrectionService{
+		repo:         repo,
+		transactions: transactions,
+		clock:        func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (s *CorrectionService) SetClock(clock func() time.Time) {
+	s.clock = clock
+}
+
+func (s *CorrectionService) ResolveStuckTransaction(ctx context.Context, finding Finding, onChainStatus transaction.TransactionStatus) error {
+	if finding.Type != TypeStuck || finding.EntityType != "transaction" {
+		return fmt.Errorf("reconciliation: finding is not a stuck transaction")
+	}
+	if onChainStatus == transaction.StatusPending || onChainStatus == "" {
+		return fmt.Errorf("reconciliation: unresolved on-chain status cannot be auto-corrected")
+	}
+
+	confirmedAt := s.clock()
+	errorReason := ""
+	if onChainStatus == transaction.StatusFailed {
+		errorReason = "resolved by reconciliation"
+	}
+	if _, err := s.transactions.UpdateStatus(ctx, finding.EntityID, onChainStatus, &confirmedAt, errorReason); err != nil {
+		return err
+	}
+	return s.repo.RecordCorrection(ctx, finding.ID, strings.TrimSpace("stuck transaction advanced to "+string(onChainStatus)))
+}

--- a/apps/api/internal/reconciliation/correction_test.go
+++ b/apps/api/internal/reconciliation/correction_test.go
@@ -1,0 +1,57 @@
+package reconciliation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+)
+
+type fakeTransactionUpdater struct {
+	hash   string
+	status transaction.TransactionStatus
+}
+
+func (u *fakeTransactionUpdater) UpdateStatus(ctx context.Context, hash string, status transaction.TransactionStatus, confirmedAt *time.Time, errorReason string) (transaction.Transaction, error) {
+	u.hash = hash
+	u.status = status
+	return transaction.Transaction{TxHash: hash, Status: status, ConfirmedAt: confirmedAt}, nil
+}
+
+func TestCorrectionServiceOnlyLogsProvablyResolvedStuckTransaction(t *testing.T) {
+	repo := &fakeRepo{}
+	transactions := &fakeTransactionUpdater{}
+	service := NewCorrectionService(repo, transactions)
+	finding := Finding{
+		ID:         uuid.New(),
+		Type:       TypeStuck,
+		EntityType: "transaction",
+		EntityID:   "tx-hash",
+	}
+
+	if err := service.ResolveStuckTransaction(context.Background(), finding, transaction.StatusCompleted); err != nil {
+		t.Fatalf("ResolveStuckTransaction() error = %v", err)
+	}
+	if transactions.hash != "tx-hash" || transactions.status != transaction.StatusCompleted {
+		t.Fatalf("transaction update = %s/%s", transactions.hash, transactions.status)
+	}
+	if repo.corrections != 1 {
+		t.Fatalf("corrections = %d, want 1", repo.corrections)
+	}
+}
+
+func TestCorrectionServiceRejectsPendingStatus(t *testing.T) {
+	service := NewCorrectionService(&fakeRepo{}, &fakeTransactionUpdater{})
+	err := service.ResolveStuckTransaction(context.Background(), Finding{
+		ID:         uuid.New(),
+		Type:       TypeStuck,
+		EntityType: "transaction",
+		EntityID:   "tx-hash",
+	}, transaction.StatusPending)
+	if err == nil {
+		t.Fatal("expected pending status to be rejected")
+	}
+}

--- a/apps/api/internal/reconciliation/engine.go
+++ b/apps/api/internal/reconciliation/engine.go
@@ -1,0 +1,144 @@
+package reconciliation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Comparator interface {
+	Name() string
+	Level() Level
+	Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error)
+}
+
+type ComparisonResult struct {
+	Checked  int
+	Findings []Finding
+}
+
+type Repository interface {
+	CreateRun(ctx context.Context, run Run) (Run, error)
+	AddFinding(ctx context.Context, finding Finding) (Finding, error)
+	CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats) error
+	FailRun(ctx context.Context, runID uuid.UUID, errText string) error
+	GetCheckpoint(ctx context.Context, key string) (string, bool, error)
+	SetCheckpoint(ctx context.Context, key, value string) error
+	RecordCorrection(ctx context.Context, findingID uuid.UUID, reason string) error
+}
+
+type Alerter interface {
+	CriticalFinding(ctx context.Context, finding Finding) error
+	WarningFinding(ctx context.Context, finding Finding) error
+}
+
+type Engine struct {
+	repo        Repository
+	comparators []Comparator
+	alerter     Alerter
+	logger      *slog.Logger
+	now         func() time.Time
+}
+
+func NewEngine(repo Repository, comparators []Comparator, alerter Alerter) *Engine {
+	return &Engine{
+		repo:        repo,
+		comparators: comparators,
+		alerter:     alerter,
+		logger:      slog.Default(),
+		now:         func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (e *Engine) WithLogger(logger *slog.Logger) *Engine {
+	e.logger = logger
+	return e
+}
+
+func (e *Engine) SetClock(now func() time.Time) {
+	e.now = now
+}
+
+func (e *Engine) Run(ctx context.Context, scope Scope) (Stats, error) {
+	if scope.StartedAt.IsZero() {
+		scope.StartedAt = e.now()
+	}
+
+	var total Stats
+	for _, comparator := range e.comparators {
+		stats, err := e.runComparator(ctx, comparator, scope)
+		total.Checked += stats.Checked
+		total.Findings += stats.Findings
+		total.Critical += stats.Critical
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope Scope) (Stats, error) {
+	run, err := e.repo.CreateRun(ctx, Run{
+		ID:         uuid.New(),
+		Level:      comparator.Level(),
+		Comparator: comparator.Name(),
+		Status:     RunStatusRunning,
+		Scope:      scope,
+		StartedAt:  scope.StartedAt,
+	})
+	if err != nil {
+		return Stats{}, fmt.Errorf("reconciliation: create run: %w", err)
+	}
+
+	result, err := comparator.Reconcile(ctx, scope)
+	if err != nil {
+		_ = e.repo.FailRun(ctx, run.ID, err.Error())
+		return Stats{}, fmt.Errorf("reconciliation: %s: %w", comparator.Name(), err)
+	}
+
+	stats := Stats{Checked: result.Checked, Findings: len(result.Findings)}
+	for _, finding := range result.Findings {
+		finding.RunID = run.ID
+		finding.Level = comparator.Level()
+		if finding.ID == uuid.Nil {
+			finding.ID = uuid.New()
+		}
+		if finding.ResolutionState == "" {
+			finding.ResolutionState = ResolutionOpen
+		}
+
+		stored, err := e.repo.AddFinding(ctx, finding)
+		if err != nil {
+			_ = e.repo.FailRun(ctx, run.ID, err.Error())
+			return stats, fmt.Errorf("reconciliation: store finding: %w", err)
+		}
+		if stored.Severity == SeverityCritical {
+			stats.Critical++
+		}
+		if err := e.dispatchAlert(ctx, stored); err != nil {
+			e.logger.Error("reconciliation alert failed", "finding_id", stored.ID, "error", err)
+		}
+	}
+
+	if err := e.repo.CompleteRun(ctx, run.ID, stats); err != nil {
+		return stats, fmt.Errorf("reconciliation: complete run: %w", err)
+	}
+	return stats, nil
+}
+
+func (e *Engine) dispatchAlert(ctx context.Context, finding Finding) error {
+	if e.alerter == nil {
+		return nil
+	}
+	switch finding.Severity {
+	case SeverityCritical:
+		return e.alerter.CriticalFinding(ctx, finding)
+	case SeverityWarning:
+		return e.alerter.WarningFinding(ctx, finding)
+	default:
+		return nil
+	}
+}

--- a/apps/api/internal/reconciliation/engine_test.go
+++ b/apps/api/internal/reconciliation/engine_test.go
@@ -1,0 +1,112 @@
+package reconciliation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type fakeComparator struct {
+	result ComparisonResult
+}
+
+func (c fakeComparator) Name() string { return "fake_balance" }
+func (c fakeComparator) Level() Level { return LevelBalance }
+func (c fakeComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
+	return c.result, nil
+}
+
+type fakeRepo struct {
+	runs        []Run
+	findings    []Finding
+	corrections int
+	completed   Stats
+}
+
+func (r *fakeRepo) CreateRun(ctx context.Context, run Run) (Run, error) {
+	r.runs = append(r.runs, run)
+	return run, nil
+}
+
+func (r *fakeRepo) AddFinding(ctx context.Context, finding Finding) (Finding, error) {
+	r.findings = append(r.findings, finding)
+	return finding, nil
+}
+
+func (r *fakeRepo) CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats) error {
+	r.completed = stats
+	return nil
+}
+
+func (r *fakeRepo) FailRun(ctx context.Context, runID uuid.UUID, errText string) error {
+	return nil
+}
+
+func (r *fakeRepo) GetCheckpoint(ctx context.Context, key string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (r *fakeRepo) SetCheckpoint(ctx context.Context, key, value string) error {
+	return nil
+}
+
+func (r *fakeRepo) RecordCorrection(ctx context.Context, findingID uuid.UUID, reason string) error {
+	r.corrections++
+	return nil
+}
+
+type fakeAlerter struct {
+	critical int
+	warning  int
+}
+
+func (a *fakeAlerter) CriticalFinding(ctx context.Context, finding Finding) error {
+	a.critical++
+	return nil
+}
+
+func (a *fakeAlerter) WarningFinding(ctx context.Context, finding Finding) error {
+	a.warning++
+	return nil
+}
+
+func TestEngineRecordsFindingAndDoesNotAutoCorrect(t *testing.T) {
+	recorded := decimal.RequireFromString("250")
+	onChain := decimal.RequireFromString("100")
+	finding := NewClassifier(Classifier{
+		CriticalThreshold: decimal.RequireFromString("10"),
+	}).Classify(FindingInput{
+		Level:         LevelBalance,
+		Type:          TypeMismatch,
+		EntityType:    "vault",
+		EntityID:      "vault-1",
+		RecordedValue: &recorded,
+		OnChainValue:  &onChain,
+	}, time.Now())
+
+	repo := &fakeRepo{}
+	alerter := &fakeAlerter{}
+	engine := NewEngine(repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 1, Findings: []Finding{finding}},
+	}}, alerter)
+
+	stats, err := engine.Run(context.Background(), Scope{FullSweep: true})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if stats.Checked != 1 || stats.Findings != 1 || stats.Critical != 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	if len(repo.findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(repo.findings))
+	}
+	if repo.corrections != 0 {
+		t.Fatalf("corrections = %d, want 0", repo.corrections)
+	}
+	if alerter.critical != 1 {
+		t.Fatalf("critical alerts = %d, want 1", alerter.critical)
+	}
+}

--- a/apps/api/internal/reconciliation/model.go
+++ b/apps/api/internal/reconciliation/model.go
@@ -1,0 +1,113 @@
+// Package reconciliation compares recorded application state against
+// authoritative on-chain state and records every discrepancy for review.
+package reconciliation
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type Level string
+
+const (
+	LevelBalance     Level = "balance"
+	LevelTransaction Level = "transaction"
+	LevelInvariant   Level = "invariant"
+)
+
+type DiscrepancyType string
+
+const (
+	TypeMissing  DiscrepancyType = "missing"
+	TypeExtra    DiscrepancyType = "extra"
+	TypeMismatch DiscrepancyType = "mismatch"
+	TypeStuck    DiscrepancyType = "stuck"
+)
+
+type Severity string
+
+const (
+	SeverityInformational Severity = "informational"
+	SeverityWarning       Severity = "warning"
+	SeverityCritical      Severity = "critical"
+)
+
+type RunStatus string
+
+const (
+	RunStatusRunning   RunStatus = "running"
+	RunStatusCompleted RunStatus = "completed"
+	RunStatusFailed    RunStatus = "failed"
+)
+
+type ResolutionState string
+
+const (
+	ResolutionOpen      ResolutionState = "open"
+	ResolutionReviewing ResolutionState = "reviewing"
+	ResolutionResolved  ResolutionState = "resolved"
+)
+
+type Scope struct {
+	FullSweep bool
+	VaultID   uuid.UUID
+	EventID   string
+	StartedAt time.Time
+}
+
+type Run struct {
+	ID             uuid.UUID
+	Level          Level
+	Comparator     string
+	Status         RunStatus
+	Scope          Scope
+	StartedAt      time.Time
+	CompletedAt    *time.Time
+	CheckedCount   int
+	FindingCount   int
+	CriticalCount  int
+	CheckpointKey  string
+	CheckpointFrom string
+	CheckpointTo   string
+	Error           string
+}
+
+type Finding struct {
+	ID              uuid.UUID
+	RunID           uuid.UUID
+	Level           Level
+	Type            DiscrepancyType
+	Severity        Severity
+	EntityType      string
+	EntityID        string
+	RecordedValue   *decimal.Decimal
+	OnChainValue    *decimal.Decimal
+	Difference      *decimal.Decimal
+	Tolerance       decimal.Decimal
+	ObservedAt      time.Time
+	Details         map[string]string
+	ResolutionState ResolutionState
+}
+
+type FindingInput struct {
+	Level         Level
+	Type          DiscrepancyType
+	EntityType    string
+	EntityID      string
+	RecordedValue *decimal.Decimal
+	OnChainValue  *decimal.Decimal
+	Age           time.Duration
+	Details       map[string]string
+}
+
+type Stats struct {
+	Checked  int
+	Findings int
+	Critical int
+}
+
+func DecimalPtr(value decimal.Decimal) *decimal.Decimal {
+	return &value
+}

--- a/apps/api/internal/reconciliation/postgres_repository.go
+++ b/apps/api/internal/reconciliation/postgres_repository.go
@@ -1,0 +1,185 @@
+package reconciliation
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type PostgresRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) CreateRun(ctx context.Context, run Run) (Run, error) {
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	if run.StartedAt.IsZero() {
+		run.StartedAt = time.Now().UTC()
+	}
+	if run.Status == "" {
+		run.Status = RunStatusRunning
+	}
+	scope, err := json.Marshal(run.Scope)
+	if err != nil {
+		return Run{}, fmt.Errorf("encode run scope: %w", err)
+	}
+
+	const stmt = `
+		INSERT INTO reconciliation_runs (
+			id, level, comparator, status, scope, started_at,
+			checkpoint_key, checkpoint_from, checkpoint_to
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
+	if _, err := r.db.ExecContext(ctx, stmt,
+		run.ID,
+		string(run.Level),
+		run.Comparator,
+		string(run.Status),
+		scope,
+		run.StartedAt.UTC(),
+		nullText(run.CheckpointKey),
+		nullText(run.CheckpointFrom),
+		nullText(run.CheckpointTo),
+	); err != nil {
+		return Run{}, fmt.Errorf("create reconciliation run: %w", err)
+	}
+	return run, nil
+}
+
+func (r *PostgresRepository) AddFinding(ctx context.Context, finding Finding) (Finding, error) {
+	if finding.ID == uuid.Nil {
+		finding.ID = uuid.New()
+	}
+	if finding.ObservedAt.IsZero() {
+		finding.ObservedAt = time.Now().UTC()
+	}
+	if finding.ResolutionState == "" {
+		finding.ResolutionState = ResolutionOpen
+	}
+	details, err := json.Marshal(finding.Details)
+	if err != nil {
+		return Finding{}, fmt.Errorf("encode finding details: %w", err)
+	}
+
+	const stmt = `
+		INSERT INTO reconciliation_findings (
+			id, run_id, level, type, severity, entity_type, entity_id,
+			recorded_value, on_chain_value, difference, tolerance,
+			observed_at, details, resolution_state
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		ON CONFLICT (run_id, level, type, entity_type, entity_id)
+		DO UPDATE SET
+			severity = EXCLUDED.severity,
+			recorded_value = EXCLUDED.recorded_value,
+			on_chain_value = EXCLUDED.on_chain_value,
+			difference = EXCLUDED.difference,
+			tolerance = EXCLUDED.tolerance,
+			observed_at = EXCLUDED.observed_at,
+			details = EXCLUDED.details,
+			updated_at = NOW()
+	`
+	if _, err := r.db.ExecContext(ctx, stmt,
+		finding.ID,
+		finding.RunID,
+		string(finding.Level),
+		string(finding.Type),
+		string(finding.Severity),
+		finding.EntityType,
+		finding.EntityID,
+		decimalText(finding.RecordedValue),
+		decimalText(finding.OnChainValue),
+		decimalText(finding.Difference),
+		finding.Tolerance.String(),
+		finding.ObservedAt.UTC(),
+		details,
+		string(finding.ResolutionState),
+	); err != nil {
+		return Finding{}, fmt.Errorf("add reconciliation finding: %w", err)
+	}
+	return finding, nil
+}
+
+func (r *PostgresRepository) CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats) error {
+	const stmt = `
+		UPDATE reconciliation_runs
+		SET status = $2,
+			completed_at = NOW(),
+			checked_count = $3,
+			finding_count = $4,
+			critical_count = $5,
+			updated_at = NOW()
+		WHERE id = $1
+	`
+	_, err := r.db.ExecContext(ctx, stmt, runID, string(RunStatusCompleted), stats.Checked, stats.Findings, stats.Critical)
+	return err
+}
+
+func (r *PostgresRepository) FailRun(ctx context.Context, runID uuid.UUID, errText string) error {
+	const stmt = `
+		UPDATE reconciliation_runs
+		SET status = $2, completed_at = NOW(), error = $3, updated_at = NOW()
+		WHERE id = $1
+	`
+	_, err := r.db.ExecContext(ctx, stmt, runID, string(RunStatusFailed), errText)
+	return err
+}
+
+func (r *PostgresRepository) GetCheckpoint(ctx context.Context, key string) (string, bool, error) {
+	const stmt = `SELECT value FROM reconciliation_checkpoints WHERE key = $1`
+	var value string
+	if err := r.db.QueryRowContext(ctx, stmt, key).Scan(&value); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return value, true, nil
+}
+
+func (r *PostgresRepository) SetCheckpoint(ctx context.Context, key, value string) error {
+	const stmt = `
+		INSERT INTO reconciliation_checkpoints (key, value, updated_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (key)
+		DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+	`
+	_, err := r.db.ExecContext(ctx, stmt, key, value)
+	return err
+}
+
+func (r *PostgresRepository) RecordCorrection(ctx context.Context, findingID uuid.UUID, reason string) error {
+	const stmt = `
+		UPDATE reconciliation_findings
+		SET resolution_state = $2,
+			resolution_note = $3,
+			resolved_at = NOW(),
+			updated_at = NOW()
+		WHERE id = $1
+	`
+	_, err := r.db.ExecContext(ctx, stmt, findingID, string(ResolutionResolved), reason)
+	return err
+}
+
+func nullText(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func decimalText(value *decimal.Decimal) any {
+	if value == nil {
+		return nil
+	}
+	return value.String()
+}

--- a/apps/api/migrations/061_create_reconciliation_audit.down.sql
+++ b/apps/api/migrations/061_create_reconciliation_audit.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS reconciliation_checkpoints;
+DROP TABLE IF EXISTS reconciliation_findings;
+DROP TABLE IF EXISTS reconciliation_runs;

--- a/apps/api/migrations/061_create_reconciliation_audit.up.sql
+++ b/apps/api/migrations/061_create_reconciliation_audit.up.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS reconciliation_runs (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    level           TEXT        NOT NULL CHECK (level IN ('balance', 'transaction', 'invariant')),
+    comparator      TEXT        NOT NULL,
+    status          TEXT        NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+    scope           JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ,
+    checked_count   INTEGER     NOT NULL DEFAULT 0,
+    finding_count   INTEGER     NOT NULL DEFAULT 0,
+    critical_count  INTEGER     NOT NULL DEFAULT 0,
+    checkpoint_key  TEXT,
+    checkpoint_from TEXT,
+    checkpoint_to   TEXT,
+    error           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_runs_level_started
+    ON reconciliation_runs (level, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS reconciliation_findings (
+    id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id           UUID        NOT NULL REFERENCES reconciliation_runs(id) ON DELETE CASCADE,
+    level            TEXT        NOT NULL CHECK (level IN ('balance', 'transaction', 'invariant')),
+    type             TEXT        NOT NULL CHECK (type IN ('missing', 'extra', 'mismatch', 'stuck')),
+    severity         TEXT        NOT NULL CHECK (severity IN ('informational', 'warning', 'critical')),
+    entity_type      TEXT        NOT NULL,
+    entity_id        TEXT        NOT NULL,
+    recorded_value   NUMERIC(38, 18),
+    on_chain_value   NUMERIC(38, 18),
+    difference       NUMERIC(38, 18),
+    tolerance        NUMERIC(38, 18) NOT NULL DEFAULT 0,
+    observed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    details          JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    resolution_state TEXT        NOT NULL DEFAULT 'open' CHECK (resolution_state IN ('open', 'reviewing', 'resolved')),
+    resolution_note  TEXT,
+    resolved_at      TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (run_id, level, type, entity_type, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_findings_open_severity
+    ON reconciliation_findings (resolution_state, severity, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_findings_entity
+    ON reconciliation_findings (entity_type, entity_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS reconciliation_checkpoints (
+    key        TEXT        PRIMARY KEY,
+    value      TEXT        NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Summary
- Adds a reconciliation engine foundation that records auditable on-chain/off-chain checks, classifies discrepancies, dispatches severity-based alerts, and prevents silent auto-correction.

Issue
- Closes #831

Changes
- Added `internal/reconciliation` models for runs, findings, scopes, discrepancy types, severities, and resolution states.
- Added a shared classifier for missing, extra, mismatch, and stuck discrepancies with dust, warning, and critical thresholds.
- Added an engine that runs balance, transaction, and invariant comparators, persists runs/findings, and routes warning/critical findings to alert hooks.
- Added balance and transaction comparators using existing vault/transaction domain contracts and Stellar-compatible balance/status reader interfaces.
- Added default reconciliation cadences and checkpoint key helpers for scheduled full sweeps and targeted checks.
- Added a correction service that only advances provably resolved stuck transactions and records the correction.
- Added Postgres persistence for reconciliation runs, findings, checkpoints, and logged corrections via migration `061_create_reconciliation_audit`.
- Added unit tests for dust tolerance, material mismatch severity, stuck transaction classification, no silent auto-correction, alert dispatch, and logged stuck-transaction correction.

Validation
- Ran `git diff --check`.
- `go test ./internal/reconciliation` was not run locally because Go is not installed on this machine.
- Attempted Docker-based Go validation, but Docker Desktop engine is not running (`dockerDesktopLinuxEngine` pipe unavailable).

Notes
- Existing money-moving services are not rewritten in this PR. The new package provides the shared classifier, audit schema, comparator interfaces, and engine foundation needed to wire scheduled and targeted reconciliation safely in follow-up integration work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reconciliation audits for balances, transactions, and protocol invariants.
  * Reconciliation runs now track discrepancies, severity, progress, checkpoints, and completion status.
  * Added configurable schedules for recurring reconciliation checks.
  * Added alerts for warning and critical findings.
  * Added correction workflows for provably resolved stuck transactions.
  * Findings now classify missing, extra, mismatched, and stuck records by severity.
* **Bug Fixes**
  * Prevented automatic correction when transaction status remains pending or cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->