### PR TITLE
AI savings coaching, AI rebalance engine, PWA offline support, i18n framework

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -606,6 +606,18 @@ func run() error {
 	intelligenceHandler := handler.NewIntelligenceHandler(intelProxy, prometheusClient)
 	intelligenceHandler.Register(mux)
 
+	// AI progress coaching (#112): on-demand endpoint plus a weekly background nudge.
+	savingsGoalHandler.SetCoachingProvider(prometheusClient)
+	goalCoachingScheduler := service.NewGoalCoachingScheduler(
+		savingsGoalRepo,
+		prometheusClient,
+		notificationDispatcher2,
+		baseLogger.WithGroup("goal-coaching"),
+	)
+	goalCoachingCtx, cancelGoalCoaching := context.WithCancel(context.Background())
+	defer cancelGoalCoaching()
+	go goalCoachingScheduler.Run(goalCoachingCtx, 7*24*time.Hour)
+
 	intelRelay := service.NewRelayHandler(http.DefaultClient, service.RelayConfig{
 		BaseURL: intelURL,
 		APIKey:  cfg.Intelligence().ServiceAPIKey(),

--- a/apps/api/internal/domain/intelligence/model.go
+++ b/apps/api/internal/domain/intelligence/model.go
@@ -58,3 +58,45 @@ type SavingsPlanResponse struct {
 	Narrative              string                `json:"narrative"`
 	Milestones             []MilestoneProjection `json:"milestones"`
 }
+
+// SavingsGoalContext mirrors the intelligence service's SavingsGoalContext
+// pydantic model, sent when requesting AI progress coaching for a goal.
+type SavingsGoalContext struct {
+	ID            string  `json:"id,omitempty"`
+	TargetAmount  float64 `json:"target_amount"`
+	Currency      string  `json:"currency"`
+	Deadline      string  `json:"deadline"`
+	Description   string  `json:"description,omitempty"`
+	CurrentAmount float64 `json:"current_amount"`
+	ProgressPct   float64 `json:"progress_pct"`
+}
+
+// PortfolioContext mirrors the intelligence service's PortfolioContext model.
+type PortfolioContext struct {
+	TotalBalanceUSD float64          `json:"total_balance_usd"`
+	// omitempty: a nil slice must be omitted rather than sent as JSON null —
+	// the intelligence service's pydantic model rejects null for this list field.
+	Vaults []map[string]any `json:"vaults,omitempty"`
+}
+
+// CoachingRequest mirrors the intelligence service's CoachingRequest model.
+type CoachingRequest struct {
+	Goal      SavingsGoalContext `json:"goal"`
+	Portfolio PortfolioContext   `json:"portfolio"`
+}
+
+// DepositScheduleItem mirrors the intelligence service's DepositScheduleItem model.
+type DepositScheduleItem struct {
+	Date      string  `json:"date"`
+	AmountUSD float64 `json:"amount_usdc"`
+	Note      string  `json:"note,omitempty"`
+}
+
+// CoachingResponse mirrors the intelligence service's CoachingResponse model:
+// a weekly AI-generated progress assessment and deposit schedule for a goal.
+type CoachingResponse struct {
+	ProgressAssessment string                `json:"progress_assessment"`
+	DepositSchedule    []DepositScheduleItem `json:"deposit_schedule"`
+	Nudges             []string              `json:"nudges"`
+	Confidence         string                `json:"confidence"`
+}

--- a/apps/api/internal/handler/intelligence_handler.go
+++ b/apps/api/internal/handler/intelligence_handler.go
@@ -33,6 +33,8 @@ func (h *IntelligenceHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/intelligence/portfolio/{userId}", h.GetPortfolioInsights)
 	mux.HandleFunc("GET /api/v1/portfolio/{user_id}/insights", h.portfolioInsightsByPath)
 	mux.HandleFunc("POST /api/v1/intelligence/savings-plan", h.CreateSavingsPlan)
+	mux.HandleFunc("POST /api/v1/vaults/{id}/rebalance/suggest", h.suggestAIRebalance)
+	mux.HandleFunc("POST /api/v1/vaults/{id}/rebalance/execute", h.executeAIRebalance)
 }
 
 func (h *IntelligenceHandler) GetVaultRecommendations(w http.ResponseWriter, r *http.Request) {
@@ -168,6 +170,38 @@ func (h *IntelligenceHandler) portfolioInsightsByPath(w http.ResponseWriter, r *
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, response.OK(insights))
+}
+
+// suggestAIRebalance proxies to the intelligence service's risk-adjusted
+// rebalancing engine. Distinct from the rule-based /rebalance-suggestion
+// endpoint on VaultHandler: this one is Claude-assisted and scores protocols
+// via the Sharpe-ratio inspired risk model.
+func (h *IntelligenceHandler) suggestAIRebalance(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.PathValue("id")
+	if vaultID == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id is required"))
+		return
+	}
+	if h.proxy == nil {
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UNAVAILABLE", "intelligence not configured"))
+		return
+	}
+	h.proxy.Forward(w, r, "/vaults/"+vaultID+"/rebalance/suggest")
+}
+
+// executeAIRebalance proxies to the intelligence service to build an
+// unsigned Stellar transaction for a user-approved AI rebalance suggestion.
+func (h *IntelligenceHandler) executeAIRebalance(w http.ResponseWriter, r *http.Request) {
+	vaultID := r.PathValue("id")
+	if vaultID == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id is required"))
+		return
+	}
+	if h.proxy == nil {
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UNAVAILABLE", "intelligence not configured"))
+		return
+	}
+	h.proxy.Forward(w, r, "/vaults/"+vaultID+"/rebalance/execute")
 }
 
 func (h *IntelligenceHandler) authorizeUserInsights(w http.ResponseWriter, r *http.Request, userID string) bool {

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsschedule"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
@@ -43,16 +44,29 @@ type SavingsGoalManager interface {
 }
 
 type SavingsGoalHandler struct {
-	svc       SavingsGoalManager
-	schedules SavingsScheduleActiveReader
+	svc              SavingsGoalManager
+	schedules        SavingsScheduleActiveReader
+	coachingProvider GoalCoachingProvider
 }
 
 type SavingsScheduleActiveReader interface {
 	GetActive(ctx context.Context, userID, goalID uuid.UUID) (*savingsschedule.SavingsSchedule, error)
 }
 
+// GoalCoachingProvider requests an AI-generated progress assessment and
+// deposit schedule for a savings goal from the intelligence service (#112).
+type GoalCoachingProvider interface {
+	GetGoalCoaching(ctx context.Context, request intelligence.CoachingRequest) (*intelligence.CoachingResponse, error)
+}
+
 func NewSavingsGoalHandler(svc SavingsGoalManager, schedules SavingsScheduleActiveReader) *SavingsGoalHandler {
 	return &SavingsGoalHandler{svc: svc, schedules: schedules}
+}
+
+// SetCoachingProvider wires the AI coaching backend. Left nil, the
+// /coaching endpoint responds 503 rather than failing to construct the handler.
+func (h *SavingsGoalHandler) SetCoachingProvider(p GoalCoachingProvider) {
+	h.coachingProvider = p
 }
 
 func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
@@ -66,6 +80,8 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/pause", h.pause)
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
 	mux.HandleFunc("GET /api/v1/users/savings-goals/{id}/contributions", h.listContributions)
+	// #112 AI progress coaching
+	mux.HandleFunc("GET /api/v1/users/savings-goals/{id}/coaching", h.coaching)
 	// #716 manual completion
 	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/complete", h.complete)
 	// #684 archive / #721 unarchive
@@ -245,6 +261,60 @@ func (h *SavingsGoalHandler) get(w http.ResponseWriter, r *http.Request) {
 type savingsGoalDetail struct {
 	savingsgoal.SavingsGoal
 	ActiveSchedule *savingsschedule.SavingsSchedule `json:"active_schedule,omitempty"`
+}
+
+// coaching returns an on-demand AI-generated progress assessment and deposit
+// schedule for the goal (#112). The same underlying call is made on a
+// weekly cadence by GoalCoachingScheduler so users get a fresh nudge even
+// without opening the app.
+func (h *SavingsGoalHandler) coaching(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	if h.coachingProvider == nil {
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "UNAVAILABLE", "coaching service not configured"))
+		return
+	}
+	goal, err := h.svc.Get(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+
+	result, err := h.coachingProvider.GetGoalCoaching(r.Context(), goalCoachingRequest(goal))
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("goal coaching failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusBadGateway, response.Err(http.StatusBadGateway, "UPSTREAM_ERROR", err.Error()))
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(result))
+}
+
+// goalCoachingRequest builds the intelligence service request payload from an
+// already-progress-enriched savings goal.
+func goalCoachingRequest(goal savingsgoal.SavingsGoal) intelligence.CoachingRequest {
+	targetAmount, _ := goal.TargetAmount.Float64()
+	currentAmount, _ := goal.CurrentAmount.Float64()
+	return intelligence.CoachingRequest{
+		Goal: intelligence.SavingsGoalContext{
+			ID:            goal.ID.String(),
+			TargetAmount:  targetAmount,
+			Currency:      goal.Currency,
+			Deadline:      goal.Deadline.Format(time.RFC3339),
+			Description:   goal.Description,
+			CurrentAmount: currentAmount,
+			ProgressPct:   goal.ProgressPct,
+		},
+		Portfolio: intelligence.PortfolioContext{
+			TotalBalanceUSD: currentAmount,
+		},
+	}
 }
 
 func (h *SavingsGoalHandler) list(w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/handler/savings_goal_handler_coaching_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_coaching_test.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+)
+
+type fakeCoachingProvider struct {
+	resp *intelligence.CoachingResponse
+	err  error
+	got  intelligence.CoachingRequest
+}
+
+func (f *fakeCoachingProvider) GetGoalCoaching(_ context.Context, req intelligence.CoachingRequest) (*intelligence.CoachingResponse, error) {
+	f.got = req
+	return f.resp, f.err
+}
+
+func TestSavingsGoalHandler_Coaching_ReturnsAIAssessment(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {
+			ID:            goalID,
+			UserID:        userID,
+			TargetAmount:  decimal.NewFromInt(1000),
+			Currency:      "USDC",
+			Deadline:      time.Now().Add(60 * 24 * time.Hour),
+			CurrentAmount: decimal.NewFromInt(340),
+			ProgressPct:   34,
+		},
+	}}
+	provider := &fakeCoachingProvider{resp: &intelligence.CoachingResponse{
+		ProgressAssessment: "You're 34% toward your goal.",
+		Nudges:             []string{"Keep going!"},
+		Confidence:         "high",
+	}}
+
+	h := NewSavingsGoalHandler(svc, nil)
+	h.SetCoachingProvider(provider)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	handler := middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(
+		withAuthUser(mux, userID),
+	)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals/" + goalID.String() + "/coaching")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Data intelligence.CoachingResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data.ProgressAssessment != "You're 34% toward your goal." {
+		t.Errorf("ProgressAssessment = %q", body.Data.ProgressAssessment)
+	}
+	if provider.got.Goal.Currency != "USDC" || provider.got.Goal.ProgressPct != 34 {
+		t.Errorf("coaching request not built from goal correctly: %+v", provider.got.Goal)
+	}
+}
+
+func TestSavingsGoalHandler_Coaching_UnconfiguredReturns503(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: userID},
+	}}
+	h := NewSavingsGoalHandler(svc, nil) // no coaching provider set
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	handler := withAuthUser(mux, userID)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals/" + goalID.String() + "/coaching")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestSavingsGoalHandler_Coaching_NotFoundForOtherUsersGoal(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: otherUserID},
+	}}
+	h := NewSavingsGoalHandler(svc, nil)
+	h.SetCoachingProvider(&fakeCoachingProvider{resp: &intelligence.CoachingResponse{}})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	handler := withAuthUser(mux, userID)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/users/savings-goals/" + goalID.String() + "/coaching")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/notifications/notifications.go
+++ b/apps/api/internal/notifications/notifications.go
@@ -53,6 +53,7 @@ const (
 	EventScheduledDepositCompleted EventType = "scheduled_deposit_completed"
 	EventSavingsStreak             EventType = "savings_streak_milestone"
 	EventProtocolHealthAlert       EventType = "protocol_health_alert"
+	EventGoalCoaching              EventType = "goal_coaching"
 )
 
 // ChannelKind is the transport a notification is delivered over.
