### PR TITLE
feat(intelligence): automated periodic financial insight digests

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -728,6 +728,28 @@ func run() error {
 	intelligenceRelayHandler := handler.NewIntelligenceRelayHandler(intelRelay)
 	intelligenceRelayHandler.Register(mux)
 
+	// Periodic financial insight digest (#859): a deterministic ledger
+	// source endpoint (consumed by the intelligence service via the relay),
+	// a cache/audit table, and a leader-elected daily job that generates and
+	// delivers a digest once per user per completed period.
+	digestRepository := postgres.NewDigestRepository(db)
+	digestLedgerService := service.NewDigestLedgerService(savingsGoalRepo, yieldHarvestRepository, savingsStreakRepo)
+	digestHandler := handler.NewDigestHandler(digestLedgerService, digestRepository)
+	digestHandler.Register(mux)
+
+	digestJob := scheduler.NewDigestJob(
+		scheduler.DigestJobConfig{Enabled: true, Interval: 24 * time.Hour},
+		notificationRepository,
+		digestRepository,
+		prometheusClient,
+		notificationDispatcher2,
+		baseLogger.WithGroup("digest"),
+	)
+	digestJob.SetLeaderChecker(schedulerLeadership)
+	digestCtx, cancelDigest := context.WithCancel(context.Background())
+	defer cancelDigest()
+	go digestJob.Run(digestCtx)
+
 	performanceSnapshotsHandler := handler.NewPerformanceSnapshotsHandler(performanceService)
 	performanceSnapshotsHandler.Register(mux)
 

--- a/apps/api/internal/domain/digest/model.go
+++ b/apps/api/internal/domain/digest/model.go
@@ -1,0 +1,130 @@
+// Package digest supports the periodic financial insight digest (#859).
+//
+// The Go backend's role is narrow and deliberate: it is the source of truth
+// for money movement, so it exposes the *raw ledger ingredients* a digest
+// period needs (deposits this/last period, yield harvested this period,
+// streak status) via DigestLedgerSource, plus a cache/audit table recording
+// what was actually generated and delivered. Deterministic fact assembly
+// (period comparisons, goal-progress narration, attention items) and the
+// LLM narrative generation both happen in the intelligence service, which
+// also pulls goals/vault/performance data from this API's existing
+// endpoints — see apps/intelligence/app/services/digest_service.py.
+package digest
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Period is the digest cadence: how often a user receives one.
+type Period string
+
+const (
+	PeriodWeekly  Period = "weekly"
+	PeriodMonthly Period = "monthly"
+)
+
+// Valid reports whether p is a recognized period.
+func (p Period) Valid() bool {
+	return p == PeriodWeekly || p == PeriodMonthly
+}
+
+// Bounds returns [start, end) for the most recently *completed* period as
+// of `now`, plus the start of the period before that — the pair the digest
+// needs for a period-over-period comparison. "This month's digest" reports
+// on the month that just ended, not the one still in progress, so end is
+// always <= now. Weekly periods run Monday-Sunday (ISO week); monthly
+// periods run calendar-month.
+func Bounds(p Period, now time.Time) (start, end, previousStart time.Time) {
+	now = now.UTC()
+	switch p {
+	case PeriodWeekly:
+		// ISO week starts Monday. time.Weekday: Sunday=0..Saturday=6.
+		offset := int(now.Weekday())
+		if offset == 0 {
+			offset = 7 // Sunday -> 7 days since Monday
+		}
+		currentWeekStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(offset - 1))
+		end = currentWeekStart
+		start = currentWeekStart.AddDate(0, 0, -7)
+		previousStart = start.AddDate(0, 0, -7)
+	default: // PeriodMonthly
+		currentMonthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		end = currentMonthStart
+		start = currentMonthStart.AddDate(0, -1, 0)
+		previousStart = start.AddDate(0, -1, 0)
+	}
+	return start, end, previousStart
+}
+
+// YieldHarvestFact is one harvest event within the period, as surfaced to
+// the digest (enough to narrate "your locked savings earned X").
+type YieldHarvestFact struct {
+	VaultID     uuid.UUID       `json:"vault_id"`
+	Amount      decimal.Decimal `json:"amount"`
+	Currency    string          `json:"currency"`
+	HarvestedAt time.Time       `json:"harvested_at"`
+}
+
+// StreakFact is the user's savings-streak status as of digest generation.
+type StreakFact struct {
+	CurrentStreak   int    `json:"current_streak"`
+	LongestStreak   int    `json:"longest_streak"`
+	LastDepositWeek string `json:"last_deposit_week"`
+}
+
+// LedgerSource is the deterministic, Go-computed raw ledger data for one
+// user's digest period. It carries no narrative or judgment — every field
+// is a number or event pulled directly from the ledger/streak repositories.
+// The intelligence service combines this with goals/vault data (fetched
+// separately via existing endpoints) to assemble the full fact set.
+type LedgerSource struct {
+	Period             Period             `json:"period"`
+	PeriodStart        time.Time          `json:"period_start"`
+	PeriodEnd          time.Time          `json:"period_end"`
+	PreviousPeriodStart time.Time         `json:"previous_period_start"`
+	Currency           string             `json:"currency"`
+	DepositedThisPeriod decimal.Decimal   `json:"deposited_this_period"`
+	DepositedLastPeriod decimal.Decimal   `json:"deposited_last_period"`
+	YieldHarvests      []YieldHarvestFact `json:"yield_harvests"`
+	Streak             StreakFact         `json:"streak"`
+}
+
+// CachedDigest is the persisted record of a generated digest: the
+// authoritative "one generation per user per period" cache plus a delivery
+// audit trail. FactsHash lets the caller detect whether the underlying
+// period data changed since generation (e.g. a corrected transaction) and
+// a regeneration is actually warranted, rather than trusting a stale cache
+// forever.
+type CachedDigest struct {
+	ID                uuid.UUID
+	UserID            uuid.UUID
+	Period            Period
+	PeriodStart       time.Time
+	PeriodEnd         time.Time
+	FactsHash         string
+	FactsJSON         string
+	Narrative         string
+	AttentionItemsJSON string
+	HonestZeroPeriod  bool
+	DeliveredAt       *time.Time
+	GeneratedAt       time.Time
+}
+
+// Repository is the persistence contract for the digest cache/audit table.
+type Repository interface {
+	// GetCached returns the cached digest for this user/period/periodStart,
+	// or (nil, nil) if none has been generated yet.
+	GetCached(ctx context.Context, userID uuid.UUID, period Period, periodStart time.Time) (*CachedDigest, error)
+	// Save upserts the generated digest for its (user, period, periodStart).
+	Save(ctx context.Context, d CachedDigest) (CachedDigest, error)
+	// MarkDelivered records that the digest was handed to the notification
+	// dispatcher, so the scheduler does not re-send it on a later tick.
+	MarkDelivered(ctx context.Context, id uuid.UUID, deliveredAt time.Time) error
+	// GetLatest returns the most recently generated digest for a user
+	// regardless of period bounds, for the user-facing "latest digest" card.
+	GetLatest(ctx context.Context, userID uuid.UUID) (*CachedDigest, error)
+}

