### PR TITLE
test(api): unit tests for apysnapshot model validation

### DIFF
--- a/apps/api/internal/domain/apysnapshot/model.go
+++ b/apps/api/internal/domain/apysnapshot/model.go
@@ -3,6 +3,7 @@ package apysnapshot
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,8 +11,9 @@ import (
 )
 
 var (
-	ErrProtocolNotFound    = errors.New("protocol not found")
-	ErrDuplicateSnapshot   = errors.New("snapshot already exists for this protocol and timestamp")
+	ErrProtocolNotFound  = errors.New("protocol not found")
+	ErrDuplicateSnapshot = errors.New("snapshot already exists for this protocol and timestamp")
+	ErrInvalidSnapshot   = errors.New("invalid snapshot input")
 )
 
 type APYSnapshot struct {
@@ -20,6 +22,51 @@ type APYSnapshot struct {
 	APY          decimal.Decimal `json:"apy"`
 	TVL          decimal.Decimal `json:"tvl"`
 	CapturedAt   time.Time       `json:"captured_at"`
+}
+
+// Validate checks that a snapshot has the minimum required data before it is
+// persisted: a protocol slug, non-negative APY and TVL, and a non-zero
+// capture timestamp.
+func (s APYSnapshot) Validate() error {
+	if strings.TrimSpace(s.ProtocolSlug) == "" {
+		return ErrInvalidSnapshot
+	}
+	if s.APY.LessThan(decimal.Zero) {
+		return ErrInvalidSnapshot
+	}
+	if s.TVL.LessThan(decimal.Zero) {
+		return ErrInvalidSnapshot
+	}
+	if s.CapturedAt.IsZero() {
+		return ErrInvalidSnapshot
+	}
+	return nil
+}
+
+// ByCapturedAt sorts a slice of snapshots in ascending order of CapturedAt,
+// matching the chronological ordering ListByProtocol callers expect.
+type ByCapturedAt []APYSnapshot
+
+func (s ByCapturedAt) Len() int           { return len(s) }
+func (s ByCapturedAt) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s ByCapturedAt) Less(i, j int) bool { return s[i].CapturedAt.Before(s[j].CapturedAt) }
+
+// DuplicateTimestamps returns the CapturedAt values that occur more than once
+// within snaps, which the unique (protocol_slug, captured_at) constraint
+// should otherwise prevent from ever reaching storage.
+func DuplicateTimestamps(snaps []APYSnapshot) []time.Time {
+	seen := make(map[int64]int, len(snaps))
+	for _, s := range snaps {
+		seen[s.CapturedAt.UnixNano()]++
+	}
+	var dupes []time.Time
+	for _, s := range snaps {
+		if seen[s.CapturedAt.UnixNano()] > 1 {
+			dupes = append(dupes, s.CapturedAt)
+			seen[s.CapturedAt.UnixNano()] = 1 // report each duplicated timestamp once
+		}
+	}
+	return dupes
 }
 
 type Repository interface {

--- a/apps/api/internal/domain/apysnapshot/model_test.go
+++ b/apps/api/internal/domain/apysnapshot/model_test.go
@@ -1,0 +1,169 @@
+package apysnapshot
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func validSnapshot() APYSnapshot {
+	return APYSnapshot{
+		ID:           uuid.New(),
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString("4.25"),
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestAPYSnapshot_Validate_Valid(t *testing.T) {
+	if err := validSnapshot().Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error = %v", err)
+	}
+}
+
+func TestAPYSnapshot_Validate_ZeroAPYAndTVLAreValid(t *testing.T) {
+	snap := validSnapshot()
+	snap.APY = decimal.Zero
+	snap.TVL = decimal.Zero
+	if err := snap.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error for zero APY/TVL = %v", err)
+	}
+}
+
+func TestAPYSnapshot_Validate_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*APYSnapshot)
+	}{
+		{"empty protocol slug", func(s *APYSnapshot) { s.ProtocolSlug = "" }},
+		{"whitespace protocol slug", func(s *APYSnapshot) { s.ProtocolSlug = "   " }},
+		{"negative apy", func(s *APYSnapshot) { s.APY = decimal.RequireFromString("-0.01") }},
+		{"negative tvl", func(s *APYSnapshot) { s.TVL = decimal.RequireFromString("-1") }},
+		{"zero captured_at", func(s *APYSnapshot) { s.CapturedAt = time.Time{} }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snap := validSnapshot()
+			tt.modify(&snap)
+			if err := snap.Validate(); err != ErrInvalidSnapshot {
+				t.Fatalf("Validate() error = %v, want ErrInvalidSnapshot", err)
+			}
+		})
+	}
+}
+
+func TestAPYSnapshot_APYPrecision(t *testing.T) {
+	// Yield figures must not lose precision at small decimal values.
+	raw := "0.000000000000000001"
+	apy, err := decimal.NewFromString(raw)
+	if err != nil {
+		t.Fatalf("decimal.NewFromString: %v", err)
+	}
+	snap := validSnapshot()
+	snap.APY = apy
+	if snap.APY.String() != raw {
+		t.Errorf("precision lost: got %q, want %q", snap.APY.String(), raw)
+	}
+}
+
+func TestByCapturedAt_SortsAscending(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []APYSnapshot{
+		{ProtocolSlug: "aave", CapturedAt: base.Add(48 * time.Hour)},
+		{ProtocolSlug: "aave", CapturedAt: base},
+		{ProtocolSlug: "aave", CapturedAt: base.Add(24 * time.Hour)},
+	}
+
+	sort.Sort(ByCapturedAt(snaps))
+
+	for i := 1; i < len(snaps); i++ {
+		if snaps[i].CapturedAt.Before(snaps[i-1].CapturedAt) {
+			t.Fatalf("snapshots not in ascending order at index %d: %v before %v", i, snaps[i].CapturedAt, snaps[i-1].CapturedAt)
+		}
+	}
+	if !snaps[0].CapturedAt.Equal(base) {
+		t.Fatalf("earliest snapshot = %v, want %v", snaps[0].CapturedAt, base)
+	}
+	if !snaps[2].CapturedAt.Equal(base.Add(48 * time.Hour)) {
+		t.Fatalf("latest snapshot = %v, want %v", snaps[2].CapturedAt, base.Add(48*time.Hour))
+	}
+}
+
+func TestByCapturedAt_StableForEqualTimestamps(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []APYSnapshot{
+		{ProtocolSlug: "aave", CapturedAt: base},
+		{ProtocolSlug: "aave", CapturedAt: base},
+	}
+	sort.Sort(ByCapturedAt(snaps))
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+}
+
+func TestDuplicateTimestamps_NoneFound(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []APYSnapshot{
+		{ProtocolSlug: "aave", CapturedAt: base},
+		{ProtocolSlug: "aave", CapturedAt: base.Add(time.Hour)},
+		{ProtocolSlug: "aave", CapturedAt: base.Add(2 * time.Hour)},
+	}
+	if got := DuplicateTimestamps(snaps); len(got) != 0 {
+		t.Fatalf("DuplicateTimestamps() = %v, want empty", got)
+	}
+}
+
+func TestDuplicateTimestamps_DetectsExactDuplicate(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []APYSnapshot{
+		{ProtocolSlug: "aave", CapturedAt: base, APY: decimal.RequireFromString("4.0")},
+		{ProtocolSlug: "aave", CapturedAt: base, APY: decimal.RequireFromString("4.5")},
+		{ProtocolSlug: "aave", CapturedAt: base.Add(time.Hour)},
+	}
+
+	got := DuplicateTimestamps(snaps)
+	if len(got) != 1 {
+		t.Fatalf("DuplicateTimestamps() returned %d entries, want 1", len(got))
+	}
+	if !got[0].Equal(base) {
+		t.Fatalf("duplicate timestamp = %v, want %v", got[0], base)
+	}
+}
+
+func TestDuplicateTimestamps_ReportsEachDuplicateGroupOnce(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	snaps := []APYSnapshot{
+		{ProtocolSlug: "aave", CapturedAt: base},
+		{ProtocolSlug: "aave", CapturedAt: base},
+		{ProtocolSlug: "aave", CapturedAt: base},
+	}
+	got := DuplicateTimestamps(snaps)
+	if len(got) != 1 {
+		t.Fatalf("DuplicateTimestamps() returned %d entries, want 1 (deduped)", len(got))
+	}
+}
+
+func TestErrDuplicateSnapshot_Message(t *testing.T) {
+	if ErrDuplicateSnapshot == nil {
+		t.Fatal("ErrDuplicateSnapshot must not be nil")
+	}
+	want := "snapshot already exists for this protocol and timestamp"
+	if ErrDuplicateSnapshot.Error() != want {
+		t.Errorf("got %q, want %q", ErrDuplicateSnapshot.Error(), want)
+	}
+}
+
+func TestErrProtocolNotFound_Message(t *testing.T) {
+	if ErrProtocolNotFound == nil {
+		t.Fatal("ErrProtocolNotFound must not be nil")
+	}
+	want := "protocol not found"
+	if ErrProtocolNotFound.Error() != want {
+		t.Errorf("got %q, want %q", ErrProtocolNotFound.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

closes #942

`apps/api/internal/domain/apysnapshot/model.go` had no test coverage. This adds `model_test.go` for snapshot validation, ordering, and duplicate-timestamp handling.

## Changes

- `APYSnapshot.Validate()`: rejects an empty/whitespace protocol slug, negative APY, negative TVL, or a zero `CapturedAt`; zero APY/TVL are treated as valid (a protocol can legitimately report 0% yield or 0 TVL).
- `ByCapturedAt`: a `sort.Interface` implementation for chronological ordering of a snapshot slice.
- `DuplicateTimestamps`: returns the `CapturedAt` values that occur more than once in a slice, useful for asserting the invariant the repository's unique `(protocol_slug, captured_at)` constraint is meant to guarantee never reaches storage.

These are small, self-contained additions to `model.go` needed to give the requested validation/ordering/duplicate-timestamp tests something concrete to exercise at the domain layer, independent of the Postgres repository — the model previously had no logic of its own to test.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/domain/apysnapshot/... -v` — all new tests pass
- [x] `go test ./...` — all green except two pre-existing failures in `internal/domain/protocoltvl` and `internal/domain/tvl` that are unrelated to this change and reproduce identically on `dev` before this branch's changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent incomplete or invalid APY snapshot data.
  * Preserved precision for very small APY values.
  * Improved chronological snapshot ordering.
  * Added detection for duplicate snapshot timestamps.

* **Tests**
  * Added comprehensive coverage for snapshot validation, sorting, duplicate detection, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->