@@ -81,6 +82,7 @@ var eventChannelMatrix = map[EventType][]ChannelKind{
 	EventScheduledDepositCompleted: {ChannelEmail, ChannelWebSocket, ChannelPush},
 	EventSavingsStreak:             {ChannelPush},
 	EventProtocolHealthAlert:       {ChannelEmail, ChannelPush, ChannelWebSocket},
+	EventGoalCoaching:              {ChannelPush},
 }
 
 // ChannelsFor returns the channels configured to deliver the given event,

--- a/apps/api/internal/service/goal_coaching_scheduler.go
+++ b/apps/api/internal/service/goal_coaching_scheduler.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+// goalCoachingLookaheadDays is passed to ListActiveApproachingDeadline to
+// approximate "all active goals": savings goal deadlines are always in the
+// future relative to creation, and ~27 years comfortably covers any
+// realistic goal horizon without requiring a new repository method.
+const goalCoachingLookaheadDays = 10_000
+
+// GoalCoachingRepository is the read the weekly coaching job needs.
+type GoalCoachingRepository interface {
+	ListActiveApproachingDeadline(ctx context.Context, maxDays int) ([]savingsgoal.SavingsGoal, error)
+}
+
+// GoalCoachingClient requests an AI progress assessment for a single goal.
+type GoalCoachingClient interface {
+	GetGoalCoaching(ctx context.Context, request intelligence.CoachingRequest) (*intelligence.CoachingResponse, error)
+}
+
+// GoalCoachingScheduler periodically generates and delivers an AI progress
+// coaching notification for every active savings goal (#112 "AI coaching
+// message generated weekly per goal").
+type GoalCoachingScheduler struct {
+	repo       GoalCoachingRepository
+	coaching   GoalCoachingClient
+	dispatcher *notifications.Dispatcher
+	logger     *slog.Logger
+}
+
+func NewGoalCoachingScheduler(
+	repo GoalCoachingRepository,
+	coaching GoalCoachingClient,
+	dispatcher *notifications.Dispatcher,
+	logger *slog.Logger,
+) *GoalCoachingScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &GoalCoachingScheduler{repo: repo, coaching: coaching, dispatcher: dispatcher, logger: logger}
+}
+
+// Run ticks every `interval` (weekly in production) until ctx is cancelled,
+// sending one coaching notification per active goal on each tick. A tick
+// also fires once immediately on start so coaching isn't delayed a full
+// interval after deploy.
+func (s *GoalCoachingScheduler) Run(ctx context.Context, interval time.Duration) {
+	s.tick(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *GoalCoachingScheduler) tick(ctx context.Context) {
+	if s.repo == nil || s.coaching == nil || s.dispatcher == nil {
+		return
+	}
+
+	goals, err := s.repo.ListActiveApproachingDeadline(ctx, goalCoachingLookaheadDays)
+	if err != nil {
+		s.logger.Error("goal coaching: failed to list active goals", "error", err.Error())
+		return
+	}
+
+	for _, goal := range goals {
+		s.sendCoaching(ctx, goal)
+	}
+}
+
+func (s *GoalCoachingScheduler) sendCoaching(ctx context.Context, goal savingsgoal.SavingsGoal) {
+	targetAmount, _ := goal.TargetAmount.Float64()
+	currentAmount, _ := goal.CurrentAmount.Float64()
+
+	result, err := s.coaching.GetGoalCoaching(ctx, intelligence.CoachingRequest{
+		Goal: intelligence.SavingsGoalContext{
+			ID:            goal.ID.String(),
+			TargetAmount:  targetAmount,
+			Currency:      goal.Currency,
+			Deadline:      goal.Deadline.Format(time.RFC3339),
+			Description:   goal.Description,
+			CurrentAmount: currentAmount,
+			ProgressPct:   goal.ProgressPct,
+		},
+		Portfolio: intelligence.PortfolioContext{
+			TotalBalanceUSD: currentAmount,
+		},
+	})
+	if err != nil {
+		s.logger.Warn("goal coaching: generation failed", "goal_id", goal.ID.String(), "error", err.Error())
+		return
+	}
+
+	title := "Your weekly savings check-in"
+	_ = s.dispatcher.Send(ctx, goal.UserID, notifications.EventGoalCoaching, title, result.ProgressAssessment, map[string]any{
+		"goal_id":  goal.ID.String(),
+		"currency": goal.Currency,
+		"nudges":   result.Nudges,
+	})
+}

--- a/apps/api/internal/service/goal_coaching_scheduler_test.go
+++ b/apps/api/internal/service/goal_coaching_scheduler_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+type fakeGoalCoachingRepo struct {
+	goals []savingsgoal.SavingsGoal
+	err   error
+}
+
+func (f fakeGoalCoachingRepo) ListActiveApproachingDeadline(_ context.Context, _ int) ([]savingsgoal.SavingsGoal, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.goals, nil
+}
+
+type fakeGoalCoachingClient struct {
+	resp *intelligence.CoachingResponse
+	err  error
+}
+
+func (f fakeGoalCoachingClient) GetGoalCoaching(_ context.Context, _ intelligence.CoachingRequest) (*intelligence.CoachingResponse, error) {
+	return f.resp, f.err
+}
+
+type fakePreferenceStore struct{}
+
+func (fakePreferenceStore) Get(_ context.Context, _ uuid.UUID) (notifications.Preferences, error) {
+	return notifications.DefaultPreferences(), nil
+}
+
+type recordingChannel struct {
+	mu        sync.Mutex
+	delivered []notifications.Notification
+}
+
+func (c *recordingChannel) Kind() notifications.ChannelKind { return notifications.ChannelPush }
+
+func (c *recordingChannel) Deliver(_ context.Context, n notifications.Notification) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.delivered = append(c.delivered, n)
+	return nil
+}
+
+func (c *recordingChannel) all() []notifications.Notification {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]notifications.Notification, len(c.delivered))
+	copy(out, c.delivered)
+	return out
+}
+
+func TestGoalCoachingScheduler_TickSendsOnePerActiveGoal(t *testing.T) {
+	userID := uuid.New()
+	goal := savingsgoal.SavingsGoal{
+		ID:            uuid.New(),
+		UserID:        userID,
+		TargetAmount:  decimal.NewFromInt(1000),
+		Currency:      "USDC",
+		Deadline:      time.Now().Add(90 * 24 * time.Hour),
+		CurrentAmount: decimal.NewFromInt(340),
+		ProgressPct:   34,
+	}
+
+	channel := &recordingChannel{}
+	dispatcher := notifications.New([]notifications.Channel{channel}, fakePreferenceStore{}, nil)
+
+	scheduler := NewGoalCoachingScheduler(
+		fakeGoalCoachingRepo{goals: []savingsgoal.SavingsGoal{goal}},
+		fakeGoalCoachingClient{resp: &intelligence.CoachingResponse{
+			ProgressAssessment: "You're 34% toward your goal.",
+			Nudges:             []string{"Keep going!"},
+		}},
+		dispatcher,
+		nil,
+	)
+
+	scheduler.tick(t.Context())
+
+	delivered := channel.all()
+	if len(delivered) != 1 {
+		t.Fatalf("expected 1 delivered notification, got %d", len(delivered))
+	}
+	if delivered[0].UserID != userID {
+		t.Errorf("UserID = %s, want %s", delivered[0].UserID, userID)
+	}
+	if delivered[0].Type != notifications.EventGoalCoaching {
+		t.Errorf("Type = %s, want %s", delivered[0].Type, notifications.EventGoalCoaching)
+	}
+	if delivered[0].Body != "You're 34% toward your goal." {
+		t.Errorf("Body = %q", delivered[0].Body)
+	}
+	if delivered[0].Payload["goal_id"] != goal.ID.String() {
+		t.Errorf("Payload[goal_id] = %v, want %s", delivered[0].Payload["goal_id"], goal.ID.String())
+	}
+}
+
+func TestGoalCoachingScheduler_TickSkipsGoalOnCoachingError(t *testing.T) {
+	userID := uuid.New()
+	goal := savingsgoal.SavingsGoal{ID: uuid.New(), UserID: userID, Currency: "USDC"}
+
+	channel := &recordingChannel{}
+	dispatcher := notifications.New([]notifications.Channel{channel}, fakePreferenceStore{}, nil)
+
+	scheduler := NewGoalCoachingScheduler(
+		fakeGoalCoachingRepo{goals: []savingsgoal.SavingsGoal{goal}},
+		fakeGoalCoachingClient{err: context.DeadlineExceeded},
+		dispatcher,
+		nil,
+	)
+
+	scheduler.tick(t.Context())
+
+	if len(channel.all()) != 0 {
+		t.Fatalf("expected no notifications delivered when coaching fails, got %d", len(channel.all()))
+	}
+}
+
+func TestGoalCoachingScheduler_TickNoopWithoutDependencies(t *testing.T) {
+	scheduler := NewGoalCoachingScheduler(nil, nil, nil, nil)
+	scheduler.tick(t.Context()) // must not panic
+}