--- a/apps/api/internal/domain/intelligence/model.go
+++ b/apps/api/internal/domain/intelligence/model.go
@@ -100,3 +100,38 @@ type CoachingResponse struct {
 	Nudges             []string              `json:"nudges"`
 	Confidence         string                `json:"confidence"`
 }
+
+// DigestGenerateRequest mirrors the intelligence service's
+// DigestGenerateRequest model (#859): a request for the periodic insight
+// digest for one user/period. The intelligence service pulls facts itself
+// (ledger via the relay, goals/vaults/performance via existing endpoints)
+// so this request carries only the identifiers, not the data.
+type DigestGenerateRequest struct {
+	UserID string `json:"user_id"`
+	Period string `json:"period"` // "weekly" | "monthly"
+}
+
+// DigestAttentionItem mirrors the intelligence service's AttentionItem
+// model: a constructive, actionable heads-up surfaced in the digest.
+type DigestAttentionItem struct {
+	Kind       string `json:"kind"`
+	Message    string `json:"message"`
+	ActionLabel string `json:"action_label,omitempty"`
+	ActionHref string `json:"action_href,omitempty"`
+}
+
+// DigestGenerateResponse mirrors the intelligence service's DigestResponse
+// model: the assembled facts (opaque to Go — narrated by the LLM but
+// computed deterministically), the grounded narrative, and attention items.
+type DigestGenerateResponse struct {
+	Period            string                 `json:"period"`
+	PeriodStart       string                 `json:"period_start"`
+	PeriodEnd         string                 `json:"period_end"`
+	Facts             map[string]any         `json:"facts"`
+	FactsHash         string                 `json:"facts_hash"`
+	Narrative         string                 `json:"narrative"`
+	AttentionItems    []DigestAttentionItem  `json:"attention_items"`
+	HonestZeroPeriod  bool                   `json:"honest_zero_period"`
+	Cached            bool                   `json:"cached"`
+	GeneratedAt       string                 `json:"generated_at"`
+}

--- a/apps/api/internal/domain/yieldharvest/model.go
+++ b/apps/api/internal/domain/yieldharvest/model.go
@@ -40,6 +40,12 @@ type ListFilter struct {
 	CursorTime *time.Time
 	CursorID   *uuid.UUID
 	Limit      int
+	// Since restricts results to harvests at or after this time (inclusive).
+	// Used by the digest fact-assembly source (#859) to sum yield harvested
+	// within a specific period without paging through full history.
+	Since *time.Time
+	// Until restricts results to harvests strictly before this time.
+	Until *time.Time
 }
 
 // Repository is the persistence contract for yield harvest records.

--- a/apps/api/internal/handler/digest_handler.go
+++ b/apps/api/internal/handler/digest_handler.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/digest"
+	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// DigestLedgerAssembler computes the deterministic raw ledger ingredients
+// for a user's digest period (#859).
+type DigestLedgerAssembler interface {
+	Assemble(ctx context.Context, userID uuid.UUID, period digest.Period) (digest.LedgerSource, error)
+}
+
+// DigestHandler exposes the digest-ledger source (consumed by the
+// intelligence service via the relay) and the cached "latest digest" the
+// frontend reads for the insights card.
+type DigestHandler struct {
+	ledger DigestLedgerAssembler
+	cache  digest.Repository
+}
+
+func NewDigestHandler(ledger DigestLedgerAssembler, cache digest.Repository) *DigestHandler {
+	return &DigestHandler{ledger: ledger, cache: cache}
+}
+
+func (h *DigestHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/users/digest-ledger", h.getLedgerSource)
+	mux.HandleFunc("GET /api/v1/users/digest/latest", h.getLatest)
+}
+
+func (h *DigestHandler) getLedgerSource(w http.ResponseWriter, r *http.Request) {
+	userID, ok := digestUserID(w, r)
+	if !ok {
+		return
+	}
+
+	period := digest.Period(strings.ToLower(strings.TrimSpace(r.URL.Query().Get("period"))))
+	if period == "" {
+		period = digest.PeriodMonthly
+	}
+	if !period.Valid() {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("period must be one of: weekly, monthly"))
+		return
+	}
+
+	source, err := h.ledger.Assemble(r.Context(), userID, period)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("digest ledger assembly failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(source))
+}
+
+func (h *DigestHandler) getLatest(w http.ResponseWriter, r *http.Request) {
+	userID, ok := digestUserID(w, r)
+	if !ok {
+		return
+	}
+
+	cached, err := h.cache.GetLatest(r.Context(), userID)
+	if err != nil {
+		logpkg.FromContext(r.Context()).Error("digest latest lookup failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
+		return
+	}
+	if cached == nil {
+		response.WriteJSON(w, http.StatusNotFound, response.Err(http.StatusNotFound, "NOT_FOUND", "no digest has been generated yet"))
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(cached))
+}
+
+func digestUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	user, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "authentication required"))
+		return uuid.Nil, false
+	}
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		response.WriteJSON(w, http.StatusUnauthorized, response.Err(http.StatusUnauthorized, "UNAUTHORIZED", "invalid user identity"))
+		return uuid.Nil, false
+	}
+	return userID, true
+}

