### PR TITLE
#588 chore(security): create load and stress testing plan for vault A…

### DIFF
--- a/.github/workflows/load-soak.yml
+++ b/.github/workflows/load-soak.yml
@@ -1,0 +1,38 @@
+name: Nightly staging load soak
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  soak:
+    name: k6 soak (staging)
+    runs-on: ubuntu-latest
+    # A missing secret must never cause a test to fall back to localhost or production.
+    if: ${{ secrets.STAGING_LOAD_API_BASE_URL != '' }}
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run isolated staging soak
+        env:
+          API_BASE_URL: ${{ secrets.STAGING_LOAD_API_BASE_URL }}
+          INTELLIGENCE_BASE_URL: ${{ secrets.STAGING_LOAD_INTELLIGENCE_BASE_URL }}
+          WS_URL: ${{ secrets.STAGING_LOAD_WS_URL }}
+          VAULT_ID: ${{ secrets.STAGING_LOAD_VAULT_ID }}
+          AUTH_TOKEN: ${{ secrets.STAGING_LOAD_AUTH_TOKEN }}
+        run: |
+          mkdir -p results
+          docker run --rm --network host \
+            -e API_BASE_URL -e INTELLIGENCE_BASE_URL -e WS_URL -e VAULT_ID -e AUTH_TOKEN \
+            -v "$PWD:/work" -w /work grafana/k6:latest \
+            run --summary-export results/soak-summary.json tests/load/soak.js
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: k6-soak-summary-${{ github.run_id }}
+          path: results/soak-summary.json
+          if-no-files-found: warn

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -1,0 +1,73 @@
+# Load testing
+
+This directory contains **k6** workload definitions for the Nester launch-critical paths. They are intentionally external black-box tests: run them only against a disposable local environment or an approved, isolated staging environment. **Never run them against production.**
+
+## Coverage and workload contract
+
+| Surface | k6 scenario | target | Notes |
+| --- | --- | ---: | --- |
+| Vault deposit/write | `deposit` | 50 RPS | The current API route is `POST /api/v1/vaults/{VAULT_ID}/deposit`, not the issue's generic `/transactions/deposit`. |
+| Vault listing/read | `vaults` | 500 RPS | p95 must remain below 500 ms in steady state. |
+| Portfolio aggregation/read | `portfolio` | 200 RPS | Defaults to the implemented `GET /api/v1/portfolio/summary`; override `PORTFOLIO_URL` if testing a user-scoped deployment route. p95 must remain below 500 ms in steady state. |
+| Intelligence chat | `chat` | 20 RPS | Calls `POST /intelligence/chat` directly, so set `INTELLIGENCE_BASE_URL`; do not spend real Claude budget without approval. |
+| Auth challenge | `challenge` | 200 RPS | Exercises Redis-backed challenge creation. Set `CHALLENGE_WALLETS` to a comma-separated pool of valid Stellar addresses to exercise distinct Redis keys. |
+| WebSocket hub | `websocket` | 1,000 connections | Steady state holds 500 connections, satisfying the acceptance gate; ramp/spike exercise the stated 2x/5x limits. |
+
+The four scripts run all six scenarios concurrently:
+
+- `steady.js`: 50% of every HTTP target for 10 minutes and 500 WebSocket connections.
+- `ramp.js`: linear 0 → 2x target over 5 minutes.
+- `spike.js`: 50% baseline, 5x burst for 30 seconds, then return to baseline.
+- `soak.js`: 20% target for 2 hours and 200 persistent WebSocket connections.
+
+The event indexer is not an HTTP endpoint. During each write workload, monitor its event lag, duplicate/failed event count, pending transaction count, Postgres pool saturation, Redis memory, and API RSS. This detects the data-desynchronisation risk without forging chain events.
+
+## Prerequisites and configuration
+
+Install [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) (v0.49 or newer). Start the local dependency stack first:
+
+```bash
+docker compose up -d postgres redis api intelligence
+# Wait until: curl -f http://localhost:8080/readyz
+```
+
+Use a **dedicated load-test account/vault**, an authenticated token where the target requires it, and a testnet Stellar operator. Deposits are writes and can invoke chain logic.
+
+```bash
+export API_BASE_URL=http://localhost:8080/api/v1
+export INTELLIGENCE_BASE_URL=http://localhost:8000/intelligence
+export WS_URL=ws://localhost:8080/ws
+export VAULT_ID='<dedicated-test-vault-uuid>'
+export AUTH_TOKEN='<dedicated-test-jwt>'
+# Optional only if route differs in that environment:
+# export DEPOSIT_URL="$API_BASE_URL/transactions/deposit"
+# export PORTFOLIO_URL="$API_BASE_URL/users/portfolio"
+```
+
+Before a run, ensure rate limits are sized for the test source (or allowlist that source only in staging). Default per-IP API limits intentionally reject these traffic levels; treating those expected `429`s as a performance pass would invalidate the result.
+
+## Run and save evidence
+
+```bash
+mkdir -p results
+k6 run --summary-export results/steady-summary.json tests/load/steady.js
+k6 run --summary-export results/ramp-summary.json tests/load/ramp.js
+k6 run --summary-export results/spike-summary.json tests/load/spike.js
+k6 run --summary-export results/soak-summary.json tests/load/soak.js
+```
+
+Use a generator with enough CPU, file descriptors, ephemeral ports, and network capacity—especially for the 5,000-connection spike. If it emits `dropped_iterations`, increase `preAllocatedVUs`/`maxVUs` or distribute the test before attributing a failure to Nester.
+
+## Interpretation and gates
+
+k6 fails the run when any declared threshold fails:
+
+- `http_req_duration{endpoint:vaults}` and `{endpoint:portfolio}`: p95 < **500 ms**;
+- total HTTP failure rate < **1%** and checks > **99%**;
+- WebSocket connection p95 < **1 s**.
+
+Record p50, p95, p99, error rate, dropped iterations, websocket connection failures, API/worker RSS, goroutines, database connections/slow queries, Redis memory/evictions, and indexer lag. Compare soak start/end values: monotonic RSS, open FD/goroutine, connection, or lag growth is a leak/regression. HTTP `401`, `403`, `404`, `422`, and `429` are configuration or data errors—not successful load-test responses.
+
+## CI
+
+`.github/workflows/load-soak.yml` runs the two-hour soak nightly and can be launched manually. It requires the `STAGING_LOAD_API_BASE_URL`, `STAGING_LOAD_INTELLIGENCE_BASE_URL`, `STAGING_LOAD_WS_URL`, `STAGING_LOAD_VAULT_ID`, and `STAGING_LOAD_AUTH_TOKEN` repository secrets. The workflow exits safely when the staging API URL secret is absent and uploads the k6 JSON summary when it runs. Keep staging isolated and use a dedicated test vault.

