### PR TITLE
feat(api): cache layer, scalable WebSocket hub, notification service, and oracle aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,12 @@ jobs:
     env:
       DATABASE_URL: postgres://nester:nester@localhost:5432/nester_test?sslmode=disable
       REDIS_URL: redis://localhost:6379
+      # Redis-backed tests (internal/cache, internal/notifications,
+      # internal/ws) skip via t.Skip when this is unset, following the
+      # convention in internal/middleware/ratelimit_backend_test.go. REDIS_URL
+      # above is what the app itself reads; without this, every such test
+      # silently skips in CI even though the redis service below is running.
+      REDIS_ADDR: localhost:6379
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -265,6 +265,11 @@ func run() error {
 	oracleService := oracle.NewRateService(cfg.Stellar().HorizonURL(), cfg.Stellar().USDCIssuer())
 	rateHandler := handler.NewRateHandler(oracleService)
 
+	// maxWSConnsPerIP bounds simultaneous WebSocket connections from one
+	// client IP (nester#828), mirroring the per-route rate limits already
+	// applied via middleware.NewLimiter below. 0 would mean unlimited.
+	const maxWSConnsPerIP = 20
+
 	wsHub := ws.NewHub(baseLogger.WithGroup("websocket"), func(token string) (userID, sessionID string, err error) {
 		if token == "" {
 			return "", "", fmt.Errorf("missing token")
@@ -283,7 +288,7 @@ func run() error {
 			}
 		}
 		return claims.Subject, claims.SessionID, nil
-	}, cfg.AllowedOrigins(), redisClient, ws.DefaultMaxConnectionsPerIP)
+	}, cfg.AllowedOrigins(), redisClient, maxWSConnsPerIP)
 
 	wsCtx, wsCancel := context.WithCancel(context.Background())
 	defer wsCancel()
@@ -431,12 +436,47 @@ func run() error {
 	defer cancelPoller()
 	go txPoller.Run(pollerCtx)
 
+	// notificationRateLimit/-Window bound how many notifications a user can
+	// receive per category in a burst (#829's "a burst of deposits does not
+	// produce a burst of near-identical notifications"). Safety-category
+	// events bypass this entirely (see notifications.Category doc comment).
+	const notificationRateLimit = 20
+	const notificationRateWindow = 5 * time.Minute
+	notificationRateLimiter := middleware.NewLimiter(redisClient, "notifications", notificationRateLimit, notificationRateWindow)
+
+	// notificationDedup is process-local when Redis isn't configured, and
+	// Redis-backed (cross-instance) otherwise — same dual-mode pattern as
+	// middleware.NewLimiter above.
+	var notificationDedup notifications.Deduplicator = notifications.NewInMemoryDeduplicator()
+	if redisClient != nil {
+		notificationDedup = notifications.NewRedisDeduplicator(redisClient)
+	}
+
 	notificationDispatcher := notifications.New(
 		[]notifications.Channel{
-			// notifications.NewWebSocketChannel(wsHub), // TODO: Fix interface implementation
+			notifications.NewWebSocketChannel(wsHub),
 		},
 		notificationRepository,
 		nil,
+		notifications.WithDeduplicator(notificationDedup),
+		notifications.WithRateLimiter(notificationRateLimiter),
+	)
+
+	// notificationDispatcher2 carries the real Push channel — separate from
+	// notificationDispatcher above (WebSocket-only) because a failed
+	// WebSocket delivery is never retried by design (see
+	// notifications.RetryEnqueuer's doc comment), while a failed Push send
+	// is. NoopPushSender is the same placeholder nudgeNotificationDispatcher
+	// already uses below — a real provider integration is deliberately
+	// deferred (see #829's commit message).
+	notificationDispatcher2 := notifications.New(
+		[]notifications.Channel{
+			notifications.NewPushChannel(notifications.NoopPushSender{}, notificationRepository),
+		},
+		notificationRepository,
+		nil,
+		notifications.WithDeduplicator(notificationDedup),
+		notifications.WithRateLimiter(notificationRateLimiter),
 	)
 
 	var ready atomic.Bool
@@ -609,6 +649,8 @@ func run() error {
 		},
 		notificationRepository,
 		nil,
+		notifications.WithDeduplicator(notificationDedup),
+		notifications.WithRateLimiter(notificationRateLimiter),
 	)
 
 	nudgeEngineSvc = service.NewNudgeEngineService(
@@ -683,6 +725,16 @@ func run() error {
 	jobQueueMetrics := jobqueue.NewStdMetrics()
 	jobQueueClient := jobqueue.NewClient(jobQueueRepo, jobQueueMetrics)
 
+	// Durable retry for failed notification deliveries (#829), now that the
+	// job queue client exists. Only notificationDispatcher2 gets a
+	// RetryEnqueuer: it's the only one of the two dispatchers above with a
+	// real Push channel registered. notificationDispatcher only has
+	// WebSocket registered, and WebSocket failures are never retried by
+	// design (see notifications.RetryEnqueuer's doc comment) — wiring retry
+	// there would only ever enqueue jobs for Email/Push that it has no
+	// adapter to actually redeliver.
+	notificationDispatcher2.SetRetryEnqueuer(notifications.NewJobQueueRetryEnqueuer(jobQueueClient))
+
 	// Recurring deposit sweep (#846): classified SINGLETON (money-moving —
 	// see RecurringDepositJob's doc comment). The sweep loop itself only
 	// enqueues a durable per-occurrence job onto jobQueueClient rather than
@@ -738,6 +790,12 @@ func run() error {
 	harvestExecutor := harvest.NewServiceExecutor(vaultService, userService)
 	jobWorker.Register(harvest.DefaultJobType,
 		harvest.NewJobHandler(harvestExecutor, baseLogger.WithGroup("harvest-job")), 0)
+
+	// Notification retry (#829): redelivers a failed Push notification via
+	// notificationDispatcher2 (see the RetryEnqueuer wiring above for why
+	// only that dispatcher is used here).
+	jobWorker.Register(notifications.NotificationRetryJobType,
+		notifications.NewNotificationRetryJobHandler(notificationDispatcher2), 0)
 
 	// Recurring-deposit occurrence handler (#846): processes the jobs
 	// recurringDepositJob (above) enqueues. Fixes the #846 idempotency bug —

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -283,7 +283,7 @@ func run() error {
 			}
 		}
 		return claims.Subject, claims.SessionID, nil
-	}, cfg.AllowedOrigins())
+	}, cfg.AllowedOrigins(), redisClient, ws.DefaultMaxConnectionsPerIP)
 
 	wsCtx, wsCancel := context.WithCancel(context.Background())
 	defer wsCancel()

--- a/apps/api/internal/cache/cache.go
+++ b/apps/api/internal/cache/cache.go
@@ -1,0 +1,337 @@
+// Package cache provides a typed GetOrCompute cache backed by Redis with an
+// in-memory (direct-compute) fallback, single-flight recomputation, jittered
+// TTLs, serve-stale-while-revalidate, and namespace-scoped invalidation
+// (nester#827).
+//
+// Single-flight is enforced at two levels:
+//   - In-process: golang.org/x/sync/singleflight collapses concurrent callers
+//     on the same instance into one compute, regardless of whether Redis is
+//     configured. This is a hard guarantee.
+//   - Cross-process: a short-lived Redis lock (SET NX EX) is best-effort. If
+//     an instance can't acquire it, it waits briefly for the winning
+//     instance's result to land in cache; if it still hasn't after that,
+//     it computes locally rather than blocking indefinitely. Under high
+//     cross-instance contention this can mean an occasional duplicate
+//     compute — an availability/latency tradeoff, not a correctness bug (the
+//     in-process guarantee still holds).
+//
+// Degradation: any Redis error (including the client being nil, i.e. no
+// REDIS_ADDR configured — see cmd/api/main.go's redisClient wiring) falls
+// through to calling the compute function directly. A Redis outage makes the
+// app slower, never broken.
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/sync/singleflight"
+)
+
+// schemaVersion is embedded in every cache key. Bump it when a cached value's
+// shape changes so old, incompatible entries are never deserialized as new
+// ones — they simply miss under the new key prefix.
+const schemaVersion = "v1"
+
+// jitterFraction is how far TTLs are randomly shifted (± this fraction of the
+// base TTL) so a batch of keys populated together does not all expire in the
+// same instant.
+const jitterFraction = 0.10
+
+// crossProcessLockTTL bounds how long one instance's "I'm computing this"
+// claim is honored by others before it's considered stale (e.g. the compute
+// crashed mid-flight) and up for grabs again.
+const crossProcessLockTTL = 5 * time.Second
+
+// crossProcessWait is how long a losing instance waits for the winner's
+// result to land in cache before giving up and computing locally itself.
+const crossProcessWait = 150 * time.Millisecond
+
+// redisOpTimeout bounds every individual Redis round trip, mirroring
+// middleware.redisCallTimeout's rationale: a degraded Redis must never add
+// unbounded latency before the cache falls through to direct compute.
+const redisOpTimeout = 200 * time.Millisecond
+
+// backgroundRefreshTimeout bounds a stale-while-revalidate refresh kicked off
+// after the calling request has already been served its stale value.
+const backgroundRefreshTimeout = 10 * time.Second
+
+// Stats is a point-in-time snapshot of cache activity, exposed for a metrics
+// endpoint to scrape. Counters are cumulative since process start.
+type Stats struct {
+	Hits               int64
+	Misses             int64
+	StampedeSuppressed int64
+	RedisErrors        int64
+}
+
+// Cache is a typed GetOrCompute layer over an optional shared Redis client.
+// Construct one with New and reuse it — do not create a Cache per call site.
+type Cache struct {
+	redis  *redis.Client
+	logger *slog.Logger
+	sf     singleflight.Group
+
+	hits               atomic.Int64
+	misses             atomic.Int64
+	stampedeSuppressed atomic.Int64
+	redisErrors        atomic.Int64
+}
+
+// New constructs a Cache. Pass the shared *redis.Client used elsewhere in the
+// app (see cmd/api/main.go's redisClient) — never open a second connection
+// pool. rc may be nil (no Redis configured); the cache still works, providing
+// only in-process single-flight and no cross-instance sharing.
+func New(rc *redis.Client, logger *slog.Logger) *Cache {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Cache{redis: rc, logger: logger}
+}
+
+// Stats returns a snapshot of cumulative hit/miss/suppression/error counts.
+func (c *Cache) Stats() Stats {
+	return Stats{
+		Hits:               c.hits.Load(),
+		Misses:             c.misses.Load(),
+		StampedeSuppressed: c.stampedeSuppressed.Load(),
+		RedisErrors:        c.redisErrors.Load(),
+	}
+}
+
+// Invalidate deletes the cached entry for namespace/id, if any. Scoped to a
+// single key — clearing an entire namespace at once is intentionally not
+// supported (Redis has no atomic "delete by prefix"; a SCAN-based bulk clear
+// would need to be its own explicitly-opt-in operation, not the default
+// invalidation path, to avoid an accidental full-namespace wipe under load).
+func (c *Cache) Invalidate(ctx context.Context, namespace, id string) error {
+	if c.redis == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	if err := c.redis.Del(ctx, buildKey(namespace, id)).Err(); err != nil {
+		c.redisErrors.Add(1)
+		return fmt.Errorf("cache: invalidate %s/%s: %w", namespace, id, err)
+	}
+	return nil
+}
+
+func buildKey(namespace, id string) string {
+	return fmt.Sprintf("cache:%s:%s:%s", schemaVersion, namespace, id)
+}
+
+// envelope is the JSON shape stored in Redis. ComputedAt/SoftExpiresAt let a
+// reader decide whether to serve-stale-and-revalidate vs. block-and-recompute
+// without a second round trip.
+type envelope[T any] struct {
+	Value         T         `json:"value"`
+	ComputedAt    time.Time `json:"computed_at"`
+	SoftExpiresAt time.Time `json:"soft_expires_at"`
+	HardExpiresAt time.Time `json:"hard_expires_at"`
+}
+
+// Options configures one GetOrCompute call.
+type Options struct {
+	// Namespace groups related keys (e.g. "vault", "apy", "oracle-rate") so
+	// Invalidate can target one without risk of touching another namespace's
+	// keys — the namespace is part of the key, not a separate index.
+	Namespace string
+	// ID identifies the specific entry within Namespace (e.g. a vault ID).
+	ID string
+	// HardTTL is the absolute point past which a cached value is never
+	// served, even stale — GetOrCompute blocks on a fresh compute.
+	HardTTL time.Duration
+	// SoftTTL, if set and less than HardTTL, enables serve-stale-while-
+	// revalidate: once passed, cached reads return immediately with the
+	// stale value while a background refresh runs. Zero (or >= HardTTL)
+	// disables this — every read past HardTTL blocks on recompute, with no
+	// stale window at all.
+	SoftTTL time.Duration
+}
+
+func (o Options) key() string { return buildKey(o.Namespace, o.ID) }
+
+func jitteredTTL(base time.Duration) time.Duration {
+	if base <= 0 {
+		return base
+	}
+	spread := float64(base) * jitterFraction
+	offset := time.Duration(rand.Float64()*2*spread - spread) // [-spread, +spread]
+	return base + offset
+}
+
+func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, redisOpTimeout)
+}
+
+// GetOrCompute returns the cached value for opts.Namespace/opts.ID, computing
+// it via compute on a miss or hard-expiry. See the package doc for the
+// single-flight and degradation guarantees.
+//
+// Go methods cannot introduce their own type parameters, so this is a free
+// function taking *Cache rather than a generic method on Cache — the
+// standard shape for a typed cache over a non-generic client in Go.
+func GetOrCompute[T any](ctx context.Context, c *Cache, opts Options, compute func(ctx context.Context) (T, error)) (T, error) {
+	key := opts.key()
+
+	// singleflight.Group predates generics, so its Do callback is boxed to
+	// `(any, error)`; getOrComputeTyped does the real, correctly-typed work
+	// and its result is unboxed back to T immediately below.
+	result, err, shared := c.sf.Do(key, func() (any, error) {
+		return getOrComputeTyped(ctx, c, key, opts, compute)
+	})
+	if shared {
+		c.stampedeSuppressed.Add(1)
+	}
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return result.(T), nil
+}
+
+func getOrComputeTyped[T any](ctx context.Context, c *Cache, key string, opts Options, compute func(context.Context) (T, error)) (T, error) {
+	var zero T
+
+	if c.redis != nil {
+		if env, ok := readEnvelope[T](ctx, c, key); ok {
+			c.hits.Add(1)
+			if time.Now().After(env.SoftExpiresAt) {
+				refreshInBackground(c, key, opts, compute)
+			}
+			return env.Value, nil
+		}
+	}
+
+	if c.redis == nil {
+		v, err := compute(ctx)
+		if err != nil {
+			return zero, err
+		}
+		c.misses.Add(1)
+		return v, nil
+	}
+
+	lockKey := "lock:" + key
+	lockCtx, cancel := withTimeout(ctx)
+	acquired, lockErr := c.redis.SetNX(lockCtx, lockKey, "1", crossProcessLockTTL).Result()
+	cancel()
+
+	if lockErr != nil {
+		c.redisErrors.Add(1)
+		// Redis is failing right now: degrade to direct compute rather than
+		// erroring the caller.
+		v, err := compute(ctx)
+		if err != nil {
+			return zero, err
+		}
+		c.misses.Add(1)
+		return v, nil
+	}
+
+	if !acquired {
+		// Another instance is already computing this key. Wait a short,
+		// bounded window for its result rather than blocking indefinitely.
+		time.Sleep(crossProcessWait)
+		if env, ok := readEnvelope[T](ctx, c, key); ok {
+			c.hits.Add(1)
+			return env.Value, nil
+		}
+	}
+
+	v, err := compute(ctx)
+	if err != nil {
+		return zero, err
+	}
+	c.misses.Add(1)
+	c.writeBack(ctx, key, opts, v)
+	return v, nil
+}
+
+// readEnvelope returns the cached envelope if present and not hard-expired.
+// Genuinely stale (past soft, before hard) entries are still returned here —
+// it's the caller's job to notice env.SoftExpiresAt has passed and trigger a
+// background refresh; readEnvelope only filters out hard-expired misses.
+func readEnvelope[T any](ctx context.Context, c *Cache, key string) (envelope[T], bool) {
+	var zero envelope[T]
+
+	getCtx, cancel := withTimeout(ctx)
+	raw, err := c.redis.Get(getCtx, key).Bytes()
+	cancel()
+	if err != nil {
+		if err != redis.Nil {
+			c.redisErrors.Add(1)
+		}
+		return zero, false
+	}
+
+	var env envelope[T]
+	if err := json.Unmarshal(raw, &env); err != nil {
+		// Corrupt, or a schema-version collision that somehow still shares a
+		// key — treat as a miss rather than erroring the caller.
+		return zero, false
+	}
+	if time.Now().After(env.HardExpiresAt) {
+		return zero, false
+	}
+	return env, true
+}
+
+func (c *Cache) writeBack(ctx context.Context, key string, opts Options, value any) {
+	now := time.Now()
+	hardTTL := jitteredTTL(opts.HardTTL)
+	soft := opts.SoftTTL
+	if soft <= 0 || soft > opts.HardTTL {
+		soft = opts.HardTTL
+	}
+
+	env := map[string]any{
+		"value":           value,
+		"computed_at":     now,
+		"soft_expires_at": now.Add(soft),
+		"hard_expires_at": now.Add(hardTTL),
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		c.logger.WarnContext(ctx, "cache: failed to marshal value for write-back", "key", key, "error", err)
+		return
+	}
+
+	setCtx, cancel := withTimeout(ctx)
+	setErr := c.redis.Set(setCtx, key, raw, hardTTL).Err()
+	cancel()
+	if setErr != nil {
+		c.redisErrors.Add(1)
+		c.logger.WarnContext(ctx, "cache: redis write-back failed", "key", key, "error", setErr)
+	}
+
+	// Best-effort lock release so a fast recompute doesn't leave the next
+	// caller waiting out the full crossProcessLockTTL for no reason.
+	delCtx, cancel2 := withTimeout(ctx)
+	_ = c.redis.Del(delCtx, "lock:"+key).Err()
+	cancel2()
+}
+
+// refreshInBackground recomputes and writes back a soft-expired key without
+// making the current caller wait. Uses its own bounded context, independent
+// of the request that triggered it, since that request may return (and its
+// context may be cancelled) before the refresh finishes.
+func refreshInBackground[T any](c *Cache, key string, opts Options, compute func(context.Context) (T, error)) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), backgroundRefreshTimeout)
+		defer cancel()
+		v, err := compute(ctx)
+		if err != nil {
+			c.logger.WarnContext(ctx, "cache: background refresh failed", "key", key, "error", err)
+			return
+		}
+		c.writeBack(ctx, key, opts, v)
+	}()
+}