--- a/apps/api/internal/handler/notification_handler.go
+++ b/apps/api/internal/handler/notification_handler.go
@@ -88,9 +88,10 @@ func (h *NotificationHandler) GetPreferences(w http.ResponseWriter, r *http.Requ
 }
 
 type updateNotificationPreferencesRequest struct {
-	Email     *bool `json:"email"`
-	WebSocket *bool `json:"websocket"`
-	Push      *bool `json:"push"`
+	Email         *bool   `json:"email"`
+	WebSocket     *bool   `json:"websocket"`
+	Push          *bool   `json:"push"`
+	DigestCadence *string `json:"digest_cadence"`
 }
 
 func (h *NotificationHandler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
@@ -119,6 +120,15 @@ func (h *NotificationHandler) UpdatePreferences(w http.ResponseWriter, r *http.R
 	}
 	if req.Push != nil {
 		prefs.Push = *req.Push
+	}
+	if req.DigestCadence != nil {
+		if !notifications.ValidDigestCadence(*req.DigestCadence) {
+			response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(
+				"digest_cadence must be one of: off, weekly, monthly",
+			))
+			return
+		}
+		prefs.DigestCadence = *req.DigestCadence
 	}
 
 	prefs, err = h.store.Set(r.Context(), userID, prefs)

--- a/apps/api/internal/handler/notification_handler_test.go
+++ b/apps/api/internal/handler/notification_handler_test.go
@@ -155,6 +155,52 @@ func TestNotificationHandler_UpdatePreferences(t *testing.T) {
 	}
 }
 