--- a/docs/LOAD_TESTING_BASELINE.md
+++ b/docs/LOAD_TESTING_BASELINE.md
@@ -1,0 +1,17 @@
+# Load-test baseline report
+
+**Status:** Pending first approved staging execution. This repository change supplies reproducible tests; no measurements have been fabricated from a developer machine.
+
+| Run date/commit | Environment | Scenario | p50 | p95 | p99 | Error rate | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| Not yet run | Approved staging | Steady (vaults) | — | — | — | — | Pending |
+| Not yet run | Approved staging | Steady (portfolio) | — | — | — | — | Pending |
+| Not yet run | Approved staging | WebSocket (500 connections) | — | — | — | — | Pending |
+
+Run `k6 run --summary-export results/steady-summary.json tests/load/steady.js`, transfer p50/p95/p99 and error rate here, and attach the JSON artifact. Acceptance requires read p95 below 500 ms and no WebSocket OOM at 500 concurrent connections.
+
+## Initial bottleneck / remediation
+
+**Identified bottleneck: deployment rate limits can mask capacity and reject the defined workload.** The API defaults (`RATELIMIT_GLOBAL_LIMIT=100/min`, write `20/min`, auth `10/min`) are far below the issue targets (for example, vault reads are 500 RPS and auth challenges 200 RPS). A load run from one generator would therefore mostly return `429`, making latency figures meaningless and hiding database/indexer behavior.
+
+**Recommended fix:** in an isolated staging load-test environment only, use Redis-backed distributed limits and a narrowly scoped, audited load-generator allowlist (or traffic-class-specific test limits) at the edge. Retain strict production limits; do not disable them globally. Run generators from several source IPs only when this mirrors production traffic. Monitor PostgreSQL pool wait time and event-indexer lag alongside the test; then tune pool size/replica routing and add/verify indexes only from observed slow queries.