--- a/apps/api/internal/cache/cache_test.go
+++ b/apps/api/internal/cache/cache_test.go
@@ -1,0 +1,302 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/cache"
+)
+
+// ---------------------------------------------------------------------------
+// No-Redis (nil client) tests: in-process behavior only, no external deps.
+// ---------------------------------------------------------------------------
+
+func TestGetOrCompute_NoRedis_CallsComputeEveryTimeButSingleFlightsConcurrent(t *testing.T) {
+	c := cache.New(nil, nil)
+	ctx := context.Background()
+
+	var calls atomic.Int64
+	compute := func(context.Context) (int, error) {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond) // widen the window so concurrent callers overlap
+		return 42, nil
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	results := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			v, err := cache.GetOrCompute(ctx, c, cache.Options{
+				Namespace: "test", ID: "same-key", HardTTL: time.Minute,
+			}, compute)
+			require.NoError(t, err)
+			results[i] = v
+		}(i)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		assert.Equal(t, 42, r)
+	}
+	// Without Redis, single-flight is still enforced in-process: all
+	// concurrent callers for the same key collapse into one compute.
+	assert.Equal(t, int64(1), calls.Load(), "expected exactly one compute call for concurrent same-key misses")
+}
+
+func TestGetOrCompute_NoRedis_PropagatesComputeError(t *testing.T) {
+	c := cache.New(nil, nil)
+	ctx := context.Background()
+	wantErr := errors.New("boom")
+
+	_, err := cache.GetOrCompute(ctx, c, cache.Options{
+		Namespace: "test", ID: "err-key", HardTTL: time.Minute,
+	}, func(context.Context) (int, error) {
+		return 0, wantErr
+	})
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestGetOrCompute_NoRedis_DifferentKeysComputeIndependently(t *testing.T) {
+	c := cache.New(nil, nil)
+	ctx := context.Background()
+	var calls atomic.Int64
+
+	compute := func(context.Context) (int, error) {
+		return int(calls.Add(1)), nil
+	}
+
+	v1, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns", ID: "a", HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+	v2, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns", ID: "b", HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, v1, v2, "different keys must not share a single-flight group")
+}
+
+func TestCache_Invalidate_NoRedis_IsNoOp(t *testing.T) {
+	c := cache.New(nil, nil)
+	err := c.Invalidate(context.Background(), "ns", "id")
+	assert.NoError(t, err)
+}
+
+func TestCache_Stats_TracksHitsAndMisses(t *testing.T) {
+	c := cache.New(nil, nil)
+	ctx := context.Background()
+
+	_, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns", ID: "x", HardTTL: time.Minute},
+		func(context.Context) (int, error) { return 1, nil })
+	require.NoError(t, err)
+
+	stats := c.Stats()
+	// Without Redis every call is a "miss" (there's no cache to hit).
+	assert.GreaterOrEqual(t, stats.Misses, int64(1))
+}
+
+// ---------------------------------------------------------------------------
+// Redis-backed tests: skip when REDIS_ADDR is unset/unreachable, matching
+// the existing convention in internal/middleware/ratelimit_backend_test.go
+// (no miniredis/redismock in go.mod).
+// ---------------------------------------------------------------------------
+
+func newTestRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set; skipping redis-backed cache test")
+	}
+	rc := redis.NewClient(&redis.Options{Addr: addr})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rc.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not reachable at %s: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+type cachedThing struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestGetOrCompute_Redis_CachesAcrossCalls(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	ns, id := "it-cache", uniqueID(t)
+	t.Cleanup(func() { _ = c.Invalidate(context.Background(), ns, id) })
+
+	var calls atomic.Int64
+	compute := func(context.Context) (cachedThing, error) {
+		calls.Add(1)
+		return cachedThing{Name: "hello", Count: int(calls.Load())}, nil
+	}
+
+	first, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+	assert.Equal(t, cachedThing{Name: "hello", Count: 1}, first)
+
+	second, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "second call should be served from cache, not recompute")
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestGetOrCompute_Redis_ConcurrentMissesSuppressStampede(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	ns, id := "it-stampede", uniqueID(t)
+	t.Cleanup(func() { _ = c.Invalidate(context.Background(), ns, id) })
+
+	var calls atomic.Int64
+	compute := func(context.Context) (int, error) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return 7, nil
+	}
+
+	const n = 15
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: time.Minute}, compute)
+			assert.NoError(t, err)
+			assert.Equal(t, 7, v)
+		}()
+	}
+	wg.Wait()
+
+	// In-process single-flight collapses same-instance concurrent callers to
+	// exactly one compute regardless of Redis.
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestCache_Invalidate_Redis_ClearsEntry(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	ns, id := "it-invalidate", uniqueID(t)
+
+	var calls atomic.Int64
+	compute := func(context.Context) (int, error) {
+		return int(calls.Add(1)), nil
+	}
+
+	first, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, first)
+
+	require.NoError(t, c.Invalidate(ctx, ns, id))
+
+	second, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: time.Minute}, compute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, second, "invalidated entry must recompute, not serve the old value")
+}
+
+func TestCache_Invalidate_Redis_DoesNotTouchOtherNamespace(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	id := uniqueID(t)
+	t.Cleanup(func() {
+		_ = c.Invalidate(context.Background(), "ns-a", id)
+		_ = c.Invalidate(context.Background(), "ns-b", id)
+	})
+
+	compute := func(v int) func(context.Context) (int, error) {
+		return func(context.Context) (int, error) { return v, nil }
+	}
+
+	_, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns-a", ID: id, HardTTL: time.Minute}, compute(1))
+	require.NoError(t, err)
+	_, err = cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns-b", ID: id, HardTTL: time.Minute}, compute(2))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Invalidate(ctx, "ns-a", id))
+
+	// ns-b's entry (same id, different namespace) must survive.
+	var calledB atomic.Bool
+	v, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: "ns-b", ID: id, HardTTL: time.Minute},
+		func(context.Context) (int, error) { calledB.Store(true); return 999, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 2, v)
+	assert.False(t, calledB.Load(), "ns-b entry should still be cached after invalidating ns-a")
+}
+
+func TestGetOrCompute_Redis_TTLIsJittered(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	ns := "it-jitter"
+
+	base := 10 * time.Second
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 5; i++ {
+		id := uniqueID(t)
+		_, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: base},
+			func(context.Context) (int, error) { return 1, nil })
+		require.NoError(t, err)
+
+		ttl := rc.TTL(ctx, "cache:v1:"+ns+":"+id).Val()
+		_ = c.Invalidate(context.Background(), ns, id)
+		seen[ttl.Round(time.Second)] = true
+	}
+	// Not a strict proof of randomness, but across 5 runs with a ±10% jitter
+	// window we expect at least one distinct TTL bucket, i.e. it isn't a
+	// hardcoded constant.
+	assert.Greater(t, len(seen), 1, "expected jittered TTLs to vary across calls, got identical TTL every time: %v", seen)
+}
+
+func TestGetOrCompute_Redis_ServesStaleWhileRevalidating(t *testing.T) {
+	rc := newTestRedisClient(t)
+	c := cache.New(rc, nil)
+	ctx := context.Background()
+	ns, id := "it-swr", uniqueID(t)
+	t.Cleanup(func() { _ = c.Invalidate(context.Background(), ns, id) })
+
+	var calls atomic.Int64
+	compute := func(context.Context) (int, error) {
+		n := calls.Add(1)
+		return int(n), nil
+	}
+
+	// First call: soft TTL already in the past relative to a near-zero value
+	// forces every subsequent read into the "soft-expired" branch immediately.
+	opts := cache.Options{Namespace: ns, ID: id, HardTTL: 5 * time.Second, SoftTTL: 1 * time.Millisecond}
+	first, err := cache.GetOrCompute(ctx, c, opts, compute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, first)
+
+	time.Sleep(20 * time.Millisecond) // ensure we're past the 1ms soft TTL
+
+	// This read should get the stale value (1) immediately, not block on a
+	// synchronous recompute.
+	second, err := cache.GetOrCompute(ctx, c, opts, compute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, second, "expected the stale value to be served immediately")
+
+	// The background refresh should complete shortly after.
+	require.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond, "expected a background refresh to have run")
+}
+
+func uniqueID(t *testing.T) string {
+	t.Helper()
+	return t.Name() + "-" + time.Now().Format("150405.000000000")
+}