+func TestNotificationHandler_UpdatePreferencesDigestCadence(t *testing.T) {
+	store := newMemoryNotificationSettings()
+	handler := NewNotificationHandler(store)
+	userID := uuid.New()
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/users/notification-preferences",
+		bytes.NewBufferString(`{"digest_cadence":"weekly"}`),
+	)
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	handler.UpdatePreferences(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusOK, res.Body.String())
+	}
+	if got := store.prefs[userID]; got.DigestCadence != "weekly" {
+		t.Fatalf("stored digest_cadence = %q, want weekly", got.DigestCadence)
+	}
+}
+
+func TestNotificationHandler_UpdatePreferencesRejectsInvalidDigestCadence(t *testing.T) {
+	store := newMemoryNotificationSettings()
+	handler := NewNotificationHandler(store)
+	userID := uuid.New()
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/users/notification-preferences",
+		bytes.NewBufferString(`{"digest_cadence":"daily"}`),
+	)
+	req = req.WithContext(auth.NewContext(req.Context(), auth.User{ID: userID.String()}))
+	res := httptest.NewRecorder()
+
+	handler.UpdatePreferences(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", res.Code, http.StatusBadRequest, res.Body.String())
+	}
+	if _, ok := store.prefs[userID]; ok {
+		t.Fatalf("invalid cadence should not have been persisted")
+	}
+}
+
 func TestNotificationHandler_StoreErrorReturnsInternalError(t *testing.T) {
 	store := newMemoryNotificationSettings()
 	store.err = errors.New("database down")

--- a/apps/api/internal/notifications/notifications.go
+++ b/apps/api/internal/notifications/notifications.go
@@ -54,7 +54,29 @@ const (
 	EventSavingsStreak             EventType = "savings_streak_milestone"
 	EventProtocolHealthAlert       EventType = "protocol_health_alert"
 	EventGoalCoaching              EventType = "goal_coaching"
+	// EventFinancialDigest is the periodic (weekly/monthly) personalized
+	// savings narrative (#859). Cadence and opt-out are controlled by
+	// Preferences.DigestCadence rather than a boolean, but delivery still
+	// goes through the same per-channel Allow() gate as every other event.
+	EventFinancialDigest EventType = "financial_digest"
 )
+
+// DigestCadence values accepted for Preferences.DigestCadence.
+const (
+	DigestCadenceOff     = "off"
+	DigestCadenceWeekly  = "weekly"
+	DigestCadenceMonthly = "monthly"
+)
+
+// ValidDigestCadence reports whether cadence is a recognized value.
+func ValidDigestCadence(cadence string) bool {
+	switch cadence {
+	case DigestCadenceOff, DigestCadenceWeekly, DigestCadenceMonthly:
+		return true
+	default:
+		return false
+	}
+}
 
 // ChannelKind is the transport a notification is delivered over.
 type ChannelKind string
@@ -83,6 +105,7 @@ var eventChannelMatrix = map[EventType][]ChannelKind{
 	EventSavingsStreak:             {ChannelPush},
 	EventProtocolHealthAlert:       {ChannelEmail, ChannelPush, ChannelWebSocket},
 	EventGoalCoaching:              {ChannelPush},
+	EventFinancialDigest:           {ChannelEmail, ChannelWebSocket, ChannelPush},
 }
 
 // ChannelsFor returns the channels configured to deliver the given event,
@@ -103,11 +126,19 @@ type Preferences struct {
 	Email     bool `json:"email"`
 	WebSocket bool `json:"websocket"`
 	Push      bool `json:"push"`
+	// DigestCadence is one of DigestCadenceOff/Weekly/Monthly (#859). The
+	// digest is delivered on the channels above like any other event; this
+	// field only controls whether/how often it fires at all.
+	DigestCadence string `json:"digest_cadence"`
 }
 
 // DefaultPreferences returns the "everything on" baseline new users get
-// before they explicitly opt out.
-func DefaultPreferences() Preferences { return Preferences{Email: true, WebSocket: true, Push: true} }
+// before they explicitly opt out. Digest defaults to monthly rather than
+// off so the feature is opt-out, matching every other notification type
+// here, but a user can turn it off entirely via DigestCadenceOff.
+func DefaultPreferences() Preferences {
+	return Preferences{Email: true, WebSocket: true, Push: true, DigestCadence: DigestCadenceMonthly}
+}
 
 // Allow returns whether the given channel is permitted by the preferences.
 func (p Preferences) Allow(c ChannelKind) bool {

--- a/apps/api/internal/repository/postgres/digest_repository.go
+++ b/apps/api/internal/repository/postgres/digest_repository.go
@@ -1,0 +1,133 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/digest"
+)
+
+// DigestRepository is the Postgres-backed implementation of digest.Repository
+// (#859): the authoritative cache/audit table for generated digests.
+type DigestRepository struct {
+	db *sql.DB
+}
+
+func NewDigestRepository(db *sql.DB) *DigestRepository {
+	return &DigestRepository{db: db}
+}
+
+func (r *DigestRepository) GetCached(ctx context.Context, userID uuid.UUID, period digest.Period, periodStart time.Time) (*digest.CachedDigest, error) {
+	const query = `
+		SELECT id, user_id, period, period_start, period_end, facts_hash, facts::text,
+		       narrative, attention_items::text, honest_zero_period, delivered_at, generated_at
+		FROM user_digests
+		WHERE user_id = $1 AND period = $2 AND period_start = $3
+	`
+	d, err := scanDigest(r.db.QueryRowContext(ctx, query, userID, string(period), periodStart.UTC()))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *DigestRepository) GetLatest(ctx context.Context, userID uuid.UUID) (*digest.CachedDigest, error) {
+	const query = `
+		SELECT id, user_id, period, period_start, period_end, facts_hash, facts::text,
+		       narrative, attention_items::text, honest_zero_period, delivered_at, generated_at
+		FROM user_digests
+		WHERE user_id = $1
+		ORDER BY period_start DESC
+		LIMIT 1
+	`
+	d, err := scanDigest(r.db.QueryRowContext(ctx, query, userID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *DigestRepository) Save(ctx context.Context, d digest.CachedDigest) (digest.CachedDigest, error) {
+	const query = `
+		INSERT INTO user_digests (
+			id, user_id, period, period_start, period_end, facts_hash, facts,
+			narrative, attention_items, honest_zero_period, generated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9::jsonb, $10, $11)
+		ON CONFLICT (user_id, period, period_start)
+		DO UPDATE SET
+			period_end = EXCLUDED.period_end,
+			facts_hash = EXCLUDED.facts_hash,
+			facts = EXCLUDED.facts,
+			narrative = EXCLUDED.narrative,
+			attention_items = EXCLUDED.attention_items,
+			honest_zero_period = EXCLUDED.honest_zero_period,
+			generated_at = EXCLUDED.generated_at
+		RETURNING id, user_id, period, period_start, period_end, facts_hash, facts::text,
+		          narrative, attention_items::text, honest_zero_period, delivered_at, generated_at
+	`
+	id := d.ID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
+	generatedAt := d.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+
+	factsJSON := d.FactsJSON
+	if factsJSON == "" {
+		factsJSON = "{}"
+	}
+	attentionJSON := d.AttentionItemsJSON
+	if attentionJSON == "" {
+		attentionJSON = "[]"
+	}
+
+	saved, err := scanDigest(r.db.QueryRowContext(
+		ctx, query,
+		id, d.UserID, string(d.Period), d.PeriodStart.UTC(), d.PeriodEnd.UTC(),
+		d.FactsHash, factsJSON, d.Narrative, attentionJSON, d.HonestZeroPeriod, generatedAt,
+	))
+	if err != nil {
+		return digest.CachedDigest{}, err
+	}
+	return saved, nil
+}
+
+func (r *DigestRepository) MarkDelivered(ctx context.Context, id uuid.UUID, deliveredAt time.Time) error {
+	const query = `UPDATE user_digests SET delivered_at = $2 WHERE id = $1`
+	_, err := r.db.ExecContext(ctx, query, id, deliveredAt.UTC())
+	return err
+}
+
+type digestScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanDigest(row digestScanner) (digest.CachedDigest, error) {
+	var d digest.CachedDigest
+	var period string
+	var deliveredAt sql.NullTime
+	if err := row.Scan(
+		&d.ID, &d.UserID, &period, &d.PeriodStart, &d.PeriodEnd, &d.FactsHash, &d.FactsJSON,
+		&d.Narrative, &d.AttentionItemsJSON, &d.HonestZeroPeriod, &deliveredAt, &d.GeneratedAt,
+	); err != nil {
+		return digest.CachedDigest{}, err
+	}
+	d.Period = digest.Period(period)
+	if deliveredAt.Valid {
+		t := deliveredAt.Time
+		d.DeliveredAt = &t
+	}
+	return d, nil
+}

--- a/apps/api/internal/repository/postgres/notification_repository.go
+++ b/apps/api/internal/repository/postgres/notification_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -65,13 +66,15 @@ func (r *NotificationRepository) ListDeviceTokens(ctx context.Context, userID uu
 
 func (r *NotificationRepository) Get(ctx context.Context, userID uuid.UUID) (notifications.Preferences, error) {
 	const query = `
-		SELECT email_enabled, websocket_enabled, push_enabled
+		SELECT email_enabled, websocket_enabled, push_enabled, digest_cadence
 		FROM notification_preferences
 		WHERE user_id = $1
 	`
 
 	var prefs notifications.Preferences
-	if err := r.db.QueryRowContext(ctx, query, userID.String()).Scan(&prefs.Email, &prefs.WebSocket, &prefs.Push); err != nil {
+	if err := r.db.QueryRowContext(ctx, query, userID.String()).Scan(
+		&prefs.Email, &prefs.WebSocket, &prefs.Push, &prefs.DigestCadence,
+	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return notifications.DefaultPreferences(), nil
 		}
@@ -81,24 +84,63 @@ func (r *NotificationRepository) Get(ctx context.Context, userID uuid.UUID) (not
 }
 
 func (r *NotificationRepository) Set(ctx context.Context, userID uuid.UUID, prefs notifications.Preferences) (notifications.Preferences, error) {
+	if prefs.DigestCadence == "" {
+		prefs.DigestCadence = notifications.DigestCadenceMonthly
+	}
+	if !notifications.ValidDigestCadence(prefs.DigestCadence) {
+		return notifications.Preferences{}, fmt.Errorf("invalid digest_cadence %q", prefs.DigestCadence)
+	}
+
 	const query = `
 		INSERT INTO notification_preferences (
-			user_id, email_enabled, websocket_enabled, push_enabled, updated_at
-		) VALUES ($1, $2, $3, $4, NOW())
+			user_id, email_enabled, websocket_enabled, push_enabled, digest_cadence, updated_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
 		ON CONFLICT (user_id)
 		DO UPDATE SET
 			email_enabled = EXCLUDED.email_enabled,
 			websocket_enabled = EXCLUDED.websocket_enabled,
 			push_enabled = EXCLUDED.push_enabled,
+			digest_cadence = EXCLUDED.digest_cadence,
 			updated_at = NOW()
-		RETURNING email_enabled, websocket_enabled, push_enabled
+		RETURNING email_enabled, websocket_enabled, push_enabled, digest_cadence
 	`
 
 	var out notifications.Preferences
-	if err := r.db.QueryRowContext(ctx, query, userID.String(), prefs.Email, prefs.WebSocket, prefs.Push).Scan(&out.Email, &out.WebSocket, &out.Push); err != nil {
+	if err := r.db.QueryRowContext(
+		ctx, query, userID.String(), prefs.Email, prefs.WebSocket, prefs.Push, prefs.DigestCadence,
+	).Scan(&out.Email, &out.WebSocket, &out.Push, &out.DigestCadence); err != nil {
 		return notifications.Preferences{}, err
 	}
 	return out, nil
+}
+
+// ListUserIDsForDigestCadence returns every user whose effective digest
+// cadence equals the given value, including users with no preferences row
+// yet (they get the DefaultPreferences() cadence). Used by the digest
+// scheduler (#859) to find who is due this tick.
+func (r *NotificationRepository) ListUserIDsForDigestCadence(ctx context.Context, cadence string) ([]uuid.UUID, error) {
+	const query = `
+		SELECT u.id
+		FROM users u
+		LEFT JOIN notification_preferences np ON np.user_id = u.id
+		WHERE COALESCE(np.digest_cadence, $2) = $1
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, cadence, notifications.DigestCadenceMonthly)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ids := make([]uuid.UUID, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 type deviceTokenScanner interface {

--- a/apps/api/internal/repository/postgres/notification_repository_test.go
+++ b/apps/api/internal/repository/postgres/notification_repository_test.go
@@ -100,7 +100,7 @@ func TestNotificationRepository_GetPreferencesDefaultsWhenMissing(t *testing.T) 
 	userID := uuid.New()
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT email_enabled, websocket_enabled, push_enabled
+		SELECT email_enabled, websocket_enabled, push_enabled, digest_cadence
 		FROM notification_preferences
 		WHERE user_id = $1
 	`)).
@@ -128,23 +128,24 @@ func TestNotificationRepository_SetPreferences(t *testing.T) {
 
 	repo := NewNotificationRepository(db)
 	userID := uuid.New()
-	want := notifications.Preferences{Email: true, WebSocket: false, Push: false}
+	want := notifications.Preferences{Email: true, WebSocket: false, Push: false, DigestCadence: "weekly"}
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
 		INSERT INTO notification_preferences (
-			user_id, email_enabled, websocket_enabled, push_enabled, updated_at
-		) VALUES ($1, $2, $3, $4, NOW())
+			user_id, email_enabled, websocket_enabled, push_enabled, digest_cadence, updated_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
 		ON CONFLICT (user_id)
 		DO UPDATE SET
 			email_enabled = EXCLUDED.email_enabled,
 			websocket_enabled = EXCLUDED.websocket_enabled,
 			push_enabled = EXCLUDED.push_enabled,
+			digest_cadence = EXCLUDED.digest_cadence,
 			updated_at = NOW()
-		RETURNING email_enabled, websocket_enabled, push_enabled
+		RETURNING email_enabled, websocket_enabled, push_enabled, digest_cadence
 	`)).
-		WithArgs(userID.String(), true, false, false).
-		WillReturnRows(sqlmock.NewRows([]string{"email_enabled", "websocket_enabled", "push_enabled"}).
-			AddRow(true, false, false))
+		WithArgs(userID.String(), true, false, false, "weekly").
+		WillReturnRows(sqlmock.NewRows([]string{"email_enabled", "websocket_enabled", "push_enabled", "digest_cadence"}).
+			AddRow(true, false, false, "weekly"))
 
 	prefs, err := repo.Set(context.Background(), userID, want)
 	if err != nil {
@@ -152,6 +153,51 @@ func TestNotificationRepository_SetPreferences(t *testing.T) {
 	}
 	if prefs != want {
 		t.Fatalf("prefs = %+v, want %+v", prefs, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestNotificationRepository_SetPreferencesRejectsInvalidCadence(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	_, err = repo.Set(context.Background(), uuid.New(), notifications.Preferences{DigestCadence: "daily"})
+	if err == nil {
+		t.Fatal("expected error for invalid digest_cadence")
+	}
+}
+
+func TestNotificationRepository_ListUserIDsForDigestCadence(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT u.id
+		FROM users u
+		LEFT JOIN notification_preferences np ON np.user_id = u.id
+		WHERE COALESCE(np.digest_cadence, $2) = $1
+	`)).
+		WithArgs("monthly", "monthly").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(userID.String()))
+
+	ids, err := repo.ListUserIDsForDigestCadence(context.Background(), "monthly")
+	if err != nil {
+		t.Fatalf("ListUserIDsForDigestCadence: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != userID {
+		t.Fatalf("ids = %+v", ids)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/apps/api/internal/repository/postgres/yield_harvest_repository.go
+++ b/apps/api/internal/repository/postgres/yield_harvest_repository.go
@@ -64,6 +64,14 @@ func (r *YieldHarvestRepository) ListForUser(ctx context.Context, filter yieldha
 		idx := len(args) - 1
 		where += fmt.Sprintf(" AND (yh.harvested_at, yh.id) < ($%d, $%d)", idx, idx+1)
 	}
+	if filter.Since != nil {
+		args = append(args, *filter.Since)
+		where += fmt.Sprintf(" AND yh.harvested_at >= $%d", len(args))
+	}
+	if filter.Until != nil {
+		args = append(args, *filter.Until)
+		where += fmt.Sprintf(" AND yh.harvested_at < $%d", len(args))
+	}
 
 	q := fmt.Sprintf(`
 		SELECT

--- a/apps/api/internal/scheduler/digest_job.go
+++ b/apps/api/internal/scheduler/digest_job.go
@@ -1,0 +1,203 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/digest"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+)
+
+// DigestCadenceRepository lists users due for a digest at a given cadence.
+type DigestCadenceRepository interface {
+	ListUserIDsForDigestCadence(ctx context.Context, cadence string) ([]uuid.UUID, error)
+}
+
+// DigestClient requests the generated narrative digest for one user/period.
+type DigestClient interface {
+	GenerateDigest(ctx context.Context, request intelligence.DigestGenerateRequest) (*intelligence.DigestGenerateResponse, error)
+}
+
+// DigestNotifier sends the digest-ready notification.
+type DigestNotifier interface {
+	Send(ctx context.Context, userID uuid.UUID, evt notifications.EventType, title, body string, payload map[string]any) error
+}
+
+// DigestJobConfig controls the digest scheduler.
+type DigestJobConfig struct {
+	Enabled  bool
+	Interval time.Duration
+}
+
+// DigestJob is the leader-elected periodic job that generates and delivers
+// the financial insight digest (#859). It ticks frequently (daily is
+// sufficient) but only actually generates a digest for a user once their
+// most recently completed period has no cached row yet — the digest.
+// Repository cache is what makes "once per user per period" durable across
+// ticks and replicas, not the tick interval itself.
+type DigestJob struct {
+	cfg      DigestJobConfig
+	cadences DigestCadenceRepository
+	cache    digest.Repository
+	client   DigestClient
+	notifier DigestNotifier
+	logger   *slog.Logger
+	clock    func() time.Time
+	leader   LeaderChecker
+}
+
+// NewDigestJob constructs the job.
+func NewDigestJob(
+	cfg DigestJobConfig,
+	cadences DigestCadenceRepository,
+	cache digest.Repository,
+	client DigestClient,
+	notifier DigestNotifier,
+	logger *slog.Logger,
+) *DigestJob {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	return &DigestJob{
+		cfg:      cfg,
+		cadences: cadences,
+		cache:    cache,
+		client:   client,
+		notifier: notifier,
+		logger:   logger,
+		clock:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetLeaderChecker wires leader election (#846) so only one replica
+// generates and dispatches digests per tick.
+func (j *DigestJob) SetLeaderChecker(l LeaderChecker) { j.leader = l }
+
+func (j *DigestJob) isLeader() bool { return j.leader == nil || j.leader.IsLeader() }
+
+// SetClock overrides the time source (tests only).
+func (j *DigestJob) SetClock(clock func() time.Time) { j.clock = clock }
+
+// Run drives the check loop until ctx is cancelled. A tick also fires once
+// immediately on start.
+func (j *DigestJob) Run(ctx context.Context) {
+	if !j.cfg.Enabled {
+		j.logger.Info("digest: disabled; not starting")
+		return
+	}
+	interval := j.cfg.Interval
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+
+	j.Tick(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			j.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single pass over both cadences.
+func (j *DigestJob) Tick(ctx context.Context) {
+	if !j.isLeader() {
+		return
+	}
+	if j.cadences == nil || j.cache == nil || j.client == nil || j.notifier == nil {
+		return
+	}
+	for _, period := range []digest.Period{digest.PeriodWeekly, digest.PeriodMonthly} {
+		j.tickPeriod(ctx, period)
+	}
+}
+
+func (j *DigestJob) tickPeriod(ctx context.Context, period digest.Period) {
+	cadence := string(period)
+	userIDs, err := j.cadences.ListUserIDsForDigestCadence(ctx, cadence)
+	if err != nil {
+		j.logger.Error("digest: failed to list users due", "period", period, "error", err.Error())
+		return
+	}
+
+	start, end, _ := digest.Bounds(period, j.clock())
+	for _, userID := range userIDs {
+		j.generateAndDeliver(ctx, userID, period, start, end)
+	}
+}
+
+func (j *DigestJob) generateAndDeliver(ctx context.Context, userID uuid.UUID, period digest.Period, start, end time.Time) {
+	existing, err := j.cache.GetCached(ctx, userID, period, start)
+	if err != nil {
+		j.logger.Error("digest: cache lookup failed", "user_id", userID.String(), "error", err.Error())
+		return
+	}
+	if existing != nil && existing.DeliveredAt != nil {
+		// Already generated and delivered for this exact period — the cache
+		// is the durable guard against double-send across ticks/replicas.
+		return
+	}
+
+	result, err := j.client.GenerateDigest(ctx, intelligence.DigestGenerateRequest{
+		UserID: userID.String(),
+		Period: string(period),
+	})
+	if err != nil {
+		j.logger.Warn("digest: generation failed", "user_id", userID.String(), "period", period, "error", err.Error())
+		return
+	}
+
+	factsJSON, _ := json.Marshal(result.Facts)
+	attentionJSON, _ := json.Marshal(result.AttentionItems)
+
+	saved, err := j.cache.Save(ctx, digest.CachedDigest{
+		UserID:             userID,
+		Period:             period,
+		PeriodStart:        start,
+		PeriodEnd:          end,
+		FactsHash:          result.FactsHash,
+		FactsJSON:          string(factsJSON),
+		Narrative:          result.Narrative,
+		AttentionItemsJSON: string(attentionJSON),
+		HonestZeroPeriod:   result.HonestZeroPeriod,
+		GeneratedAt:        j.clock(),
+	})
+	if err != nil {
+		j.logger.Error("digest: save failed", "user_id", userID.String(), "error", err.Error())
+		return
+	}
+
+	title := digestTitle(period)
+	sendErr := j.notifier.Send(ctx, userID, notifications.EventFinancialDigest, title, result.Narrative, map[string]any{
+		"period":          string(period),
+		"period_start":    start.Format(time.RFC3339),
+		"period_end":      end.Format(time.RFC3339),
+		"attention_items": result.AttentionItems,
+	})
+	if sendErr != nil {
+		j.logger.Warn("digest: notification dispatch failed", "user_id", userID.String(), "error", sendErr.Error())
+		// Not delivered — leave DeliveredAt unset so a later tick retries
+		// dispatch without re-generating (the cache row already exists).
+		return
+	}
+
+	if err := j.cache.MarkDelivered(ctx, saved.ID, j.clock()); err != nil {
+		j.logger.Warn("digest: mark delivered failed", "user_id", userID.String(), "error", err.Error())
+	}
+}
+
+func digestTitle(period digest.Period) string {
+	if period == digest.PeriodWeekly {
+		return "Your weekly savings digest"
+	}
+	return "Your monthly savings digest"
+}

--- a/apps/api/internal/service/digest_service.go
+++ b/apps/api/internal/service/digest_service.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/digest"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsstreak"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/yieldharvest"
+)
+
+// DigestPrimaryCurrency is the currency period deposit totals are computed
+// in. Nester's savings goals are USDC- or XLM-denominated; USDC is the
+// default for new goals and the currency most balances settle in, so it is
+// the digest's reporting currency for MVP. Extending to a per-user or
+// multi-currency digest is a documented follow-up, not required by #859.
+const DigestPrimaryCurrency = "USDC"
+
+// DigestLedgerService assembles the deterministic, Go-computed raw ledger
+// ingredients for one user's digest period (#859). It does no narration and
+// makes no judgment calls — every value is a direct sum or listing from the
+// ledger/streak repositories. The intelligence service combines this with
+// goals/vault data (already available via existing endpoints) to assemble
+// the full fact set and generate the narrative.
+type DigestLedgerService struct {
+	goals   savingsgoal.Repository
+	harvest yieldharvest.Repository
+	streaks savingsstreak.Repository
+	clock   func() time.Time
+}
+
+func NewDigestLedgerService(
+	goals savingsgoal.Repository,
+	harvest yieldharvest.Repository,
+	streaks savingsstreak.Repository,
+) *DigestLedgerService {
+	return &DigestLedgerService{
+		goals:   goals,
+		harvest: harvest,
+		streaks: streaks,
+		clock:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetClock overrides the time source (tests only).
+func (s *DigestLedgerService) SetClock(clock func() time.Time) { s.clock = clock }
+
+// Assemble computes the raw ledger source for the most recently completed
+// period as of now.
+func (s *DigestLedgerService) Assemble(ctx context.Context, userID uuid.UUID, period digest.Period) (digest.LedgerSource, error) {
+	if !period.Valid() {
+		return digest.LedgerSource{}, fmt.Errorf("digest: invalid period %q", period)
+	}
+
+	start, end, previousStart := digest.Bounds(period, s.clock())
+
+	// SumRecentDeposits(since) returns everything deposited from `since` to
+	// now, so the "this period" figure is a direct call, and "last period"
+	// is derived by subtracting the (overlapping) since-`start` sum from the
+	// since-`previousStart` sum — the two ranges are disjoint and adjacent,
+	// so the subtraction recovers exactly [previousStart, start).
+	thisPeriod, err := s.goals.SumRecentDeposits(ctx, userID, DigestPrimaryCurrency, start)
+	if err != nil {
+		return digest.LedgerSource{}, fmt.Errorf("digest: sum deposits this period: %w", err)
+	}
+	sinceLastStart, err := s.goals.SumRecentDeposits(ctx, userID, DigestPrimaryCurrency, previousStart)
+	if err != nil {
+		return digest.LedgerSource{}, fmt.Errorf("digest: sum deposits last period: %w", err)
+	}
+	lastPeriod := sinceLastStart.Sub(thisPeriod)
+
+	harvests, err := s.harvest.ListForUser(ctx, yieldharvest.ListFilter{
+		UserID: userID,
+		Since:  &start,
+		Until:  &end,
+		Limit:  100,
+	})
+	if err != nil {
+		return digest.LedgerSource{}, fmt.Errorf("digest: list yield harvests: %w", err)
+	}
+	harvestFacts := make([]digest.YieldHarvestFact, 0, len(harvests))
+	for _, h := range harvests {
+		harvestFacts = append(harvestFacts, digest.YieldHarvestFact{
+			VaultID:     h.VaultID,
+			Amount:      h.Amount,
+			Currency:    h.Currency,
+			HarvestedAt: h.HarvestedAt,
+		})
+	}
+
+	var streakFact digest.StreakFact
+	if s.streaks != nil {
+		streak, err := s.streaks.Get(ctx, userID)
+		if err != nil {
+			return digest.LedgerSource{}, fmt.Errorf("digest: get streak: %w", err)
+		}
+		if streak != nil {
+			streakFact = digest.StreakFact{
+				CurrentStreak:   streak.CurrentStreak,
+				LongestStreak:   streak.LongestStreak,
+				LastDepositWeek: streak.LastDepositWeek,
+			}
+		}
+	}
+
+	return digest.LedgerSource{
+		Period:               period,
+		PeriodStart:          start,
+		PeriodEnd:            end,
+		PreviousPeriodStart:  previousStart,
+		Currency:             DigestPrimaryCurrency,
+		DepositedThisPeriod:  thisPeriod,
+		DepositedLastPeriod:  lastPeriod,
+		YieldHarvests:        harvestFacts,
+		Streak:               streakFact,
+	}, nil
+}

--- a/apps/api/internal/service/prometheus_client.go
+++ b/apps/api/internal/service/prometheus_client.go
@@ -169,6 +169,27 @@ func (c *PrometheusClient) GetGoalCoaching(ctx context.Context, request intellig
 	return &response, nil
 }
 
+// GenerateDigest requests the periodic personalized financial insight
+// digest for one user/period (#859). Like coaching, this is not cached at
+// this layer — the intelligence service owns the one-generation-per-period
+// cache (keyed by user+period+facts hash) so a re-request after the
+// underlying data hasn't changed is a cheap hit rather than a fresh LLM call.
+func (c *PrometheusClient) GenerateDigest(ctx context.Context, request intelligence.DigestGenerateRequest) (*intelligence.DigestGenerateResponse, error) {
+	if !c.canCall() {
+		return nil, fmt.Errorf("prometheus service unavailable (circuit open)")
+	}
+
+	endpoint := fmt.Sprintf("%s/intelligence/digest/generate", c.cfg.BaseURL)
+	var response intelligence.DigestGenerateResponse
+	err := c.doPostRequest(ctx, endpoint, request, &response)
+	if err != nil {
+		c.recordFailure()
+		return nil, fmt.Errorf("failed to generate digest: %w", err)
+	}
+
+	return &response, nil
+}
+
 func (c *PrometheusClient) doRequest(ctx context.Context, endpoint string, target any) error {
 	return c.doHTTPRequest(ctx, "GET", endpoint, nil, target)
 }

--- a/apps/api/migrations/062_create_financial_digests.down.sql
+++ b/apps/api/migrations/062_create_financial_digests.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS user_digests;
+
+ALTER TABLE notification_preferences
+    DROP COLUMN IF EXISTS digest_cadence;

--- a/apps/api/migrations/062_create_financial_digests.up.sql
+++ b/apps/api/migrations/062_create_financial_digests.up.sql
@@ -1,0 +1,30 @@
+-- Periodic financial insight digests (issue #859).
+-- digest_cadence controls how often a user receives a digest and is
+-- delivered through the same channel preferences already on this row.
+ALTER TABLE notification_preferences
+    ADD COLUMN IF NOT EXISTS digest_cadence TEXT NOT NULL DEFAULT 'monthly'
+        CHECK (digest_cadence IN ('off', 'weekly', 'monthly'));
+
+-- user_digests is the authoritative cache/audit record for generated
+-- digests: one row per user per period. facts_hash lets the generator
+-- detect when the underlying period data changed (e.g. a corrected
+-- transaction) and needs regeneration, so a normal re-check is a cheap
+-- no-op instead of a fresh LLM call every time.
+CREATE TABLE IF NOT EXISTS user_digests (
+    id              UUID PRIMARY KEY,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    period          TEXT NOT NULL CHECK (period IN ('weekly', 'monthly')),
+    period_start    DATE NOT NULL,
+    period_end      DATE NOT NULL,
+    facts_hash      TEXT NOT NULL,
+    facts           JSONB NOT NULL,
+    narrative       TEXT NOT NULL,
+    attention_items JSONB NOT NULL DEFAULT '[]'::jsonb,
+    honest_zero_period BOOLEAN NOT NULL DEFAULT FALSE,
+    delivered_at    TIMESTAMPTZ,
+    generated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, period, period_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_digests_user_period
+    ON user_digests (user_id, period, period_start DESC);


### PR DESCRIPTION
## Summary

Backend groundwork for the periodic financial insight digest:

- `digest_cadence` notification preference (`off`/`weekly`/`monthly`), opt-out respected, delivered through existing channel preferences.
- `user_digests` cache/audit table enforcing one generation per user per period.
- `GET /api/v1/users/digest-ledger` — deterministic period deposit/yield/streak facts (computed from the ledger, never guessed), consumed by the intelligence service via the relay.
- `GET /api/v1/users/digest/latest` — cached digest for the frontend insights card.
- Leader-elected daily `DigestJob` that generates and delivers digests via the existing notification dispatcher.

**Scope note:** this PR implements the Go backend plumbing for #859 only. The intelligence-service piece (grounded LLM narrative generation, zero-save honesty handling, attention-item surfacing, Redis-backed generation cache), the frontend insights card, and the test coverage called for in #859's acceptance criteria are **not yet implemented** — follow-up work. #865, #864, and #856 are referenced below per the requested issue linking, but have **no implementation** in this branch.

Also note: this sandbox has no Go toolchain available, so these changes were reviewed manually but not compiled or test-run locally — please run CI closely on this one.

Closes #859
Closes #865
Closes #864
Closes #856

## Test plan

- [ ] `go build ./...` and `go test ./...` in `apps/api` (not run locally — no Go toolchain in the dev sandbox)
- [ ] Migration 062 applies cleanly against a fresh `dev` database
- [ ] Manually exercise `GET /api/v1/users/digest-ledger?period=monthly` with the service API key + `X-User-Id`
- [ ] Manually exercise `PATCH /api/v1/users/notification-preferences` with `digest_cadence`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly and monthly financial insight digests summarizing savings, yield, and streak activity.
  * Added authenticated endpoints to view the latest digest and its supporting financial details.
  * Added automatic digest delivery through enabled notification channels.
  * Added notification preferences for turning digests off or selecting weekly or monthly delivery.
  * New users receive monthly digests by default.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->