--- a/apps/api/internal/service/prometheus_client.go
+++ b/apps/api/internal/service/prometheus_client.go
@@ -149,6 +149,26 @@ func (c *PrometheusClient) CreateSavingsPlan(ctx context.Context, request intell
 	return &response, nil
 }
 
+// GetGoalCoaching requests a weekly AI-generated progress assessment and
+// deposit schedule for a single savings goal (issue #112). Unlike the other
+// Get* methods this is not cached: coaching should reflect the goal's latest
+// progress each time it is requested.
+func (c *PrometheusClient) GetGoalCoaching(ctx context.Context, request intelligence.CoachingRequest) (*intelligence.CoachingResponse, error) {
+	if !c.canCall() {
+		return nil, fmt.Errorf("prometheus service unavailable (circuit open)")
+	}
+
+	endpoint := fmt.Sprintf("%s/intelligence/coaching", c.cfg.BaseURL)
+	var response intelligence.CoachingResponse
+	err := c.doPostRequest(ctx, endpoint, request, &response)
+	if err != nil {
+		c.recordFailure()
+		return nil, fmt.Errorf("failed to get goal coaching: %w", err)
+	}
+
+	return &response, nil
+}
+
 func (c *PrometheusClient) doRequest(ctx context.Context, endpoint string, target any) error {
 	return c.doHTTPRequest(ctx, "GET", endpoint, nil, target)
 }

--- a/apps/api/internal/service/prometheus_client_test.go
+++ b/apps/api/internal/service/prometheus_client_test.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+)
+
+func TestPrometheusClient_GetGoalCoaching(t *testing.T) {
+	var gotPath string
+	var gotBody intelligence.CoachingRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(intelligence.CoachingResponse{
+			ProgressAssessment: "You're on track.",
+			Nudges:             []string{"Nice work"},
+			Confidence:         "high",
+		})
+	}))
+	defer server.Close()
+
+	client := NewPrometheusClient(PrometheusConfig{BaseURL: server.URL, Timeout: 2 * time.Second})
+
+	resp, err := client.GetGoalCoaching(t.Context(), intelligence.CoachingRequest{
+		Goal: intelligence.SavingsGoalContext{
+			TargetAmount:  1000,
+			Currency:      "USDC",
+			CurrentAmount: 340,
+			ProgressPct:   34,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetGoalCoaching() error = %v", err)
+	}
+	if gotPath != "/intelligence/coaching" {
+		t.Errorf("path = %q, want /intelligence/coaching", gotPath)
+	}
+	if gotBody.Goal.Currency != "USDC" {
+		t.Errorf("request body not forwarded correctly: %+v", gotBody)
+	}
+	if resp.ProgressAssessment != "You're on track." {
+		t.Errorf("ProgressAssessment = %q", resp.ProgressAssessment)
+	}
+}
+
+func TestPrometheusClient_GetGoalCoaching_UpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewPrometheusClient(PrometheusConfig{BaseURL: server.URL, Timeout: 2 * time.Second})
+
+	_, err := client.GetGoalCoaching(t.Context(), intelligence.CoachingRequest{})
+	if err == nil {
+		t.Fatal("expected error on upstream 500, got nil")
+	}
+}

--- a/apps/dapp/frontend/__tests__/format.test.ts
+++ b/apps/dapp/frontend/__tests__/format.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatCurrency, formatNumber, formatDate } from "@/lib/i18n/format";
+
+describe("formatCurrency", () => {
+    it("formats USD for the en locale", () => {
+        expect(formatCurrency(1234.5, "USD", "en")).toBe("$1,234.50");
+    });
+
+    it("formats EUR for the fr locale using French grouping/decimal marks", () => {
+        const result = formatCurrency(1234.5, "EUR", "fr");
+        // fr-FR uses non-breaking spaces as the thousands separator and a
+        // comma decimal mark; normalize whitespace before comparing.
+        expect(result.replace(/ | /g, " ")).toBe("1 234,50 €");
+    });
+
+    it("rounds to 2 decimal places regardless of input precision", () => {
+        expect(formatCurrency(10, "USD", "en")).toBe("$10.00");
+        expect(formatCurrency(10.999, "USD", "en")).toBe("$11.00");
+    });
+
+    it("falls back to a plain number + currency code for a non-ISO currency", () => {
+        const result = formatCurrency(100, "XLM", "en");
+        expect(result).toContain("100.00");
+        expect(result).toContain("XLM");
+    });
+
+    it("defaults to the en locale when none is passed", () => {
+        expect(formatCurrency(5, "USD")).toBe("$5.00");
+    });
+});
+
+describe("formatNumber", () => {
+    it("formats a number using locale grouping", () => {
+        expect(formatNumber(1234567, "en")).toBe("1,234,567");
+    });
+});
+
+describe("formatDate", () => {
+    it("formats a date deterministically for a fixed locale", () => {
+        const result = formatDate("2026-01-15T00:00:00Z", "en", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            timeZone: "UTC",
+        });
+        expect(result).toBe("Jan 15, 2026");
+    });
+});

--- a/apps/dapp/frontend/__tests__/useOfflineStatus.test.tsx
+++ b/apps/dapp/frontend/__tests__/useOfflineStatus.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+
+function setOnline(value: boolean) {
+    Object.defineProperty(window.navigator, "onLine", {
+        configurable: true,
+        value,
+    });
+}
+
+describe("useOfflineStatus", () => {
+    beforeEach(() => {
+        setOnline(true);
+    });
+
+    afterEach(() => {
+        setOnline(true);
+        vi.useRealTimers();
+    });
+
+    it("reflects navigator.onLine as false on mount when offline", () => {
+        setOnline(false);
+        const { result } = renderHook(() => useOfflineStatus());
+        expect(result.current.isOffline).toBe(true);
+    });
+
+    it("reflects navigator.onLine as true on mount when online", () => {
+        setOnline(true);
+        const { result } = renderHook(() => useOfflineStatus());
+        expect(result.current.isOffline).toBe(false);
+        expect(result.current.lastSynced).not.toBeNull();
+    });
+
+    it("flips to offline when the window 'offline' event fires", () => {
+        const { result } = renderHook(() => useOfflineStatus());
+        expect(result.current.isOffline).toBe(false);
+
+        act(() => {
+            setOnline(false);
+            window.dispatchEvent(new Event("offline"));
+        });
+
+        expect(result.current.isOffline).toBe(true);
+    });
+
+    it("flips back to online and updates lastSynced when the 'online' event fires", () => {
+        setOnline(false);
+        const { result } = renderHook(() => useOfflineStatus());
+        expect(result.current.isOffline).toBe(true);
+
+        act(() => {
+            setOnline(true);
+            window.dispatchEvent(new Event("online"));
+        });
+
+        expect(result.current.isOffline).toBe(false);
+        expect(result.current.lastSynced).not.toBeNull();
+    });
+
+    it("removes its event listeners on unmount", () => {
+        const addSpy = vi.spyOn(window, "addEventListener");
+        const removeSpy = vi.spyOn(window, "removeEventListener");
+
+        const { unmount } = renderHook(() => useOfflineStatus());
+        expect(addSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+        expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
+
+        unmount();
+
+        expect(removeSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+        expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function));
+    });
+});

--- a/apps/dapp/frontend/app/dashboard/page.tsx
+++ b/apps/dapp/frontend/app/dashboard/page.tsx
@@ -30,6 +30,7 @@ import { useTokenPrices } from "@/hooks/useTokenPrices";
 import { useNetwork } from "@/hooks/useNetwork";
 import { AppShell } from "@/components/app-shell";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { useLocale, useTranslations } from "@/context/locale-context";
 import { formatDistanceToNow } from "date-fns";
 import { useVaults, type VaultWithPerf } from "@/hooks/useVaults";
 import { useSettlements } from "@/hooks/useSettlements";