--- a/tests/load/common.js
+++ b/tests/load/common.js
@@ -1,0 +1,58 @@
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check, sleep } from 'k6';
+
+// URLs and credentials deliberately come only from the environment. Never point
+// load tests at production or place real tokens/keys in this repository.
+export const apiBase = (__ENV.API_BASE_URL || 'http://localhost:8080/api/v1').replace(/\/$/, '');
+export const intelligenceBase = (__ENV.INTELLIGENCE_BASE_URL || 'http://localhost:8000/intelligence').replace(/\/$/, '');
+export const wsURL = __ENV.WS_URL || apiBase.replace(/^http/, 'ws').replace(/\/api\/v1$/, '/ws');
+export const authHeaders = __ENV.AUTH_TOKEN ? { Authorization: `Bearer ${__ENV.AUTH_TOKEN}` } : {};
+export const vaultID = __ENV.VAULT_ID || '00000000-0000-0000-0000-000000000000';
+export const portfolioURL = __ENV.PORTFOLIO_URL || `${apiBase}/portfolio/summary`;
+// The API's deposit route is vault-scoped. Override only when a deployment exposes
+// a compatibility /transactions/deposit route.
+export const depositURL = __ENV.DEPOSIT_URL || `${apiBase}/vaults/${vaultID}/deposit`;
+
+const jsonHeaders = { 'Content-Type': 'application/json', ...authHeaders };
+const expected = (response, name) => check(response, {
+  [`${name}: successful response`]: r => r.status >= 200 && r.status < 300,
+});
+
+export function requestFor(name) {
+  switch (name) {
+    case 'vaults': return expected(http.get(`${apiBase}/vaults`, { headers: authHeaders, tags: { endpoint: 'vaults' } }), name);
+    case 'portfolio': return expected(http.get(portfolioURL, { headers: authHeaders, tags: { endpoint: 'portfolio' } }), name);
+    case 'challenge': {
+      // Supply a comma-separated pool of valid Stellar addresses to exercise
+      // distinct Redis keys. The default is a valid testnet-format address.
+      const wallets = (__ENV.CHALLENGE_WALLETS || 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN').split(',');
+      const wallet = wallets[(__VU + __ITER) % wallets.length].trim();
+      return expected(http.post(`${apiBase}/auth/challenge`, JSON.stringify({ wallet_address: wallet }), { headers: jsonHeaders, tags: { endpoint: 'challenge' } }), name);
+    }
+    case 'deposit': return expected(http.post(depositURL, JSON.stringify({ amount: __ENV.DEPOSIT_AMOUNT || '1', asset: __ENV.DEPOSIT_ASSET || 'USDC' }), { headers: jsonHeaders, tags: { endpoint: 'deposit' } }), name);
+    case 'chat': return expected(http.post(`${intelligenceBase}/chat`, JSON.stringify({ message: __ENV.CHAT_MESSAGE || 'Load-test health check' }), { headers: jsonHeaders, timeout: '60s', tags: { endpoint: 'chat' } }), name);
+    default: throw new Error(`unknown load-test endpoint: ${name}`);
+  }
+}
+
+export function websocket() {
+  const response = ws.connect(wsURL, { headers: authHeaders, tags: { endpoint: 'websocket' } }, socket => {
+    socket.on('open', () => {
+      if (__ENV.WS_CHANNEL) socket.send(JSON.stringify({ type: 'subscribe', channel: __ENV.WS_CHANNEL }));
+    });
+    socket.setTimeout(() => socket.close(), Number(__ENV.WS_HOLD_MS || 30000));
+    socket.on('error', error => console.error(`websocket error: ${error.error()}`));
+  });
+  check(response, { 'websocket: connected (101)': r => r && r.status === 101 });
+  sleep(0.1);
+}
+
+export const endpointTargets = { deposit: 50, vaults: 500, portfolio: 200, chat: 20, challenge: 200 };
+export const readThresholds = {
+  'http_req_duration{endpoint:vaults}': ['p(95)<500'],
+  'http_req_duration{endpoint:portfolio}': ['p(95)<500'],
+  'http_req_failed': ['rate<0.01'],
+  'checks': ['rate>0.99'],
+  'ws_connecting': ['p(95)<1000'],
+};

--- a/tests/load/ramp.js
+++ b/tests/load/ramp.js
@@ -1,0 +1,6 @@
+import exec from 'k6/execution';
+import { endpointTargets, readThresholds, requestFor, websocket } from './common.js';
+const scenarios = Object.fromEntries(Object.entries(endpointTargets).map(([name, rate]) => [name, { executor: 'ramping-arrival-rate', startRate: 0, timeUnit: '1s', preAllocatedVUs: Math.max(20, Math.ceil(rate / 2)), maxVUs: Math.max(100, rate * 3), stages: [{ target: rate * 2, duration: '5m' }] }]));
+scenarios.websocket = { executor: 'ramping-vus', startVUs: 0, stages: [{ target: 2000, duration: '5m' }], gracefulRampDown: '10s' };
+export const options = { scenarios, thresholds: readThresholds, tags: { test_type: 'ramp' } };
+export default function () { return exec.scenario.name === 'websocket' ? websocket() : requestFor(exec.scenario.name); }

--- a/tests/load/soak.js
+++ b/tests/load/soak.js
@@ -1,0 +1,6 @@
+import exec from 'k6/execution';
+import { endpointTargets, readThresholds, requestFor, websocket } from './common.js';
+const scenarios = Object.fromEntries(Object.entries(endpointTargets).map(([name, rate]) => [name, { executor: 'constant-arrival-rate', rate: rate / 5, timeUnit: '1s', duration: '2h', preAllocatedVUs: Math.max(10, Math.ceil(rate / 10)), maxVUs: Math.max(50, rate) }]));
+scenarios.websocket = { executor: 'constant-vus', vus: 200, duration: '2h', gracefulStop: '10s' };
+export const options = { scenarios, thresholds: readThresholds, tags: { test_type: 'soak' } };
+export default function () { return exec.scenario.name === 'websocket' ? websocket() : requestFor(exec.scenario.name); }

--- a/tests/load/spike.js
+++ b/tests/load/spike.js
@@ -1,0 +1,6 @@
+import exec from 'k6/execution';
+import { endpointTargets, readThresholds, requestFor, websocket } from './common.js';
+const scenarios = Object.fromEntries(Object.entries(endpointTargets).map(([name, rate]) => [name, { executor: 'ramping-arrival-rate', startRate: rate / 2, timeUnit: '1s', preAllocatedVUs: Math.max(20, rate), maxVUs: Math.max(100, rate * 8), stages: [{ target: rate / 2, duration: '30s' }, { target: rate * 5, duration: '1s' }, { target: rate * 5, duration: '30s' }, { target: rate / 2, duration: '1s' }, { target: rate / 2, duration: '30s' }] }]));
+scenarios.websocket = { executor: 'ramping-vus', startVUs: 500, stages: [{ target: 500, duration: '30s' }, { target: 5000, duration: '1s' }, { target: 5000, duration: '30s' }, { target: 500, duration: '1s' }, { target: 500, duration: '30s' }], gracefulRampDown: '10s' };
+export const options = { scenarios, thresholds: readThresholds, tags: { test_type: 'spike' } };
+export default function () { return exec.scenario.name === 'websocket' ? websocket() : requestFor(exec.scenario.name); }

--- a/tests/load/steady.js
+++ b/tests/load/steady.js
@@ -1,0 +1,6 @@
+import exec from 'k6/execution';
+import { endpointTargets, readThresholds, requestFor, websocket } from './common.js';
+const scenarios = Object.fromEntries(Object.entries(endpointTargets).map(([name, rate]) => [name, { executor: 'constant-arrival-rate', rate: rate / 2, timeUnit: '1s', duration: '10m', preAllocatedVUs: Math.max(10, Math.ceil(rate / 5)), maxVUs: Math.max(50, rate) }]));
+scenarios.websocket = { executor: 'constant-vus', vus: 500, duration: '10m', gracefulStop: '10s' };
+export const options = { scenarios, thresholds: readThresholds, tags: { test_type: 'steady' } };
+export default function () { return exec.scenario.name === 'websocket' ? websocket() : requestFor(exec.scenario.name); }


### PR DESCRIPTION
## Summary

Adds a complete k6 load-testing plan for Nester’s highest-risk launch surfaces: vault deposits, vault reads, portfolio aggregation, intelligence chat, authentication challenges, and the WebSocket hub. It also adds load-test documentation, a baseline report template, operational bottleneck guidance, and an optional nightly staging soak-test workflow.

## Related Issues

Closes #588 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation

## Changes Made

- Added configurable k6 load-test scripts under `tests/load/`:
  - `steady.js` — 50% target load for 10 minutes, including 500 concurrent WebSocket connections.
  - `ramp.js` — 0 to 2× target load over 5 minutes.
  - `spike.js` — 5× burst for 30 seconds before returning to baseline.
  - `soak.js` — 20% target load for 2 hours.
  - `common.js` — shared HTTP, WebSocket, authentication, target-rate, and threshold helpers.

- Added coverage for:
  - `POST /api/v1/vaults/{id}/deposit`
  - `GET /api/v1/vaults`
  - `GET /api/v1/portfolio/summary`
  - `POST /intelligence/chat`
  - `POST /api/v1/auth/challenge`
  - WebSocket hub at `/ws`

- Added p95 performance thresholds for read paths:
  - Vault reads: p95 < 500 ms
  - Portfolio reads: p95 < 500 ms
  - HTTP failure rate < 1%
  - WebSocket connection p95 < 1 second

- Added `docs/LOAD_TESTING.md` with local/staging setup, environment variables, execution commands, CI instructions, monitoring guidance, and result interpretation.

- Added `docs/LOAD_TESTING_BASELINE.md` with baseline-report structure and an identified operational bottleneck:
  - Existing default rate limits are lower than the planned load-test workload and can cause misleading `429` results.
  - Recommended staging-only remediation: Redis-backed distributed limits plus a narrowly scoped, audited load-generator allowlist or traffic class.

- Added `.github/workflows/load-soak.yml` for a nightly/manual staging soak test that uploads the k6 summary JSON as a workflow artifact.

## Testing Done

- Validated all k6 JavaScript files with Node syntax checks:

  ```bash
  node --check tests/load/common.js
  node --check tests/load/steady.js
  node --check tests/load/ramp.js
  node --check tests/load/spike.js
  node --check tests/load/soak.js
  ```

- Performed structural validation to verify every defined target operation is represented:

  ```text
  deposit
  vaults
  portfolio
  chat
  challenge
  websocket
  ```

- Parsed and validated the new GitHub Actions workflow YAML.

- Ran:

  ```bash
  git diff --check
  ```

- Full Go tests, Docker Compose startup, and real k6 execution could not be run in the current workspace because Go, Docker, pnpm, and k6 were unavailable. The documented commands are included for execution in local development or isolated staging.

## Screenshots

Not applicable — no UI changes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [x] No secrets or credentials in the code
- [x] Smart contract changes reviewed for security implications — no smart contract changes were made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated nightly and manually triggered staging load tests.
  - Added steady, ramp, spike, and soak workload scenarios covering key HTTP and WebSocket activity.
  - Load-test results are saved and uploaded for review.

- **Documentation**
  - Added guidance for configuring, running, and interpreting load tests.
  - Documented performance targets, acceptance criteria, operational safeguards, and baseline tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->