--- a/apps/api/internal/handler/vault_handler_harvest_test.go
+++ b/apps/api/internal/handler/vault_handler_harvest_test.go
@@ -109,7 +109,7 @@ func TestVaultHandlerHarvestBroadcastsWebSocketEvent(t *testing.T) {
 	vaultService := service.NewVaultService(repository)
 
 	handler := NewVaultHandler(vaultService)
-	hub := ws.NewHub(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
+	hub := ws.NewHub(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, 0)
 	handler.SetWSHub(hub)
 	go hub.Run(t.Context())
 

--- a/apps/api/internal/notifications/dedup_redis.go
+++ b/apps/api/internal/notifications/dedup_redis.go
@@ -1,0 +1,43 @@
+package notifications
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// redisDedupOpTimeout bounds each Redis round trip so a degraded Redis
+// never adds unbounded latency to a Send call.
+const redisDedupOpTimeout = 150 * time.Millisecond
+
+// RedisDeduplicator is a cross-instance Deduplicator backed by Redis
+// SET-NX-EX: the first caller for a key within the window gets seen=false
+// ("go ahead and send"); every other caller within the same window gets
+// seen=true. Namespaced under "notif:dedup:" so it can't collide with
+// unrelated keys on a shared Redis instance.
+type RedisDeduplicator struct {
+	rc *redis.Client
+}
+
+// NewRedisDeduplicator constructs a RedisDeduplicator. rc must not be nil —
+// callers with no Redis configured should use InMemoryDeduplicator instead.
+func NewRedisDeduplicator(rc *redis.Client) *RedisDeduplicator {
+	return &RedisDeduplicator{rc: rc}
+}
+
+// SeenRecently implements Deduplicator. A Redis error fails open (returns
+// seen=false, i.e. "not deduped, go ahead and send") — a degraded Redis
+// must never silently drop a legitimate notification because dedup
+// couldn't be checked, mirroring the fail-open philosophy already used by
+// internal/middleware's rate limiter and internal/cache.
+func (r *RedisDeduplicator) SeenRecently(ctx context.Context, key string, window time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, redisDedupOpTimeout)
+	defer cancel()
+
+	wasNewlySet, err := r.rc.SetNX(ctx, "notif:dedup:"+key, "1", window).Result()
+	if err != nil {
+		return false, err
+	}
+	return !wasNewlySet, nil
+}

--- a/apps/api/internal/notifications/dedup_redis_test.go
+++ b/apps/api/internal/notifications/dedup_redis_test.go
@@ -1,0 +1,90 @@
+package notifications
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestRedisClientForDedup(t *testing.T) *redis.Client {
+	t.Helper()
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set; skipping redis-backed dedup test")
+	}
+	rc := redis.NewClient(&redis.Options{Addr: addr})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rc.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not reachable at %s: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func TestRedisDeduplicator_FirstCallNotSeenSecondCallSeen(t *testing.T) {
+	rc := newTestRedisClientForDedup(t)
+	dedup := NewRedisDeduplicator(rc)
+	key := "it-dedup-" + t.Name()
+	t.Cleanup(func() { rc.Del(context.Background(), "notif:dedup:"+key) })
+
+	seen, err := dedup.SeenRecently(context.Background(), key, time.Minute)
+	if err != nil {
+		t.Fatalf("first SeenRecently: %v", err)
+	}
+	if seen {
+		t.Fatal("expected first call to report not-seen")
+	}
+
+	seen, err = dedup.SeenRecently(context.Background(), key, time.Minute)
+	if err != nil {
+		t.Fatalf("second SeenRecently: %v", err)
+	}
+	if !seen {
+		t.Fatal("expected second call within the window to report seen")
+	}
+}
+
+func TestRedisDeduplicator_ExpiresAfterWindow(t *testing.T) {
+	rc := newTestRedisClientForDedup(t)
+	dedup := NewRedisDeduplicator(rc)
+	key := "it-dedup-expiry-" + t.Name()
+	t.Cleanup(func() { rc.Del(context.Background(), "notif:dedup:"+key) })
+
+	if _, err := dedup.SeenRecently(context.Background(), key, 500*time.Millisecond); err != nil {
+		t.Fatalf("first SeenRecently: %v", err)
+	}
+	time.Sleep(700 * time.Millisecond)
+
+	seen, err := dedup.SeenRecently(context.Background(), key, time.Minute)
+	if err != nil {
+		t.Fatalf("SeenRecently after expiry: %v", err)
+	}
+	if seen {
+		t.Fatal("expected dedup entry to have expired, but it was still reported as seen")
+	}
+}
+
+func TestRedisDeduplicator_DifferentKeysIndependent(t *testing.T) {
+	rc := newTestRedisClientForDedup(t)
+	dedup := NewRedisDeduplicator(rc)
+	keyA := "it-dedup-a-" + t.Name()
+	keyB := "it-dedup-b-" + t.Name()
+	t.Cleanup(func() {
+		rc.Del(context.Background(), "notif:dedup:"+keyA, "notif:dedup:"+keyB)
+	})
+
+	if _, err := dedup.SeenRecently(context.Background(), keyA, time.Minute); err != nil {
+		t.Fatalf("keyA SeenRecently: %v", err)
+	}
+	seen, err := dedup.SeenRecently(context.Background(), keyB, time.Minute)
+	if err != nil {
+		t.Fatalf("keyB SeenRecently: %v", err)
+	}
+	if seen {
+		t.Fatal("expected an unrelated key to be independent, not affected by keyA's dedup entry")
+	}
+}

--- a/apps/api/internal/notifications/dispatcher_category_test.go
+++ b/apps/api/internal/notifications/dispatcher_category_test.go
@@ -1,0 +1,440 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// --- test doubles specific to #829 behavior ---
+
+type fakeRateLimiter struct {
+	mu    sync.Mutex
+	allow bool
+	calls []string
+}
+
+func (f *fakeRateLimiter) Allow(_ context.Context, key string) (bool, time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, key)
+	return f.allow, 0
+}
+
+func (f *fakeRateLimiter) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// categoryAwarePreferences implements both PreferenceStore and
+// CategoryPreferenceStore so tests can prove the dispatcher prefers the
+// category-scoped resolution when available.
+type categoryAwarePreferences struct {
+	mu    sync.Mutex
+	byCat map[Category]Preferences
+	calls []Category
+}
+
+func newCategoryAwarePreferences() *categoryAwarePreferences {
+	return &categoryAwarePreferences{byCat: map[Category]Preferences{}}
+}
+
+func (c *categoryAwarePreferences) Get(_ context.Context, _ uuid.UUID) (Preferences, error) {
+	return DefaultPreferences(), nil
+}
+
+func (c *categoryAwarePreferences) GetForCategory(_ context.Context, _ uuid.UUID, category Category) (Preferences, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, category)
+	if p, ok := c.byCat[category]; ok {
+		return p, nil
+	}
+	return DefaultPreferencesForCategory(category), nil
+}
+
+func (c *categoryAwarePreferences) Set(category Category, p Preferences) *categoryAwarePreferences {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byCat[category] = p
+	return c
+}
+
+type errPushSender struct{}
+
+func (errPushSender) Send(context.Context, []string, string, string, map[string]any) error {
+	return errors.New("push provider down")
+}
+
+type recordingRetryEnqueuer struct {
+	mu    sync.Mutex
+	calls []struct {
+		Notification Notification
+		Channel      ChannelKind
+	}
+	err error
+}
+
+func (r *recordingRetryEnqueuer) EnqueueRetry(_ context.Context, n Notification, channel ChannelKind) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, struct {
+		Notification Notification
+		Channel      ChannelKind
+	}{n, channel})
+	return r.err
+}
+
+func (r *recordingRetryEnqueuer) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+// --- Category classification ---
+
+func TestCategoryFor_KnownExceptionsAndDefault(t *testing.T) {
+	if CategoryFor(EventProtocolHealthAlert) != CategorySafety {
+		t.Errorf("protocol health alert must be safety")
+	}
+	if CategoryFor(EventVaultPaused) != CategorySafety {
+		t.Errorf("vault paused must be safety")
+	}
+	if CategoryFor(EventFinancialDigest) != CategoryPromotional {
+		t.Errorf("financial digest must be promotional")
+	}
+	if CategoryFor(EventDepositConfirmed) != CategoryTransactional {
+		t.Errorf("deposit confirmed must default to transactional")
+	}
+}
+
+// --- Safety bypasses preferences and rate limits ---
+
+func TestDispatcher_SafetyBypassesPreferenceOptOut(t *testing.T) {
+	mail := &RecordingMailSender{}
+	hub := &RecordingHub{}
+	prefs := NewMemoryPreferences()
+	uid := uuid.New()
+	// Fully opted out of everything.
+	prefs.Set(uid, Preferences{Email: false, WebSocket: false, Push: false})
+
+	d := New(
+		[]Channel{NewEmailChannel(mail, StaticEmailLookup{Addr: "u@example.com"}), NewWebSocketChannel(hub)},
+		prefs,
+		nil,
+	)
+
+	if err := d.Send(context.Background(), uid, EventVaultPaused, "Vault paused", "body", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(mail.Calls) != 1 {
+		t.Errorf("safety notification must deliver by email despite opt-out, got %d calls", len(mail.Calls))
+	}
+	if len(hub.Calls) != 1 {
+		t.Errorf("safety notification must deliver by websocket despite opt-out, got %d calls", len(hub.Calls))
+	}
+}
+
+func TestDispatcher_SafetyBypassesRateLimit(t *testing.T) {
+	hub := &RecordingHub{}
+	mail := &RecordingMailSender{}
+	limiter := &fakeRateLimiter{allow: false} // would deny every non-safety call
+	d := New(
+		// EventVaultPaused's matrix is {Email, WebSocket}; register both so
+		// the assertion below is purely about the rate-limit bypass, not
+		// muddied by "no adapter registered" outcomes.
+		[]Channel{NewWebSocketChannel(hub), NewEmailChannel(mail, StaticEmailLookup{Addr: "u@example.com"})},
+		NewMemoryPreferences(),
+		nil,
+		WithRateLimiter(limiter),
+	)
+
+	if err := d.Send(context.Background(), uuid.New(), EventVaultPaused, "x", "y", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(hub.Calls) != 1 {
+		t.Errorf("safety notification must bypass rate limiting, got %d calls", len(hub.Calls))
+	}
+	if limiter.callCount() != 0 {
+		t.Errorf("rate limiter must not even be consulted for safety events, got %d calls", limiter.callCount())
+	}
+}
+
+// --- Promotional suppression is recorded, not silently dropped ---
+
+func TestDispatcher_PromotionalSuppressedByDefaultOptOut_AndRecorded(t *testing.T) {
+	hub := &RecordingHub{}
+	persistence := &RecordingPersistenceStore{}
+	catPrefs := newCategoryAwarePreferences() // defaults: promotional = Email:false, WebSocket:true, Push:false
+	catPrefs.Set(CategoryPromotional, Preferences{Email: false, WebSocket: false, Push: false, DigestCadence: DigestCadenceOff})
+
+	d := New(
+		[]Channel{NewWebSocketChannel(hub)},
+		catPrefs,
+		persistence,
+	)
+
+	if err := d.Send(context.Background(), uuid.New(), EventGoalCoaching, "Coaching", "body", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(hub.Calls) != 0 {
+		t.Errorf("expected promotional to be fully suppressed, got %d hub calls", len(hub.Calls))
+	}
+	if persistence.Count() != 1 {
+		t.Fatalf("expected the suppressed notification to still be persisted, got %d saved", persistence.Count())
+	}
+	saved := persistence.Saved[0]
+	if !saved.Suppressed || saved.SuppressedReason != SuppressedByPreference {
+		t.Errorf("expected Suppressed=true reason=preference, got suppressed=%v reason=%q", saved.Suppressed, saved.SuppressedReason)
+	}
+}
+
+func TestDispatcher_CategoryAwarePreferencesPreferredOverFlat(t *testing.T) {
+	catPrefs := newCategoryAwarePreferences()
+	d := New(nil, catPrefs, nil)
+
+	_ = d.Send(context.Background(), uuid.New(), EventGoalCoaching, "x", "y", nil)
+
+	if len(catPrefs.calls) != 1 || catPrefs.calls[0] != CategoryPromotional {
+		t.Errorf("expected GetForCategory to be called with CategoryPromotional, got %+v", catPrefs.calls)
+	}
+}
+
+// --- Dedup ---
+
+func TestDispatcher_DedupSuppressesRepeatWithinWindow(t *testing.T) {
+	hub := &RecordingHub{}
+	dedup := NewInMemoryDeduplicator()
+	fixedNow := time.Now()
+	dedup.nowFunc = func() time.Time { return fixedNow }
+
+	d := New([]Channel{NewWebSocketChannel(hub)}, NewMemoryPreferences(), nil, WithDeduplicator(dedup))
+	uid := uuid.New()
+	opts := SendOptions{DedupWindow: time.Minute}
+
+	// EventRebalanceExecuted's matrix is websocket-only, so only the
+	// registered channel is ever attempted.
+	if err := d.SendWithOptions(context.Background(), uid, EventRebalanceExecuted, "a", "b", nil, opts); err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	if err := d.SendWithOptions(context.Background(), uid, EventRebalanceExecuted, "a", "b", nil, opts); err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if len(hub.Calls) != 1 {
+		t.Errorf("expected exactly one delivery within the dedup window, got %d", len(hub.Calls))
+	}
+
+	// After the window elapses, the next Send must go through again.
+	fixedNow = fixedNow.Add(2 * time.Minute)
+	if err := d.SendWithOptions(context.Background(), uid, EventRebalanceExecuted, "a", "b", nil, opts); err != nil {
+		t.Fatalf("third Send: %v", err)
+	}
+	if len(hub.Calls) != 2 {
+		t.Errorf("expected delivery to resume after the dedup window elapsed, got %d calls", len(hub.Calls))
+	}
+}
+
+func TestDispatcher_DedupSuppressionIsRecorded(t *testing.T) {
+	persistence := &RecordingPersistenceStore{}
+	dedup := NewInMemoryDeduplicator()
+	d := New(nil, NewMemoryPreferences(), persistence, WithDeduplicator(dedup))
+	uid := uuid.New()
+	opts := SendOptions{DedupWindow: time.Hour}
+
+	_ = d.SendWithOptions(context.Background(), uid, EventDepositConfirmed, "a", "b", nil, opts)
+	_ = d.SendWithOptions(context.Background(), uid, EventDepositConfirmed, "a", "b", nil, opts)
+
+	if persistence.Count() != 2 {
+		t.Fatalf("expected both the delivered and the suppressed notification to be persisted, got %d", persistence.Count())
+	}
+	if !persistence.Saved[1].Suppressed || persistence.Saved[1].SuppressedReason != SuppressedByDedup {
+		t.Errorf("expected second save to be recorded as dedup-suppressed, got %+v", persistence.Saved[1])
+	}
+}
+
+// --- Rate limiting ---
+
+func TestDispatcher_RateLimitSuppressesAndRecords(t *testing.T) {
+	hub := &RecordingHub{}
+	persistence := &RecordingPersistenceStore{}
+	limiter := &fakeRateLimiter{allow: false}
+	d := New([]Channel{NewWebSocketChannel(hub)}, NewMemoryPreferences(), persistence, WithRateLimiter(limiter))
+
+	if err := d.Send(context.Background(), uuid.New(), EventDepositConfirmed, "a", "b", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(hub.Calls) != 0 {
+		t.Errorf("expected rate-limited send to deliver nowhere, got %d calls", len(hub.Calls))
+	}
+	if persistence.Count() != 1 || !persistence.Saved[0].Suppressed || persistence.Saved[0].SuppressedReason != SuppressedByRateLimit {
+		t.Fatalf("expected a persisted rate-limit-suppressed record, got %+v", persistence.Saved)
+	}
+}
+
+// --- Fallback ---
+
+func TestDispatcher_PushFailureFallsBackToWebSocket(t *testing.T) {
+	hub := &RecordingHub{}
+	tokens := NewMemoryDeviceTokens()
+	uid := uuid.New()
+	tokens.Set(uid, []DeviceToken{{Token: "tok", Enabled: true}})
+
+	d := New(
+		[]Channel{NewPushChannel(errPushSender{}, tokens), NewWebSocketChannel(hub)},
+		NewMemoryPreferences(),
+		nil,
+	)
+
+	// EventYieldMilestone's matrix is Push-only, so WebSocket is not
+	// normally attempted for it — proving any delivery is the fallback.
+	err := d.Send(context.Background(), uid, EventYieldMilestone, "Milestone", "body", nil)
+	if err == nil {
+		t.Fatal("expected the push failure to surface as an error")
+	}
+	if len(hub.Calls) != 1 {
+		t.Fatalf("expected websocket fallback delivery after push failure, got %d calls", len(hub.Calls))
+	}
+}
+
+func TestDispatcher_FallbackDoesNotDoubleDeliverWhenWebSocketAlreadyInMatrix(t *testing.T) {
+	hub := &RecordingHub{}
+	mail := &RecordingMailSender{}
+	d := New(
+		[]Channel{NewEmailChannel(errMailSender{}, StaticEmailLookup{Addr: "u@example.com"}), NewWebSocketChannel(hub)},
+		NewMemoryPreferences(),
+		nil,
+	)
+	_ = mail
+
+	// EventSettlementCompleted's matrix already includes WebSocket, so the
+	// fallback triggered by Email's failure must not re-deliver a second
+	// time on top of the normal in-matrix WebSocket delivery.
+	_ = d.Send(context.Background(), uuid.New(), EventSettlementCompleted, "Done", "body", nil)
+	if len(hub.Calls) != 1 {
+		t.Errorf("expected exactly one websocket delivery, got %d (fallback must not double-deliver)", len(hub.Calls))
+	}
+}
+
+func TestDispatcher_DeliveryOutcomesRecorded(t *testing.T) {
+	hub := &RecordingHub{}
+	persistence := &RecordingPersistenceStore{}
+	d := New(
+		[]Channel{NewEmailChannel(errMailSender{}, StaticEmailLookup{Addr: "u@example.com"}), NewWebSocketChannel(hub)},
+		NewMemoryPreferences(),
+		persistence,
+	)
+
+	_ = d.Send(context.Background(), uuid.New(), EventSettlementCompleted, "Done", "body", nil)
+
+	if persistence.Count() != 1 {
+		t.Fatalf("expected one saved notification, got %d", persistence.Count())
+	}
+	n := persistence.Saved[0]
+	outcomes, ok := persistence.RecordedOutcomes[n.ID]
+	if !ok {
+		t.Fatalf("expected RecordOutcome to have been called for notification %s", n.ID)
+	}
+
+	foundFailedEmail, foundFallbackWebSocket := false, false
+	for _, o := range outcomes {
+		if o.Channel == ChannelEmail && !o.Delivered && o.Error != "" {
+			foundFailedEmail = true
+		}
+		if o.Channel == ChannelWebSocket && o.Delivered && o.IsFallback {
+			foundFallbackWebSocket = true
+		}
+	}
+	if !foundFailedEmail {
+		t.Errorf("expected a failed email outcome, got %+v", outcomes)
+	}
+	if !foundFallbackWebSocket {
+		t.Errorf("expected websocket to be recorded as a fallback delivery, got %+v", outcomes)
+	}
+}
+
+// --- Retry enqueue ---
+
+func TestDispatcher_EnqueuesRetryForFailedEmailButNotWebSocket(t *testing.T) {
+	retry := &recordingRetryEnqueuer{}
+	d := New(
+		[]Channel{NewEmailChannel(errMailSender{}, StaticEmailLookup{Addr: "u@example.com"})},
+		NewMemoryPreferences(),
+		nil,
+		WithRetryEnqueuer(retry),
+	)
+
+	// EventKYCRejected is email-only, so there's no websocket fallback to
+	// muddy the assertion.
+	_ = d.Send(context.Background(), uuid.New(), EventKYCRejected, "x", "y", nil)
+
+	if retry.count() != 1 {
+		t.Fatalf("expected exactly one retry enqueue for the failed email, got %d", retry.count())
+	}
+	if retry.calls[0].Channel != ChannelEmail {
+		t.Errorf("expected retry for ChannelEmail, got %q", retry.calls[0].Channel)
+	}
+}
+
+func TestDispatcher_NoRetryEnqueuedForWebSocketFailure(t *testing.T) {
+	retry := &recordingRetryEnqueuer{}
+	// A hub whose PushToUser always fails, to exercise a pure websocket
+	// failure path (EventRebalanceExecuted is websocket-only).
+	failingHub := recordingHubFunc(func(context.Context, uuid.UUID, string, any) error {
+		return errors.New("client disconnected")
+	})
+	d := New(
+		[]Channel{NewWebSocketChannel(failingHub)},
+		NewMemoryPreferences(),
+		nil,
+		WithRetryEnqueuer(retry),
+	)
+
+	_ = d.Send(context.Background(), uuid.New(), EventRebalanceExecuted, "x", "y", nil)
+
+	if retry.count() != 0 {
+		t.Errorf("websocket failures must never be retried through the job queue, got %d enqueues", retry.count())
+	}
+}
+
+type recordingHubFunc func(context.Context, uuid.UUID, string, any) error
+
+func (f recordingHubFunc) PushToUser(ctx context.Context, userID uuid.UUID, eventName string, payload any) error {
+	return f(ctx, userID, eventName, payload)
+}
+
+// --- Stats ---
+
+func TestDispatcher_StatsTracksPerCategoryOutcomes(t *testing.T) {
+	hub := &RecordingHub{}
+	d := New([]Channel{NewWebSocketChannel(hub)}, NewMemoryPreferences(), nil)
+
+	_ = d.Send(context.Background(), uuid.New(), EventRebalanceExecuted, "x", "y", nil) // transactional, delivered
+	_ = d.Send(context.Background(), uuid.New(), EventVaultPaused, "x", "y", nil)       // safety, delivered
+
+	stats := d.Stats()
+	txn := stats[CategoryTransactional]
+	if txn.Attempted != 1 || txn.Delivered != 1 || txn.Failed != 0 {
+		t.Errorf("transactional stats = %+v, want Attempted=1 Delivered=1", txn)
+	}
+	safety := stats[CategorySafety]
+	if safety.Attempted != 1 || safety.Delivered != 1 {
+		t.Errorf("safety stats = %+v, want Attempted=1 Delivered=1", safety)
+	}
+}
+
+func TestDispatcher_StatsTracksSuppressed(t *testing.T) {
+	limiter := &fakeRateLimiter{allow: false}
+	d := New(nil, NewMemoryPreferences(), nil, WithRateLimiter(limiter))
+
+	_ = d.Send(context.Background(), uuid.New(), EventDepositConfirmed, "x", "y", nil)
+
+	stats := d.Stats()
+	if stats[CategoryTransactional].Suppressed != 1 {
+		t.Errorf("expected 1 suppressed transactional send, got %+v", stats[CategoryTransactional])
+	}
+}

--- a/apps/api/internal/notifications/notifications.go
+++ b/apps/api/internal/notifications/notifications.go
@@ -40,13 +40,13 @@ import (
 type EventType string
 
 const (
-	EventSettlementCompleted EventType = "settlement_completed"
-	EventSettlementFailed    EventType = "settlement_failed"
-	EventDepositConfirmed    EventType = "deposit_confirmed"
-	EventYieldMilestone      EventType = "yield_milestone"
-	EventVaultAPYDrop        EventType = "vault_apy_drop"
-	EventVaultPaused         EventType = "vault_paused"
-	EventRebalanceExecuted   EventType = "rebalance_executed"
+	EventSettlementCompleted       EventType = "settlement_completed"
+	EventSettlementFailed          EventType = "settlement_failed"
+	EventDepositConfirmed          EventType = "deposit_confirmed"
+	EventYieldMilestone            EventType = "yield_milestone"
+	EventVaultAPYDrop              EventType = "vault_apy_drop"
+	EventVaultPaused               EventType = "vault_paused"
+	EventRebalanceExecuted         EventType = "rebalance_executed"
 	EventKYCApproved               EventType = "kyc_approved"
 	EventKYCRejected               EventType = "kyc_rejected"
 	EventGoalMilestone             EventType = "goal_milestone"
@@ -79,6 +79,45 @@ func ValidDigestCadence(cadence string) bool {
 	}
 }
 
+// Category classifies an EventType for suppressibility policy (#829).
+// Safety notifications always deliver regardless of user preferences or
+// rate limits — suppressing a safety message to respect a preference is
+// the wrong trade-off. Promotional notifications fully honor opt-out.
+// Transactional sits in between (on by default, opt-out like promotional).
+type Category string
+
+const (
+	CategorySafety        Category = "safety"
+	CategoryTransactional Category = "transactional"
+	CategoryPromotional   Category = "promotional"
+)
+
+// safetyEvents and promotionalEvents are the explicit exception sets;
+// everything else defaults to CategoryTransactional. Kept as small,
+// explicit sets rather than a second full matrix so the common case (a new
+// event type is transactional) needs no entry here at all.
+var safetyEvents = map[EventType]bool{
+	EventProtocolHealthAlert: true,
+	EventVaultPaused:         true,
+	EventSettlementFailed:    true,
+}
+
+var promotionalEvents = map[EventType]bool{
+	EventGoalCoaching:    true,
+	EventFinancialDigest: true,
+}
+
+// CategoryFor returns t's suppressibility category.
+func CategoryFor(t EventType) Category {
+	if safetyEvents[t] {
+		return CategorySafety
+	}
+	if promotionalEvents[t] {
+		return CategoryPromotional
+	}
+	return CategoryTransactional
+}
+
 // ChannelKind is the transport a notification is delivered over.
 type ChannelKind string
 
@@ -92,13 +131,13 @@ const (
 // computes the union of channels per event, then filters by the user's
 // preferences.
 var eventChannelMatrix = map[EventType][]ChannelKind{
-	EventSettlementCompleted: {ChannelEmail, ChannelWebSocket, ChannelPush},
-	EventSettlementFailed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
-	EventDepositConfirmed:    {ChannelEmail, ChannelWebSocket, ChannelPush},
-	EventYieldMilestone:      {ChannelPush},
-	EventVaultAPYDrop:        {ChannelEmail, ChannelPush},
-	EventVaultPaused:         {ChannelEmail, ChannelWebSocket},
-	EventRebalanceExecuted:   {ChannelWebSocket},
+	EventSettlementCompleted:       {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventSettlementFailed:          {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventDepositConfirmed:          {ChannelEmail, ChannelWebSocket, ChannelPush},
+	EventYieldMilestone:            {ChannelPush},
+	EventVaultAPYDrop:              {ChannelEmail, ChannelPush},
+	EventVaultPaused:               {ChannelEmail, ChannelWebSocket},
+	EventRebalanceExecuted:         {ChannelWebSocket},
 	EventKYCApproved:               {ChannelEmail},
 	EventKYCRejected:               {ChannelEmail},
 	EventGoalMilestone:             {ChannelPush},
@@ -156,6 +195,48 @@ func (p Preferences) Allow(c ChannelKind) bool {
 	}
 }
 
+// DefaultPreferencesForCategory returns the sensible default for a given
+// category (#829): transactional and safety default to everything on
+// (safety bypasses preferences entirely at send time regardless, but a
+// sensible default still matters for what a settings page would show);
+// promotional defaults to minimal — off except the free in-app bell,
+// matching the issue's "promotional off or minimal" guidance.
+func DefaultPreferencesForCategory(c Category) Preferences {
+	if c == CategoryPromotional {
+		return Preferences{Email: false, WebSocket: true, Push: false, DigestCadence: DigestCadenceOff}
+	}
+	return DefaultPreferences()
+}
+
+// CategoryPreferenceStore is an optional upgrade to PreferenceStore: a store
+// that can resolve preferences per category rather than one flat set for
+// every event (#829). The dispatcher type-asserts for this at send time; a
+// store that only implements PreferenceStore keeps working exactly as
+// before (every category uses the same flat preferences).
+type CategoryPreferenceStore interface {
+	GetForCategory(ctx context.Context, userID uuid.UUID, category Category) (Preferences, error)
+}
+
+// SuppressionReason records why a notification was not attempted on any
+// channel, so the suppression is auditable rather than silently dropped
+// (#829's "suppressed notifications are recorded with their reason").
+type SuppressionReason string
+
+const (
+	SuppressedByPreference SuppressionReason = "preference"
+	SuppressedByDedup      SuppressionReason = "dedup"
+	SuppressedByRateLimit  SuppressionReason = "rate_limit"
+)
+
+// ChannelOutcome records what happened when delivery was attempted on one
+// channel — the per-channel delivery tracking (#829).
+type ChannelOutcome struct {
+	Channel    ChannelKind `json:"channel"`
+	Delivered  bool        `json:"delivered"`
+	Error      string      `json:"error,omitempty"`
+	IsFallback bool        `json:"is_fallback,omitempty"`
+}
+
 // Notification is one delivered message. It carries everything the
 // channel adapters need to render + transport, plus the metadata the
 // future history-read API will return.
@@ -163,10 +244,22 @@ type Notification struct {
 	ID        uuid.UUID
 	UserID    uuid.UUID
 	Type      EventType
+	Category  Category
 	Title     string
 	Body      string
 	Payload   map[string]any
 	CreatedAt time.Time
+
+	// Suppressed and SuppressedReason are set when the notification was not
+	// attempted on any channel (preference/dedup/rate-limit). Delivered
+	// notifications — even ones with partial per-channel failures — leave
+	// these zero-valued: "suppressed" specifically means zero delivery
+	// attempts were made, which is a distinct, auditable outcome from "we
+	// tried and some channels failed" (see DeliveryOutcomes).
+	Suppressed       bool              `json:"suppressed,omitempty"`
+	SuppressedReason SuppressionReason `json:"suppressed_reason,omitempty"`
+	// DeliveryOutcomes has one entry per channel actually attempted.
+	DeliveryOutcomes []ChannelOutcome `json:"delivery_outcomes,omitempty"`
 }
 
 // DeviceToken is a mobile push destination registered by a user device.
@@ -214,10 +307,13 @@ type NoopPersistenceStore struct{}
 
 func (NoopPersistenceStore) Save(_ context.Context, _ Notification) error { return nil }
 
-// RecordingPersistenceStore captures persisted notifications for tests.
+// RecordingPersistenceStore captures persisted notifications for tests. It
+// also implements DeliveryOutcomeRecorder so tests can assert on recorded
+// per-channel outcomes (#829).
 type RecordingPersistenceStore struct {
-	mu    sync.Mutex
-	Saved []Notification
+	mu               sync.Mutex
+	Saved            []Notification
+	RecordedOutcomes map[uuid.UUID][]ChannelOutcome
 }
 
 func (r *RecordingPersistenceStore) Save(_ context.Context, n Notification) error {
@@ -233,6 +329,110 @@ func (r *RecordingPersistenceStore) Count() int {
 	return len(r.Saved)
 }
 
+// RecordOutcome implements DeliveryOutcomeRecorder.
+func (r *RecordingPersistenceStore) RecordOutcome(_ context.Context, notificationID uuid.UUID, outcomes []ChannelOutcome) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.RecordedOutcomes == nil {
+		r.RecordedOutcomes = make(map[uuid.UUID][]ChannelOutcome)
+	}
+	r.RecordedOutcomes[notificationID] = outcomes
+	return nil
+}
+
+// Deduplicator suppresses repeat sends of the same logical event within a
+// window (#829). SeenRecently records key on first call and returns false;
+// subsequent calls for the same key within window return true without
+// resetting the window's own expiry.
+//
+// This is a separate, generic mechanism from goal_milestone_notifier's
+// notified_milestones table (see that file's doc comment), not a
+// replacement for it — that table is a permanent, non-windowed
+// source-of-truth dedup on a correctness-sensitive path (never send the
+// same milestone twice, ever), whereas this is a short-window "don't fire
+// the same logical event twice in a burst" primitive. Migrating
+// notified_milestones onto this is exactly the kind of unreviewed,
+// correctness-sensitive change this PR intentionally defers rather than
+// risks — see the PR description.
+type Deduplicator interface {
+	SeenRecently(ctx context.Context, key string, window time.Duration) (bool, error)
+}
+
+// InMemoryDeduplicator is a process-local Deduplicator: the default when no
+// Redis is configured. It does not coordinate across instances — a
+// horizontally-scaled deployment should use RedisDeduplicator (see
+// dedup_redis.go) instead.
+type InMemoryDeduplicator struct {
+	mu        sync.Mutex
+	expiresAt map[string]time.Time
+	nowFunc   func() time.Time
+}
+
+// NewInMemoryDeduplicator constructs an InMemoryDeduplicator.
+func NewInMemoryDeduplicator() *InMemoryDeduplicator {
+	return &InMemoryDeduplicator{expiresAt: make(map[string]time.Time), nowFunc: time.Now}
+}
+
+// SeenRecently implements Deduplicator.
+func (d *InMemoryDeduplicator) SeenRecently(_ context.Context, key string, window time.Duration) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := d.nowFunc()
+	if exp, ok := d.expiresAt[key]; ok && now.Before(exp) {
+		return true, nil
+	}
+	d.expiresAt[key] = now.Add(window)
+
+	// Opportunistic cleanup so this map does not grow unbounded across a
+	// long process lifetime. Each key's own expiry is stored (rather than a
+	// "last seen" timestamp compared against the current call's window), so
+	// this is correct even when different calls use different windows.
+	for k, exp := range d.expiresAt {
+		if !now.Before(exp) {
+			delete(d.expiresAt, k)
+		}
+	}
+	return false, nil
+}
+
+// RateLimiter caps how often a given key may proceed within a window
+// (#829). Deliberately structurally compatible with middleware.Limiter so
+// middleware.NewLimiter(...) can be passed directly without notifications
+// importing the middleware package.
+type RateLimiter interface {
+	Allow(ctx context.Context, key string) (allowed bool, retryAfter time.Duration)
+}
+
+// RetryEnqueuer schedules a durable retry for a channel delivery that
+// failed on a retryable channel (#829). WebSocket delivery is intentionally
+// never retried through this path — a socket that failed is, by
+// definition, not connected right now, and the persisted notification row
+// (always saved regardless of channel outcome) is the correct fallback for
+// that case, not a queued retry. See retry_job.go for the jobqueue-backed
+// implementation.
+type RetryEnqueuer interface {
+	EnqueueRetry(ctx context.Context, n Notification, channel ChannelKind) error
+}
+
+// CategoryStats is a point-in-time count of dispatcher activity for one
+// category, exposed via Dispatcher.Stats() for a metrics endpoint to scrape
+// (#829's "per-category delivery success rates exposed as metrics").
+type CategoryStats struct {
+	// Attempted counts Send calls that resulted in at least one delivery
+	// attempt (i.e. were not suppressed).
+	Attempted int64
+	// Delivered/Failed count individual channel deliveries, not Send calls —
+	// one Send can contribute to both if e.g. email fails and websocket
+	// succeeds.
+	Delivered int64
+	Failed    int64
+	// Suppressed counts Send calls suppressed before any delivery attempt
+	// (by preference, dedup, or rate limit — see Notification.SuppressedReason
+	// for the breakdown on individual records).
+	Suppressed int64
+}
+
 // Dispatcher is the service the producers call. Construct with `New`
 // and call `Send(ctx, userID, evt, title, body, payload)`.
 type Dispatcher struct {
@@ -240,16 +440,59 @@ type Dispatcher struct {
 	preferences PreferenceStore
 	persistence PersistenceStore
 	clock       func() time.Time
+
+	dedup       Deduplicator
+	rateLimiter RateLimiter
+	retry       RetryEnqueuer
+
+	statsMu sync.Mutex
+	stats   map[Category]*CategoryStats
+}
+
+// DispatcherOption configures optional Dispatcher capabilities added in
+// #829. Kept as functional options (rather than new New() parameters) so
+// every existing New(channels, preferences, persistence) call site keeps
+// compiling unchanged.
+type DispatcherOption func(*Dispatcher)
+
+// WithDeduplicator enables dedup for SendWithOptions calls that set a
+// non-zero SendOptions.DedupWindow.
+func WithDeduplicator(dedup Deduplicator) DispatcherOption {
+	return func(d *Dispatcher) { d.dedup = dedup }
+}
+
+// WithRateLimiter enables per-user-per-category rate limiting. Safety-
+// category events always bypass this.
+func WithRateLimiter(rl RateLimiter) DispatcherOption {
+	return func(d *Dispatcher) { d.rateLimiter = rl }
+}
+
+// WithRetryEnqueuer enables durable job-queue retry of failed Email/Push
+// deliveries.
+func WithRetryEnqueuer(r RetryEnqueuer) DispatcherOption {
+	return func(d *Dispatcher) { d.retry = r }
+}
+
+// SetRetryEnqueuer wires (or replaces) the RetryEnqueuer after
+// construction. Exists alongside WithRetryEnqueuer because some callers
+// build their job-queue client after the dispatcher already exists (job
+// queue setup naturally happens once, later, after other wiring) — see
+// cmd/api/main.go. Like handler.SetWSHub elsewhere in this codebase, this
+// is a startup-only wiring seam: call it once before the dispatcher starts
+// serving Send calls, not concurrently with them.
+func (d *Dispatcher) SetRetryEnqueuer(r RetryEnqueuer) {
+	d.retry = r
 }
 
 // New constructs a Dispatcher with the given channel adapters. When
 // `persistence` is nil, a NoopPersistenceStore is used.
-func New(channels []Channel, preferences PreferenceStore, persistence PersistenceStore) *Dispatcher {
+func New(channels []Channel, preferences PreferenceStore, persistence PersistenceStore, opts ...DispatcherOption) *Dispatcher {
 	d := &Dispatcher{
 		channels:    make(map[ChannelKind]Channel, len(channels)),
 		preferences: preferences,
 		persistence: persistence,
 		clock:       time.Now,
+		stats:       make(map[Category]*CategoryStats),
 	}
 	if d.persistence == nil {
 		d.persistence = NoopPersistenceStore{}
@@ -257,17 +500,73 @@ func New(channels []Channel, preferences PreferenceStore, persistence Persistenc
 	for _, c := range channels {
 		d.channels[c.Kind()] = c
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
 	return d
 }
 
+// Stats returns a snapshot of cumulative activity per category.
+func (d *Dispatcher) Stats() map[Category]CategoryStats {
+	d.statsMu.Lock()
+	defer d.statsMu.Unlock()
+	out := make(map[Category]CategoryStats, len(d.stats))
+	for cat, s := range d.stats {
+		out[cat] = *s
+	}
+	return out
+}
+
+// countFor returns (creating if needed) the counters for cat. Caller must
+// hold d.statsMu.
+func (d *Dispatcher) countFor(cat Category) *CategoryStats {
+	s, ok := d.stats[cat]
+	if !ok {
+		s = &CategoryStats{}
+		d.stats[cat] = s
+	}
+	return s
+}
+
+func (d *Dispatcher) recordAttempted(cat Category) {
+	d.statsMu.Lock()
+	defer d.statsMu.Unlock()
+	d.countFor(cat).Attempted++
+}
+
+func (d *Dispatcher) recordSuppressed(cat Category) {
+	d.statsMu.Lock()
+	defer d.statsMu.Unlock()
+	d.countFor(cat).Suppressed++
+}
+
+func (d *Dispatcher) recordChannelOutcome(cat Category, delivered bool) {
+	d.statsMu.Lock()
+	defer d.statsMu.Unlock()
+	s := d.countFor(cat)
+	if delivered {
+		s.Delivered++
+	} else {
+		s.Failed++
+	}
+}
+
+// SendOptions configures one Send call beyond the defaults (#829). The zero
+// value disables dedup (DedupWindow <= 0 means "no dedup check").
+type SendOptions struct {
+	// DedupKey optionally scopes dedup more specifically than userID+evt
+	// alone (e.g. a specific vault ID within EventVaultAPYDrop). Empty means
+	// dedup solely on userID+evt.
+	DedupKey string
+	// DedupWindow, if > 0 (and a Deduplicator is configured via
+	// WithDeduplicator), suppresses a repeat Send for the same
+	// (userID, evt, DedupKey) within this window.
+	DedupWindow time.Duration
+}
+
 // Send dispatches the event to every channel the matrix says should
-// carry it, filtered by the user's preferences.
-//
-// The dispatcher returns the first delivery error it encounters but
-// always attempts every eligible channel — so a failed email never
-// blocks the websocket fan-out, and vice versa. The returned error is
-// joined for visibility but the dispatcher does NOT retry; retry is a
-// follow-up.
+// carry it, filtered by the user's preferences. Equivalent to
+// SendWithOptions with the zero SendOptions (no dedup).
 func (d *Dispatcher) Send(
 	ctx context.Context,
 	userID uuid.UUID,
@@ -276,50 +575,243 @@ func (d *Dispatcher) Send(
 	body string,
 	payload map[string]any,
 ) error {
-	prefs, err := d.preferences.Get(ctx, userID)
+	return d.SendWithOptions(ctx, userID, evt, title, body, payload, SendOptions{})
+}
+
+// SendWithOptions is Send with dedup control (#829). See SendOptions.
+//
+// Behavior:
+//   - Category (CategoryFor(evt)) drives suppressibility: CategorySafety
+//     bypasses preference and rate-limit checks entirely (dedup still
+//     applies — that's "don't repeat the identical alert", a different
+//     concern from opt-out).
+//   - Dedup and rate-limit checks run before anything else; a suppressed
+//     Send is still persisted (Notification.Suppressed = true with a
+//     SuppressedReason) so it is auditable, never silently dropped.
+//   - Delivery is durability-first: the notification is persisted BEFORE
+//     any channel.Deliver call, so a persistence failure means nothing was
+//     "delivered" that wasn't durably recorded first.
+//   - Every eligible channel is attempted independently — a failed email
+//     never blocks the websocket fan-out, and vice versa (this dispatcher
+//     intentionally delivers to every eligible channel simultaneously
+//     rather than a single preferred channel, since e.g.
+//     EventSettlementCompleted wants email+push+in-app together, not
+//     "whichever one works"). Per-channel fallback still applies: if Push
+//     or Email fails, WebSocket is attempted as a live fallback (skipped if
+//     already attempted as part of the normal matrix). Failed Email/Push
+//     deliveries are hard-routed through the durable job queue for retry,
+//     if a RetryEnqueuer is configured.
+//   - Every attempted channel's outcome is recorded in
+//     Notification.DeliveryOutcomes and (if the persistence store also
+//     implements DeliveryOutcomeRecorder) persisted as a best-effort
+//     follow-up update after delivery completes.
+func (d *Dispatcher) SendWithOptions(
+	ctx context.Context,
+	userID uuid.UUID,
+	evt EventType,
+	title string,
+	body string,
+	payload map[string]any,
+	opts SendOptions,
+) error {
+	category := CategoryFor(evt)
+
+	if opts.DedupWindow > 0 && d.dedup != nil {
+		key := userID.String() + ":" + string(evt) + ":" + opts.DedupKey
+		if seen, err := d.dedup.SeenRecently(ctx, key, opts.DedupWindow); err == nil && seen {
+			return d.suppress(ctx, userID, evt, category, title, body, payload, SuppressedByDedup)
+		}
+	}
+
+	if category != CategorySafety && d.rateLimiter != nil {
+		key := userID.String() + ":" + string(category)
+		if allowed, _ := d.rateLimiter.Allow(ctx, key); !allowed {
+			return d.suppress(ctx, userID, evt, category, title, body, payload, SuppressedByRateLimit)
+		}
+	}
+
+	prefs, err := d.resolvePreferences(ctx, userID, category)
 	if err != nil {
 		return fmt.Errorf("notifications: load preferences for %s: %w", userID, err)
 	}
 
-	channels := ChannelsFor(evt)
-	if len(channels) == 0 {
+	matrix := ChannelsFor(evt)
+	if len(matrix) == 0 {
 		return fmt.Errorf("notifications: unknown event type %q", evt)
+	}
+
+	var toAttempt []ChannelKind
+	for _, kind := range matrix {
+		if category == CategorySafety || prefs.Allow(kind) {
+			toAttempt = append(toAttempt, kind)
+		}
 	}
 
 	n := Notification{
 		ID:        uuid.New(),
 		UserID:    userID,
 		Type:      evt,
+		Category:  category,
 		Title:     title,
 		Body:      body,
 		Payload:   payload,
 		CreatedAt: d.clock(),
 	}
 
+	if len(toAttempt) == 0 {
+		n.Suppressed = true
+		n.SuppressedReason = SuppressedByPreference
+		d.recordSuppressed(category)
+		if err := d.persistence.Save(ctx, n); err != nil {
+			return fmt.Errorf("notifications: persist suppressed %s: %w", n.ID, err)
+		}
+		return nil
+	}
+
+	// Durability-first: persist before any delivery attempt. If this fails
+	// we must not pretend anything was delivered.
 	if err := d.persistence.Save(ctx, n); err != nil {
-		// We intentionally surface this — if we can't record the
-		// notification, we shouldn't pretend we delivered it either.
 		return fmt.Errorf("notifications: persist %s: %w", n.ID, err)
 	}
 
+	attempted := make(map[ChannelKind]bool, len(toAttempt)+1)
+	var outcomes []ChannelOutcome
 	var joined []error
-	for _, kind := range channels {
-		if !prefs.Allow(kind) {
-			continue
+
+	deliver := func(kind ChannelKind, isFallback bool) bool {
+		if attempted[kind] {
+			return false
 		}
+		attempted[kind] = true
+
 		ch, ok := d.channels[kind]
 		if !ok {
 			joined = append(joined, fmt.Errorf("notifications: no adapter for channel %q", kind))
+			outcomes = append(outcomes, ChannelOutcome{Channel: kind, Delivered: false, Error: "no adapter registered", IsFallback: isFallback})
+			d.recordChannelOutcome(category, false)
+			return false
+		}
+
+		deliverErr := ch.Deliver(ctx, n)
+		outcome := ChannelOutcome{Channel: kind, Delivered: deliverErr == nil, IsFallback: isFallback}
+		if deliverErr != nil {
+			outcome.Error = deliverErr.Error()
+			joined = append(joined, fmt.Errorf("notifications: channel %q deliver: %w", kind, deliverErr))
+		}
+		outcomes = append(outcomes, outcome)
+		d.recordChannelOutcome(category, deliverErr == nil)
+		return deliverErr == nil
+	}
+
+	for _, kind := range toAttempt {
+		if ok := deliver(kind, false); ok {
 			continue
 		}
-		if err := ch.Deliver(ctx, n); err != nil {
-			joined = append(joined, fmt.Errorf("notifications: channel %q deliver: %w", kind, err))
+		if fb := fallbackChannel(kind); fb != "" {
+			deliver(fb, true)
+		}
+		if (kind == ChannelEmail || kind == ChannelPush) && d.retry != nil {
+			if err := d.retry.EnqueueRetry(ctx, n, kind); err != nil {
+				joined = append(joined, fmt.Errorf("notifications: enqueue retry for %q: %w", kind, err))
+			}
 		}
 	}
+
+	d.recordAttempted(category)
+	n.DeliveryOutcomes = outcomes
+	if rec, ok := d.persistence.(DeliveryOutcomeRecorder); ok {
+		if err := rec.RecordOutcome(ctx, n.ID, outcomes); err != nil {
+			// Best-effort: the notification is already durably saved above,
+			// so losing this update is an audit/metrics gap, not a lost
+			// notification — it does not fail the Send call.
+			joined = append(joined, fmt.Errorf("notifications: record delivery outcome: %w", err))
+		}
+	}
+
 	if len(joined) > 0 {
 		return errors.Join(joined...)
 	}
 	return nil
+}
+
+// resolvePreferences uses category-scoped preferences when the configured
+// PreferenceStore supports it (see CategoryPreferenceStore), falling back
+// to the flat PreferenceStore.Get for stores that don't.
+func (d *Dispatcher) resolvePreferences(ctx context.Context, userID uuid.UUID, category Category) (Preferences, error) {
+	if cp, ok := d.preferences.(CategoryPreferenceStore); ok {
+		return cp.GetForCategory(ctx, userID, category)
+	}
+	return d.preferences.Get(ctx, userID)
+}
+
+// suppress persists a Notification marked Suppressed with the given reason,
+// without attempting any delivery. Shared by the dedup, rate-limit, and
+// preference suppression paths so "record a suppressed notification" has
+// exactly one implementation.
+func (d *Dispatcher) suppress(
+	ctx context.Context,
+	userID uuid.UUID,
+	evt EventType,
+	category Category,
+	title, body string,
+	payload map[string]any,
+	reason SuppressionReason,
+) error {
+	n := Notification{
+		ID:               uuid.New(),
+		UserID:           userID,
+		Type:             evt,
+		Category:         category,
+		Title:            title,
+		Body:             body,
+		Payload:          payload,
+		CreatedAt:        d.clock(),
+		Suppressed:       true,
+		SuppressedReason: reason,
+	}
+	d.recordSuppressed(category)
+	if err := d.persistence.Save(ctx, n); err != nil {
+		return fmt.Errorf("notifications: persist suppressed %s: %w", n.ID, err)
+	}
+	return nil
+}
+
+// fallbackChannel returns the next channel to try when kind fails, or ""
+// if kind has no further fallback. WebSocket is the terminal live channel —
+// beyond it, the persisted notification row (always saved regardless of
+// channel outcome, above) is the true final fallback, not another live
+// channel, matching "in-app is always available as the terminal fallback
+// since it is just a database row the client reads."
+func fallbackChannel(kind ChannelKind) ChannelKind {
+	switch kind {
+	case ChannelPush, ChannelEmail:
+		return ChannelWebSocket
+	default:
+		return ""
+	}
+}
+
+// RedeliverChannel attempts delivery of n on exactly one channel, bypassing
+// preferences/dedup/rate-limiting (those already ran on the original Send
+// call that enqueued the retry) and stats recording (the job queue's own
+// success/failure signal is authoritative for a retry attempt). Used by the
+// notification-retry job handler in retry_job.go.
+func (d *Dispatcher) RedeliverChannel(ctx context.Context, n Notification, channel ChannelKind) error {
+	ch, ok := d.channels[channel]
+	if !ok {
+		return fmt.Errorf("notifications: no adapter for channel %q", channel)
+	}
+	return ch.Deliver(ctx, n)
+}
+
+// DeliveryOutcomeRecorder is an optional upgrade to PersistenceStore
+// (#829): a store that can record per-channel delivery outcomes for an
+// already-saved notification. The dispatcher type-asserts for this after
+// delivery completes; a store that only implements PersistenceStore keeps
+// working exactly as before (the notification is saved once, pre-delivery,
+// with no outcome update).
+type DeliveryOutcomeRecorder interface {
+	RecordOutcome(ctx context.Context, notificationID uuid.UUID, outcomes []ChannelOutcome) error
 }
 
 // --- Concrete channels (MVP) ---

--- a/apps/api/internal/notifications/retry_job.go
+++ b/apps/api/internal/notifications/retry_job.go
@@ -1,0 +1,95 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/jobqueue"
+)
+
+// NotificationRetryJobType is the durable job type used to retry a failed
+// channel delivery (#829's "failed deliveries on a retryable channel go
+// through the durable job queue for retry"). Register the handler from
+// NewNotificationRetryJobHandler on the shared jobqueue.Worker.
+const NotificationRetryJobType = "notification_retry"
+
+// notificationRetryPayload is what's actually persisted in the job queue —
+// small and JSON-serializable, not the full Notification (its Payload
+// field is carried through as-is since channel adapters need it to
+// re-render the message).
+type notificationRetryPayload struct {
+	NotificationID uuid.UUID      `json:"notification_id"`
+	UserID         uuid.UUID      `json:"user_id"`
+	Type           EventType      `json:"type"`
+	Category       Category       `json:"category"`
+	Title          string         `json:"title"`
+	Body           string         `json:"body"`
+	Payload        map[string]any `json:"payload"`
+	Channel        ChannelKind    `json:"channel"`
+}
+
+// JobQueueRetryEnqueuer adapts a *jobqueue.Client to the RetryEnqueuer seam
+// the Dispatcher uses, so the low-level notifications package's own types
+// don't need every caller to also depend on jobqueue.
+type JobQueueRetryEnqueuer struct {
+	client *jobqueue.Client
+}
+
+// NewJobQueueRetryEnqueuer constructs a JobQueueRetryEnqueuer.
+func NewJobQueueRetryEnqueuer(client *jobqueue.Client) *JobQueueRetryEnqueuer {
+	return &JobQueueRetryEnqueuer{client: client}
+}
+
+// EnqueueRetry implements RetryEnqueuer.
+func (e *JobQueueRetryEnqueuer) EnqueueRetry(ctx context.Context, n Notification, channel ChannelKind) error {
+	payload := notificationRetryPayload{
+		NotificationID: n.ID,
+		UserID:         n.UserID,
+		Type:           n.Type,
+		Category:       n.Category,
+		Title:          n.Title,
+		Body:           n.Body,
+		Payload:        n.Payload,
+		Channel:        channel,
+	}
+	// Idempotency key scopes retries to one (notification, channel) pair so
+	// a delivery that fails on two channels in the same Send call enqueues
+	// two independent, non-duplicating retry jobs, and a crash-and-restart
+	// of the enqueue itself doesn't double-enqueue the same retry.
+	idempotencyKey := fmt.Sprintf("%s:%s", n.ID, channel)
+	_, err := e.client.EnqueueJSON(ctx, NotificationRetryJobType, payload, jobqueue.WithIdempotencyKey(idempotencyKey))
+	return err
+}
+
+// NewNotificationRetryJobHandler builds the jobqueue.Handler that
+// redelivers a failed channel on retry via dispatcher.RedeliverChannel. A
+// retry that still fails returns a plain (non-Permanent) error so the job
+// queue's own backoff/dead-letter policy applies — this handler does not
+// re-implement retry counting itself.
+func NewNotificationRetryJobHandler(dispatcher *Dispatcher) jobqueue.Handler {
+	return jobqueue.HandlerFunc(func(ctx context.Context, job jobqueue.Job) error {
+		var payload notificationRetryPayload
+		if err := json.Unmarshal(job.Payload, &payload); err != nil {
+			return jobqueue.Permanent(fmt.Errorf("notification retry: unmarshal payload: %w", err))
+		}
+
+		n := Notification{
+			ID:        payload.NotificationID,
+			UserID:    payload.UserID,
+			Type:      payload.Type,
+			Category:  payload.Category,
+			Title:     payload.Title,
+			Body:      payload.Body,
+			Payload:   payload.Payload,
+			CreatedAt: time.Now(),
+		}
+		if err := dispatcher.RedeliverChannel(ctx, n, payload.Channel); err != nil {
+			return fmt.Errorf("notification retry: redeliver %q: %w", payload.Channel, err)
+		}
+		return nil
+	})
+}

--- a/apps/api/internal/oracle/aggregator.go
+++ b/apps/api/internal/oracle/aggregator.go
@@ -1,0 +1,349 @@
+// Multi-source consensus aggregation (nester#830). Aggregate queries every
+// healthy registered source for a data type in parallel, reconciles their
+// responses with median-with-deviation-band outlier rejection, and attaches
+// a confidence signal derived from source agreement (and, via
+// DecayConfidenceForStaleness, freshness for callers serving a cached
+// value). HealthTracker records per-source success/failure history and
+// applies exponential backoff so a persistently failing source is skipped
+// rather than queried on every request.
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AggregationOptions configures one Aggregate call. Callers should document
+// their chosen minimums per data type: a price steering a rebalance should
+// demand more source agreement than a fiat rate shown for display.
+type AggregationOptions struct {
+	// MaxDeviationBPS is how far (in basis points from the pre-outlier-
+	// rejection median) a source's value may sit before it is discarded as
+	// an outlier. Zero disables outlier rejection entirely.
+	MaxDeviationBPS int
+	// MinAgreeingSources is the number of sources that must survive outlier
+	// rejection for the result to be treated as full-confidence. Fewer than
+	// this does not make the result Unavailable (see Aggregate's doc
+	// comment) — it lowers Confidence instead.
+	MinAgreeingSources int
+	// PerSourceTimeout bounds how long any one source may take; a slow
+	// source is treated exactly like a failed one so it cannot stall the
+	// aggregate. Required — zero would mean "no timeout" via
+	// context.WithTimeout, which is never the intent here.
+	PerSourceTimeout time.Duration
+}
+
+// AggregatedValue is the result of reconciling one or more sources.
+type AggregatedValue struct {
+	Value      float64
+	Confidence float64 // 0..1
+	// SourcesUsed survived outlier rejection and contributed to Value.
+	SourcesUsed []string
+	// SourcesRejected responded but were discarded as outliers.
+	SourcesRejected []string
+	// SourcesSkipped were not queried at all (unhealthy, in backoff).
+	SourcesSkipped []string
+	// SourcesFailed were queried but errored or timed out.
+	SourcesFailed []string
+	// Unavailable is true only when zero sources produced a usable value.
+	Unavailable bool
+}
+
+// SourceName joins SourcesUsed for a human-readable/back-compat Source
+// label: a single surviving source reports its own name unchanged (so a
+// caller migrating an existing single-source-at-a-time field, like
+// ExchangeRate.Source, sees no change in the common case), while genuine
+// multi-source agreement reports all contributing names.
+func (a AggregatedValue) SourceName() string {
+	return strings.Join(a.SourcesUsed, "+")
+}
+
+type sourceResult struct {
+	name  string
+	value float64
+	err   error
+}
+
+// Aggregate queries every healthy source in `sources` for base/quote in
+// parallel (each bounded by opts.PerSourceTimeout), then reconciles the
+// responses into a consensus value via median-with-deviation-band outlier
+// rejection.
+//
+// Availability policy: Aggregate reports Unavailable=true (and returns a
+// non-nil error) only when zero sources produce a usable value. A lone
+// responding source below opts.MinAgreeingSources is NOT treated as
+// unavailable — sources being used partly *as* failover (the behavior this
+// replaces for XLM/USD) depends on a single surviving source still being
+// usable — but its Confidence is reduced, so callers that need full
+// consensus should gate on Confidence rather than merely on the presence of
+// a value.
+func Aggregate(ctx context.Context, base, quote string, sources []Provider, health *HealthTracker, opts AggregationOptions) (AggregatedValue, error) {
+	var toQuery []Provider
+	var skipped []string
+	for _, p := range sources {
+		if health != nil && !health.IsHealthy(p.Name()) {
+			skipped = append(skipped, p.Name())
+			continue
+		}
+		toQuery = append(toQuery, p)
+	}
+
+	results := make([]sourceResult, len(toQuery))
+	var wg sync.WaitGroup
+	for i, p := range toQuery {
+		wg.Add(1)
+		go func(i int, p Provider) {
+			defer wg.Done()
+			callCtx, cancel := context.WithTimeout(ctx, opts.PerSourceTimeout)
+			defer cancel()
+			v, err := p.Fetch(callCtx, base, quote)
+			results[i] = sourceResult{name: p.Name(), value: v, err: err}
+		}(i, p)
+	}
+	wg.Wait()
+
+	var succeeded []sourceResult
+	var failed []string
+	for _, r := range results {
+		if r.err != nil {
+			failed = append(failed, r.name)
+			if health != nil {
+				health.RecordFailure(r.name, r.err)
+			}
+			continue
+		}
+		succeeded = append(succeeded, r)
+		if health != nil {
+			health.RecordSuccess(r.name)
+		}
+	}
+
+	if len(succeeded) == 0 {
+		return AggregatedValue{
+			SourcesSkipped: skipped,
+			SourcesFailed:  failed,
+			Unavailable:    true,
+		}, fmt.Errorf("oracle: aggregate %s/%s: all sources unavailable", base, quote)
+	}
+
+	vals := make([]float64, len(succeeded))
+	for i, r := range succeeded {
+		vals[i] = r.value
+	}
+	refMedian := median(vals)
+
+	var survivors []sourceResult
+	var rejected []string
+	maxDevFraction := float64(opts.MaxDeviationBPS) / 10000.0
+	for _, r := range succeeded {
+		deviation := deviationFrom(refMedian, r.value)
+		if opts.MaxDeviationBPS > 0 && deviation > maxDevFraction {
+			rejected = append(rejected, r.name)
+			continue
+		}
+		survivors = append(survivors, r)
+	}
+	// A degenerate reference (e.g. refMedian == 0 making every relative
+	// deviation infinite) must not report Unavailable when real responses
+	// exist — fall back to the unfiltered set rather than reject everything.
+	if len(survivors) == 0 {
+		survivors = succeeded
+		rejected = nil
+	}
+
+	survivorVals := make([]float64, len(survivors))
+	survivorNames := make([]string, len(survivors))
+	for i, r := range survivors {
+		survivorVals[i] = r.value
+		survivorNames[i] = r.name
+	}
+
+	return AggregatedValue{
+		Value:           median(survivorVals),
+		Confidence:      confidenceFor(len(survivors), len(sources), opts.MinAgreeingSources),
+		SourcesUsed:     survivorNames,
+		SourcesRejected: rejected,
+		SourcesSkipped:  skipped,
+		SourcesFailed:   failed,
+	}, nil
+}
+
+// deviationFrom returns |value-ref|/ref as a fraction, treating a zero
+// reference specially (relative deviation is undefined at zero) so a
+// non-zero value against a zero reference is always rejected as an outlier
+// rather than dividing by zero, while value==ref==0 is a perfect (zero
+// deviation) match.
+func deviationFrom(ref, value float64) float64 {
+	if ref == 0 {
+		if value == 0 {
+			return 0
+		}
+		return math.Inf(1)
+	}
+	return math.Abs(value-ref) / math.Abs(ref)
+}
+
+func median(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), vals...)
+	sort.Float64s(sorted)
+	n := len(sorted)
+	if n%2 == 1 {
+		return sorted[n/2]
+	}
+	return (sorted[n/2-1] + sorted[n/2]) / 2
+}
+
+// confidenceFor derives a 0..1 confidence signal from how many sources
+// agreed (survived outlier rejection) relative to how many are registered
+// in total — a source being unhealthy/down depresses confidence exactly
+// like a source that responded but was rejected as an outlier, since both
+// mean the consensus rests on fewer independent observations. An
+// additional penalty applies when fewer than minAgreeing sources agreed.
+// The freshness component of confidence (per #830) is applied separately by
+// DecayConfidenceForStaleness when a caller serves an aging cached value.
+func confidenceFor(agreeing, totalRegistered, minAgreeing int) float64 {
+	if totalRegistered == 0 {
+		return 0
+	}
+	base := float64(agreeing) / float64(totalRegistered)
+	if minAgreeing > 0 && agreeing < minAgreeing {
+		base *= 0.5
+	}
+	return math.Min(base, 1.0)
+}
+
+// DecayConfidenceForStaleness scales confidence down as a served value ages
+// toward maxAge, reaching confidence*0.5 at maxAge (age beyond maxAge is
+// clamped there — staleness alone never fully zeroes confidence, since a
+// recently-stale value is still informative, just less so than fresh).
+// Intended for callers serving a stale cache entry rather than a fresh
+// aggregation.
+func DecayConfidenceForStaleness(confidence float64, age, maxAge time.Duration) float64 {
+	if maxAge <= 0 || age <= 0 {
+		return confidence
+	}
+	ratio := float64(age) / float64(maxAge)
+	if ratio > 1 {
+		ratio = 1
+	}
+	return confidence * (1 - 0.5*ratio)
+}
+
+// healthBackoffBase/-Max bound the exponential backoff HealthTracker
+// applies after consecutive failures: base * 2^(failures-1), capped at max.
+const (
+	healthBackoffBase = 5 * time.Second
+	healthBackoffMax  = 5 * time.Minute
+)
+
+// SourceHealth is a point-in-time snapshot of one source's health, exposed
+// via HealthTracker.Snapshot for a metrics endpoint to scrape.
+type SourceHealth struct {
+	Name                string
+	ConsecutiveFailures int
+	LastError           string
+	LastSuccessAt       time.Time
+	LastFailureAt       time.Time
+	BackoffUntil        time.Time
+}
+
+// HealthTracker tracks per-source success/failure history and derives
+// exponential backoff so a persistently failing source is skipped rather
+// than queried on every request. Safe for concurrent use; share one
+// instance across every Aggregate call for a given set of sources.
+type HealthTracker struct {
+	mu      sync.Mutex
+	sources map[string]*SourceHealth
+	now     func() time.Time
+}
+
+// NewHealthTracker returns an empty HealthTracker. Every source starts
+// healthy (no failure history).
+func NewHealthTracker() *HealthTracker {
+	return &HealthTracker{sources: make(map[string]*SourceHealth), now: time.Now}
+}
+
+// SetNowFuncForTest overrides the clock HealthTracker uses to evaluate and
+// set backoff windows. Exported (rather than an unexported field) because
+// this package's own tests live in the external oracle_test package,
+// matching the existing service_test.go convention.
+func (h *HealthTracker) SetNowFuncForTest(now func() time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.now = now
+}
+
+// entry returns (creating if needed) the health record for name. Caller
+// must hold h.mu.
+func (h *HealthTracker) entry(name string) *SourceHealth {
+	s, ok := h.sources[name]
+	if !ok {
+		s = &SourceHealth{Name: name}
+		h.sources[name] = s
+	}
+	return s
+}
+
+// IsHealthy reports whether name may be queried right now: true if it has
+// no failure history, or its backoff window has elapsed (a probe is due).
+func (h *HealthTracker) IsHealthy(name string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s, ok := h.sources[name]
+	if !ok {
+		return true
+	}
+	return !h.now().Before(s.BackoffUntil)
+}
+
+// RecordSuccess clears a source's failure history and backoff.
+func (h *HealthTracker) RecordSuccess(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.entry(name)
+	s.ConsecutiveFailures = 0
+	s.LastError = ""
+	s.LastSuccessAt = h.now()
+	s.BackoffUntil = time.Time{}
+}
+
+// RecordFailure records a failure and extends the source's backoff window
+// exponentially so a persistently-down source is probed with increasing
+// patience rather than hammered every request.
+func (h *HealthTracker) RecordFailure(name string, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.entry(name)
+	s.ConsecutiveFailures++
+	if err != nil {
+		s.LastError = err.Error()
+	}
+	s.LastFailureAt = h.now()
+
+	shift := min(s.ConsecutiveFailures-1, 10) // cap the shift so this can't overflow
+	backoff := healthBackoffBase * time.Duration(1<<uint(shift))
+	if backoff > healthBackoffMax {
+		backoff = healthBackoffMax
+	}
+	s.BackoffUntil = h.now().Add(backoff)
+}
+
+// Snapshot returns a copy of every tracked source's health, for a metrics
+// endpoint to scrape.
+func (h *HealthTracker) Snapshot() map[string]SourceHealth {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make(map[string]SourceHealth, len(h.sources))
+	for name, s := range h.sources {
+		out[name] = *s
+	}
+	return out
+}

--- a/apps/api/internal/oracle/aggregator_test.go
+++ b/apps/api/internal/oracle/aggregator_test.go
@@ -1,0 +1,267 @@
+package oracle_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
+)
+
+func defaultOpts() oracle.AggregationOptions {
+	return oracle.AggregationOptions{
+		MaxDeviationBPS:    300, // 3%
+		MinAgreeingSources: 2,
+		PerSourceTimeout:   time.Second,
+	}
+}
+
+func TestAggregate_AgreeingSourcesProduceConsensus(t *testing.T) {
+	sources := []oracle.Provider{
+		&stubProvider{name: "a", rate: 100.0},
+		&stubProvider{name: "b", rate: 100.5},
+		&stubProvider{name: "c", rate: 99.5},
+	}
+	health := oracle.NewHealthTracker()
+
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", sources, health, defaultOpts())
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if result.Unavailable {
+		t.Fatal("expected a usable consensus value")
+	}
+	if result.Value != 100.0 {
+		t.Errorf("expected median 100.0, got %v", result.Value)
+	}
+	if len(result.SourcesUsed) != 3 {
+		t.Errorf("expected all 3 agreeing sources used, got %v", result.SourcesUsed)
+	}
+	if result.Confidence != 1.0 {
+		t.Errorf("expected full confidence with all sources agreeing, got %v", result.Confidence)
+	}
+}
+
+func TestAggregate_OutlierRejectedConsensusUnaffected(t *testing.T) {
+	sources := []oracle.Provider{
+		&stubProvider{name: "a", rate: 100.0},
+		&stubProvider{name: "b", rate: 100.2},
+		&stubProvider{name: "manipulated", rate: 500.0}, // wildly off
+	}
+	health := oracle.NewHealthTracker()
+
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", sources, health, defaultOpts())
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if result.Value > 101 || result.Value < 99 {
+		t.Errorf("expected consensus near 100, got %v (outlier must not move it)", result.Value)
+	}
+	found := false
+	for _, r := range result.SourcesRejected {
+		if r == "manipulated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'manipulated' to be rejected as an outlier, got rejected=%v", result.SourcesRejected)
+	}
+	for _, u := range result.SourcesUsed {
+		if u == "manipulated" {
+			t.Error("manipulated source must not be counted among SourcesUsed")
+		}
+	}
+}
+
+func TestAggregate_AllButOneDown_LowConfidenceNotUnavailable(t *testing.T) {
+	sources := []oracle.Provider{
+		&stubProvider{name: "a", err: errors.New("down")},
+		&stubProvider{name: "b", err: errors.New("down")},
+		&stubProvider{name: "c", rate: 42.0},
+	}
+	health := oracle.NewHealthTracker()
+
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", sources, health, defaultOpts())
+	if err != nil {
+		t.Fatalf("expected a value despite two sources down, got error: %v", err)
+	}
+	if result.Unavailable {
+		t.Fatal("a lone responding source must not be reported Unavailable")
+	}
+	if result.Value != 42.0 {
+		t.Errorf("expected the lone source's value, got %v", result.Value)
+	}
+	// MinAgreeingSources is 2 in defaultOpts; only 1 responded, so
+	// confidence must be reduced below what full agreement would give.
+	if result.Confidence >= 1.0 {
+		t.Errorf("expected reduced confidence with only 1 of 3 sources responding, got %v", result.Confidence)
+	}
+	if result.Confidence <= 0 {
+		t.Errorf("expected a nonzero confidence for a usable lone response, got %v", result.Confidence)
+	}
+}
+
+func TestAggregate_AllSourcesDown_Unavailable(t *testing.T) {
+	sources := []oracle.Provider{
+		&stubProvider{name: "a", err: errors.New("down")},
+		&stubProvider{name: "b", err: errors.New("down")},
+	}
+	health := oracle.NewHealthTracker()
+
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", sources, health, defaultOpts())
+	if err == nil {
+		t.Fatal("expected an error when every source is down")
+	}
+	if !result.Unavailable {
+		t.Error("expected Unavailable=true when every source is down")
+	}
+}
+
+func TestAggregate_SlowSourceTimesOutAndDoesNotStallResult(t *testing.T) {
+	slow := &blockingProvider{name: "slow", delay: 5 * time.Second}
+	fast := &stubProvider{name: "fast", rate: 10.0}
+	health := oracle.NewHealthTracker()
+
+	opts := defaultOpts()
+	opts.PerSourceTimeout = 50 * time.Millisecond
+	opts.MinAgreeingSources = 1
+
+	start := time.Now()
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", []oracle.Provider{slow, fast}, health, opts)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected the slow source's timeout to bound total latency, took %v", elapsed)
+	}
+	if result.Value != 10.0 {
+		t.Errorf("expected the fast source's value, got %v", result.Value)
+	}
+	found := false
+	for _, f := range result.SourcesFailed {
+		if f == "slow" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected the timed-out source recorded as failed, got %v", result.SourcesFailed)
+	}
+}
+
+func TestHealthTracker_RepeatedFailuresMarkUnhealthyAndSkipped(t *testing.T) {
+	h := oracle.NewHealthTracker()
+	h.RecordFailure("flaky", errors.New("boom"))
+
+	if h.IsHealthy("flaky") {
+		t.Fatal("expected source to be unhealthy immediately after a failure (backoff just started)")
+	}
+
+	failing := &stubProvider{name: "flaky", err: errors.New("boom")}
+	ok := &stubProvider{name: "ok", rate: 5.0}
+
+	result, err := oracle.Aggregate(context.Background(), "X", "Y", []oracle.Provider{failing, ok}, h, oracle.AggregationOptions{
+		MaxDeviationBPS: 300, MinAgreeingSources: 1, PerSourceTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if failing.callCount != 0 {
+		t.Errorf("expected the unhealthy source to be skipped (not queried), got %d calls", failing.callCount)
+	}
+	found := false
+	for _, s := range result.SourcesSkipped {
+		if s == "flaky" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'flaky' recorded as skipped, got %v", result.SourcesSkipped)
+	}
+}
+
+func TestHealthTracker_BackoffExpiresAndSourceIsProbedAgain(t *testing.T) {
+	h := oracle.NewHealthTracker()
+	fakeNow := time.Now()
+	h.SetNowFuncForTest(func() time.Time { return fakeNow })
+
+	h.RecordFailure("flaky", errors.New("boom"))
+	if h.IsHealthy("flaky") {
+		t.Fatal("expected unhealthy immediately after failure")
+	}
+
+	// Advance past the first backoff window (base backoff is 5s).
+	fakeNow = fakeNow.Add(10 * time.Second)
+	if !h.IsHealthy("flaky") {
+		t.Fatal("expected the source to be probed again once its backoff window elapsed")
+	}
+}
+
+func TestHealthTracker_BackoffGrowsExponentiallyWithConsecutiveFailures(t *testing.T) {
+	h := oracle.NewHealthTracker()
+	fakeNow := time.Now()
+	h.SetNowFuncForTest(func() time.Time { return fakeNow })
+
+	h.RecordFailure("flaky", errors.New("1"))
+	snap1 := h.Snapshot()["flaky"]
+	firstBackoff := snap1.BackoffUntil.Sub(fakeNow)
+
+	// Immediately fail again (still within the first backoff window) to
+	// accumulate a second consecutive failure.
+	h.RecordFailure("flaky", errors.New("2"))
+	snap2 := h.Snapshot()["flaky"]
+	secondBackoff := snap2.BackoffUntil.Sub(fakeNow)
+
+	if secondBackoff <= firstBackoff {
+		t.Errorf("expected backoff to grow with consecutive failures: first=%v second=%v", firstBackoff, secondBackoff)
+	}
+}
+
+func TestHealthTracker_SuccessClearsFailureHistory(t *testing.T) {
+	h := oracle.NewHealthTracker()
+	h.RecordFailure("recovering", errors.New("boom"))
+	h.RecordSuccess("recovering")
+
+	if !h.IsHealthy("recovering") {
+		t.Fatal("expected a source to be healthy immediately after a recorded success")
+	}
+	snap := h.Snapshot()["recovering"]
+	if snap.ConsecutiveFailures != 0 {
+		t.Errorf("expected ConsecutiveFailures reset to 0, got %d", snap.ConsecutiveFailures)
+	}
+}
+
+func TestDecayConfidenceForStaleness_DecaysTowardHalfAtMaxAge(t *testing.T) {
+	full := oracle.DecayConfidenceForStaleness(1.0, 0, time.Minute)
+	if full != 1.0 {
+		t.Errorf("zero age must not decay confidence, got %v", full)
+	}
+	atMax := oracle.DecayConfidenceForStaleness(1.0, time.Minute, time.Minute)
+	if atMax != 0.5 {
+		t.Errorf("expected confidence*0.5 at maxAge, got %v", atMax)
+	}
+	beyondMax := oracle.DecayConfidenceForStaleness(1.0, 10*time.Minute, time.Minute)
+	if beyondMax != 0.5 {
+		t.Errorf("expected age beyond maxAge to clamp at *0.5, got %v", beyondMax)
+	}
+}
+
+// blockingProvider simulates a slow source that never returns before its
+// context is cancelled.
+type blockingProvider struct {
+	name  string
+	delay time.Duration
+}
+
+func (p *blockingProvider) Name() string { return p.name }
+
+func (p *blockingProvider) Fetch(ctx context.Context, _, _ string) (float64, error) {
+	select {
+	case <-time.After(p.delay):
+		return 0, errors.New("should not reach here in the timeout test")
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}

--- a/apps/api/internal/oracle/rate.go
+++ b/apps/api/internal/oracle/rate.go
@@ -20,6 +20,24 @@ type ExchangeRate struct {
 	FetchedAt time.Time
 	ExpiresAt time.Time
 	Stale     bool
+
+	// Confidence is a 0..1 signal derived from source agreement (see
+	// Aggregate/AggregatedValue) and, once served stale, freshness (see
+	// DecayConfidenceForStaleness). Zero-valued for rates that never went
+	// through the aggregator (the fixed USDC/USD peg, and single-source
+	// fiat lookups that don't have a second source to reconcile against).
+	Confidence float64
+	// SourcesUsed lists every source that contributed to Rate via
+	// consensus. Empty for rates not produced by Aggregate.
+	SourcesUsed []string
+}
+
+// MeetsConfidenceThreshold reports whether r's confidence is at least min.
+// Intended for downstream consumers (risk engine, allocation strategy,
+// on-chain attestation signer) that must refuse to act on a low-confidence
+// value rather than treating "a value came back" as sufficient (#830).
+func (r ExchangeRate) MeetsConfidenceThreshold(threshold float64) bool {
+	return r.Confidence >= threshold
 }
 
 // Provider fetches a numeric rate for a given base/quote pair.

--- a/apps/api/internal/oracle/service.go
+++ b/apps/api/internal/oracle/service.go
@@ -11,17 +11,37 @@ const (
 	fiatTTL   = 5 * time.Minute
 )
 
-// RateService resolves exchange rates using a priority-ordered set of providers
-// and an in-memory TTL cache. On source failure it serves stale cached data
-// rather than propagating an error.
-type RateService struct {
-	cache       *RateCache
-	xlmFetchers []Provider // tried in order: first success wins
-	fiatFetcher Provider
+// xlmAggregationOptions governs XLM/USD consensus (#830). MaxDeviationBPS
+// of 300 (3%) is wide enough to tolerate normal cross-venue spread while
+// still catching a genuinely bad or manipulated print; MinAgreeingSources
+// is 1 rather than len(xlmFetchers) because this price's two sources
+// (Horizon, DeFiLlama) were originally registered purely as primary/
+// fallback for *availability* — requiring both to agree would regress
+// uptime whenever either source is briefly down, which is exactly the
+// failure mode having two sources was meant to protect against. Confidence
+// still correctly reflects "only one of two responded" as lower than "both
+// agreed" (see confidenceFor), so a caller that genuinely needs full
+// two-source consensus can gate on Confidence instead.
+var xlmAggregationOptions = AggregationOptions{
+	MaxDeviationBPS:    300,
+	MinAgreeingSources: 1,
+	PerSourceTimeout:   3 * time.Second,
 }
 
-// NewRateService constructs a RateService with Horizon (primary) and DeFiLlama
-// (fallback) for crypto rates and the open.er-api.com feed for fiat rates.
+// RateService resolves exchange rates using a multi-source consensus
+// aggregator (#830) for crypto rates and an in-memory TTL cache. On source
+// failure it serves stale cached data rather than propagating an error.
+type RateService struct {
+	cache       *RateCache
+	xlmFetchers []Provider // reconciled via Aggregate, not tried in priority order
+	fiatFetcher Provider
+	health      *HealthTracker
+}
+
+// NewRateService constructs a RateService with Horizon and DeFiLlama as
+// independent XLM/USD sources (reconciled via consensus, not priority
+// failover — see xlmAggregationOptions) and the open.er-api.com feed for
+// fiat rates.
 func NewRateService(horizonURL, usdcIssuer string) *RateService {
 	return NewRateServiceWithFetchers(
 		[]Provider{NewStellarProvider(horizonURL, usdcIssuer), NewDefiLlamaProvider()},
@@ -35,8 +55,13 @@ func NewRateServiceWithFetchers(xlmFetchers []Provider, fiatFetcher Provider) *R
 		cache:       NewRateCache(),
 		xlmFetchers: xlmFetchers,
 		fiatFetcher: fiatFetcher,
+		health:      NewHealthTracker(),
 	}
 }
+
+// Health returns the source-health tracker backing XLM/USD aggregation, for
+// a metrics endpoint to scrape (#830).
+func (s *RateService) Health() *HealthTracker { return s.health }
 
 // Cache returns the underlying cache so tests can pre-fill or inspect entries.
 func (s *RateService) Cache() *RateCache { return s.cache }
@@ -99,31 +124,30 @@ func (s *RateService) fetch(ctx context.Context, base, quote string) (ExchangeRa
 // Sanity bounds for XLM/USD price. These are intentionally wide — they exist
 // to catch feed corruption (e.g. a 1000× spike), not to predict the market.
 const (
-	xlmMinUSD = 0.001  // XLM has never traded this low
-	xlmMaxUSD = 100.0  // XLM at $100 would be an unprecedented 200× from its ATH
+	xlmMinUSD = 0.001 // XLM has never traded this low
+	xlmMaxUSD = 100.0 // XLM at $100 would be an unprecedented 200× from its ATH
 )
 
 func (s *RateService) fetchXLM(ctx context.Context) (ExchangeRate, error) {
-	var lastErr error
-	for _, p := range s.xlmFetchers {
-		rate, err := p.Fetch(ctx, "XLM", "USD")
-		if err == nil && rate >= xlmMinUSD && rate <= xlmMaxUSD {
-			now := time.Now().UTC()
-			return ExchangeRate{
-				Base: "XLM", Quote: "USD", Rate: rate,
-				Source: p.Name(), FetchedAt: now, ExpiresAt: now.Add(cryptoTTL),
-			}, nil
-		}
-		if err != nil {
-			lastErr = err
-		} else {
-			lastErr = fmt.Errorf("xlm: rate %v outside sanity bounds [%v, %v]", rate, xlmMinUSD, xlmMaxUSD)
-		}
+	agg, err := Aggregate(ctx, "XLM", "USD", s.xlmFetchers, s.health, xlmAggregationOptions)
+	if err != nil {
+		return ExchangeRate{}, fmt.Errorf("xlm: %w", err)
 	}
-	if lastErr == nil {
-		lastErr = ErrNoSource
+	// The sanity bounds remain as a second, independent line of defense
+	// beyond deviation-band outlier rejection: they catch the case where
+	// every registered source is simultaneously corrupted or manipulated in
+	// the same direction (deviation-band rejection alone can't catch that,
+	// since nothing would look like an outlier relative to the others).
+	if agg.Value < xlmMinUSD || agg.Value > xlmMaxUSD {
+		return ExchangeRate{}, fmt.Errorf("xlm: consensus rate %v outside sanity bounds [%v, %v]", agg.Value, xlmMinUSD, xlmMaxUSD)
 	}
-	return ExchangeRate{}, fmt.Errorf("xlm: all sources failed: %w", lastErr)
+
+	now := time.Now().UTC()
+	return ExchangeRate{
+		Base: "XLM", Quote: "USD", Rate: agg.Value,
+		Source: agg.SourceName(), FetchedAt: now, ExpiresAt: now.Add(cryptoTTL),
+		Confidence: agg.Confidence, SourcesUsed: agg.SourcesUsed,
+	}, nil
 }
 
 func (s *RateService) fetchFiat(ctx context.Context, quote string) (float64, string, error) {

--- a/apps/api/internal/repository/postgres/notification_repository.go
+++ b/apps/api/internal/repository/postgres/notification_repository.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -112,6 +113,59 @@ func (r *NotificationRepository) Set(ctx context.Context, userID uuid.UUID, pref
 		return notifications.Preferences{}, err
 	}
 	return out, nil
+}
+
+// GetForCategory implements notifications.CategoryPreferenceStore (#829):
+// it reads the per-category override stored in the category_overrides JSONB
+// column (see migration 069) and falls back to
+// notifications.DefaultPreferencesForCategory when the user has no row, or
+// no override for this specific category — the Go-side default is the
+// single source of truth, not a SQL default, so there is only one place
+// that logic lives.
+func (r *NotificationRepository) GetForCategory(ctx context.Context, userID uuid.UUID, category notifications.Category) (notifications.Preferences, error) {
+	const query = `
+		SELECT category_overrides -> $2
+		FROM notification_preferences
+		WHERE user_id = $1
+	`
+
+	var raw sql.NullString
+	if err := r.db.QueryRowContext(ctx, query, userID.String(), string(category)).Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return notifications.DefaultPreferencesForCategory(category), nil
+		}
+		return notifications.Preferences{}, err
+	}
+	if !raw.Valid || raw.String == "" || raw.String == "null" {
+		return notifications.DefaultPreferencesForCategory(category), nil
+	}
+
+	var prefs notifications.Preferences
+	if err := json.Unmarshal([]byte(raw.String), &prefs); err != nil {
+		return notifications.Preferences{}, fmt.Errorf("notification_repository: unmarshal category override for %s/%s: %w", userID, category, err)
+	}
+	return prefs, nil
+}
+
+// SetCategoryOverride implements the write side of #829's per-category
+// preferences: it merges category's entry into the existing
+// category_overrides JSONB (creating the user's row if it doesn't exist
+// yet) without disturbing any other category's override.
+func (r *NotificationRepository) SetCategoryOverride(ctx context.Context, userID uuid.UUID, category notifications.Category, prefs notifications.Preferences) error {
+	raw, err := json.Marshal(prefs)
+	if err != nil {
+		return fmt.Errorf("notification_repository: marshal category override: %w", err)
+	}
+
+	const query = `
+		INSERT INTO notification_preferences (user_id, category_overrides, updated_at)
+		VALUES ($1, jsonb_build_object($2::text, $3::jsonb), NOW())
+		ON CONFLICT (user_id) DO UPDATE SET
+			category_overrides = notification_preferences.category_overrides || jsonb_build_object($2::text, $3::jsonb),
+			updated_at = NOW()
+	`
+	_, err = r.db.ExecContext(ctx, query, userID.String(), string(category), string(raw))
+	return err
 }
 
 // ListUserIDsForDigestCadence returns every user whose effective digest

--- a/apps/api/internal/repository/postgres/notification_repository_test.go
+++ b/apps/api/internal/repository/postgres/notification_repository_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"regexp"
 	"testing"
 	"time"
@@ -170,6 +171,124 @@ func TestNotificationRepository_SetPreferencesRejectsInvalidCadence(t *testing.T
 	_, err = repo.Set(context.Background(), uuid.New(), notifications.Preferences{DigestCadence: "daily"})
 	if err == nil {
 		t.Fatal("expected error for invalid digest_cadence")
+	}
+}
+
+func TestNotificationRepository_GetForCategory_NoRowDefaultsToCategoryDefault(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT category_overrides -> $2
+		FROM notification_preferences
+		WHERE user_id = $1
+	`)).
+		WithArgs(userID.String(), "promotional").
+		WillReturnError(sql.ErrNoRows)
+
+	prefs, err := repo.GetForCategory(context.Background(), userID, notifications.CategoryPromotional)
+	if err != nil {
+		t.Fatalf("GetForCategory: %v", err)
+	}
+	if prefs != notifications.DefaultPreferencesForCategory(notifications.CategoryPromotional) {
+		t.Fatalf("prefs = %+v, want category default", prefs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestNotificationRepository_GetForCategory_NoOverrideDefaultsToCategoryDefault(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+
+	// Row exists (user has set preferences before) but has no override for
+	// this specific category — the JSONB path expression returns SQL NULL.
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT category_overrides -> $2
+		FROM notification_preferences
+		WHERE user_id = $1
+	`)).
+		WithArgs(userID.String(), "transactional").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(nil))
+
+	prefs, err := repo.GetForCategory(context.Background(), userID, notifications.CategoryTransactional)
+	if err != nil {
+		t.Fatalf("GetForCategory: %v", err)
+	}
+	if prefs != notifications.DefaultPreferencesForCategory(notifications.CategoryTransactional) {
+		t.Fatalf("prefs = %+v, want category default", prefs)
+	}
+}
+
+func TestNotificationRepository_GetForCategory_ReturnsStoredOverride(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+	stored := `{"email":false,"websocket":true,"push":false,"digest_cadence":"off"}`
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT category_overrides -> $2
+		FROM notification_preferences
+		WHERE user_id = $1
+	`)).
+		WithArgs(userID.String(), "promotional").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(stored))
+
+	prefs, err := repo.GetForCategory(context.Background(), userID, notifications.CategoryPromotional)
+	if err != nil {
+		t.Fatalf("GetForCategory: %v", err)
+	}
+	want := notifications.Preferences{Email: false, WebSocket: true, Push: false, DigestCadence: "off"}
+	if prefs != want {
+		t.Fatalf("prefs = %+v, want %+v", prefs, want)
+	}
+}
+
+func TestNotificationRepository_SetCategoryOverride(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewNotificationRepository(db)
+	userID := uuid.New()
+	prefs := notifications.Preferences{Email: true, WebSocket: false, Push: false, DigestCadence: "off"}
+	raw, _ := json.Marshal(prefs)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+		INSERT INTO notification_preferences (user_id, category_overrides, updated_at)
+		VALUES ($1, jsonb_build_object($2::text, $3::jsonb), NOW())
+		ON CONFLICT (user_id) DO UPDATE SET
+			category_overrides = notification_preferences.category_overrides || jsonb_build_object($2::text, $3::jsonb),
+			updated_at = NOW()
+	`)).
+		WithArgs(userID.String(), "promotional", string(raw)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repo.SetCategoryOverride(context.Background(), userID, notifications.CategoryPromotional, prefs); err != nil {
+		t.Fatalf("SetCategoryOverride: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }
 

--- a/apps/api/internal/ws/client.go
+++ b/apps/api/internal/ws/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	send      chan Event
 	userID    string
 	sessionID string
+	remoteIP  string
 
 	mu   sync.Mutex
 	subs map[string]bool
@@ -50,7 +51,7 @@ func (c *Client) readPump() {
 			}
 			break
 		}
-		
+
 		var msg ClientMessage
 		if err := json.Unmarshal(message, &msg); err == nil {
 			if msg.Action == "subscribe" {

--- a/apps/api/internal/ws/hub.go
+++ b/apps/api/internal/ws/hub.go
@@ -2,14 +2,18 @@ package ws
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
 )
 
 func isOriginAllowed(r *http.Request, allowedOrigins []string) bool {
@@ -31,7 +35,52 @@ func isOriginAllowed(r *http.Request, allowedOrigins []string) bool {
 
 const (
 	maxEventHistory = 50 // Buffer last N events per channel
+
+	// redisPubSubPrefix namespaces this hub's fan-out channels in Redis so
+	// they can't collide with keys/channels used by unrelated features.
+	redisPubSubPrefix = "ws:pubsub:"
+	// presenceKeyPrefix namespaces per-user presence entries in Redis.
+	presenceKeyPrefix = "ws:presence:"
+	// presenceTTL bounds how long a presence entry survives without a
+	// heartbeat refresh — a crashed instance's entries self-expire instead
+	// of lingering forever (#828).
+	presenceTTL = 90 * time.Second
+	// presenceHeartbeatInterval is how often a connected client's presence
+	// entry is refreshed. Comfortably inside presenceTTL so a brief Redis
+	// hiccup doesn't cause a spurious expiry.
+	presenceHeartbeatInterval = 30 * time.Second
+	// redisOpTimeout bounds every individual Redis call the hub makes so a
+	// degraded Redis never adds unbounded latency to a subscribe/unsubscribe
+	// or broadcast — the hub keeps working locally either way.
+	redisOpTimeout = 200 * time.Millisecond
+
+	// DefaultMaxConnectionsPerIP bounds how many simultaneous WebSocket
+	// connections one client IP may hold, so a single actor can't exhaust
+	// connection slots (#828). 0 (the zero value) means "no limit" — see
+	// NewHub's maxConnsPerIP parameter. Exported so callers constructing the
+	// production Hub (cmd/api/main.go) have a sensible default to pass
+	// without hardcoding a magic number at the call site.
+	DefaultMaxConnectionsPerIP = 0
 )
+
+// wireEvent is what actually crosses Redis pub/sub: the Event plus which
+// instance produced it, so that instance can ignore its own echo (it already
+// delivered the event to its local clients synchronously in BroadcastEvent)
+// rather than double-delivering.
+type wireEvent struct {
+	Event          Event  `json:"event"`
+	OriginInstance string `json:"origin_instance"`
+}
+
+// HubStats is a point-in-time snapshot of hub activity for a metrics endpoint
+// to scrape (#828's "connected-client count, delivery latency and
+// dropped-client metrics").
+type HubStats struct {
+	ConnectedClients int64
+	DroppedSlow      int64 // clients disconnected for a full send buffer
+	RejectedPerIP    int64 // connections rejected by the per-IP limit
+	RedisErrors      int64
+}
 
 type Hub struct {
 	clients    map[*Client]bool
@@ -48,9 +97,27 @@ type Hub struct {
 	logger         *slog.Logger
 	upgrader       websocket.Upgrader
 	mu             sync.RWMutex
+
+	// Redis pub/sub fan-out (#828). redis is nil in single-instance
+	// deployments (no REDIS_ADDR) — every method below checks for that and
+	// degrades to purely in-process behavior, identical to today.
+	redis         *redis.Client
+	instanceID    string
+	redisPubSub   *redis.PubSub
+	redisTopics   map[string]int // eventChannel -> local subscriber count, so we know when to (un)subscribe in Redis
+	maxConnsPerIP int
+	connsByIP     map[string]int
+
+	connectedClients atomic.Int64
+	droppedSlow      atomic.Int64
+	rejectedPerIP    atomic.Int64
+	redisErrors      atomic.Int64
 }
 
-func NewHub(logger *slog.Logger, authFunc func(string) (userID, sessionID string, err error), allowedOrigins []string) *Hub {
+// NewHub constructs a Hub. rc may be nil (no Redis configured — the
+// single-instance behavior from before #828 is unchanged). maxConnsPerIP
+// bounds simultaneous connections from one client IP; 0 means unlimited.
+func NewHub(logger *slog.Logger, authFunc func(string) (userID, sessionID string, err error), allowedOrigins []string, rc *redis.Client, maxConnsPerIP int) *Hub {
 	h := &Hub{
 		clients:        make(map[*Client]bool),
 		channels:       make(map[string]map[*Client]bool),
@@ -61,78 +128,169 @@ func NewHub(logger *slog.Logger, authFunc func(string) (userID, sessionID string
 		authenticator:  authFunc,
 		allowedOrigins: allowedOrigins,
 		logger:         logger,
+		redis:          rc,
+		instanceID:     uuid.New().String(),
+		redisTopics:    make(map[string]int),
+		maxConnsPerIP:  maxConnsPerIP,
+		connsByIP:      make(map[string]int),
 	}
 	h.upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 		CheckOrigin:     func(r *http.Request) bool { return isOriginAllowed(r, h.allowedOrigins) },
 	}
+	if rc != nil {
+		// An empty-channel PubSub; individual topics are added/removed via
+		// Subscribe/Unsubscribe as local subscriber counts transition
+		// to/from zero (subscribeRedisTopic / unsubscribeRedisTopic below).
+		h.redisPubSub = rc.Subscribe(context.Background())
+	}
 	return h
 }
 
+// Stats returns a snapshot of cumulative hub activity counters.
+func (h *Hub) Stats() HubStats {
+	return HubStats{
+		ConnectedClients: h.connectedClients.Load(),
+		DroppedSlow:      h.droppedSlow.Load(),
+		RejectedPerIP:    h.rejectedPerIP.Load(),
+		RedisErrors:      h.redisErrors.Load(),
+	}
+}
+
 func (h *Hub) Run(ctx context.Context) {
+	if h.redisPubSub != nil {
+		go h.consumeRedis(ctx)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			h.logger.Info("hub stopping")
-			// Disconnect all clients gracefully
+			// Disconnect all clients gracefully, and release Redis-side
+			// state (subscriptions + presence) so other instances/clients
+			// aren't left waiting on a dead instance (#828's graceful
+			// shutdown requirement, coordinated with issue #786).
 			h.mu.Lock()
 			for client := range h.clients {
 				close(client.send)
 				client.conn.Close()
+				h.clearPresence(client.userID)
 			}
 			h.mu.Unlock()
+			if h.redisPubSub != nil {
+				_ = h.redisPubSub.Close()
+			}
 			return
 
 		case client := <-h.register:
 			h.mu.Lock()
 			h.clients[client] = true
 			h.mu.Unlock()
+			h.connectedClients.Add(1)
+			h.markPresent(client.userID)
 
 		case client := <-h.unregister:
 			h.removeClient(client)
 
 		case event := <-h.broadcast:
-			h.mu.Lock()
-			// Update history
-			history := h.history[event.Channel]
-			history = append(history, event)
-			if len(history) > maxEventHistory {
-				history = history[len(history)-maxEventHistory:]
-			}
-			h.history[event.Channel] = history
-
-			// Broadcast to subscribed clients
-			if subbed, ok := h.channels[event.Channel]; ok {
-				for client := range subbed {
-					select {
-					case client.send <- event:
-					default:
-						// If the client's send buffer is full, drop the event to apply backpressure
-						select {
-						case client.send <- Event{Channel: event.Channel, Type: EventEventsDropped}:
-						default:
-							// Client completely blocked, kick them
-							h.removeClientLocked(client)
-						}
-					}
-				}
-			}
-			h.mu.Unlock()
+			h.deliverLocally(event)
 		}
 	}
 }
 
+// deliverLocally fans an event out to this instance's own subscribed
+// clients and records it in per-channel history. Shared by both
+// locally-produced events (via BroadcastEvent) and events received from
+// other instances over Redis (via consumeRedis) — one delivery code path.
+func (h *Hub) deliverLocally(event Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	history := h.history[event.Channel]
+	history = append(history, event)
+	if len(history) > maxEventHistory {
+		history = history[len(history)-maxEventHistory:]
+	}
+	h.history[event.Channel] = history
+
+	if subbed, ok := h.channels[event.Channel]; ok {
+		for client := range subbed {
+			select {
+			case client.send <- event:
+			default:
+				// If the client's send buffer is full, apply backpressure by
+				// dropping the event and notifying the client.
+				select {
+				case client.send <- Event{Channel: event.Channel, Type: EventEventsDropped}:
+				default:
+					// Client completely blocked, kick them.
+					h.droppedSlow.Add(1)
+					h.removeClientLocked(client)
+				}
+			}
+		}
+	}
+}
+
+// BroadcastEvent delivers evt to this instance's own subscribed clients
+// immediately, and (when Redis is configured) publishes it so every other
+// instance's subscribed clients receive it too (#828).
 func (h *Hub) BroadcastEvent(evt Event) {
 	if evt.Timestamp.IsZero() {
 		evt.Timestamp = time.Now()
 	}
 	h.broadcast <- evt
+	h.publishToRedis(evt)
+}
+
+func (h *Hub) publishToRedis(evt Event) {
+	if h.redis == nil {
+		return
+	}
+	payload, err := json.Marshal(wireEvent{Event: evt, OriginInstance: h.instanceID})
+	if err != nil {
+		h.logger.Warn("websocket: failed to marshal event for redis publish", "error", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	if err := h.redis.Publish(ctx, redisPubSubPrefix+evt.Channel, payload).Err(); err != nil {
+		h.redisErrors.Add(1)
+		h.logger.Warn("websocket: redis publish failed; other instances will not see this event",
+			"channel", evt.Channel, "error", err)
+	}
+}
+
+// consumeRedis reads events published by any instance (including this one)
+// and re-broadcasts locally, skipping this instance's own events since
+// BroadcastEvent already delivered those synchronously above.
+func (h *Hub) consumeRedis(ctx context.Context) {
+	ch := h.redisPubSub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var we wireEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &we); err != nil {
+				h.logger.Warn("websocket: failed to unmarshal redis event", "error", err)
+				continue
+			}
+			if we.OriginInstance == h.instanceID {
+				continue // already delivered locally by BroadcastEvent
+			}
+			h.deliverLocally(we.Event)
+		}
+	}
 }
 
 // PushToUser satisfies notifications.WebSocketHub. It broadcasts a typed event
 // to the user-scoped channel "notifications/{userID}" so any client subscribed
-// to that channel receives the payload in real time.
+// to that channel receives the payload in real time, on any instance.
 func (h *Hub) PushToUser(_ context.Context, userID uuid.UUID, eventName string, payload any) error {
 	h.BroadcastEvent(Event{
 		Channel:   fmt.Sprintf("notifications/%s", userID),
@@ -145,11 +303,11 @@ func (h *Hub) PushToUser(_ context.Context, userID uuid.UUID, eventName string, 
 
 func (h *Hub) subscribe(client *Client, channel string) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	if _, ok := h.channels[channel]; !ok {
 		h.channels[channel] = make(map[*Client]bool)
 	}
+	isFirstLocalSubscriber := len(h.channels[channel]) == 0
 	h.channels[channel][client] = true
 
 	// Send history to client upon subscription
@@ -161,40 +319,198 @@ func (h *Hub) subscribe(client *Client, channel string) {
 			}
 		}
 	}
+	h.mu.Unlock()
+
+	if isFirstLocalSubscriber {
+		h.subscribeRedisTopic(channel)
+	}
 }
 
 func (h *Hub) unsubscribe(client *Client, channel string) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
+	becameEmpty := false
 	if subs, ok := h.channels[channel]; ok {
 		delete(subs, client)
 		if len(subs) == 0 {
 			delete(h.channels, channel)
+			becameEmpty = true
 		}
 	}
+	h.mu.Unlock()
+
+	if becameEmpty {
+		h.unsubscribeRedisTopic(channel)
+	}
+}
+
+// subscribeRedisTopic and unsubscribeRedisTopic re-evaluate this instance's
+// Redis subscriptions as clients (un)subscribe, so an instance is only woken
+// for topics its own connected clients actually care about (#828). Reference
+// counted by redisTopics since multiple local clients can subscribe to the
+// same channel independently.
+func (h *Hub) subscribeRedisTopic(channel string) {
+	if h.redis == nil {
+		return
+	}
+	h.mu.Lock()
+	h.redisTopics[channel]++
+	first := h.redisTopics[channel] == 1
+	h.mu.Unlock()
+	if !first {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	if err := h.redisPubSub.Subscribe(ctx, redisPubSubPrefix+channel); err != nil {
+		h.redisErrors.Add(1)
+		h.logger.Warn("websocket: redis subscribe failed", "channel", channel, "error", err)
+	}
+}
+
+func (h *Hub) unsubscribeRedisTopic(channel string) {
+	if h.redis == nil {
+		return
+	}
+	h.mu.Lock()
+	h.redisTopics[channel]--
+	last := h.redisTopics[channel] <= 0
+	if last {
+		delete(h.redisTopics, channel)
+	}
+	h.mu.Unlock()
+	if !last {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	if err := h.redisPubSub.Unsubscribe(ctx, redisPubSubPrefix+channel); err != nil {
+		h.redisErrors.Add(1)
+		h.logger.Warn("websocket: redis unsubscribe failed", "channel", channel, "error", err)
+	}
+}
+
+// markPresent records that userID is connected on this instance, with a
+// heartbeat-refreshed TTL so a crashed instance's entries self-expire
+// (#828) rather than falsely reporting a user connected forever.
+func (h *Hub) markPresent(userID string) {
+	if h.redis == nil || userID == "" {
+		return
+	}
+	h.refreshPresence(userID)
+	go h.heartbeatPresence(userID)
+}
+
+func (h *Hub) refreshPresence(userID string) {
+	if h.redis == nil || userID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	if err := h.redis.Set(ctx, presenceKeyPrefix+userID, h.instanceID, presenceTTL).Err(); err != nil {
+		h.redisErrors.Add(1)
+	}
+}
+
+// heartbeatPresence refreshes userID's presence TTL periodically until the
+// user is no longer connected on this instance (checked via isUserConnected
+// rather than a dedicated stop channel, keeping this self-contained per
+// call — it naturally stops within one heartbeat interval of the last
+// connection for userID closing).
+func (h *Hub) heartbeatPresence(userID string) {
+	ticker := time.NewTicker(presenceHeartbeatInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if !h.isUserConnected(userID) {
+			return
+		}
+		h.refreshPresence(userID)
+	}
+}
+
+func (h *Hub) isUserConnected(userID string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for client := range h.clients {
+		if client.userID == userID {
+			return true
+		}
+	}
+	return false
+}
+
+// clearPresence releases userID's presence entry immediately. Called on
+// disconnect and on graceful shutdown; the TTL is also a self-healing
+// backstop if this is never reached (a crash).
+func (h *Hub) clearPresence(userID string) {
+	if h.redis == nil || userID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	if err := h.redis.Del(ctx, presenceKeyPrefix+userID).Err(); err != nil {
+		h.redisErrors.Add(1)
+	}
+}
+
+// IsUserPresent reports whether userID has a live connection on any
+// instance (per Redis presence tracking). Always false when Redis isn't
+// configured — presence is a distributed-deployment feature.
+func (h *Hub) IsUserPresent(ctx context.Context, userID string) bool {
+	if h.redis == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	exists, err := h.redis.Exists(ctx, presenceKeyPrefix+userID).Result()
+	if err != nil {
+		h.redisErrors.Add(1)
+		return false
+	}
+	return exists > 0
 }
 
 func (h *Hub) removeClient(client *Client) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.removeClientLocked(client)
+	h.mu.Unlock()
 }
 
+// removeClientLocked must be called with h.mu held.
 func (h *Hub) removeClientLocked(client *Client) {
 	if _, ok := h.clients[client]; ok {
 		delete(h.clients, client)
+		h.connectedClients.Add(-1)
 		// Remove from all channels using h.channels (already under h.mu),
 		// avoiding acquiring client.mu which would invert the lock order.
+		var emptiedChannels []string
 		for ch, subs := range h.channels {
 			if _, in := subs[client]; in {
 				delete(subs, client)
 				if len(subs) == 0 {
 					delete(h.channels, ch)
+					emptiedChannels = append(emptiedChannels, ch)
 				}
 			}
 		}
 		close(client.send)
+		h.decrementIPLocked(client.remoteIP)
+
+		// Redis (un)subscription bookkeeping and presence release must not
+		// run while holding h.mu (they make network calls) — dispatch after
+		// unlocking. removeClientLocked itself stays synchronous/locked;
+		// callers (removeClient, Run's unregister case) unlock right after
+		// returning, so do the network work there instead. To keep this
+		// simple and avoid every caller repeating that dance, do it via a
+		// goroutine here: the topics/user are already fully decided above.
+		userID := client.userID
+		go func() {
+			for _, ch := range emptiedChannels {
+				h.unsubscribeRedisTopic(ch)
+			}
+			if !h.isUserConnected(userID) {
+				h.clearPresence(userID)
+			}
+		}()
 	}
 }
 
@@ -232,6 +548,45 @@ func (h *Hub) CloseConnectionsForUser(userID string) {
 	}
 }
 
+func (h *Hub) incrementIPLocked(ip string) (allowed bool) {
+	if h.maxConnsPerIP <= 0 || ip == "" {
+		return true
+	}
+	if h.connsByIP[ip] >= h.maxConnsPerIP {
+		return false
+	}
+	h.connsByIP[ip]++
+	return true
+}
+
+func (h *Hub) decrementIPLocked(ip string) {
+	if ip == "" {
+		return
+	}
+	if h.connsByIP[ip] <= 1 {
+		delete(h.connsByIP, ip)
+		return
+	}
+	h.connsByIP[ip]--
+}
+
+// clientIP extracts the caller's IP for per-IP connection limiting,
+// preferring a proxy-supplied X-Forwarded-For (first hop) and falling back
+// to the raw remote address.
+func clientIP(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if idx := strings.IndexByte(fwd, ','); idx != -1 {
+			return strings.TrimSpace(fwd[:idx])
+		}
+		return strings.TrimSpace(fwd)
+	}
+	host := r.RemoteAddr
+	if idx := strings.LastIndexByte(host, ':'); idx != -1 {
+		return host[:idx]
+	}
+	return host
+}
+
 func (h *Hub) ServeWs(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
 	var userID, sessionID string
@@ -246,8 +601,22 @@ func (h *Hub) ServeWs(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	ip := clientIP(r)
+	h.mu.Lock()
+	allowed := h.incrementIPLocked(ip)
+	h.mu.Unlock()
+	if !allowed {
+		h.rejectedPerIP.Add(1)
+		h.logger.Warn("websocket connection rejected: per-IP limit exceeded", "ip", ip)
+		http.Error(w, "Too Many Connections", http.StatusTooManyRequests)
+		return
+	}
+
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
+		h.mu.Lock()
+		h.decrementIPLocked(ip)
+		h.mu.Unlock()
 		h.logger.Error("websocket upgrade failed", "error", err)
 		return
 	}
@@ -258,6 +627,7 @@ func (h *Hub) ServeWs(w http.ResponseWriter, r *http.Request) {
 		send:      make(chan Event, 256),
 		userID:    userID,
 		sessionID: sessionID,
+		remoteIP:  ip,
 		subs:      make(map[string]bool),
 	}
 	client.hub.register <- client

--- a/apps/api/internal/ws/hub_redis_test.go
+++ b/apps/api/internal/ws/hub_redis_test.go
@@ -1,0 +1,295 @@
+package ws
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
+)
+
+// newTestRedisClient returns a *redis.Client for the address in REDIS_ADDR,
+// skipping the test if it's unset or unreachable — same convention as
+// internal/cache's tests and internal/middleware/ratelimit_backend_test.go.
+func newTestRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set; skipping redis-backed websocket test")
+	}
+	rc := redis.NewClient(&redis.Options{Addr: addr})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rc.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not reachable at %s: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func newTestHubWithRedis(rc *redis.Client, maxConnsPerIP int) *Hub {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return NewHub(logger, func(token string) (string, string, error) {
+		if token == "invalid" {
+			return "", "", os.ErrPermission
+		}
+		return "user-" + token, "session-" + token, nil
+	}, []string{"http://localhost:3000"}, rc, maxConnsPerIP)
+}
+
+// TestHub_Redis_CrossInstanceDelivery is #828's core acceptance criterion: two
+// Hubs sharing one Redis, each with a client connected to a *different*
+// instance, must both receive an event published on either instance.
+func TestHub_Redis_CrossInstanceDelivery(t *testing.T) {
+	rc := newTestRedisClient(t)
+
+	hubA := newTestHubWithRedis(rc, 0)
+	hubB := newTestHubWithRedis(rc, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hubA.Run(ctx)
+	go hubB.Run(ctx)
+
+	serverA := httptest.NewServer(http.HandlerFunc(hubA.ServeWs))
+	defer serverA.Close()
+	serverB := httptest.NewServer(http.HandlerFunc(hubB.ServeWs))
+	defer serverB.Close()
+
+	channel := "vault:cross-instance-" + t.Name()
+
+	connA := dialAndSubscribe(t, serverA.URL, "tokA", channel)
+	defer connA.Close()
+	connB := dialAndSubscribe(t, serverB.URL, "tokB", channel)
+	defer connB.Close()
+
+	// Give both instances a moment to register their Redis subscription.
+	time.Sleep(100 * time.Millisecond)
+
+	// Produced on instance A only.
+	hubA.BroadcastEvent(Event{Channel: channel, Type: EventBalanceUpdated, Data: map[string]any{"via": "A"}})
+
+	assertReceivesOnChannel(t, connA, channel, "hubA's own client")
+	assertReceivesOnChannel(t, connB, channel, "hubB's client via redis fan-out from hubA")
+
+	// And the reverse direction, produced on instance B.
+	hubB.BroadcastEvent(Event{Channel: channel, Type: EventBalanceUpdated, Data: map[string]any{"via": "B"}})
+	assertReceivesOnChannel(t, connA, channel, "hubA's client via redis fan-out from hubB")
+	assertReceivesOnChannel(t, connB, channel, "hubB's own client")
+}
+
+func dialAndSubscribe(t *testing.T, httpURL, token, channel string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(httpURL, "http") + "?token=" + token
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial %s failed: %v (resp=%v)", httpURL, err, resp)
+	}
+	if err := conn.WriteJSON(ClientMessage{Action: "subscribe", Channels: []string{channel}}); err != nil {
+		t.Fatalf("subscribe write failed: %v", err)
+	}
+	return conn
+}
+
+func assertReceivesOnChannel(t *testing.T, conn *websocket.Conn, wantChannel, desc string) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var evt Event
+	if err := conn.ReadJSON(&evt); err != nil {
+		t.Fatalf("%s: expected to receive event, got error: %v", desc, err)
+	}
+	if evt.Channel != wantChannel {
+		t.Errorf("%s: expected channel %s, got %s", desc, wantChannel, evt.Channel)
+	}
+}
+
+// TestHub_Redis_OwnEventNotDoubleDelivered proves an instance does not
+// deliver its own published event twice (once locally, once via its own
+// Redis subscription echo).
+func TestHub_Redis_OwnEventNotDoubleDelivered(t *testing.T) {
+	rc := newTestRedisClient(t)
+	hub := newTestHubWithRedis(rc, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(hub.ServeWs))
+	defer server.Close()
+
+	channel := "vault:no-double-delivery-" + t.Name()
+	conn := dialAndSubscribe(t, server.URL, "tok", channel)
+	defer conn.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	hub.BroadcastEvent(Event{Channel: channel, Type: EventBalanceUpdated})
+
+	assertReceivesOnChannel(t, conn, channel, "first (only) delivery")
+
+	// A second read within a short window must time out — there should be no
+	// duplicate.
+	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	var evt Event
+	if err := conn.ReadJSON(&evt); err == nil {
+		t.Fatalf("expected no second delivery, got duplicate event on channel %s", evt.Channel)
+	}
+}
+
+// TestHub_Redis_ReconnectMovesSubscriptionCleanly proves that when a user's
+// first connection (on hubA) drops and they reconnect on a different
+// instance (hubB), the new instance delivers events for that channel and
+// the old instance's now-empty subscription doesn't linger or duplicate.
+func TestHub_Redis_ReconnectMovesSubscriptionCleanly(t *testing.T) {
+	rc := newTestRedisClient(t)
+	hubA := newTestHubWithRedis(rc, 0)
+	hubB := newTestHubWithRedis(rc, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hubA.Run(ctx)
+	go hubB.Run(ctx)
+
+	serverA := httptest.NewServer(http.HandlerFunc(hubA.ServeWs))
+	defer serverA.Close()
+	serverB := httptest.NewServer(http.HandlerFunc(hubB.ServeWs))
+	defer serverB.Close()
+
+	channel := "vault:reconnect-" + t.Name()
+
+	connA := dialAndSubscribe(t, serverA.URL, "tok", channel)
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate a drop and reconnect elsewhere.
+	connA.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	connB := dialAndSubscribe(t, serverB.URL, "tok", channel)
+	defer connB.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	hubA.BroadcastEvent(Event{Channel: channel, Type: EventBalanceUpdated, Data: "after-reconnect"})
+	assertReceivesOnChannel(t, connB, channel, "hubB's client after reconnect")
+}
+
+// TestHub_Redis_PresenceTracksConnectionAndExpiresOnDisconnect exercises the
+// distributed presence tracking: connecting sets a presence entry visible
+// from *another* hub sharing the same Redis, and disconnecting clears it.
+func TestHub_Redis_PresenceTracksConnectionAndExpiresOnDisconnect(t *testing.T) {
+	rc := newTestRedisClient(t)
+	hubA := newTestHubWithRedis(rc, 0)
+	hubB := newTestHubWithRedis(rc, 0) // a second instance sharing the same Redis, to prove presence is cross-instance
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hubA.Run(ctx)
+	go hubB.Run(ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(hubA.ServeWs))
+	defer server.Close()
+
+	userToken := "presence-user-" + t.Name()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?token=" + userToken
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+
+	userID := "user-" + userToken
+	if !waitFor(t, 2*time.Second, func() bool { return hubB.IsUserPresent(context.Background(), userID) }) {
+		t.Fatal("expected hubB to observe user as present via shared redis presence tracking")
+	}
+
+	conn.Close()
+
+	if !waitFor(t, 2*time.Second, func() bool { return !hubB.IsUserPresent(context.Background(), userID) }) {
+		t.Fatal("expected presence to clear shortly after disconnect")
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestHub_SlowClient_DisconnectedOnBufferOverflow proves a client that never
+// reads its send buffer is disconnected rather than allowed to accumulate
+// unbounded memory (#828's backpressure requirement). No Redis needed.
+func TestHub_SlowClient_DisconnectedOnBufferOverflow(t *testing.T) {
+	hub := newTestHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	client := &Client{
+		hub:  hub,
+		conn: nil,
+		// A tiny buffer so we can overflow it quickly without a real slow
+		// network peer.
+		send: make(chan Event, 2),
+		subs: make(map[string]bool),
+	}
+	hub.mu.Lock()
+	hub.clients[client] = true
+	hub.mu.Unlock()
+	hub.subscribe(client, "vault:slow")
+
+	// Flood well past the buffer size without ever draining client.send,
+	// exactly like a client that stopped reading.
+	for i := 0; i < 20; i++ {
+		hub.BroadcastEvent(Event{Channel: "vault:slow", Type: EventBalanceUpdated})
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	hub.mu.RLock()
+	_, stillConnected := hub.clients[client]
+	hub.mu.RUnlock()
+	if stillConnected {
+		t.Error("expected slow client to be disconnected after send-buffer overflow, but it is still registered")
+	}
+}
+
+// TestHub_PerIPConnectionLimit_RejectsBeyondLimit proves ServeWs enforces
+// the configured per-IP cap (#828's abuse-prevention requirement).
+func TestHub_PerIPConnectionLimit_RejectsBeyondLimit(t *testing.T) {
+	hub := newTestHubWithRedis(nil, 1) // limit of 1 connection per IP, no redis needed
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(hub.ServeWs))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?token=tok1"
+	conn1, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("first dial should succeed: %v", err)
+	}
+	defer conn1.Close()
+
+	// All httptest.Server client connections share the same loopback IP, so a
+	// second connection must be rejected under a per-IP limit of 1.
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		t.Fatal("expected second connection from the same IP to be rejected")
+	}
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		status := -1
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Errorf("expected 429 Too Many Requests, got %d", status)
+	}
+}

--- a/apps/api/internal/ws/hub_test.go
+++ b/apps/api/internal/ws/hub_test.go
@@ -21,7 +21,7 @@ func newTestHub() *Hub {
 			return "", "", os.ErrPermission
 		}
 		return "user-123", "session-123", nil
-	}, []string{"http://localhost:3000"})
+	}, []string{"http://localhost:3000"}, nil, 0)
 }
 
 func TestHub_SubscriptionManagement(t *testing.T) {
@@ -136,7 +136,7 @@ func TestHub_UnauthorizedReject(t *testing.T) {
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?token=invalid"
 	dialer := websocket.Dialer{}
 	_, resp, err := dialer.Dial(wsURL, nil)
-	
+
 	if err == nil {
 		t.Fatalf("Expected connection failure on invalid token")
 	}

--- a/apps/api/migrations/069_add_notification_category_preferences.down.sql
+++ b/apps/api/migrations/069_add_notification_category_preferences.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_preferences
+    DROP COLUMN IF EXISTS category_overrides;

--- a/apps/api/migrations/069_add_notification_category_preferences.up.sql
+++ b/apps/api/migrations/069_add_notification_category_preferences.up.sql
@@ -1,0 +1,15 @@
+-- Per-category channel preference overrides (nester#829). Categories are
+-- "safety" | "transactional" | "promotional"; safety notifications always
+-- bypass this table (and preferences generally) at the application layer, so
+-- no row for "safety" is ever expected to matter, but nothing stops one from
+-- being stored for forward-compatibility.
+--
+-- Stored as JSONB rather than per-category columns to avoid a 3-category x
+-- 3-channel column explosion; shape is:
+--   {"promotional": {"email": false, "websocket": true, "push": false}, ...}
+-- A category missing from the JSON (the common case — most users never touch
+-- this) falls back to notifications.DefaultPreferencesForCategory at the
+-- application layer, NOT to a SQL default, since that logic already exists in
+-- Go and duplicating it in SQL would be a second source of truth.
+ALTER TABLE notification_preferences
+    ADD COLUMN IF NOT EXISTS category_overrides JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary

Four related backend reliability/scalability features, each independently committed:

closes #827
closes #828
closes #829
closes #830

## Changes

- **#827 — Typed GetOrCompute cache layer** (`internal/cache`): generic Redis-backed cache with in-process single-flight (hard guarantee, works even without Redis) plus a best-effort cross-process Redis lock, jittered TTLs, serve-stale-while-revalidate via a soft/hard TTL split, and namespace-scoped single-key invalidation. Degrades to in-process-only behavior with a nil Redis client.

- **#828 — Horizontally-scalable WebSocket hub** (`internal/ws`): events now fan out through Redis pub/sub so any API instance can deliver an event to any connected client regardless of which instance produced it or holds the socket. Per-topic Redis subscriptions are reference-counted against local subscriber counts (an instance only subscribes to what its own clients need) and released on last-unsubscribe or graceful shutdown. Adds Redis-backed presence tracking with heartbeat TTLs (self-expiring on instance crash), per-IP connection limits (429 on exceeding the cap), and keeps the existing slow-client backpressure disconnect intact. All Redis behavior is nil-safe and degrades to the pre-existing single-instance behavior.

- **#829 — Multi-channel notification service** (`internal/notifications`): adds a Category (safety/transactional/promotional) per event type driving suppressibility — safety bypasses preference and rate-limit checks entirely; adds dedup (in-memory + Redis) and per-user-per-category rate limiting, both of which persist a suppressed notification with its reason rather than silently dropping it; adds per-channel delivery outcome tracking with a Push/Email→WebSocket fallback; failed Email/Push deliveries enqueue a durable retry job through the existing job queue. Also fixes a stale `// TODO: Fix interface implementation` in `main.go` that had left the WebSocket notification channel disabled — it now actually delivers.

- **#830 — Oracle aggregation layer** (`internal/oracle`): adds `Aggregate`, which queries every healthy registered source in parallel and reconciles responses via median-with-deviation-band outlier rejection, plus `HealthTracker` for per-source exponential-backoff failover. Wires this into `RateService.fetchXLM`, replacing the previous "try in priority order, first success wins" loop with genuine two-source (Horizon, DeFiLlama) consensus, while keeping the existing sanity-bounds check as a second line of defense. `ExchangeRate` gains `Confidence`/`SourcesUsed` fields and a `MeetsConfidenceThreshold` helper.

- **CI fix**: the `api` job's Redis service only exported `REDIS_URL`; every Redis-backed test (existing `internal/cache` tests included) skips on `REDIS_ADDR` specifically, so these tests have been silently skipping in CI. Now sets both.

## Test plan

- All packages build clean (`go build ./...`) and vet clean (`go vet ./...`).
- Full repo test suite (`go test ./...`) passes with a real Redis instance available (`REDIS_ADDR` set) — every Redis-backed test (cache, ws cross-instance delivery/presence/per-IP-limit, notifications dedup) exercised for real, not just skip-branches.
- New/extended test coverage per feature:
  - `internal/cache`: existing 11 tests (5 no-Redis, 6 Redis-backed) all passing for real.
  - `internal/ws`: existing hub tests + new cross-instance delivery, own-event-not-double-delivered, reconnect-moves-subscriptions, cross-instance presence, slow-client-disconnect, and per-IP-limit tests, run with `-race`.
  - `internal/notifications`: existing dispatcher tests unchanged/passing + new tests for safety bypass, promotional suppression+recording, dedup (in-memory and Redis), rate-limit suppression, Push→WebSocket fallback (with no double-delivery when WebSocket is already in the event's matrix), delivery-outcome recording, retry-enqueue (and non-enqueue for WebSocket failures), and per-category `Stats()`.
  - `internal/oracle`: new aggregator tests for consensus, outlier rejection, all-but-one-down low-confidence-not-unavailable, all-down unavailable, slow-source timeout, health backoff/recovery/exponential-growth, and confidence staleness decay — plus all existing `service_test.go` cases pass unchanged.
  - `internal/repository/postgres`: new sqlmock tests for the category-preference read/write path added for #829.

## Deliberately deferred (disclosed, not silently skipped)

- **#829**: HTTP handler/frontend surface for editing category preferences (the existing flat-preference handler/settings page is unchanged, only the storage layer gained category granularity); migrating `goal_milestone_notifier`'s own `notified_milestones` dedup onto the new generic `Deduplicator` — that table is a permanent, non-windowed, correctness-sensitive dedup, and migrating it is exactly the kind of unreviewed, regression-risk change this PR intentionally avoids; real SMTP/push provider integrations (existing `MailSender`/`PushSender` seams are unchanged).
- **#830**: a second independent source for TVL and for the DeFiLlama-sourced APY pipeline (`apy_service.go`/`apy_refresh.go`) — those have only one real external provider each in this codebase today, and standing up a second genuine external data provider integration was out of scope here; migrating `risk_service.go` and the on-chain attestation signer (a separate contracts repo) onto `Confidence` gating. One added cost worth flagging: `Aggregate` queries every healthy source in parallel rather than stopping at the first success, so DeFiLlama is now called on every XLM/USD refresh even when Horizon succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved exchange-rate reliability using multi-source consensus with confidence and health tracking.
  * Added category-based notification preferences (safety/transactional/promotional) and Redis-backed deduplication, rate limiting, delivery outcome tracking, and durable retry redelivery.
  * Enabled Redis-backed multi-instance WebSocket fan-out, distributed presence, and per-IP connection caps.
  * Introduced a typed Redis-backed cache with single-flight computation and stale-while-revalidating.
* **Bug Fixes**
  * Reduced silent CI Redis test skipping and ensured consistent Redis CI connectivity.
  * Improved fallback behavior so failed push/email can route through WebSocket without double-delivering.
* **Tests**
  * Added extensive coverage for cache, notifications dedup/dispatcher logic, WebSocket Redis hub behavior, and oracle aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->