@@ -451,6 +452,8 @@ export default function Dashboard() {
     const { isConnected, address } = useWallet();
     const { isAuthenticated, userId, isSigningIn, signIn } = useAuth();
     const { prices: tokenPrices } = useTokenPrices();
+    const { formatCurrency } = useLocale();
+    const t = useTranslations();
     const router = useRouter();
     const [selectedVault, setSelectedVault] = useState<VaultWithPerf | null>(null);
     const [chartPeriod, setChartPeriod] = useState<ChartPeriod>("1M");
@@ -583,9 +586,9 @@ export default function Dashboard() {
                     ) : (
                         <div>
                             <p className="text-[42px] font-light leading-none text-black dark:text-white tracking-[-0.02em]" aria-live="polite">
-                                ${fmtUsd(totalBalanceUsd)}
+                                {formatCurrency(totalBalanceUsd, "USD")}
                             </p>
-                            <p className="mt-2 text-[12px] text-black/35 dark:text-white/35 tracking-wide">Protocol Balance</p>
+                            <p className="mt-2 text-[12px] text-black/35 dark:text-white/35 tracking-wide">{t("dashboard.totalBalance")}</p>
                             {lastSynced && (
                                 <p className="mt-1.5 text-[11px] text-black/25 dark:text-white/25">
                                     Last updated {formatDistanceToNow(lastSynced)} ago
@@ -605,12 +608,12 @@ export default function Dashboard() {
                             )}
                         </div>
                         <div className="flex items-center justify-between">
-                            <span className="text-[13px] text-black/40 dark:text-white/40">Total earnings</span>
+                            <span className="text-[13px] text-black/40 dark:text-white/40">{t("dashboard.totalYieldEarned")}</span>
                             {vaultsLoading ? (
                                 <div className="h-4 w-16 animate-pulse rounded bg-black/[0.06] dark:bg-white/[0.06]" />
                             ) : (
                                 <span className="text-[13px] font-medium text-black dark:text-white">
-                                    ${fmtUsd(totalYield)}
+                                    {formatCurrency(totalYield, "USD")}
                                 </span>
                             )}
                         </div>
@@ -710,7 +713,7 @@ export default function Dashboard() {
                 className="mt-8 rounded-2xl dash-border bg-white dark:bg-[#100F0F]"
             >
                 <div className="px-8 pt-7">
-                    <h2 className="text-[16px] font-semibold text-black dark:text-white">Recent Activity</h2>
+                    <h2 className="text-[16px] font-semibold text-black dark:text-white">{t("dashboard.recentActivity")}</h2>
                 </div>
                 <div className="px-8 pb-8 pt-6">
                     <ActivityFeed

--- a/apps/dapp/frontend/app/layout.tsx
+++ b/apps/dapp/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { Inter } from "next/font/google";
 import { PortfolioProvider } from "@/components/portfolio-provider";
@@ -10,9 +10,11 @@ import { WebSocketProvider } from "@/components/websocket-provider";
 import { ReactQueryProvider } from "@/components/react-query-provider";
 import { OfflineBanner } from "@/components/offline-banner";
 import { SettingsProvider } from "@/context/settings-context";
+import { LocaleProvider } from "@/context/locale-context";
 import { OnboardingProvider } from "@/hooks/useOnboarding";
 import { NetworkProvider } from "@/context/NetworkProvider";
 import { NetworkBanner } from "@/components/network/NetworkSelector";
+import { ServiceWorkerRegister } from "@/components/service-worker-register";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
@@ -21,10 +23,15 @@ export const metadata: Metadata = {
     title: "Nester | DApp",
     description:
         "Decentralized savings and instant fiat settlements powered by Stellar.",
+    manifest: "/manifest.webmanifest",
     icons: {
         icon: "/logo.png",
         apple: "/logo.png",
     },
+};
+
+export const viewport: Viewport = {
+    themeColor: "#0a0a0a",
 };
 
 import { ToastProvider } from "@/components/ui/toast/toast-provider";
@@ -73,26 +80,29 @@ export default function RootLayout({
                     <ConsentProvider>
                         <ReactQueryProvider>
                             <NetworkProvider>
-                                <SettingsProvider>
-                                    <WalletProvider>
-                                        <AuthProvider>
-                                            <NotificationsProvider>
-                                                <OfflineBanner />
-                                                <NetworkBanner />
-                                                <PortfolioProvider>
-                                                    <WebSocketProvider>
-                                                        <OnboardingProvider>
-                                                            {children}
-                                                            <NotificationsToaster />
-                                                            <ConsentGatedPrometheus />
-                                                            <CookieConsentBanner />
-                                                        </OnboardingProvider>
-                                                    </WebSocketProvider>
-                                                </PortfolioProvider>
-                                            </NotificationsProvider>
-                                        </AuthProvider>
-                                    </WalletProvider>
-                                </SettingsProvider>
+                                <LocaleProvider>
+                                    <SettingsProvider>
+                                        <WalletProvider>
+                                            <AuthProvider>
+                                                <NotificationsProvider>
+                                                    <ServiceWorkerRegister />
+                                                    <OfflineBanner />
+                                                    <NetworkBanner />
+                                                    <PortfolioProvider>
+                                                        <WebSocketProvider>
+                                                            <OnboardingProvider>
+                                                                {children}
+                                                                <NotificationsToaster />
+                                                                <ConsentGatedPrometheus />
+                                                                <CookieConsentBanner />
+                                                            </OnboardingProvider>
+                                                        </WebSocketProvider>
+                                                    </PortfolioProvider>
+                                                </NotificationsProvider>
+                                            </AuthProvider>
+                                        </WalletProvider>
+                                    </SettingsProvider>
+                                </LocaleProvider>
                             </NetworkProvider>
                         </ReactQueryProvider>
                     </ConsentProvider>

--- a/apps/dapp/frontend/app/offline/page.tsx
+++ b/apps/dapp/frontend/app/offline/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { WifiOff, RefreshCw } from "lucide-react";
+
+export default function OfflinePage() {
+    return (
+        <div className="min-h-screen bg-white dark:bg-[#100F0F] flex flex-col items-center justify-center px-4">
+            <Link href="/" className="flex items-center gap-2.5 mb-16">
+                <Image
+                    src="/logo.png"
+                    alt="Nester"
+                    width={36}
+                    height={36}
+                    className="rounded-xl"
+                />
+                <span className="font-heading text-[15px] font-medium text-black dark:text-white">
+                    Nester
+                </span>
+            </Link>
+
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-black/[0.04] dark:bg-white/[0.06] mb-6">
+                <WifiOff className="h-7 w-7 text-black/40 dark:text-white/40" />
+            </div>
+
+            <div className="text-center">
+                <h1 className="text-xl sm:text-2xl text-black dark:text-white mb-3">
+                    You&apos;re offline
+                </h1>
+                <p className="text-sm text-black/40 dark:text-white/40 max-w-sm leading-relaxed">
+                    This page needs a connection to load. Check your network
+                    and try again. Your balances and vaults will resume
+                    syncing automatically once you&apos;re back online.
+                </p>
+            </div>
+
+            <button
+                onClick={() => window.location.reload()}
+                className="mt-10 inline-flex items-center gap-2 rounded-full bg-black dark:bg-blue-600 px-5 py-2.5 text-sm text-white transition-opacity hover:opacity-75"
+            >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Try again
+            </button>
+
+            <p className="mt-16 font-mono text-[11px] text-black/20 dark:text-white/20">
+                nester.finance
+            </p>
+        </div>
+    );
+}

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -41,6 +41,8 @@ import {
 import { SaveAccountPrompt } from "@/components/offramp/SaveAccountPrompt";
 import { useBankResolver } from "@/hooks/useBankResolver";
 import { fetchBankList } from "@/lib/api/bank";
+import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { useTranslations } from "@/context/locale-context";
 
 const SEND_ASSETS = [
     { symbol: "USDC", name: "USD Coin", image: "/usdc.png" },
@@ -124,6 +126,8 @@ export default function OfframpPage() {
     const { isConnected } = useWallet();
     const { addNotification } = useNotifications();
     const router = useRouter();
+    const { isOffline } = useOfflineStatus();
+    const t = useTranslations();
 
     // In a real app, this would come from the user's KYC state loaded via API
     const [kycStatus] = useState<KYCStatus>("unverified");
@@ -269,6 +273,9 @@ export default function OfframpPage() {
             : 0;
 
     const handleWithdraw = handleSubmit((data) => {
+        if (isOffline) {
+            return;
+        }
         const quote = selectedQuote;
         const canSubmit =
             payoutMode.type === "saved"
@@ -351,10 +358,10 @@ export default function OfframpPage() {
                     className="text-center mb-6 sm:mb-8"
                 >
                     <h1 className="font-heading text-xl sm:text-2xl font-semibold text-foreground">
-                        Cash Out
+                        {t("offramp.title")}
                     </h1>
                     <p className="mt-1 text-sm text-muted-foreground">
-                        Convert crypto to fiat, directly to your bank account
+                        {t("offramp.subtitle")}
                     </p>
                 </motion.div>
 
@@ -730,6 +737,7 @@ export default function OfframpPage() {
                     <div className="p-4 sm:p-5 pt-0">
                         <button
                             disabled={
+                                isOffline ||
                                 !isValid ||
                                 quotePhase !== "done" ||
                                 resolveState === "loading" ||
@@ -740,10 +748,12 @@ export default function OfframpPage() {
                             onClick={handleWithdraw}
                             className="w-full rounded-xl bg-foreground text-background py-4 text-sm font-medium transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
                         >
-                            {!numericAmount
-                                ? "Enter an amount"
+                            {isOffline
+                                ? t("offramp.offlineMessage")
+                                : !numericAmount
+                                ? t("offramp.enterAmount")
                                 : !selectedBankCode
-                                    ? "Select a bank"
+                                    ? t("offramp.selectBank")
                                     : (accountNumber?.length || 0) !== 10
                                         ? "Enter account number"
                                         : resolveState === "loading"

--- a/apps/dapp/frontend/app/savings/page.tsx
+++ b/apps/dapp/frontend/app/savings/page.tsx
@@ -46,6 +46,7 @@ import {
 import { buildSavingsVaults } from "@/lib/savings/apply-live-apy";
 import { SavingsGoalsSection } from "@/components/savings/SavingsGoalsSection";
 import { CreateGoalModal } from "@/components/savings/CreateGoalModal";
+import { useLocale, useTranslations } from "@/context/locale-context";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -712,6 +713,8 @@ const CHART_PERIODS: APYHistoryPeriod[] = ["7d", "30d", "90d"];
 
 function SavingsOverview({ savingsVaults }: { savingsVaults: SavingsVault[] }) {
     const { positions } = usePortfolio();
+    const { formatCurrency } = useLocale();
+    const t = useTranslations();
     const [period, setPeriod] = useState<APYHistoryPeriod>("30d");
 
     const activeVaultPositions = useMemo(() => {
@@ -814,8 +817,8 @@ function SavingsOverview({ savingsVaults }: { savingsVaults: SavingsVault[] }) {
     );
 
     const stats = [
-        { label: "Total Deposited", value: `$${totalPrincipal.toLocaleString()}`, icon: ArrowDownLeftIcon, sub: "Principal" },
-        { label: "Yield Earned", value: `+$${totalYield.toLocaleString(undefined, { minimumFractionDigits: 2 })}`, icon: Zap, sub: "Total profit" },
+        { label: t("savings.totalDeposited"), value: formatCurrency(totalPrincipal, "USD"), icon: ArrowDownLeftIcon, sub: "Principal" },
+        { label: t("savings.yieldEarned"), value: `+${formatCurrency(totalYield, "USD")}`, icon: Zap, sub: "Total profit" },
         { label: "Effective APY", value: `${effectiveApy.toFixed(1)}%`, icon: Activity, sub: "Annualised" },
         { label: "Days Saving", value: String(daysSaving), icon: Clock, sub: "Since first deposit" },
     ];
@@ -900,6 +903,7 @@ const FILTERS: { label: string; value: SavingsVaultType | "all" }[] = [
 export default function SavingsPage() {
     const { isConnected } = useWallet();
     const { positions } = usePortfolio();
+    const t = useTranslations();
     const [filter, setFilter] = useState<SavingsVaultType | "all">("all");
     const [selectedVault, setSelectedVault] = useState<SavingsVault | null>(null);
     const [viewMode, setViewMode] = useState<"products" | "goals">("products");
@@ -932,9 +936,9 @@ export default function SavingsPage() {
                 >
                     <div className="flex items-start justify-between gap-4 flex-wrap">
                         <div>
-                            <h1 className="text-2xl text-black dark:text-white sm:text-3xl font-semibold">Savings</h1>
+                            <h1 className="text-2xl text-black dark:text-white sm:text-3xl font-semibold">{t("savings.title")}</h1>
                             <p className="mt-1 text-sm text-black/60 dark:text-white/60 font-medium">
-                                Choose a savings plan and start earning yield on your USDC.
+                                {t("savings.subtitle")}
                             </p>
                         </div>
                         <div className="flex items-center gap-2">
@@ -943,7 +947,7 @@ export default function SavingsPage() {
                                 className="flex items-center gap-2 rounded-xl bg-black dark:bg-blue-600 px-5 py-2.5 text-xs font-bold text-white transition-opacity hover:opacity-75 focus-visible:ring-2 focus-visible:ring-black"
                             >
                                 <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
-                                Create Plan
+                                {t("savings.createPlan")}
                             </button>
                             <button
                                 onClick={() => setShowHowItWorks(!showHowItWorks)}

--- a/apps/dapp/frontend/app/settings/page.tsx
+++ b/apps/dapp/frontend/app/settings/page.tsx
@@ -10,6 +10,8 @@ import { useWallet } from "@/components/wallet-provider";
 import { KYCSection, type KYCStatus } from "@/components/kyc/KYCSection";
 import { BankAccountsSection } from "@/components/settings/bank-accounts-section";
 import { cn } from "@/lib/utils";
+import { useLocale, useTranslations } from "@/context/locale-context";
+import { SUPPORTED_LOCALES, LOCALE_LABELS, type Locale } from "@/lib/i18n/config";
 
 // --- Savings goal notification settings (#740) ---
 
@@ -163,6 +165,8 @@ export default function SettingsPage() {
     const { isConnected, address } = useWallet();
     const router = useRouter();
     const [activeTab, setActiveTab] = useState<Tab>("profile");
+    const { locale, setLocale } = useLocale();
+    const t = useTranslations();
 
     const kyc = useKYCState();
 
@@ -314,6 +318,29 @@ export default function SettingsPage() {
                                             <option value="GBP">GBP (£)</option>
                                             <option value="NGN">NGN (₦)</option>
                                         </select>
+                                    </div>
+                                    <div>
+                                        <label
+                                            htmlFor="locale-select"
+                                            className="mb-1.5 block text-xs text-black/45 dark:text-white/45"
+                                        >
+                                            {t("settings.language")}
+                                        </label>
+                                        <select
+                                            id="locale-select"
+                                            value={locale}
+                                            onChange={(e) => setLocale(e.target.value as Locale)}
+                                            className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none appearance-none focus:border-black/25 dark:focus:border-white/25"
+                                        >
+                                            {SUPPORTED_LOCALES.map((l) => (
+                                                <option key={l} value={l}>
+                                                    {LOCALE_LABELS[l]}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <p className="mt-1.5 text-xs text-black/40 dark:text-white/40">
+                                            {t("settings.languageDescription")}
+                                        </p>
                                     </div>
                                     <BankAccountsSection />
                                 </div>

--- a/apps/dapp/frontend/components/service-worker-register.tsx
+++ b/apps/dapp/frontend/components/service-worker-register.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegister() {
+    useEffect(() => {
+        if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+            return;
+        }
+        // Registering after `load` keeps the SW off the critical rendering path.
+        const register = () => {
+            navigator.serviceWorker.register("/sw.js").catch((err) => {
+                console.warn("Service worker registration failed:", err);
+            });
+        };
+        window.addEventListener("load", register);
+        return () => window.removeEventListener("load", register);
+    }, []);
+
+    return null;
+}

--- a/apps/dapp/frontend/context/locale-context.tsx
+++ b/apps/dapp/frontend/context/locale-context.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@/lib/i18n/config";
+import {
+    formatCurrency as formatCurrencyBase,
+    formatDate as formatDateBase,
+    formatNumber as formatNumberBase,
+} from "@/lib/i18n/format";
+import en from "@/lib/i18n/locales/en.json";
+import fr from "@/lib/i18n/locales/fr.json";
+
+const CATALOGS: Record<Locale, Messages> = { en, fr };
+
+type Messages = typeof en;
+
+const LOCALE_STORAGE_KEY = "nester-locale";
+
+function getMessage(catalog: Messages, key: string): string {
+    const value = key
+        .split(".")
+        .reduce<unknown>(
+            (acc, part) =>
+                acc && typeof acc === "object" ? (acc as Record<string, unknown>)[part] : undefined,
+            catalog
+        );
+    return typeof value === "string" ? value : key;
+}
+
+interface LocaleContextValue {
+    locale: Locale;
+    setLocale: (locale: Locale) => void;
+    t: (key: string) => string;
+    formatCurrency: (amount: number, currency: string) => string;
+    formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string;
+    formatDate: (value: Date | string | number, options?: Intl.DateTimeFormatOptions) => string;
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+    const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+        if (isSupportedLocale(stored)) {
+            // Deferred a tick so the client's first render matches the
+            // server-rendered default locale, avoiding a hydration mismatch.
+            const timer = setTimeout(() => setLocaleState(stored), 0);
+            return () => clearTimeout(timer);
+        }
+    }, []);
+
+    const setLocale = useCallback((next: Locale) => {
+        setLocaleState(next);
+        if (typeof window !== "undefined") {
+            localStorage.setItem(LOCALE_STORAGE_KEY, next);
+        }
+    }, []);
+
+    const t = useCallback((key: string) => getMessage(CATALOGS[locale], key), [locale]);
+
+    const formatCurrency = useCallback(
+        (amount: number, currency: string) => formatCurrencyBase(amount, currency, locale),
+        [locale]
+    );
+    const formatNumber = useCallback(
+        (value: number, options?: Intl.NumberFormatOptions) => formatNumberBase(value, locale, options),
+        [locale]
+    );
+    const formatDate = useCallback(
+        (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+            formatDateBase(value, locale, options),
+        [locale]
+    );
+
+    return (
+        <LocaleContext.Provider
+            value={{ locale, setLocale, t, formatCurrency, formatNumber, formatDate }}
+        >
+            {children}
+        </LocaleContext.Provider>
+    );
+}
+
+export function useLocale(): LocaleContextValue {
+    const ctx = useContext(LocaleContext);
+    if (!ctx) {
+        throw new Error("useLocale must be used within a LocaleProvider");
+    }
+    return ctx;
+}
+
+/** Convenience hook for components that only need the translate function. */
+export function useTranslations(): (key: string) => string {
+    return useLocale().t;
+}

--- a/apps/dapp/frontend/lib/i18n/config.ts
+++ b/apps/dapp/frontend/lib/i18n/config.ts
@@ -1,0 +1,20 @@
+export const SUPPORTED_LOCALES = ["en", "fr"] as const;
+
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+export const LOCALE_LABELS: Record<Locale, string> = {
+    en: "English",
+    fr: "Français",
+};
+
+// Maps an app locale to the BCP-47 tag Intl.NumberFormat/DateTimeFormat expect.
+export const LOCALE_TAGS: Record<Locale, string> = {
+    en: "en-US",
+    fr: "fr-FR",
+};
+
+export function isSupportedLocale(value: string | null | undefined): value is Locale {
+    return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}

--- a/apps/dapp/frontend/lib/i18n/format.ts
+++ b/apps/dapp/frontend/lib/i18n/format.ts
@@ -1,0 +1,42 @@
+import { LOCALE_TAGS, type Locale } from "./config";
+
+function resolveTag(locale: Locale): string {
+    return LOCALE_TAGS[locale] ?? "en-US";
+}
+
+/**
+ * Locale-aware currency formatter. Replaces ad-hoc `$${n.toFixed(2)}` /
+ * `n.toLocaleString("en-US", ...)` calls scattered across the dApp so every
+ * screen formats money the same way for the user's chosen locale + currency.
+ */
+export function formatCurrency(amount: number, currency: string, locale: Locale = "en"): string {
+    try {
+        return new Intl.NumberFormat(resolveTag(locale), {
+            style: "currency",
+            currency,
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        }).format(amount);
+    } catch {
+        // Intl throws on an unknown ISO 4217 code (e.g. a crypto ticker like
+        // "XLM"). Fall back to a plain number plus the raw currency code.
+        return `${formatNumber(amount, locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
+    }
+}
+
+export function formatNumber(
+    value: number,
+    locale: Locale = "en",
+    options?: Intl.NumberFormatOptions
+): string {
+    return new Intl.NumberFormat(resolveTag(locale), options).format(value);
+}
+
+export function formatDate(
+    value: Date | string | number,
+    locale: Locale = "en",
+    options?: Intl.DateTimeFormatOptions
+): string {
+    const date = value instanceof Date ? value : new Date(value);
+    return new Intl.DateTimeFormat(resolveTag(locale), options).format(date);
+}

--- a/apps/dapp/frontend/lib/i18n/locales/en.json
+++ b/apps/dapp/frontend/lib/i18n/locales/en.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "loading": "Loading...",
+    "retry": "Try again",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Your portfolio at a glance",
+    "totalBalance": "Total balance",
+    "totalYieldEarned": "Total yield earned",
+    "activeVaults": "Active vaults",
+    "recentActivity": "Recent activity",
+    "noActivity": "No activity yet"
+  },
+  "savings": {
+    "title": "Savings",
+    "subtitle": "Choose a savings plan and start earning yield on your USDC.",
+    "createPlan": "Create Plan",
+    "totalDeposited": "Total Deposited",
+    "yieldEarned": "Yield Earned",
+    "newGoal": "New goal",
+    "noGoals": "You don't have any savings goals yet",
+    "onTrack": "On track",
+    "atRisk": "At risk",
+    "targetLabel": "Target",
+    "deadlineLabel": "Deadline"
+  },
+  "offramp": {
+    "title": "Cash Out",
+    "subtitle": "Convert crypto to fiat, directly to your bank account",
+    "amountLabel": "Amount",
+    "bankLabel": "Bank",
+    "accountNumberLabel": "Account number",
+    "offlineMessage": "You're offline — withdrawals are paused",
+    "enterAmount": "Enter an amount",
+    "selectBank": "Select a bank"
+  },
+  "settings": {
+    "language": "Language",
+    "languageDescription": "Choose the language used across the app"
+  }
+}

--- a/apps/dapp/frontend/lib/i18n/locales/fr.json
+++ b/apps/dapp/frontend/lib/i18n/locales/fr.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "loading": "Chargement...",
+    "retry": "Réessayer",
+    "save": "Enregistrer",
+    "cancel": "Annuler"
+  },
+  "dashboard": {
+    "title": "Tableau de bord",
+    "subtitle": "Votre portefeuille en un coup d'œil",
+    "totalBalance": "Solde total",
+    "totalYieldEarned": "Rendement total gagné",
+    "activeVaults": "Coffres actifs",
+    "recentActivity": "Activité récente",
+    "noActivity": "Aucune activité pour l'instant"
+  },
+  "savings": {
+    "title": "Épargne",
+    "subtitle": "Choisissez un plan d'épargne et commencez à gagner un rendement sur votre USDC.",
+    "createPlan": "Créer un plan",
+    "totalDeposited": "Total déposé",
+    "yieldEarned": "Rendement gagné",
+    "newGoal": "Nouvel objectif",
+    "noGoals": "Vous n'avez pas encore d'objectif d'épargne",
+    "onTrack": "Sur la bonne voie",
+    "atRisk": "À risque",
+    "targetLabel": "Cible",
+    "deadlineLabel": "Échéance"
+  },
+  "offramp": {
+    "title": "Retrait",
+    "subtitle": "Convertissez vos cryptos en monnaie locale, directement sur votre compte bancaire",
+    "amountLabel": "Montant",
+    "bankLabel": "Banque",
+    "accountNumberLabel": "Numéro de compte",
+    "offlineMessage": "Vous êtes hors ligne — les retraits sont suspendus",
+    "enterAmount": "Entrez un montant",
+    "selectBank": "Choisissez une banque"
+  },
+  "settings": {
+    "language": "Langue",
+    "languageDescription": "Choisissez la langue utilisée dans l'application"
+  }
+}

--- a/apps/dapp/frontend/public/manifest.webmanifest
+++ b/apps/dapp/frontend/public/manifest.webmanifest
@@ -1,0 +1,31 @@
+{
+  "name": "Nester",
+  "short_name": "Nester",
+  "description": "Decentralized savings and instant fiat settlements powered by Stellar.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0a0a0a",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/apps/dapp/frontend/public/sw.js
+++ b/apps/dapp/frontend/public/sw.js
@@ -1,0 +1,85 @@
+// Nester DApp service worker.
+//
+// Caching strategy (documented per #790 acceptance criteria):
+// - App shell (/, /offline, manifest, logo) is precached on install.
+// - Navigations use network-first, falling back to the cached /offline
+//   route when the network is unavailable.
+// - Static same-origin GET assets use cache-first with a network fallback
+//   that repopulates the cache.
+// - Anything under /api/ (including /api/v1/* and /api/intelligence/*) is
+//   NEVER cached and always goes straight to the network. Those responses
+//   can contain per-user, authenticated data, and caching them in a shared
+//   service worker cache would leak one user's data to the next person who
+//   uses the same browser profile/device.
+// - Cross-origin requests are left untouched (not intercepted).
+
+const CACHE_VERSION = "nester-shell-v1";
+const OFFLINE_URL = "/offline";
+const APP_SHELL = [OFFLINE_URL, "/manifest.webmanifest", "/logo.png"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_VERSION)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((key) => key !== CACHE_VERSION).map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  // Never intercept cross-origin requests (wallets, RPC nodes, CDNs, etc.).
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  // Never cache API traffic — it may be per-user and authenticated.
+  if (url.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches.match(OFFLINE_URL).then((cached) => cached || Response.error())
+      )
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const copy = response.clone();
+            caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+          }
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});

--- a/apps/intelligence/app/main.py
+++ b/apps/intelligence/app/main.py
@@ -8,7 +8,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
-from app.routers import analyze, chat, coaching, health, savings, ws_chat
+from app.routers import analyze, chat, coaching, health, rebalance, savings, ws_chat
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -49,3 +49,4 @@ app.include_router(coaching.router)
 app.include_router(analyze.router)
 app.include_router(ws_chat.router)
 app.include_router(savings.router, prefix="/intelligence")
+app.include_router(rebalance.router)

--- a/apps/intelligence/app/models/rebalance.py
+++ b/apps/intelligence/app/models/rebalance.py
@@ -1,0 +1,59 @@
+"""Pydantic models for the AI rebalancing suggestion engine."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Urgency = Literal["low", "medium", "high"]
+
+
+class ProtocolAllocation(BaseModel):
+    """A single protocol's share of a vault's current allocation."""
+
+    protocol: str
+    percentage: float = Field(ge=0, le=100)
+    apy: float = Field(ge=0)
+
+
+class RebalanceSuggestRequest(BaseModel):
+    vault_id: str
+    vault_balance_usd: float = Field(ge=0)
+    allocations: list[ProtocolAllocation]
+    # Minimum APY delta (percentage points) required to trigger a suggestion.
+    threshold_pct: float = 5.0
+
+
+class RebalanceAction(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    protocol: str
+    action: Literal["increase", "reduce", "hold"]
+    from_pct: float = Field(alias="from", ge=0, le=100)
+    to_pct: float = Field(alias="to", ge=0, le=100)
+    reason: str
+
+
+class RebalanceSuggestResponse(BaseModel):
+    vault_id: str
+    should_rebalance: bool
+    urgency: Urgency
+    current_weighted_apy: float
+    optimal_weighted_apy: float
+    yield_improvement_usd: float
+    actions: list[RebalanceAction]
+    rationale: str
+    confidence: float = Field(ge=0, le=1)
+
+
+class RebalanceExecuteRequest(BaseModel):
+    vault_id: str
+    source_account: str
+    actions: list[RebalanceAction]
+    network: Literal["testnet", "public"] = "testnet"
+
+
+class RebalanceExecuteResponse(BaseModel):
+    vault_id: str
+    unsigned_transaction_xdr: str
+    network_passphrase: str
+    source_account: str

--- a/apps/intelligence/app/routers/rebalance.py
+++ b/apps/intelligence/app/routers/rebalance.py
@@ -1,0 +1,43 @@
+"""AI rebalancing suggestion and execution endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies.auth import verify_jwt
+from app.models.rebalance import (
+    RebalanceExecuteRequest,
+    RebalanceExecuteResponse,
+    RebalanceSuggestRequest,
+    RebalanceSuggestResponse,
+)
+from app.services.rebalance_engine import rebalance_engine
+
+router = APIRouter(dependencies=[Depends(verify_jwt)])
+
+
+@router.post("/vaults/{vault_id}/rebalance/suggest", response_model=RebalanceSuggestResponse)
+async def suggest_rebalance(
+    vault_id: str,
+    body: RebalanceSuggestRequest,
+    claims: dict[str, Any] = Depends(verify_jwt),  # noqa: ARG001
+) -> RebalanceSuggestResponse:
+    """Analyze a vault's allocation and return a risk-adjusted rebalance suggestion."""
+    if body.vault_id != vault_id:
+        body = body.model_copy(update={"vault_id": vault_id})
+    return await rebalance_engine.analyze(body)
+
+
+@router.post("/vaults/{vault_id}/rebalance/execute", response_model=RebalanceExecuteResponse)
+async def execute_rebalance(
+    vault_id: str,
+    body: RebalanceExecuteRequest,
+    claims: dict[str, Any] = Depends(verify_jwt),  # noqa: ARG001
+) -> RebalanceExecuteResponse:
+    """Build an unsigned Stellar transaction for a user-approved rebalance."""
+    if body.vault_id != vault_id:
+        body = body.model_copy(update={"vault_id": vault_id})
+    try:
+        return rebalance_engine.build_unsigned_transaction(body)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/apps/intelligence/app/services/rebalance_engine.py
+++ b/apps/intelligence/app/services/rebalance_engine.py
@@ -1,0 +1,268 @@
+"""AI-powered rebalancing suggestion engine.
+
+Analyzes a vault's current allocation against live protocol APY data and the
+risk model in `app.services.risk_model`, then asks Claude for a short,
+human-readable rationale. Falls back to a deterministic rationale if Claude
+is unavailable so the endpoint never hard-fails on a model outage.
+"""
+
+import json
+import logging
+from typing import Any
+
+import anthropic
+from stellar_sdk import Account, Network, StrKey, TransactionBuilder
+
+from app.models.rebalance import (
+    ProtocolAllocation,
+    RebalanceAction,
+    RebalanceExecuteRequest,
+    RebalanceExecuteResponse,
+    RebalanceSuggestRequest,
+    RebalanceSuggestResponse,
+    Urgency,
+)
+from app.services import risk_model
+from app.services.defillama import get_client as get_defillama_client
+from app.services.prometheus import ANALYZE_MAX_TOKENS, SYSTEM_PROMPT, get_client
+
+logger = logging.getLogger(__name__)
+
+# Manage-data values are capped at 64 bytes by the Stellar protocol.
+_MANAGE_DATA_VALUE_MAX_BYTES = 64
+
+
+async def _live_apy_by_protocol() -> dict[str, float]:
+    """Best-effort live APY per protocol from DeFiLlama, keyed by lowercase name."""
+    try:
+        pools = await get_defillama_client().get_yield_pools("Stellar")
+    except Exception:
+        logger.exception("rebalance_engine: failed to fetch live APY data")
+        return {}
+
+    live: dict[str, float] = {}
+    for pool in pools:
+        project = str(pool.get("project", "")).strip().lower()
+        apy = pool.get("apy")
+        if project and isinstance(apy, (int, float)) and apy > 0:
+            # Keep the highest observed APY per project across its pools.
+            live[project] = max(live.get(project, 0.0), float(apy))
+    return live
+
+
+def _urgency_for_gain(gain_pct: float) -> Urgency:
+    if gain_pct >= 10:
+        return "high"
+    if gain_pct >= 5:
+        return "medium"
+    return "low"
+
+
+def _build_actions(
+    allocations: list[ProtocolAllocation], optimal_protocol: str, optimal_apy: float
+) -> list[RebalanceAction]:
+    actions: list[RebalanceAction] = []
+    optimal_lower = optimal_protocol.strip().lower()
+    already_allocated = {a.protocol.strip().lower() for a in allocations}
+
+    for alloc in allocations:
+        is_optimal = alloc.protocol.strip().lower() == optimal_lower
+        to_pct = 100.0 if is_optimal else 0.0
+        if to_pct == alloc.percentage:
+            action: Any = "hold"
+        elif to_pct > alloc.percentage:
+            action = "increase"
+        else:
+            action = "reduce"
+        reason = (
+            f"{alloc.protocol} is the highest risk-adjusted yield at {optimal_apy:.2f}% APY"
+            if is_optimal
+            else f"{alloc.protocol}'s risk-adjusted return trails {optimal_protocol}"
+        )
+        actions.append(
+            RebalanceAction.model_validate(
+                {
+                    "protocol": alloc.protocol,
+                    "action": action,
+                    "from": alloc.percentage,
+                    "to": to_pct,
+                    "reason": reason,
+                }
+            )
+        )
+
+    if optimal_lower not in already_allocated:
+        actions.append(
+            RebalanceAction.model_validate(
+                {
+                    "protocol": optimal_protocol,
+                    "action": "increase",
+                    "from": 0.0,
+                    "to": 100.0,
+                    "reason": (
+                        f"{optimal_protocol} offers the best risk-adjusted yield at "
+                        f"{optimal_apy:.2f}% APY"
+                    ),
+                }
+            )
+        )
+
+    return actions
+
+
+async def _generate_rationale(
+    current_apy: float, optimal_apy: float, optimal_protocol: str, actions: list[RebalanceAction]
+) -> str:
+    action_summary = ", ".join(f"{a.protocol}: {a.action} to {a.to_pct:.0f}%" for a in actions)
+    prompt = (
+        "You are Prometheus, Nester's yield-rebalancing analyst. "
+        f"Current weighted APY is {current_apy:.2f}%, the optimal risk-adjusted allocation "
+        f"yields {optimal_apy:.2f}% by favouring {optimal_protocol}. "
+        f"Planned changes: {action_summary}. "
+        "In 1-2 sentences, explain why this rebalance is worth doing (or not) for a "
+        "Nester user in Nigeria/Ghana/Kenya. Plain language, no jargon, no em dashes."
+    )
+    try:
+        client = get_client()
+        response = await client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=ANALYZE_MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = next(
+            (b.text for b in response.content if isinstance(b, anthropic.types.TextBlock)), ""
+        )
+        return text.strip() or _fallback_rationale(current_apy, optimal_apy, optimal_protocol)
+    except Exception:
+        logger.exception("rebalance_engine: rationale generation failed")
+        return _fallback_rationale(current_apy, optimal_apy, optimal_protocol)
+
+
+def _fallback_rationale(current_apy: float, optimal_apy: float, optimal_protocol: str) -> str:
+    gain = optimal_apy - current_apy
+    return (
+        f"Shifting toward {optimal_protocol} improves your weighted APY from "
+        f"{current_apy:.2f}% to {optimal_apy:.2f}%, a gain of {gain:.2f} percentage points."
+    )
+
+
+class RebalanceEngine:
+    """Analyzes vault allocations and produces AI rebalancing suggestions."""
+
+    async def analyze(self, request: RebalanceSuggestRequest) -> RebalanceSuggestResponse:
+        live_apy = await _live_apy_by_protocol()
+        data_is_live = bool(live_apy)
+
+        current_weighted_apy = sum(
+            (a.percentage / 100.0) * a.apy for a in request.allocations
+        )
+
+        candidates = {a.protocol.strip().lower(): a.apy for a in request.allocations}
+        for protocol in risk_model.PROTOCOL_RISK_FACTORS:
+            candidates.setdefault(
+                protocol, live_apy.get(protocol, risk_model.BASELINE_APY.get(protocol, 0.0))
+            )
+        for protocol, apy in live_apy.items():
+            candidates[protocol] = apy
+
+        scored = {
+            protocol: risk_model.score_protocol(protocol, apy)
+            for protocol, apy in candidates.items()
+            if apy > 0
+        }
+        if not scored:
+            optimal_protocol = request.allocations[0].protocol if request.allocations else "blend"
+            optimal_apy = current_weighted_apy
+        else:
+            optimal_protocol = max(scored, key=lambda p: scored[p])
+            optimal_apy = candidates[optimal_protocol]
+
+        gain_pct = optimal_apy - current_weighted_apy
+        should_rebalance = gain_pct > request.threshold_pct
+
+        actions = (
+            _build_actions(request.allocations, optimal_protocol, optimal_apy)
+            if should_rebalance
+            else []
+        )
+        rationale = (
+            await _generate_rationale(
+                current_weighted_apy, optimal_apy, optimal_protocol, actions
+            )
+            if should_rebalance
+            else (
+                "Your current allocation is already close to the optimal risk-adjusted "
+                "yield. No change recommended."
+            )
+        )
+
+        confidence = self._confidence(data_is_live, gain_pct)
+
+        return RebalanceSuggestResponse(
+            vault_id=request.vault_id,
+            should_rebalance=should_rebalance,
+            urgency=_urgency_for_gain(max(gain_pct, 0)),
+            current_weighted_apy=round(current_weighted_apy, 4),
+            optimal_weighted_apy=round(optimal_apy, 4),
+            yield_improvement_usd=round(
+                request.vault_balance_usd * max(gain_pct, 0) / 100.0, 2
+            ),
+            actions=actions,
+            rationale=rationale,
+            confidence=confidence,
+        )
+
+    @staticmethod
+    def _confidence(data_is_live: bool, gain_pct: float) -> float:
+        base = 0.85 if data_is_live else 0.45
+        # Larger gains are easier to be confident about than marginal ones.
+        certainty_bonus = min(abs(gain_pct) / 100.0, 0.1)
+        return round(min(base + certainty_bonus, 0.99), 2)
+
+    def build_unsigned_transaction(
+        self, request: RebalanceExecuteRequest
+    ) -> RebalanceExecuteResponse:
+        """Build an unsigned Stellar transaction encoding the approved rebalance actions.
+
+        Each action is recorded as a `manage_data` operation so the resulting
+        transaction is inspectable on-chain audit tools before the user signs
+        it. The source account's sequence number is not known to this
+        service, so it is set to 0; the caller (wallet or relaying API) must
+        refresh it from Horizon immediately before requesting a signature.
+        """
+        if not StrKey.is_valid_ed25519_public_key(request.source_account):
+            raise ValueError("source_account must be a valid Stellar public key")
+
+        network_passphrase = (
+            Network.PUBLIC_NETWORK_PASSPHRASE
+            if request.network == "public"
+            else Network.TESTNET_NETWORK_PASSPHRASE
+        )
+
+        account = Account(account=request.source_account, sequence=0)
+        builder = TransactionBuilder(
+            source_account=account,
+            network_passphrase=network_passphrase,
+            base_fee=100,
+        )
+
+        for action in request.actions:
+            data_name = f"rebalance_{action.protocol}"[:64]
+            data_value = json.dumps({"to": action.to_pct, "action": action.action})[
+                :_MANAGE_DATA_VALUE_MAX_BYTES
+            ]
+            builder.append_manage_data_op(data_name=data_name, data_value=data_value)
+
+        builder.set_timeout(300)
+        transaction = builder.build()
+
+        return RebalanceExecuteResponse(
+            vault_id=request.vault_id,
+            unsigned_transaction_xdr=transaction.to_xdr(),
+            network_passphrase=network_passphrase,
+            source_account=request.source_account,
+        )
+
+
+rebalance_engine = RebalanceEngine()

--- a/apps/intelligence/app/services/risk_model.py
+++ b/apps/intelligence/app/services/risk_model.py
@@ -1,0 +1,100 @@
+"""Risk-adjusted yield scoring for the AI rebalancing engine.
+
+Scores each supported Stellar DeFi protocol on a Sharpe-ratio inspired basis so
+the rebalance engine can rank candidate allocations by risk-adjusted return
+rather than raw APY alone.
+"""
+
+from dataclasses import dataclass
+
+# Annualised return assumed available risk-free (e.g. a stablecoin-only vault
+# tier), expressed as a percentage-point APY to match how APYs are represented
+# everywhere else in this module (4.0 means 4%, not 0.04). Used as the
+# baseline an allocation must beat to be worth the risk.
+RISK_FREE_RATE = 2.0
+
+# Floor applied to the risk_adjusted_score denominator so a protocol with a
+# perfect audit/TVL/age score and full liquidity never divides by zero.
+_MIN_DENOMINATOR = 0.01
+
+
+@dataclass(frozen=True)
+class ProtocolRiskFactors:
+    """Raw risk inputs for a single protocol, each on a 0-1 scale."""
+
+    audit_score: float  # 1.0 = fully audited by reputable firms
+    tvl_score: float  # 1.0 = large, stable TVL
+    age_score: float  # 1.0 = long track record
+    volatility_score: float  # 1.0 = highly volatile historical APY
+    liquidity_score: float  # 1.0 = fully liquid / instant withdrawal
+
+
+# Reference risk factors for protocols Nester vaults currently allocate to.
+# Values are curated estimates; update as protocols mature or new audits land.
+PROTOCOL_RISK_FACTORS: dict[str, ProtocolRiskFactors] = {
+    "blend": ProtocolRiskFactors(
+        audit_score=0.9, tvl_score=0.8, age_score=0.7, volatility_score=0.2, liquidity_score=0.9
+    ),
+    "lobstr": ProtocolRiskFactors(
+        audit_score=0.75, tvl_score=0.6, age_score=0.6, volatility_score=0.35, liquidity_score=0.8
+    ),
+    "ultra": ProtocolRiskFactors(
+        audit_score=0.7, tvl_score=0.5, age_score=0.4, volatility_score=0.45, liquidity_score=0.7
+    ),
+    "aquarius": ProtocolRiskFactors(
+        audit_score=0.8, tvl_score=0.65, age_score=0.6, volatility_score=0.3, liquidity_score=0.85
+    ),
+    "fxdao": ProtocolRiskFactors(
+        audit_score=0.65, tvl_score=0.4, age_score=0.3, volatility_score=0.55, liquidity_score=0.6
+    ),
+}
+
+# Default factors for a protocol Nester has not yet risk-rated. Deliberately
+# conservative so unknown protocols never outrank rated ones on data alone.
+_DEFAULT_RISK_FACTORS = ProtocolRiskFactors(
+    audit_score=0.4, tvl_score=0.4, age_score=0.3, volatility_score=0.6, liquidity_score=0.5
+)
+
+# Last-known APY per protocol (percentage points), used when DeFiLlama is
+# unreachable or has no live pool for a protocol. Mirrors the issue's
+# "fallback: cached last-known values" data source. Update periodically.
+BASELINE_APY: dict[str, float] = {
+    "blend": 8.4,
+    "lobstr": 6.5,
+    "ultra": 4.0,
+    "aquarius": 9.0,
+    "fxdao": 12.0,
+}
+
+
+def get_risk_factors(protocol: str) -> ProtocolRiskFactors:
+    """Return the risk factors for `protocol`, falling back to conservative defaults."""
+    return PROTOCOL_RISK_FACTORS.get(protocol.strip().lower(), _DEFAULT_RISK_FACTORS)
+
+
+def composite_risk_score(factors: ProtocolRiskFactors) -> float:
+    """Combine audit/TVL/age/volatility into a single 0-1 risk score (higher = riskier)."""
+    inverse_safety = (
+        (1 - factors.audit_score) + (1 - factors.tvl_score) + (1 - factors.age_score)
+    ) / 3
+    risk = (inverse_safety + factors.volatility_score) / 2
+    return min(max(risk, 0.0), 1.0)
+
+
+def risk_adjusted_score(apy: float, risk_score: float, liquidity_score: float) -> float:
+    """Sharpe-ratio inspired risk-adjusted return.
+
+    Mirrors the issue's reference formula: excess return over the risk-free
+    rate, penalised by both protocol risk and illiquidity. The denominator is
+    floored so a protocol with zero risk and full liquidity does not blow up
+    to infinity.
+    """
+    denominator = max(risk_score * (1 - liquidity_score), _MIN_DENOMINATOR)
+    return (apy - RISK_FREE_RATE) / denominator
+
+
+def score_protocol(protocol: str, apy: float) -> float:
+    """Convenience wrapper: look up risk factors for `protocol` and score `apy`."""
+    factors = get_risk_factors(protocol)
+    risk = composite_risk_score(factors)
+    return risk_adjusted_score(apy, risk, factors.liquidity_score)

--- a/apps/intelligence/requirements.txt
+++ b/apps/intelligence/requirements.txt
@@ -10,3 +10,4 @@ redis>=5.0.0
 aiohttp>=3.9.0
 cachetools>=5.3.0
 pytest-asyncio>=0.21.0
+stellar-sdk>=15.0.0

--- a/apps/intelligence/tests/test_rebalance_engine.py
+++ b/apps/intelligence/tests/test_rebalance_engine.py
@@ -1,0 +1,147 @@
+from types import SimpleNamespace
+
+import pytest
+from stellar_sdk import Keypair
+
+from app.models.rebalance import (
+    ProtocolAllocation,
+    RebalanceAction,
+    RebalanceExecuteRequest,
+    RebalanceSuggestRequest,
+)
+from app.services import rebalance_engine as engine_module
+from app.services.rebalance_engine import RebalanceEngine
+
+
+class DummyTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class FakeMessages:
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+
+    async def create(self, *args, **kwargs):
+        return SimpleNamespace(content=[DummyTextBlock(self.payload)])
+
+
+class FakeClient:
+    def __init__(self, payload: str) -> None:
+        self.messages = FakeMessages(payload)
+
+
+@pytest.fixture(autouse=True)
+def _no_live_apy(monkeypatch):
+    """Default all tests to the deterministic (non-live-data) code path."""
+
+    async def _empty() -> dict[str, float]:
+        return {}
+
+    monkeypatch.setattr(engine_module, "_live_apy_by_protocol", _empty)
+
+
+@pytest.mark.asyncio
+async def test_analyze_recommends_rebalance_when_gain_exceeds_threshold():
+    request = RebalanceSuggestRequest(
+        vault_id="vault-1",
+        vault_balance_usd=10_000,
+        allocations=[ProtocolAllocation(protocol="ultra", percentage=100, apy=1.0)],
+        threshold_pct=5.0,
+    )
+    result = await RebalanceEngine().analyze(request)
+
+    assert result.vault_id == "vault-1"
+    assert result.should_rebalance is True
+    assert result.optimal_weighted_apy > result.current_weighted_apy
+    assert result.yield_improvement_usd > 0
+    assert 0 <= result.confidence <= 1
+    assert len(result.actions) >= 1
+
+
+@pytest.mark.asyncio
+async def test_analyze_does_not_recommend_when_already_optimal():
+    request = RebalanceSuggestRequest(
+        vault_id="vault-2",
+        vault_balance_usd=5_000,
+        allocations=[ProtocolAllocation(protocol="blend", percentage=100, apy=50.0)],
+        threshold_pct=5.0,
+    )
+    result = await RebalanceEngine().analyze(request)
+
+    assert result.should_rebalance is False
+    assert result.actions == []
+    assert result.yield_improvement_usd == 0
+
+
+@pytest.mark.asyncio
+async def test_analyze_uses_claude_rationale_when_available(monkeypatch):
+    monkeypatch.setattr(
+        engine_module,
+        "get_client",
+        lambda: FakeClient("Move to blend for better risk-adjusted yield."),
+    )
+    monkeypatch.setattr(engine_module.anthropic.types, "TextBlock", DummyTextBlock, raising=False)
+
+    request = RebalanceSuggestRequest(
+        vault_id="vault-3",
+        vault_balance_usd=1_000,
+        allocations=[ProtocolAllocation(protocol="ultra", percentage=100, apy=1.0)],
+    )
+    result = await RebalanceEngine().analyze(request)
+
+    assert "blend" in result.rationale.lower() or result.rationale
+
+
+@pytest.mark.asyncio
+async def test_analyze_falls_back_when_claude_fails(monkeypatch):
+    def _boom():
+        raise RuntimeError("anthropic down")
+
+    monkeypatch.setattr(engine_module, "get_client", _boom)
+
+    request = RebalanceSuggestRequest(
+        vault_id="vault-4",
+        vault_balance_usd=1_000,
+        allocations=[ProtocolAllocation(protocol="ultra", percentage=100, apy=1.0)],
+    )
+    result = await RebalanceEngine().analyze(request)
+
+    assert result.should_rebalance is True
+    assert result.rationale  # deterministic fallback still produced
+
+
+def test_build_unsigned_transaction_returns_valid_xdr():
+    keypair = Keypair.random()
+    request = RebalanceExecuteRequest(
+        vault_id="vault-1",
+        source_account=keypair.public_key,
+        actions=[
+            RebalanceAction.model_validate(
+                {
+                    "protocol": "blend",
+                    "action": "increase",
+                    "from": 40,
+                    "to": 100,
+                    "reason": "best yield",
+                }
+            )
+        ],
+    )
+    response = RebalanceEngine().build_unsigned_transaction(request)
+
+    assert response.vault_id == "vault-1"
+    assert response.source_account == keypair.public_key
+    assert response.unsigned_transaction_xdr
+    assert "TESTNET" not in response.network_passphrase  # passphrase text, not the enum name
+    assert "Test SDF Network" in response.network_passphrase
+
+
+def test_build_unsigned_transaction_rejects_invalid_account():
+    request = RebalanceExecuteRequest(
+        vault_id="vault-1",
+        source_account="not-a-real-account",
+        actions=[],
+    )
+    with pytest.raises(ValueError):
+        RebalanceEngine().build_unsigned_transaction(request)

--- a/apps/intelligence/tests/test_risk_model.py
+++ b/apps/intelligence/tests/test_risk_model.py
@@ -1,0 +1,40 @@
+from app.services import risk_model
+
+
+def test_risk_adjusted_score_rewards_higher_apy():
+    low = risk_model.risk_adjusted_score(apy=5.0, risk_score=0.3, liquidity_score=0.8)
+    high = risk_model.risk_adjusted_score(apy=15.0, risk_score=0.3, liquidity_score=0.8)
+    assert high > low
+
+
+def test_risk_adjusted_score_penalizes_higher_risk():
+    safer = risk_model.risk_adjusted_score(apy=10.0, risk_score=0.2, liquidity_score=0.8)
+    riskier = risk_model.risk_adjusted_score(apy=10.0, risk_score=0.8, liquidity_score=0.8)
+    assert safer > riskier
+
+
+def test_risk_adjusted_score_never_divides_by_zero():
+    # Zero risk and full liquidity would naively divide by zero.
+    score = risk_model.risk_adjusted_score(apy=10.0, risk_score=0.0, liquidity_score=1.0)
+    assert score == score  # not NaN/inf
+    assert abs(score) < 1e6
+
+
+def test_composite_risk_score_bounds():
+    factors = risk_model.get_risk_factors("blend")
+    score = risk_model.composite_risk_score(factors)
+    assert 0.0 <= score <= 1.0
+
+
+def test_unknown_protocol_falls_back_to_conservative_defaults():
+    known = risk_model.get_risk_factors("blend")
+    unknown = risk_model.get_risk_factors("some_new_protocol")
+    assert unknown is not known
+    assert unknown.audit_score <= known.audit_score
+
+
+def test_score_protocol_matches_manual_computation():
+    factors = risk_model.get_risk_factors("lobstr")
+    risk = risk_model.composite_risk_score(factors)
+    expected = risk_model.risk_adjusted_score(10.0, risk, factors.liquidity_score)
+    assert risk_model.score_protocol("lobstr", 10.0) == expected


### PR DESCRIPTION
Closes #112, #110, #790, #789

## Summary

**#112 — Savings goal AI coaching.** The savings-goal CRUD, progress tracking, on-track status, and required-deposit math already existed in `internal/domain/savingsgoal` / `savings_goal_service.go`. The remaining gap was AI progress coaching, so this adds:
- `GET /api/v1/users/savings-goals/{id}/coaching` — on-demand AI coaching for a single goal, backed by the existing `/intelligence/coaching` endpoint.
- `GoalCoachingScheduler` — a weekly background job that generates and dispatches a coaching push notification per active goal.

**#110 — AI rebalancing engine.** The Go API already had a rule-based rebalance suggestion path (`vault_rebalance_service.go`). This adds the AI-driven engine the issue asked for, in `apps/intelligence`:
- `risk_model.py` — Sharpe-ratio inspired `risk_adjusted_score`, per-protocol risk factors (audit/TVL/age/volatility/liquidity).
- `rebalance_engine.py` — combines live DeFiLlama APY with a cached-baseline fallback, ranks candidates by risk-adjusted score, and asks Claude for a plain-language rationale (deterministic fallback if Claude is unavailable).
- `POST /vaults/{id}/rebalance/suggest` and `.../execute` (execute builds an **unsigned** Stellar transaction via `stellar-sdk` for the user to sign), proxied through the Go API at the same paths via the existing `IntelligenceProxy`.

**#790 — PWA installability + offline handling.** The offline hook (`useOfflineStatus`), banner, and deposit/withdraw offline guards already existed. This fills the remaining gaps:
- Web app manifest (`manifest.webmanifest`) + hand-rolled service worker (`public/sw.js`): app-shell precache, network-first navigation with an `/offline` fallback route, and API traffic (`/api/*`) is **never** cached (documented in the SW comments — avoids leaking authenticated per-user responses between users on a shared device).
- Offramp withdraw action now blocks with messaging when offline (deposit/withdraw modals were already guarded).

**#789 — i18n framework.** No i18n layer existed; currency/number formatting was ad-hoc and duplicated per component. This adds:
- `context/locale-context.tsx` — locale provider (`en` + `fr` catalogs) with a `t()` translate function, persisted to `localStorage`.
- `lib/i18n/format.ts` — shared `formatCurrency` / `formatNumber` / `formatDate` (Intl-based), replacing several ad-hoc formatters.
- Wired into the dashboard, savings, and offramp screens (headline stats + a representative set of strings) and a language selector in Settings > Preferences. Per the issue's explicit scope, this is not an exhaustive translation of every string in those screens.

## Verification
- Go: `go build ./...`, `go vet ./...`, `golangci-lint run` — clean. `go test ./internal/handler/... ./internal/service/... ./internal/notifications/...` — all pass.
- Python (`apps/intelligence`): `pytest` (84 tests), `ruff check`, `mypy --strict` — all clean.
- Frontend (`apps/dapp/frontend`): `vitest run` (83 tests), `tsc --noEmit`, `eslint` — all clean (no new errors or warnings introduced).

## Test plan
- [x] Automated tests above
- [ ] Manual: confirm PWA install prompt in Chromium, offline navigation fallback, offramp blocked while offline, locale switch in Settings persists across reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI progress coaching for savings goals, including an API endpoint and weekly, preference-based notifications.
  * Added AI-assisted vault rebalance endpoints for suggesting and executing actions, plus unsigned transaction payload generation.
  * Introduced English/French localization with a language selector and locale-aware currency/number/date formatting.
  * Added offline support: PWA manifest, service worker with offline fallback, and an offline page UI.
* **Tests**
  * Added automated coverage for coaching, rebalance engine, risk scoring, formatting, scheduler behavior, and offline/i18n components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->