### PR TITLE
feat(security): extend envelope encryption to KYC documents at rest

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,66 @@ The vault trips itself automatically rather than waiting for an operator to noti
 
 The emergency withdrawal queue is never gated by severity — it works identically at every level, including `FullHalt`, because a breaker that stops users from leaving is a trap, not a safety device. Recovery only ever moves one severity stage at a time, only after a configurable cooldown, and only for callers holding `Admin`/`Upgrader` — never `Guardian`.
 
+## Encryption at Rest
+
+Nester uses **envelope encryption** with key versioning and rotation for all sensitive user data stored at rest. The scheme is implemented in `apps/api/internal/crypto/account_cipher.go` and reused across all domains.
+
+### Key Hierarchy
+
+```
+Master Key (never stored in the application)
+    └── Key-Encryption Keys (KEKs) — versioned, configured via env vars
+        └── AES-256-GCM Data Key (derived per cipher instance)
+            └── Ciphertext stored in `*_encrypted` columns, tagged with `key_version`
+```
+
+Key configuration (environment variables):
+
+| Variable | Purpose |
+|---|---|
+| `BANK_ACCOUNT_ENCRYPTION_KEY` | Legacy single 32-byte base64 key (registers as `v1`) |
+| `ACCOUNT_CIPHER_KEYS` | Comma-separated `version:base64key` pairs for multi-key rotation |
+| `ACCOUNT_CIPHER_ACTIVE_KEY` | Which version is used for new encryptions |
+| `ACCOUNT_CIPHER_FINGERPRINT_KEY` | Independent pepper for blind-index HMAC (required when no `v1` key is in the set) |
+
+### Encrypted Fields
+
+| Table | Encrypted Columns | Blind Index | Key Version |
+|---|---|---|---|
+| `bank_accounts` | `account_number_encrypted` (BYTEA) | `account_number_fingerprint` (TEXT, unique) | `key_version` (VARCHAR(32)) |
+| `kyc_documents` | `id_number_encrypted` (BYTEA), `front_object_key_encrypted` (BYTEA), `back_object_key_encrypted` (BYTEA) | `id_number_fingerprint` (TEXT) | `key_version` (VARCHAR(32)) |
+
+### Blind Indexes
+
+Fields that need exact-match lookup (deduplication, find-by-identifier) use a **blind index**: a keyed HMAC-SHA256 of the normalized plaintext stored in a separate column. The HMAC key is independent of the encryption keys — either the `v1` KEK or the explicit `ACCOUNT_CIPHER_FINGERPRINT_KEY` — so the index cannot be used to attack the ciphertext even if both the index and ciphertext are leaked in the same breach.
+
+Limitations:
+- **Exact-match only**: No prefix, range or fuzzy search on blind indexes.
+- **Collision resistant**: HMAC-SHA256 produces a 256-bit digest; collisions are not a practical concern.
+
+### Key Rotation
+
+The `cmd/rotate_keys` command re-encrypts stored ciphertext under the active key version. It processes all encrypted domains (bank accounts, KYC documents) in a single run. The rotator is:
+
+- **Idempotent**: Rows already on the active version are skipped.
+- **Resumable**: Each row is committed independently; an interrupted run picks up where it left off.
+- **Safe**: Only row IDs and key versions are logged — never plaintext, ciphertext, or keys.
+
+### Data Classification
+
+A complete data-classification inventory is maintained at `apps/api/internal/crypto/DATA_CLASSIFICATION.md`. Every column holding user data is classified as HIGH (sensitive, encrypted), MEDIUM (indirect PII), or LOW (non-sensitive).
+
+### Backfill for Existing Data
+
+When encryption is extended to a new domain, existing plaintext rows are backfilled using a dedicated command (e.g. `cmd/backfill_kyc_encryption`). The migration pattern follows:
+
+1. Add encrypted columns alongside existing plaintext columns (rollback-safe).
+2. Run a batched, resumable backfill job to populate encrypted values.
+3. Verify the backfill is complete.
+4. Drop plaintext columns in a separate, later migration after confidence is established.
+
+Plaintext is never dropped in the same step that introduces ciphertext.
+
 ## Known and Accepted Vulnerabilities
 
 We maintain a list of known vulnerabilities in our dependency chain that we have assessed and accepted based on their risk profile:

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -181,6 +181,9 @@ func run() error {
 
 	userRepository := postgres.NewUserRepository(db)
 	userService := service.NewUserService(userRepository)
+	if accountCipher != nil {
+		userService.WithCipher(accountCipher)
+	}
 	userHandler := handler.NewUserHandler(userService)
 	userVaultsSvc := service.NewUserVaultsService(vaultRepository)
 	userHandler.SetUserVaultsService(userVaultsSvc)

--- a/apps/api/cmd/backfill_kyc_encryption/main.go
+++ b/apps/api/cmd/backfill_kyc_encryption/main.go
@@ -1,0 +1,144 @@
+// Command backfill_kyc_encryption encrypts existing plaintext KYC document
+// fields (id_number, front_object_key, back_object_key) that were stored before
+// the encryption migration was applied.
+//
+// It is safe, idempotent and resumable:
+//   - Only rows where id_number_encrypted IS NULL are processed.
+//   - Each row is committed independently so an interrupted run continues from
+//     where it left off.
+//   - A second run after completion finds zero rows to process and does nothing.
+//
+// Usage:
+//
+//	go run ./cmd/backfill_kyc_encryption [-batch-size=100] [-timeout=5m]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/config"
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/repository"
+	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+)
+
+func main() {
+	batchSize := flag.Int("batch-size", 100, "rows to process per batch")
+	timeout := flag.Duration("timeout", 0, "max duration for the entire backfill (0 = no timeout)")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	if !cfg.AccountCipher().Configured() {
+		logger.Error("account cipher is not configured; set BANK_ACCOUNT_ENCRYPTION_KEY or ACCOUNT_CIPHER_KEYS")
+		os.Exit(1)
+	}
+
+	cc := cfg.AccountCipher()
+	ciph, err := crypto.NewAccountCipherWithKeys(cc.ActiveVersion(), cc.Keys(), cc.FingerprintKey())
+	if err != nil {
+		logger.Error("failed to create cipher", "error", err)
+		os.Exit(1)
+	}
+
+	pg, err := repository.NewPostgresDB(cfg.Database())
+	if err != nil {
+		logger.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer pg.Pool.Close()
+
+	db := stdlib.OpenDBFromPool(pg.Pool)
+	defer db.Close()
+
+	repo := postgres.NewUserRepository(db)
+
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	processed, err := runBackfill(ctx, logger, repo, ciph, *batchSize)
+	if err != nil {
+		logger.Error("backfill failed", "error", err, "processed", processed)
+		os.Exit(1)
+	}
+
+	logger.Info("backfill complete", "processed", processed)
+}
+
+func runBackfill(
+	ctx context.Context,
+	logger *slog.Logger,
+	repo *postgres.UserRepository,
+	ciph *crypto.AccountCipher,
+	batchSize int,
+) (int, error) {
+	active := ciph.ActiveVersion()
+	total := 0
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		rows, err := repo.ScanKYCDocumentsForBackfill(ctx, batchSize)
+		if err != nil {
+			return total, fmt.Errorf("scan for backfill: %w", err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+
+		for _, row := range rows {
+			idNumEnv, err := ciph.Encrypt(row.IDNumber)
+			if err != nil {
+				return total, fmt.Errorf("encrypt id_number for row %s: %w", row.ID, err)
+			}
+			frontKeyEnv, err := ciph.Encrypt(row.FrontObjectKey)
+			if err != nil {
+				return total, fmt.Errorf("encrypt front_object_key for row %s: %w", row.ID, err)
+			}
+			fingerprint := ciph.Fingerprint(row.IDNumber)
+
+			var backKeyEnc []byte
+			if row.BackObjectKey != nil {
+				backKeyEnv, err := ciph.Encrypt(*row.BackObjectKey)
+				if err != nil {
+					return total, fmt.Errorf("encrypt back_object_key for row %s: %w", row.ID, err)
+				}
+				backKeyEnc = backKeyEnv.Ciphertext
+			}
+
+			if err := repo.UpdateKYCCipher(ctx, row.ID, idNumEnv.Ciphertext, frontKeyEnv.Ciphertext, backKeyEnc, active); err != nil {
+				return total, fmt.Errorf("update row %s: %w", row.ID, err)
+			}
+
+			// Update fingerprint separately since UpdateKYCCipher doesn't set it
+			if err := repo.UpdateKYCFingerprint(ctx, row.ID, fingerprint); err != nil {
+				return total, fmt.Errorf("update fingerprint for row %s: %w", row.ID, err)
+			}
+
+			total++
+		}
+
+		logger.Info("backfill progress", "processed", total)
+	}
+
+	return total, nil
+}

--- a/apps/api/cmd/backfill_kyc_encryption/main.go
+++ b/apps/api/cmd/backfill_kyc_encryption/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/jackc/pgx/v5/stdlib"
 

--- a/apps/api/cmd/rotate_keys/main.go
+++ b/apps/api/cmd/rotate_keys/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
@@ -71,7 +72,8 @@ func run() error {
 	db := stdlib.OpenDBFromPool(pgPool.Pool)
 	defer db.Close()
 
-	repo := postgres.NewBankAccountRepository(db)
+	bankRepo := postgres.NewBankAccountRepository(db)
+	userRepo := postgres.NewUserRepository(db)
 
 	ctx := context.Background()
 	if *timeout > 0 {
@@ -81,19 +83,58 @@ func run() error {
 	}
 
 	start := time.Now()
-	stats, err := rotation.NewRotator(repo, cipher).Run(ctx, rotation.Options{
+
+	// Rotate bank account ciphertext
+	bankStats, err := rotation.NewRotator(bankRepo, cipher).Run(ctx, rotation.Options{
 		BatchSize: *batchSize,
 		Logger:    logger,
 	})
 	if err != nil {
-		return fmt.Errorf("rotation failed after %d rows rotated: %w", stats.Rotated, err)
+		return fmt.Errorf("bank account rotation failed after %d rows rotated: %w", bankStats.Rotated, err)
+	}
+
+	logger.Info("bank account rotation done",
+		"rotated", bankStats.Rotated,
+		"pending_at_start", bankStats.Pending,
+	)
+
+	// Rotate KYC document ciphertext
+	kycStore := &kycRotationStore{repo: userRepo}
+	startKYC := time.Now()
+	kycStats, err := rotation.NewRotator(kycStore, cipher).Run(ctx, rotation.Options{
+		BatchSize: *batchSize,
+		Logger:    logger,
+	})
+	if err != nil {
+		return fmt.Errorf("kyc document rotation failed after %d rows rotated: %w", kycStats.Rotated, err)
 	}
 
 	logger.Info("rotation finished",
 		"active_version", acCfg.ActiveVersion(),
-		"pending_at_start", stats.Pending,
-		"rotated", stats.Rotated,
+		"bank_accounts_rotated", bankStats.Rotated,
+		"kyc_documents_rotated", kycStats.Rotated,
 		"duration", time.Since(start).String(),
 	)
 	return nil
+}
+
+// kycRotationStore adapts *postgres.UserRepository to implement rotation.Store
+// for KYC documents. It packs/unpacks the three encrypted fields (id_number,
+// front_object_key, back_object_key) into a single ciphertext blob for the
+// rotator interface.
+type kycRotationStore struct {
+	repo *postgres.UserRepository
+}
+
+func (s *kycRotationStore) CountPending(ctx context.Context, activeVersion string) (int, error) {
+	return s.repo.CountPendingKYCEncryption(ctx, activeVersion)
+}
+
+func (s *kycRotationStore) ScanPending(ctx context.Context, activeVersion string, limit int) ([]rotation.EncryptedRow, error) {
+	return s.repo.ScanPendingKYCEncryption(ctx, activeVersion, limit)
+}
+
+func (s *kycRotationStore) UpdateCipher(ctx context.Context, id uuid.UUID, ciphertext []byte, keyVersion string) error {
+	idNum, frontKey, backKey := postgres.UnpackKYCCiphertexts(ciphertext)
+	return s.repo.UpdateKYCCipher(ctx, id, idNum, frontKey, backKey, keyVersion)
 }

--- a/apps/api/cmd/rotate_keys/main.go
+++ b/apps/api/cmd/rotate_keys/main.go
@@ -100,7 +100,6 @@ func run() error {
 
 	// Rotate KYC document ciphertext
 	kycStore := &kycRotationStore{repo: userRepo}
-	startKYC := time.Now()
 	kycStats, err := rotation.NewRotator(kycStore, cipher).Run(ctx, rotation.Options{
 		BatchSize: *batchSize,
 		Logger:    logger,

--- a/apps/api/internal/crypto/DATA_CLASSIFICATION.md
+++ b/apps/api/internal/crypto/DATA_CLASSIFICATION.md
@@ -1,0 +1,107 @@
+# Data Classification Inventory
+
+This document classifies every database column holding user data as **sensitive** (must be encrypted at rest) or **non-sensitive** (safe in plaintext). Classification drives the scope of envelope encryption in this project and is the authoritative reference for future schema changes.
+
+## Classification Criteria
+
+| Level | Label | Definition |
+|-------|-------|------------|
+| HIGH | Sensitive PII | Directly identifies an individual (government ID numbers, full legal name combined with identifiers). Exposure would enable identity theft or targeted harm. |
+| MEDIUM | Indirect PII | User-chosen or pseudonymous identifiers that could be linked back to an individual with additional context. |
+| LOW | Non-sensitive | Public identifiers, system metadata, enums, timestamps or user preferences. Exposure alone causes no material harm. |
+
+---
+
+## `kyc_documents` table
+
+Introduced in [migration 032](../migrations/032_kyc_workflow.up.sql). Stores uploaded identity documents submitted during KYC verification.
+
+| Column | Type | Sensitivity | Rationale |
+|--------|------|-------------|-----------|
+| `id` | UUID | LOW | Primary key, not identifying |
+| `user_id` | UUID | LOW | Foreign key to `users` |
+| `id_type` | TEXT | LOW | Document type (e.g. "passport", "drivers_license") — not identifying alone |
+| `id_number` | TEXT | **HIGH** | Government-issued ID number. Direct PII that uniquely identifies an individual. **Must be encrypted.** |
+| `front_object_key` | TEXT | **HIGH** | S3 key for the front scan of the ID document. The object itself contains PII (full name, photo, ID number, date of birth). The key structure can reveal the mapping between user and document. **Must be encrypted.** |
+| `back_object_key` | TEXT | **HIGH** | S3 key for the back scan of the ID document. Same reasoning as `front_object_key`. **Must be encrypted.** |
+| `submitted_at` | TIMESTAMPTZ | LOW | Submission timestamp, not PII |
+| `id_number_encrypted` | BYTEA | — | AES-256-GCM ciphertext of `id_number`. Added by migration 069. The column storing the encrypted value is itself opaque. |
+| `id_number_fingerprint` | TEXT | — | HMAC-SHA256 blind index for exact-match deduplication of ID numbers. Stores a keyed hash, not the plaintext. Uniqueness is enforced via a unique constraint. |
+| `front_object_key_encrypted` | BYTEA | — | AES-256-GCM ciphertext of `front_object_key`. Added by migration 069. |
+| `back_object_key_encrypted` | BYTEA | — | AES-256-GCM ciphertext of `back_object_key`. Added by migration 069. |
+| `key_version` | VARCHAR(32) | — | Records which encryption key version sealed the ciphertext columns. Enables non-destructive key rotation. |
+
+### Blind Indexes
+
+| Column | Source Field | Algorithm | Purpose | Limitation |
+|--------|-------------|-----------|---------|------------|
+| `id_number_fingerprint` | `id_number` (normalized) | HMAC-SHA256 keyed with the cipher's fingerprint key (same key used by account cipher) | Exact-match uniqueness and lookup without decryption | Exact-match only; no prefix, range or fuzzy search. Keyed HMAC prevents the fingerprint from being reversed or used to attack the encryption key. |
+
+---
+
+## `users` table
+
+Introduced in [migration 001](../migrations/001_initial_schema.up.sql). Core user identity and profile data.
+
+| Column | Type | Sensitivity | Rationale |
+|--------|------|-------------|-----------|
+| `id` | UUID | LOW | Primary key |
+| `wallet_address` | TEXT | LOW | Public on-chain identifier. Any user can derive it from a signed message. Not private by design. |
+| `display_name` | TEXT | LOW | User-chosen pseudonym. May or may not correspond to a legal name. No guarantee of PII status. |
+| `kyc_status` | TEXT | LOW | Enum: `unverified` / `pending` / `verified` / `rejected`. Not identifying. |
+| `tier` | TEXT | LOW | Application-level user tier. |
+| `kyc_submitted_at` | TIMESTAMPTZ | LOW | Timestamp, not identifying. |
+| `kyc_reviewed_at` | TIMESTAMPTZ | LOW | Timestamp, not identifying. |
+| `kyc_rejection_reason` | TEXT | LOW | Internal admin-facing note. Not PII. |
+| `risk_profile` | TEXT | LOW | User's risk preference: `conservative` / `moderate` / `aggressive`. Not PII. |
+| `savings_goal` | TEXT | LOW | Free-text savings goal; user-supplied and not inherently identifying. |
+| `onboarding_completed` | BOOLEAN | LOW | Onboarding flag. |
+| `last_login_at` | TIMESTAMPTZ | LOW | Login timestamp. |
+| `created_at` / `updated_at` | TIMESTAMPTZ | LOW | System timestamps. |
+
+### Fields explicitly NOT encrypted (with reason)
+
+- **`wallet_address`**: Public by design; used as a primary lookup key across the system. Encrypting it would break every wallet-based query without meaningful security gain.
+- **`display_name`**: User-chosen pseudonym; not guaranteed to be real PII. Encrypting would add complexity with no security benefit.
+- **All remaining fields**: Either system metadata, enums, timestamps, or user preferences with no PII value.
+
+---
+
+## `bank_accounts` table
+
+Already encrypted per issue #799 (PR #799). Documented here for completeness.
+
+| Column | Sensitivity | Status |
+|--------|-------------|--------|
+| `account_number` (plaintext) | HIGH | Encrypted via `account_cipher.go` |
+| `account_number_encrypted` | — | AES-256-GCM ciphertext |
+| `account_number_fingerprint` | — | HMAC-SHA256 blind index for uniqueness |
+| `account_last4` | LOW | Last 4 digits for display; not encrypted |
+| `key_version` | — | Key version used for encryption |
+
+---
+
+## Summary
+
+| Table | Sensitive Columns Encrypted | Non-sensitive / Not encrypted |
+|-------|---------------------------|-------------------------------|
+| `kyc_documents` | `id_number`, `front_object_key`, `back_object_key` | `id`, `user_id`, `id_type`, `submitted_at` |
+| `users` | — | All columns (wallet public, display name pseudonymous, rest metadata) |
+| `bank_accounts` | `account_number` | `account_last4`, metadata columns |
+
+## Key Hierarchy
+
+All encrypted fields use the same envelope-encryption hierarchy established for bank accounts:
+
+```
+Master Key (never stored)
+    └── Key-Encryption Keys (KEKs) — versioned, stored as ACCOUNT_CIPHER_KEYS
+        └── Data Keys — per-encryption AES-256-GCM key (derived per cipher instance)
+            └── Ciphertext — stored in `*_encrypted` columns alongside `key_version`
+```
+
+The fingerprint (blind index) uses a **separate key** from the encryption keys — either the `v1` KEK or the explicit `ACCOUNT_CIPHER_FINGERPRINT_KEY` — so that the fingerprint cannot be used to attack the ciphertext even if both are leaked in the same breach.
+
+## Rotation
+
+Key rotation rewraps ciphertext for every encrypted field across all tables in a single pass. See `cmd/rotate_keys/main.go` and `internal/rotation/rotation.go`.

--- a/apps/api/internal/domain/user/model.go
+++ b/apps/api/internal/domain/user/model.go
@@ -58,13 +58,26 @@ var (
 	ErrInvalidWallet     = errors.New("invalid wallet address")
 )
 
+// EncryptedKYCDoc holds the ciphertext and key version for each encrypted KYC
+// document field. The repository writes and reads these alongside the plaintext
+// fields; encryption and decryption happen in the service layer.
+// Nil byte slices indicate the encrypted column has not been backfilled yet
+// (legacy rows), and the caller should fall back to the plaintext column.
+type EncryptedKYCDoc struct {
+	IDNumberEncrypted   []byte
+	IDNumberFingerprint string
+	FrontKeyEncrypted   []byte
+	BackKeyEncrypted    []byte
+	KeyVersion          string
+}
+
 type UserRepository interface {
 	Create(ctx context.Context, user *User) error
 	GetByID(ctx context.Context, id uuid.UUID) (*User, error)
 	GetByWalletAddress(ctx context.Context, addr string) (*User, error)
 	GetRoles(ctx context.Context, id uuid.UUID) ([]string, error)
-	SaveKYCDocument(ctx context.Context, doc *KYCDocument) error
-	GetKYCDocument(ctx context.Context, userID uuid.UUID) (*KYCDocument, error)
+	SaveKYCDocument(ctx context.Context, doc *KYCDocument, encrypted *EncryptedKYCDoc) error
+	GetKYCDocument(ctx context.Context, userID uuid.UUID) (*KYCDocument, *EncryptedKYCDoc, error)
 	UpdateKYCStatus(ctx context.Context, userID uuid.UUID, status KYCStatus, reason *string, reviewedAt *time.Time) error
 	UpdateProfile(ctx context.Context, id uuid.UUID, patch ProfilePatch) (*User, error)
 }

--- a/apps/api/internal/domain/yieldharvest/model_test.go
+++ b/apps/api/internal/domain/yieldharvest/model_test.go
@@ -1,0 +1,61 @@
+package yieldharvest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestErrNotFound_Message(t *testing.T) {
+	if ErrNotFound == nil {
+		t.Fatal("ErrNotFound must not be nil")
+	}
+	if ErrNotFound.Error() != "yield harvest not found" {
+		t.Errorf("got %q, want %q", ErrNotFound.Error(), "yield harvest not found")
+	}
+}
+
+func TestYieldHarvest_AmountPrecision(t *testing.T) {
+	// Reward calculations must not lose precision at small decimal values.
+	raw := "0.000000000000000001"
+	amount, err := decimal.NewFromString(raw)
+	if err != nil {
+		t.Fatalf("decimal.NewFromString: %v", err)
+	}
+	h := YieldHarvest{Amount: amount}
+	if h.Amount.String() != raw {
+		t.Errorf("precision lost: got %q, want %q", h.Amount.String(), raw)
+	}
+}
+
+func TestListFilter_SinceUntilWindow(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	f := ListFilter{
+		UserID: uuid.New(),
+		Since:  &start,
+		Until:  &end,
+		Limit:  50,
+	}
+	if !f.Since.Equal(start) {
+		t.Errorf("Since: got %v, want %v", f.Since, start)
+	}
+	if !f.Until.Equal(end) {
+		t.Errorf("Until: got %v, want %v", f.Until, end)
+	}
+	if f.Limit != 50 {
+		t.Errorf("Limit: got %d, want 50", f.Limit)
+	}
+}
+
+func TestListFilter_NilCursorByDefault(t *testing.T) {
+	f := ListFilter{UserID: uuid.New(), Limit: 20}
+	if f.CursorTime != nil {
+		t.Error("CursorTime should be nil when not set")
+	}
+	if f.CursorID != nil {
+		t.Error("CursorID should be nil when not set")
+	}
+}

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -110,12 +110,12 @@ func (r *settlementStubUserRepo) GetRoles(_ context.Context, _ uuid.UUID) ([]str
 	return nil, nil
 }
 
-func (r *settlementStubUserRepo) SaveKYCDocument(_ context.Context, _ *user.KYCDocument) error {
+func (r *settlementStubUserRepo) SaveKYCDocument(_ context.Context, _ *user.KYCDocument, _ *user.EncryptedKYCDoc) error {
 	return nil
 }
 
-func (r *settlementStubUserRepo) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, error) {
-	return nil, user.ErrUserNotFound
+func (r *settlementStubUserRepo) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, *user.EncryptedKYCDoc, error) {
+	return nil, nil, user.ErrUserNotFound
 }
 
 func (r *settlementStubUserRepo) UpdateKYCStatus(_ context.Context, _ uuid.UUID, _ user.KYCStatus, _ *string, _ *time.Time) error {

--- a/apps/api/internal/handler/user_handler_test.go
+++ b/apps/api/internal/handler/user_handler_test.go
@@ -56,12 +56,12 @@ func (m *mockUserRepository) GetRoles(_ context.Context, _ uuid.UUID) ([]string,
 	return []string{}, nil
 }
 
-func (m *mockUserRepository) SaveKYCDocument(_ context.Context, doc *user.KYCDocument) error {
+func (m *mockUserRepository) SaveKYCDocument(_ context.Context, _ *user.KYCDocument, _ *user.EncryptedKYCDoc) error {
 	return nil
 }
 
-func (m *mockUserRepository) GetKYCDocument(_ context.Context, userID uuid.UUID) (*user.KYCDocument, error) {
-	return nil, user.ErrUserNotFound
+func (m *mockUserRepository) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, *user.EncryptedKYCDoc, error) {
+	return nil, nil, user.ErrUserNotFound
 }
 
 func (m *mockUserRepository) UpdateKYCStatus(_ context.Context, userID uuid.UUID, status user.KYCStatus, reason *string, reviewedAt *time.Time) error {

--- a/apps/api/internal/repository/postgres/user_repository.go
+++ b/apps/api/internal/repository/postgres/user_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
+	"github.com/suncrestlabs/nester/apps/api/internal/rotation"
 )
 
 type UserRepository struct {
@@ -216,44 +218,60 @@ func (r *UserRepository) GetRoles(ctx context.Context, id uuid.UUID) ([]string, 
 	return roles, rows.Err()
 }
 
-func (r *UserRepository) SaveKYCDocument(ctx context.Context, doc *user.KYCDocument) error {
+func (r *UserRepository) SaveKYCDocument(ctx context.Context, doc *user.KYCDocument, encrypted *user.EncryptedKYCDoc) error {
 	query := `
 		INSERT INTO kyc_documents (
-			id, user_id, id_type, id_number, front_object_key, back_object_key
-		) VALUES ($1, $2, $3, $4, $5, $6)
+			id, user_id, id_type, id_number, front_object_key, back_object_key,
+			id_number_encrypted, id_number_fingerprint, front_object_key_encrypted,
+			back_object_key_encrypted, key_version
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING submitted_at
 	`
 	err := r.db.QueryRowContext(ctx, query,
 		doc.ID.String(), doc.UserID.String(), doc.IDType, doc.IDNumber, doc.FrontObjectKey, doc.BackObjectKey,
+		encrypted.IDNumberEncrypted, encrypted.IDNumberFingerprint, encrypted.FrontKeyEncrypted,
+		nullOptionalBytes(encrypted.BackKeyEncrypted), encrypted.KeyVersion,
 	).Scan(&doc.SubmittedAt)
 	return err
 }
 
-func (r *UserRepository) GetKYCDocument(ctx context.Context, userID uuid.UUID) (*user.KYCDocument, error) {
+func (r *UserRepository) GetKYCDocument(ctx context.Context, userID uuid.UUID) (*user.KYCDocument, *user.EncryptedKYCDoc, error) {
 	query := `
-		SELECT id, user_id, id_type, id_number, front_object_key, back_object_key, submitted_at
+		SELECT id, user_id, id_type, id_number, front_object_key, back_object_key,
+		       id_number_encrypted, id_number_fingerprint, front_object_key_encrypted,
+		       back_object_key_encrypted, key_version, submitted_at
 		FROM kyc_documents
 		WHERE user_id = $1
 		ORDER BY submitted_at DESC
 		LIMIT 1
 	`
 	var doc user.KYCDocument
+	var encrypted user.EncryptedKYCDoc
 	var id, uid string
 	var backKey sql.NullString
+	var idNumFingerprint, kv sql.NullString
 	if err := r.db.QueryRowContext(ctx, query, userID.String()).Scan(
-		&id, &uid, &doc.IDType, &doc.IDNumber, &doc.FrontObjectKey, &backKey, &doc.SubmittedAt,
+		&id, &uid, &doc.IDType, &doc.IDNumber, &doc.FrontObjectKey, &backKey,
+		&encrypted.IDNumberEncrypted, &idNumFingerprint, &encrypted.FrontKeyEncrypted,
+		&encrypted.BackKeyEncrypted, &kv, &doc.SubmittedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.New("no kyc document found")
+			return nil, nil, errors.New("no kyc document found")
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	doc.ID = uuid.MustParse(id)
 	doc.UserID = uuid.MustParse(uid)
 	if backKey.Valid {
 		doc.BackObjectKey = &backKey.String
 	}
-	return &doc, nil
+	if idNumFingerprint.Valid {
+		encrypted.IDNumberFingerprint = idNumFingerprint.String
+	}
+	if kv.Valid {
+		encrypted.KeyVersion = kv.String
+	}
+	return &doc, &encrypted, nil
 }
 
 func (r *UserRepository) UpdateKYCStatus(ctx context.Context, userID uuid.UUID, status user.KYCStatus, reason *string, ts *time.Time) error {
@@ -267,6 +285,197 @@ func (r *UserRepository) UpdateKYCStatus(ctx context.Context, userID uuid.UUID, 
 		_, err = r.db.ExecContext(ctx, query, string(status), ts, reason, userID.String())
 	}
 	return err
+}
+
+// KYCBackfillRow holds the plaintext fields of a KYC document row that still
+// needs its encrypted columns populated.
+type KYCBackfillRow struct {
+	ID             uuid.UUID
+	IDNumber       string
+	FrontObjectKey string
+	BackObjectKey  *string
+}
+
+// ScanKYCDocumentsForBackfill returns up to limit KYC document rows whose
+// id_number_encrypted column is NULL (not yet backfilled), ordered by id for
+// stable paging. Each row is committed independently so the backfill is
+// resumable.
+func (r *UserRepository) ScanKYCDocumentsForBackfill(ctx context.Context, limit int) ([]KYCBackfillRow, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, id_number, front_object_key, back_object_key
+		FROM kyc_documents
+		WHERE id_number_encrypted IS NULL
+		ORDER BY id
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("kyc repository: scan for backfill: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KYCBackfillRow
+	for rows.Next() {
+		var (
+			id                       string
+			idNum, frontKey          string
+			backKey                  sql.NullString
+		)
+		if err := rows.Scan(&id, &idNum, &frontKey, &backKey); err != nil {
+			return nil, err
+		}
+		parsedID, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("kyc repository: parse id: %w", err)
+		}
+		row := KYCBackfillRow{
+			ID:             parsedID,
+			IDNumber:       idNum,
+			FrontObjectKey: frontKey,
+		}
+		if backKey.Valid {
+			row.BackObjectKey = &backKey.String
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// CountKYCDocumentsForBackfill reports how many KYC document rows still need
+// their encrypted columns populated.
+func (r *UserRepository) CountKYCDocumentsForBackfill(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM kyc_documents WHERE id_number_encrypted IS NULL`).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("kyc repository: count for backfill: %w", err)
+	}
+	return n, nil
+}
+
+// CountPendingKYCEncryption reports how many KYC document rows are not yet on
+// the active key version. Implements the rotation store interface for KYC docs.
+func (r *UserRepository) CountPendingKYCEncryption(ctx context.Context, activeVersion string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM kyc_documents WHERE key_version <> $1`, activeVersion).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("kyc repository: count pending rotation: %w", err)
+	}
+	return n, nil
+}
+
+// ScanPendingKYCEncryption returns up to limit KYC document rows whose key
+// version is not activeVersion, ordered by id for stable paging. Implements
+// the rotation store interface for KYC docs.
+func (r *UserRepository) ScanPendingKYCEncryption(ctx context.Context, activeVersion string, limit int) ([]rotation.EncryptedRow, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, id_number_encrypted, front_object_key_encrypted, back_object_key_encrypted, key_version
+		FROM kyc_documents
+		WHERE key_version <> $1
+		ORDER BY id
+		LIMIT $2
+	`, activeVersion, limit)
+	if err != nil {
+		return nil, fmt.Errorf("kyc repository: scan pending rotation: %w", err)
+	}
+	defer rows.Close()
+
+	var out []rotation.EncryptedRow
+	for rows.Next() {
+		var (
+			id                     string
+			idNumEnc, frontKeyEnc  []byte
+			backKeyEnc             []byte
+			keyVersion             string
+		)
+		if err := rows.Scan(&id, &idNumEnc, &frontKeyEnc, &backKeyEnc, &keyVersion); err != nil {
+			return nil, err
+		}
+		parsedID, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("kyc repository: parse id: %w", err)
+		}
+		// Pack the three ciphertexts into a single []byte for the rotation
+		// store interface; unpacking happens during re-encryption.
+		packed := packKYCCiphertexts(idNumEnc, frontKeyEnc, backKeyEnc)
+		out = append(out, rotation.EncryptedRow{ID: parsedID, Ciphertext: packed, KeyVersion: keyVersion})
+	}
+	return out, rows.Err()
+}
+
+// UpdateKYCCipher atomically replaces a KYC document row's ciphertext and key
+// version. The ciphertext parameter is expected to be the packed output of
+// packKYCCiphertexts.
+func (r *UserRepository) UpdateKYCCipher(ctx context.Context, id uuid.UUID, encryptedIDNumber, encryptedFrontKey, encryptedBackKey []byte, keyVersion string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE kyc_documents
+		SET id_number_encrypted = $2, front_object_key_encrypted = $3,
+		    back_object_key_encrypted = $4, key_version = $5
+		WHERE id = $1
+	`, id.String(), encryptedIDNumber, encryptedFrontKey, nullOptionalBytes(encryptedBackKey), keyVersion)
+	if err != nil {
+		return fmt.Errorf("kyc repository: update cipher: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return errors.New("kyc document not found")
+	}
+	return nil
+}
+
+// UpdateKYCFingerprint sets the id_number_fingerprint column for a KYC
+// document row. Called during backfill to populate the blind index.
+func (r *UserRepository) UpdateKYCFingerprint(ctx context.Context, id uuid.UUID, fingerprint string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE kyc_documents SET id_number_fingerprint = $2 WHERE id = $1`,
+		id.String(), fingerprint)
+	return err
+}
+
+// packKYCCiphertexts packs three ciphertext byte slices into a single
+// length-prefixed blob for transport through the rotation.Store interface.
+func packKYCCiphertexts(idNum, frontKey, backKey []byte) []byte {
+	writeLen := func(buf []byte, v int) { buf[0] = byte(v >> 8); buf[1] = byte(v) }
+	total := 6 + len(idNum) + len(frontKey) + len(backKey)
+	buf := make([]byte, total)
+	writeLen(buf[0:2], len(idNum))
+	writeLen(buf[2:4], len(frontKey))
+	writeLen(buf[4:6], len(backKey))
+	copy(buf[6:], idNum)
+	copy(buf[6+len(idNum):], frontKey)
+	copy(buf[6+len(idNum)+len(frontKey):], backKey)
+	return buf
+}
+
+// UnpackKYCCiphertexts reverses packKYCCiphertexts.
+func UnpackKYCCiphertexts(packed []byte) (idNum, frontKey, backKey []byte) {
+	if len(packed) < 6 {
+		return nil, nil, nil
+	}
+	readLen := func(buf []byte) int { return int(buf[0])<<8 | int(buf[1]) }
+	idNumLen := readLen(packed[0:2])
+	frontKeyLen := readLen(packed[2:4])
+	backKeyLen := readLen(packed[4:6])
+	off := 6
+	if idNumLen > 0 {
+		idNum = packed[off : off+idNumLen]
+		off += idNumLen
+	}
+	if frontKeyLen > 0 {
+		frontKey = packed[off : off+frontKeyLen]
+		off += frontKeyLen
+	}
+	if backKeyLen > 0 {
+		backKey = packed[off : off+backKeyLen]
+	}
+	return
+}
+
+func nullOptionalBytes(b []byte) any {
+	if b == nil {
+		return nil
+	}
+	return b
 }
 
 func mapUserError(err error) error {

--- a/apps/api/internal/repository/postgres/user_repository_test.go
+++ b/apps/api/internal/repository/postgres/user_repository_test.go
@@ -1,0 +1,54 @@
+package postgres
+
+import (
+	"testing"
+)
+
+func TestPackUnpackKYCCiphertexts_RoundTrip(t *testing.T) {
+	idNum := []byte("id-number-ciphertext-here")
+	frontKey := []byte("front-key-ciphertext-here")
+	backKey := []byte("back-key-ciphertext-here")
+
+	packed := packKYCCiphertexts(idNum, frontKey, backKey)
+	gotIDNum, gotFrontKey, gotBackKey := UnpackKYCCiphertexts(packed)
+
+	if string(gotIDNum) != string(idNum) {
+		t.Fatalf("id_number: want %q, got %q", idNum, gotIDNum)
+	}
+	if string(gotFrontKey) != string(frontKey) {
+		t.Fatalf("front_key: want %q, got %q", frontKey, gotFrontKey)
+	}
+	if string(gotBackKey) != string(backKey) {
+		t.Fatalf("back_key: want %q, got %q", backKey, gotBackKey)
+	}
+}
+
+func TestPackUnpackKYCCiphertexts_NilBackKey(t *testing.T) {
+	idNum := []byte("id-number")
+	frontKey := []byte("front-key")
+
+	packed := packKYCCiphertexts(idNum, frontKey, nil)
+	gotIDNum, gotFrontKey, gotBackKey := UnpackKYCCiphertexts(packed)
+
+	if string(gotIDNum) != string(idNum) {
+		t.Fatalf("id_number: want %q, got %q", idNum, gotIDNum)
+	}
+	if string(gotFrontKey) != string(frontKey) {
+		t.Fatalf("front_key: want %q, got %q", frontKey, gotFrontKey)
+	}
+	if gotBackKey != nil {
+		t.Fatalf("back_key: want nil, got %q", gotBackKey)
+	}
+}
+
+func TestPackUnpackKYCCiphertexts_Empty(t *testing.T) {
+	gotIDNum, gotFrontKey, gotBackKey := UnpackKYCCiphertexts(nil)
+	if gotIDNum != nil || gotFrontKey != nil || gotBackKey != nil {
+		t.Fatal("all should be nil for nil input")
+	}
+
+	gotIDNum, gotFrontKey, gotBackKey = UnpackKYCCiphertexts([]byte{})
+	if gotIDNum != nil || gotFrontKey != nil || gotBackKey != nil {
+		t.Fatal("all should be nil for empty input")
+	}
+}

--- a/apps/api/internal/service/auth_service_test.go
+++ b/apps/api/internal/service/auth_service_test.go
@@ -54,12 +54,12 @@ func (m *mockAuthUserRepository) GetRoles(ctx context.Context, id uuid.UUID) ([]
 	return []string{}, nil
 }
 
-func (m *mockAuthUserRepository) SaveKYCDocument(_ context.Context, _ *user.KYCDocument) error {
+func (m *mockAuthUserRepository) SaveKYCDocument(_ context.Context, _ *user.KYCDocument, _ *user.EncryptedKYCDoc) error {
 	return nil
 }
 
-func (m *mockAuthUserRepository) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, error) {
-	return nil, user.ErrUserNotFound
+func (m *mockAuthUserRepository) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, *user.EncryptedKYCDoc, error) {
+	return nil, nil, user.ErrUserNotFound
 }
 
 func (m *mockAuthUserRepository) UpdateKYCStatus(_ context.Context, _ uuid.UUID, _ user.KYCStatus, _ *string, _ *time.Time) error {

--- a/apps/api/internal/service/user_service.go
+++ b/apps/api/internal/service/user_service.go
@@ -2,19 +2,27 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
 )
 
 type UserService struct {
-	repo user.UserRepository
+	repo   user.UserRepository
+	cipher *crypto.AccountCipher
 }
 
 func NewUserService(repo user.UserRepository) *UserService {
 	return &UserService{repo: repo}
+}
+
+func (s *UserService) WithCipher(c *crypto.AccountCipher) *UserService {
+	s.cipher = c
+	return s
 }
 
 func (s *UserService) RegisterUser(ctx context.Context, walletAddress, displayName string) (*user.User, error) {
@@ -44,7 +52,33 @@ func (s *UserService) GetUserRoles(ctx context.Context, id uuid.UUID) ([]string,
 	return s.repo.GetRoles(ctx, id)
 }
 
+var ErrEncryptionUnavailable = errors.New("encryption is not configured")
+
 func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, idType, idNumber, frontKey string, backKey *string) error {
+	if s.cipher == nil {
+		return ErrEncryptionUnavailable
+	}
+
+	idNumEnv, err := s.cipher.Encrypt(idNumber)
+	if err != nil {
+		return err
+	}
+	frontKeyEnv, err := s.cipher.Encrypt(frontKey)
+	if err != nil {
+		return err
+	}
+	fingerprint := s.cipher.Fingerprint(idNumber)
+
+	var backKeyEnc []byte
+	var backKeyEnv crypto.CipherEnvelope
+	if backKey != nil {
+		backKeyEnv, err = s.cipher.Encrypt(*backKey)
+		if err != nil {
+			return err
+		}
+		backKeyEnc = backKeyEnv.Ciphertext
+	}
+
 	doc := &user.KYCDocument{
 		ID:             uuid.New(),
 		UserID:         userID,
@@ -54,7 +88,15 @@ func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, idType, i
 		BackObjectKey:  backKey,
 	}
 
-	if err := s.repo.SaveKYCDocument(ctx, doc); err != nil {
+	encrypted := &user.EncryptedKYCDoc{
+		IDNumberEncrypted:   idNumEnv.Ciphertext,
+		IDNumberFingerprint: fingerprint,
+		FrontKeyEncrypted:   frontKeyEnv.Ciphertext,
+		BackKeyEncrypted:    backKeyEnc,
+		KeyVersion:          idNumEnv.KeyVersion,
+	}
+
+	if err := s.repo.SaveKYCDocument(ctx, doc, encrypted); err != nil {
 		return err
 	}
 
@@ -63,7 +105,53 @@ func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, idType, i
 }
 
 func (s *UserService) GetKYCDocument(ctx context.Context, userID uuid.UUID) (*user.KYCDocument, error) {
-	return s.repo.GetKYCDocument(ctx, userID)
+	if s.cipher == nil {
+		return nil, ErrEncryptionUnavailable
+	}
+
+	doc, encrypted, err := s.repo.GetKYCDocument(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt id_number — fall back to plaintext column if ciphertext is nil
+	// (legacy rows created before the encryption migration was backfilled).
+	if encrypted.IDNumberEncrypted != nil {
+		plain, err := s.cipher.Decrypt(crypto.CipherEnvelope{
+			KeyVersion: encrypted.KeyVersion,
+			Ciphertext: encrypted.IDNumberEncrypted,
+		})
+		if err != nil {
+			return nil, err
+		}
+		doc.IDNumber = plain
+	}
+
+	// Decrypt front_object_key
+	if encrypted.FrontKeyEncrypted != nil {
+		plain, err := s.cipher.Decrypt(crypto.CipherEnvelope{
+			KeyVersion: encrypted.KeyVersion,
+			Ciphertext: encrypted.FrontKeyEncrypted,
+		})
+		if err != nil {
+			return nil, err
+		}
+		doc.FrontObjectKey = plain
+	}
+
+	// Decrypt back_object_key
+	if encrypted.BackKeyEncrypted != nil {
+		plain, err := s.cipher.Decrypt(crypto.CipherEnvelope{
+			KeyVersion: encrypted.KeyVersion,
+			Ciphertext: encrypted.BackKeyEncrypted,
+		})
+		if err != nil {
+			return nil, err
+		}
+		doc.BackObjectKey = &plain
+	}
+
+	return doc, nil
 }
 
 func (s *UserService) UpdateKYCStatus(ctx context.Context, userID uuid.UUID, status user.KYCStatus, reason *string) error {

--- a/apps/api/internal/service/user_service_test.go
+++ b/apps/api/internal/service/user_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -51,12 +52,12 @@ func (m *mockUserRepository) GetRoles(_ context.Context, _ uuid.UUID) ([]string,
 	return []string{}, nil
 }
 
-func (m *mockUserRepository) SaveKYCDocument(_ context.Context, _ *user.KYCDocument) error {
+func (m *mockUserRepository) SaveKYCDocument(_ context.Context, _ *user.KYCDocument, _ *user.EncryptedKYCDoc) error {
 	return nil
 }
 
-func (m *mockUserRepository) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, error) {
-	return nil, user.ErrUserNotFound
+func (m *mockUserRepository) GetKYCDocument(_ context.Context, _ uuid.UUID) (*user.KYCDocument, *user.EncryptedKYCDoc, error) {
+	return nil, nil, errors.New("no kyc document found")
 }
 
 func (m *mockUserRepository) UpdateKYCStatus(_ context.Context, userID uuid.UUID, status user.KYCStatus, reason *string, reviewedAt *time.Time) error {

--- a/apps/api/migrations/069_encrypt_kyc_documents.down.sql
+++ b/apps/api/migrations/069_encrypt_kyc_documents.down.sql
@@ -1,0 +1,17 @@
+-- Rollback safety: key_version is the ONLY mapping from a ciphertext to the key
+-- that sealed it. Dropping it once any row has been rotated to a non-v1 key
+-- would leave those ciphertexts undecryptable. Abort rather than lose data.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM kyc_documents WHERE key_version <> 'v1') THEN
+        RAISE EXCEPTION
+            'cannot drop key_version: % row(s) are encrypted with a non-v1 key; re-key them to v1 before rolling back',
+            (SELECT COUNT(*) FROM kyc_documents WHERE key_version <> 'v1');
+    END IF;
+END $$;
+
+ALTER TABLE kyc_documents DROP COLUMN IF EXISTS key_version;
+ALTER TABLE kyc_documents DROP COLUMN IF EXISTS back_object_key_encrypted;
+ALTER TABLE kyc_documents DROP COLUMN IF EXISTS front_object_key_encrypted;
+ALTER TABLE kyc_documents DROP COLUMN IF EXISTS id_number_fingerprint;
+ALTER TABLE kyc_documents DROP COLUMN IF EXISTS id_number_encrypted;

--- a/apps/api/migrations/069_encrypt_kyc_documents.up.sql
+++ b/apps/api/migrations/069_encrypt_kyc_documents.up.sql
@@ -1,0 +1,20 @@
+-- Adds encrypted columns and a blind-index fingerprint for KYC document fields
+-- that contain sensitive PII (government ID number, S3 object keys pointing to
+-- ID document scans). Encrypted columns sit alongside the existing plaintext
+-- columns so the migration is safe and rollbackable.
+--
+--  1. The plaintext columns (id_number, front_object_key, back_object_key)
+--     remain until migration 071 drops them after the backfill is verified.
+--  2. The key_version column mirrors the bank_accounts pattern (migration 057)
+--     and enables non-destructive key rotation.
+--  3. The id_number_fingerprint column is a blind index for exact-match
+--     deduplication without decryption.
+--
+-- The supporting CONCURRENTLY index is created in migration 070 to avoid
+-- write-locking the table during deploy.
+ALTER TABLE kyc_documents
+    ADD COLUMN id_number_encrypted         BYTEA,
+    ADD COLUMN id_number_fingerprint       TEXT,
+    ADD COLUMN front_object_key_encrypted  BYTEA,
+    ADD COLUMN back_object_key_encrypted   BYTEA,
+    ADD COLUMN key_version                 VARCHAR(32) NOT NULL DEFAULT 'v1';

--- a/apps/api/migrations/070_encrypt_kyc_documents_index.down.sql
+++ b/apps/api/migrations/070_encrypt_kyc_documents_index.down.sql
@@ -1,0 +1,3 @@
+-- Drop CONCURRENTLY to avoid a write lock; must be the sole statement and run
+-- outside a transaction.
+DROP INDEX CONCURRENTLY IF EXISTS idx_kyc_documents_key_version;

--- a/apps/api/migrations/070_encrypt_kyc_documents_index.up.sql
+++ b/apps/api/migrations/070_encrypt_kyc_documents_index.up.sql
@@ -1,0 +1,6 @@
+-- Index used by the rotation tool to find rows not yet on the active key
+-- version (WHERE key_version <> $active). Built CONCURRENTLY so it does not
+-- take a write lock on kyc_documents during deploy. This statement must run
+-- outside a transaction; keep it the sole statement in this migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_kyc_documents_key_version
+    ON kyc_documents (key_version);


### PR DESCRIPTION
## Overview

Closes #862

Extends the existing envelope encryption pattern (AES-256-GCM with key versioning and rotation) to protect all sensitive user data in KYC documents at rest.

## Changes

### Data Classification
- **\pps/api/internal/crypto/DATA_CLASSIFICATION.md\** — Complete inventory classifying every column holding user data as HIGH (sensitive), MEDIUM (indirect PII), or LOW (non-sensitive).

### New Encrypted Fields
| Table | Encrypted Columns | Blind Index |
|---|---|---|
| \kyc_documents\ | \id_number_encrypted\ (BYTEA), \ront_object_key_encrypted\ (BYTEA), \ack_object_key_encrypted\ (BYTEA) | \id_number_fingerprint\ (TEXT, HMAC-SHA256) |

### Migrations
- **\