### PR TITLE
feat(contracts): signature-attested APY and TVL updates for yield reg…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,67 @@ Every role transfer is two-step (`transfer_role` / `accept_role`, cancellable vi
 
 **On-chain roles vs application roles:** the RBAC above lives entirely in the Soroban contracts. The `user_roles` tables in the API's Postgres migrations are a separate, application-level authorization layer (who can see what in the dashboard) and do not confer any on-chain authority — do not conflate the two when reasoning about contract security.
 
+## Attester Signing Key Separation (issue #820 — signature-attested APY/TVL)
+
+The `update_apy_attested` and `update_tvl_attested` registry functions require every value to
+be signed by one or more registered ed25519 attester keys before it is accepted on-chain.
+This converts "trust the caller" into "verify the data" and makes every accepted value
+independently auditable via the `VAL_ATT` event log.
+
+**The attester signing key MUST be distinct from the Stellar transaction-submitting (fee-paying) key.**
+
+This requirement is not advisory — it is the security boundary the feature is built on:
+
+- The **transaction key** pays Stellar fees and authorises the `update_apy_attested` call. It
+  is exposed to the Stellar network on every submission. Compromise of this key lets an attacker
+  submit transactions, but without a valid attester signature the on-chain contract will reject
+  the value.
+- The **attester key** signs the canonical payload (contract address, source id, field, value,
+  validity window, nonce). It never touches the Stellar network directly. Compromise of this
+  key lets an attacker forge signatures, but without the transaction key no on-chain call can
+  be submitted.
+
+If the same key plays both roles, attestation adds nothing — a compromise gives the attacker
+both halves simultaneously. The registry can be updated to any value with a single key, exactly
+as before.
+
+### Implementation requirements for the backend attester
+
+The Go APY push pipeline (`apps/api/internal/service/apy_service.go`,
+`apps/api/internal/service/performance/apy_refresh.go`) is responsible for signing attestations
+before submitting registry updates via `apps/api/internal/stellar/invoker.go`.
+
+- The attester private key **must** be stored in the same secret store as the AES cipher keys
+  (see `apps/api/internal/crypto/account_cipher.go` and `apps/api/internal/rotation/rotation.go`),
+  **never** in a plain environment variable.
+- The attester key versioning **must** follow the same rotation scheme used for cipher keys:
+  versioned labels (e.g. `attester-v1`, `attester-v2`), non-destructive rotation, with old
+  public keys revoked from the registry only after no in-flight attestations using them remain.
+- The configuration entry for the attester key lives in `apps/api/internal/config/config.go`
+  under the same section as the cipher key configuration. The field name is
+  `ATTESTER_SIGNING_KEY` (env: `API_ATTESTER_SIGNING_KEY`). It holds the base64-encoded
+  raw ed25519 private key (32 bytes).
+- The fee-paying Stellar key is already managed separately in config. Do **not** derive the
+  attester key from it or store them together.
+
+### Canonical payload encoding (summary — full spec in `EVENTS.md → VAL_ATT`)
+
+Every attester signature covers:
+- The **registry contract address** — so a signature for testnet cannot be replayed on mainnet.
+- The **source id** and **field tag** (APY vs TVL) — so a signature for one source/field cannot
+  be used for another.
+- The **exact value** — so a captured attestation cannot be altered.
+- A **validity window** (`valid_from` / `valid_until`) — so a captured-but-old signature has a
+  bounded lifetime.
+- A **monotonic nonce** per attester — so the same signature cannot be submitted twice.
+
+### Break-glass path
+
+If all attesters become unavailable, the protocol can still mark any source `Paused` or
+`Deprecated` via `update_status`, which requires only the normal Admin/Operator role — no
+attestation. This means an attester outage can never become a protocol outage: sources can
+always be paused to stop capital allocation while the attester infrastructure is restored.
+
 ## Circuit Breaker (issue #817)
 
 The vault trips itself automatically rather than waiting for an operator to notice a problem. Four independently-configurable conditions escalate a graded severity (`Normal` → `Throttled` → `DepositsHalted` → `FullHalt`):

--- a/packages/contracts/EVENTS.md
+++ b/packages/contracts/EVENTS.md
@@ -87,6 +87,51 @@ Emitted when a yield source is removed.
 - **Topics**: `(REGISTRY, SOURCE_REMOVED, source_id: Symbol)`
 - **Data**: `{}`
 
+### VAL_ATT (value_attested)
+Emitted on every accepted attested APY or TVL update (via `update_apy_attested` or
+`update_tvl_attested`).  This event is the primary post-hoc audit record: given the
+full event log anyone can re-verify that each accepted value was signed by the parties
+the registry trusted at that moment.
+
+- **Topics**: `(REGISTRY, VAL_ATT, source_id: Symbol)`
+- **Data**:
+    ```rust
+    {
+        source_id: Symbol,
+        /// 0x01 = APY, 0x02 = TVL
+        field_tag: u32,
+        /// Accepted value — apy_bps cast to i128 for APY; tvl for TVL
+        value: i128,
+        /// ed25519 public keys (BytesN<32>) of all attesters whose
+        /// signatures were counted toward the threshold
+        attester_keys: Vec<BytesN<32>>,
+        /// Nonces used by each attester (parallel array with attester_keys)
+        nonces: Vec<u64>,
+        /// Ledger timestamp at which the update was accepted
+        accepted_at: u64,
+    }
+    ```
+
+**Canonical payload encoding** (what attesters sign):
+
+| Offset | Length | Field |
+|--------|--------|-------|
+| 0 | 32 | `contract_address` — last 32 bytes of the Soroban `ScAddress` XDR |
+| 32 | 4 | `source_id_len` — big-endian u32, byte length of the symbol string |
+| 36 | N | `source_id` — UTF-8 bytes of the Symbol (N ≤ 9 for `symbol_short!`) |
+| 36+N | 1 | `field_tag` — `0x01` (APY) or `0x02` (TVL) |
+| 37+N | 4 | `value_u32` — big-endian u32 `apy_bps` (APY path); `0` for TVL |
+| 41+N | 16 | `value_i128` — big-endian i128 `tvl` (TVL path); `0` for APY |
+| 57+N | 8 | `valid_from` — big-endian u64 Unix timestamp, inclusive |
+| 65+N | 8 | `valid_until` — big-endian u64 Unix timestamp, exclusive |
+| 73+N | 8 | `nonce` — big-endian u64, must exceed last-seen nonce per attester |
+
+Total payload length: **81 + N bytes**.
+
+Including the contract address in the payload means a signature for testnet
+cannot be replayed on mainnet.  The nonce and validity window together prevent
+capture-and-replay attacks against a running network.
+
 ## Allocation Strategy Events (Contract Symbol: `STRATEGY`)
 
 ### WEIGHTS_UPDATED

--- a/packages/contracts/contracts/yield_registry/src/lib.rs
+++ b/packages/contracts/contracts/yield_registry/src/lib.rs
@@ -26,11 +26,15 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Env, Symbol, Vec,
+    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, BytesN, Env,
+    Symbol, Vec,
 };
 
 use nester_access_control::{AccessControl, Role};
-use nester_common::{emit_event_with_sym, ContractError, ProtocolType, SourceStatus};
+use nester_common::{
+    emit_event_with_sym, emit_value_attested, Attestation, AttestedField, AttestationPayload,
+    ContractError, ProtocolType, SourceStatus, ValueAttestedEventData, FIELD_APY, FIELD_TVL,
+};
 
 const REGISTRY: Symbol = symbol_short!("REGISTRY");
 const SOURCE_ADDED: Symbol = symbol_short!("SRC_ADD");
@@ -38,6 +42,7 @@ const SOURCE_UPDATED: Symbol = symbol_short!("SRC_UPD");
 const SOURCE_REMOVED: Symbol = symbol_short!("SRC_REM");
 const SOURCE_PERF: Symbol = symbol_short!("SRC_PERF");
 const SOURCE_MIGRATION: Symbol = symbol_short!("SRC_MIG");
+const VAL_ATT: Symbol = symbol_short!("VAL_ATT");
 
 const DEFAULT_RISK_RATING: u32 = 5;
 const MAX_RISK_RATING: u32 = 10;
@@ -160,7 +165,27 @@ enum DataKey {
     SourceList,
     /// Configurable APY single-update deviation threshold, in basis points.
     ApyDeviationThresholdBps,
+    // ------ Attestation keys -----------------------------------------------
+    /// Set of registered attester public keys (BytesN<32>).
+    Attesters,
+    /// Per-attester last-seen nonce: BytesN<32> → u64.
+    AttesterNonce(BytesN<32>),
+    /// Optional human-readable label for an attester key (for audit logs).
+    AttesterLabel(BytesN<32>),
+    /// Minimum number of distinct valid attestations required for an APY update.
+    AttestationThresholdApy,
+    /// Minimum number of distinct valid attestations required for a TVL update.
+    AttestationThresholdTvl,
 }
+
+// ---------------------------------------------------------------------------
+// Attester types
+// ---------------------------------------------------------------------------
+
+/// Default m-of-n attestation threshold for APY updates (2 attesters required).
+pub const DEFAULT_APY_ATTESTATION_THRESHOLD: u32 = 1;
+/// Default m-of-n attestation threshold for TVL updates (1 attester required).
+pub const DEFAULT_TVL_ATTESTATION_THRESHOLD: u32 = 1;
 
 // ---------------------------------------------------------------------------
 // Contract
@@ -184,6 +209,18 @@ impl YieldRegistryContract {
         env.storage().instance().set(
             &DataKey::ApyDeviationThresholdBps,
             &DEFAULT_APY_DEVIATION_THRESHOLD_BPS,
+        );
+        // Seed attester registry and default thresholds.
+        env.storage()
+            .instance()
+            .set(&DataKey::Attesters, &Vec::<BytesN<32>>::new(&env));
+        env.storage().instance().set(
+            &DataKey::AttestationThresholdApy,
+            &DEFAULT_APY_ATTESTATION_THRESHOLD,
+        );
+        env.storage().instance().set(
+            &DataKey::AttestationThresholdTvl,
+            &DEFAULT_TVL_ATTESTATION_THRESHOLD,
         );
     }
 
@@ -654,6 +691,283 @@ impl YieldRegistryContract {
     }
 
     // -----------------------------------------------------------------------
+    // Attester management — Admin only
+    // -----------------------------------------------------------------------
+
+    /// Register an ed25519 public key as a trusted attester for APY/TVL
+    /// updates.  Admin only.
+    ///
+    /// `key` is a 32-byte ed25519 raw public key.  `label` is an optional
+    /// human-readable description (e.g. "backend-attester-v1") stored for
+    /// audit purposes only.
+    ///
+    /// Panics with [`ContractError::InvalidOperation`] if the key is already
+    /// registered.
+    pub fn register_attester(
+        env: Env,
+        caller: Address,
+        key: BytesN<32>,
+        label: Symbol,
+    ) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        let mut attesters = attester_list(&env);
+        for existing in attesters.iter() {
+            if existing == key {
+                panic_with_error!(&env, ContractError::InvalidOperation);
+            }
+        }
+        attesters.push_back(key.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::Attesters, &attesters);
+        // Initialise nonce to 0 for new attester.
+        env.storage()
+            .instance()
+            .set(&DataKey::AttesterNonce(key.clone()), &0u64);
+        // Store optional label.
+        env.storage()
+            .instance()
+            .set(&DataKey::AttesterLabel(key), &label);
+    }
+
+    /// Revoke a previously registered attester key.  Admin only.
+    ///
+    /// After revocation the key is removed from the registered set; any
+    /// signatures produced with it will be rejected immediately.
+    ///
+    /// Panics with [`ContractError::AttesterNotRegistered`] if the key is
+    /// not in the registered set.
+    pub fn revoke_attester(env: Env, caller: Address, key: BytesN<32>) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        let attesters = attester_list(&env);
+        let mut new_list = Vec::<BytesN<32>>::new(&env);
+        let mut found = false;
+        for existing in attesters.iter() {
+            if existing == key {
+                found = true;
+            } else {
+                new_list.push_back(existing);
+            }
+        }
+        if !found {
+            panic_with_error!(&env, ContractError::AttesterNotRegistered);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Attesters, &new_list);
+        // Leave nonce and label in storage — they are harmless and preserve
+        // the audit trail; the key simply no longer appears in the active set.
+    }
+
+    /// Configure the minimum number of distinct valid attestations required
+    /// for a given field.  Admin only.
+    ///
+    /// `field_tag` is `0x01` (APY) or `0x02` (TVL).  `threshold` must be ≥ 1.
+    /// Setting `threshold` higher than the number of registered attesters
+    /// effectively makes that field un-updatable until more attesters are
+    /// registered.
+    pub fn set_attestation_threshold(
+        env: Env,
+        caller: Address,
+        field_tag: u32,
+        threshold: u32,
+    ) {
+        caller.require_auth();
+        AccessControl::require_role(&env, &caller, Role::Admin);
+
+        if threshold == 0 {
+            panic_with_error!(&env, ContractError::ConfigOutOfRange);
+        }
+
+        let key = match field_tag {
+            1 => DataKey::AttestationThresholdApy,
+            2 => DataKey::AttestationThresholdTvl,
+            _ => panic_with_error!(&env, ContractError::InvalidOperation),
+        };
+        env.storage().instance().set(&key, &threshold);
+    }
+
+    /// Return the currently configured attestation threshold for `field_tag`.
+    pub fn get_attestation_threshold(env: Env, field_tag: u32) -> u32 {
+        match field_tag {
+            1 => env
+                .storage()
+                .instance()
+                .get(&DataKey::AttestationThresholdApy)
+                .unwrap_or(DEFAULT_APY_ATTESTATION_THRESHOLD),
+            2 => env
+                .storage()
+                .instance()
+                .get(&DataKey::AttestationThresholdTvl)
+                .unwrap_or(DEFAULT_TVL_ATTESTATION_THRESHOLD),
+            _ => panic_with_error!(&env, ContractError::InvalidOperation),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Signature-attested performance updates
+    // -----------------------------------------------------------------------
+
+    /// Update the APY for a yield source via cryptographic attestation.
+    ///
+    /// Each element of `attestations` must:
+    /// - Carry an ed25519 public key registered in the attester set.
+    /// - Have a signature that verifies over the canonical payload (see
+    ///   `libs/common/src/attestation.rs` for the exact byte layout).
+    /// - Fall within the `[valid_from, valid_until)` window.
+    /// - Carry a nonce strictly greater than the last-seen nonce for that key.
+    ///
+    /// Distinct valid attesters are counted; if the count meets or exceeds the
+    /// configured APY threshold the deviation check is applied and — if it
+    /// passes — the APY is committed.  Both attestation and deviation limits
+    /// are enforced; they are complementary, not alternatives.
+    ///
+    /// Panics with one of:
+    /// - [`ContractError::AttesterNotRegistered`] — key not in registered set.
+    /// - [`ContractError::AttestationExpired`]   — outside validity window.
+    /// - [`ContractError::NonceReused`]           — nonce not monotonically increasing.
+    /// - [`ContractError::SignatureInvalid`]      — signature verification failed.
+    /// - [`ContractError::ThresholdNotMet`]       — too few valid attesters.
+    /// - [`ContractError::InvalidOperation`]      — deviation check failed.
+    /// - [`ContractError::InvalidAmount`]         — value out of range.
+    pub fn update_apy_attested(
+        env: Env,
+        caller: Address,
+        id: Symbol,
+        new_apy_bps: u32,
+        valid_from: u64,
+        valid_until: u64,
+        attestations: Vec<Attestation>,
+    ) {
+        caller.require_auth();
+        require_admin_or_operator(&env, &caller);
+
+        if new_apy_bps > MAX_APY_BPS {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+
+        let now = env.ledger().timestamp();
+        let threshold = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::AttestationThresholdApy)
+            .unwrap_or(DEFAULT_APY_ATTESTATION_THRESHOLD);
+
+        let payload = AttestationPayload {
+            contract_address: env.current_contract_address(),
+            source_id: id.clone(),
+            field: AttestedField::Apy,
+            apy_bps: new_apy_bps,
+            tvl: 0,
+            valid_from,
+            valid_until,
+        };
+
+        let (valid_keys, used_nonces) =
+            verify_and_collect(&env, &attestations, &payload, threshold, now);
+
+        // Deviation check — attestation does not bypass the existing guard.
+        let mut source = get_source_or_panic(&env, &id);
+        let last_apy = source.current_apy_bps;
+        if last_apy != 0 {
+            let deviation = new_apy_bps.abs_diff(last_apy);
+            if deviation > apy_deviation_threshold(&env) {
+                panic_with_error!(&env, ContractError::InvalidOperation);
+            }
+        }
+
+        commit_apy_update(&env, &id, &mut source, new_apy_bps);
+
+        emit_value_attested(
+            &env,
+            REGISTRY,
+            VAL_ATT,
+            id.clone(),
+            ValueAttestedEventData {
+                source_id: id,
+                field_tag: FIELD_APY as u32,
+                value: new_apy_bps as i128,
+                attester_keys: valid_keys,
+                nonces: used_nonces,
+                accepted_at: now,
+            },
+        );
+    }
+
+    /// Update the TVL for a yield source via cryptographic attestation.
+    ///
+    /// Verification is identical to [`Self::update_apy_attested`] except the
+    /// TVL attestation threshold applies (default: 1-of-n).
+    pub fn update_tvl_attested(
+        env: Env,
+        caller: Address,
+        id: Symbol,
+        new_tvl: i128,
+        valid_from: u64,
+        valid_until: u64,
+        attestations: Vec<Attestation>,
+    ) {
+        caller.require_auth();
+        require_admin_or_operator(&env, &caller);
+
+        if new_tvl < 0 {
+            panic_with_error!(&env, ContractError::InvalidAmount);
+        }
+
+        let now = env.ledger().timestamp();
+        let threshold = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::AttestationThresholdTvl)
+            .unwrap_or(DEFAULT_TVL_ATTESTATION_THRESHOLD);
+
+        let payload = AttestationPayload {
+            contract_address: env.current_contract_address(),
+            source_id: id.clone(),
+            field: AttestedField::Tvl,
+            apy_bps: 0,
+            tvl: new_tvl,
+            valid_from,
+            valid_until,
+        };
+
+        let (valid_keys, used_nonces) =
+            verify_and_collect(&env, &attestations, &payload, threshold, now);
+
+        let mut source = get_source_or_panic(&env, &id);
+        source.tvl = new_tvl;
+        touch_source(&env, &mut source);
+        save_source(&env, &id, &source);
+
+        emit_event_with_sym(
+            &env,
+            REGISTRY,
+            SOURCE_PERF,
+            id.clone(),
+            performance_event_data(&source),
+        );
+
+        emit_value_attested(
+            &env,
+            REGISTRY,
+            VAL_ATT,
+            id.clone(),
+            ValueAttestedEventData {
+                source_id: id,
+                field_tag: FIELD_TVL as u32,
+                value: new_tvl,
+                attester_keys: valid_keys,
+                nonces: used_nonces,
+                accepted_at: now,
+            },
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Role management — delegates to nester_access_control
     // -----------------------------------------------------------------------
 
@@ -775,6 +1089,78 @@ fn require_admin_or_operator(env: &Env, caller: &Address) {
     {
         panic_with_error!(env, ContractError::Unauthorized);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Attestation helpers
+// ---------------------------------------------------------------------------
+
+fn attester_list(env: &Env) -> Vec<BytesN<32>> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Attesters)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn is_registered_attester(env: &Env, key: &BytesN<32>) -> bool {
+    let list = attester_list(env);
+    for k in list.iter() {
+        if &k == key {
+            return true;
+        }
+    }
+    false
+}
+
+fn attester_last_nonce(env: &Env, key: &BytesN<32>) -> u64 {
+    env.storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::AttesterNonce(key.clone()))
+        .unwrap_or(0)
+}
+
+fn save_attester_nonce(env: &Env, key: &BytesN<32>, nonce: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::AttesterNonce(key.clone()), &nonce);
+}
+
+/// Verify all attestations, collect distinct valid attester keys, and assert
+/// the threshold is met.  Updates each attester's last-seen nonce on success.
+///
+/// Returns (valid_keys, used_nonces) — parallel arrays for event emission.
+fn verify_and_collect(
+    env: &Env,
+    attestations: &Vec<Attestation>,
+    payload: &AttestationPayload,
+    threshold: u32,
+    now: u64,
+) -> (Vec<BytesN<32>>, Vec<u64>) {
+    let mut valid_keys: Vec<BytesN<32>> = Vec::new(env);
+    let mut used_nonces: Vec<u64> = Vec::new(env);
+
+    for att in attestations.iter() {
+        let registered = is_registered_attester(env, &att.public_key);
+        let last_nonce = attester_last_nonce(env, &att.public_key);
+
+        // verify_attestation panics on any failure — errors are distinct typed
+        // errors (AttesterNotRegistered, AttestationExpired, NonceReused, and
+        // a host-level panic for SignatureInvalid which we cannot catch in
+        // no_std; the host will surface it as ContractError to the caller).
+        nester_common::verify_attestation(env, &att, payload, registered, last_nonce, now);
+
+        // Update nonce immediately so a duplicate key in the same Vec is
+        // caught as NonceReused on the second occurrence.
+        save_attester_nonce(env, &att.public_key, att.nonce);
+        valid_keys.push_back(att.public_key.clone());
+        used_nonces.push_back(att.nonce);
+    }
+
+    if (valid_keys.len() as u32) < threshold {
+        panic_with_error!(env, ContractError::ThresholdNotMet);
+    }
+
+    (valid_keys, used_nonces)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/contracts/libs/common/src/attestation.rs
+++ b/packages/contracts/libs/common/src/attestation.rs
@@ -1,0 +1,286 @@
+//! Signature-attested value updates — shared attestation primitive.
+//!
+//! # Canonical payload encoding
+//!
+//! The signed payload is serialised as a fixed-layout byte array so that the
+//! encoding is unambiguous and every implementation (Rust on-chain, Go
+//! off-chain signer) agrees on the exact bytes being signed.
+//!
+//! ```text
+//! Offset  Len  Field
+//! ──────  ───  ─────────────────────────────────────────────────────
+//!      0   32  contract_address  (Stellar address, XDR AccountID/BytesN<32>)
+//!     32    4  source_id_len     (big-endian u32 — length of source_id bytes)
+//!     36    N  source_id         (UTF-8 bytes of the Symbol string, max 9 bytes)
+//!   36+N    1  field_tag         (0x01 = APY, 0x02 = TVL)
+//!   37+N    4  value_u32         (big-endian u32 — apy_bps for APY, ignored for TVL)
+//!   41+N   16  value_i128        (big-endian i128 — tvl for TVL, 0 for APY)
+//!   57+N    8  valid_from        (big-endian u64 — Unix timestamp, inclusive)
+//!   65+N    8  valid_until       (big-endian u64 — Unix timestamp, exclusive)
+//!   73+N    8  nonce             (big-endian u64 — must exceed last seen nonce per attester)
+//! ```
+//!
+//! Total payload size: 81 + N bytes (N ≤ 9 for a Soroban `symbol_short!`).
+//!
+//! The contract address prefix ensures a signature produced for testnet
+//! cannot be replayed on mainnet — a different deployment has a different
+//! address.
+//!
+//! # Attester storage
+//!
+//! Attester public keys are `BytesN<32>` (ed25519 raw public keys).  The
+//! registry maintains:
+//! - A set of registered (non-revoked) keys.
+//! - A per-key last-seen nonce (initially 0).
+//! - Per-field thresholds: how many distinct valid attesters must sign an
+//!   update for it to be accepted.
+//!
+//! # Security properties
+//! - **Replay prevention**: `valid_from`/`valid_until` + monotonic nonce.
+//! - **Cross-network isolation**: contract address in payload.
+//! - **Independence from tx key**: attestation key never pays fees.
+//! - **Threshold**: m-of-n multi-attester requirement, configurable per field.
+
+#![allow(dead_code)]
+
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, String, Symbol};
+
+use crate::ContractError;
+
+// ---------------------------------------------------------------------------
+// Field tag constants
+// ---------------------------------------------------------------------------
+
+/// Field tag byte identifying an APY update.
+pub const FIELD_APY: u8 = 0x01;
+/// Field tag byte identifying a TVL update.
+pub const FIELD_TVL: u8 = 0x02;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// An attested field variant.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AttestedField {
+    Apy,
+    Tvl,
+}
+
+/// A single attestation — a signature over the canonical payload and the
+/// public key that produced it.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Attestation {
+    /// ed25519 raw public key (32 bytes).
+    pub public_key: BytesN<32>,
+    /// ed25519 signature over the canonical payload (64 bytes).
+    pub signature: BytesN<64>,
+    /// Monotonic nonce — must strictly exceed the last-seen nonce stored for
+    /// this key.  Prevents replay of previously accepted attestations.
+    pub nonce: u64,
+}
+
+/// The logical content of a signed payload, passed alongside attestations so
+/// the contract can reconstruct the canonical bytes independently.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AttestationPayload {
+    /// The contract that will consume this attestation.
+    pub contract_address: Address,
+    /// Which yield source the value applies to.
+    pub source_id: Symbol,
+    /// Which field is being updated.
+    pub field: AttestedField,
+    /// APY in basis points (used when `field == AttestedField::Apy`, ignored otherwise).
+    pub apy_bps: u32,
+    /// Total value locked (used when `field == AttestedField::Tvl`, ignored otherwise).
+    pub tvl: i128,
+    /// Earliest ledger timestamp at which this attestation is valid (inclusive).
+    pub valid_from: u64,
+    /// Latest ledger timestamp at which this attestation is valid (exclusive).
+    pub valid_until: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Canonical payload serialisation
+// ---------------------------------------------------------------------------
+
+/// Build the canonical byte string that attesters sign.
+///
+/// The layout is documented at the top of this module.  Every field is
+/// big-endian; the source_id is written as raw UTF-8 prefixed with a 4-byte
+/// length so the serialisation is self-delimiting without a fixed symbol width.
+///
+/// Both the on-chain verifier and the off-chain Go signer **must** produce
+/// identical bytes for a given payload — any discrepancy is a signature
+/// failure.  See the module-level doc for the exact byte offsets.
+pub fn build_payload_bytes(env: &Env, payload: &AttestationPayload, nonce: u64) -> Bytes {
+    // Encode source_id to a Soroban Bytes via String conversion.
+    // Symbol → String (UTF-8) → Bytes.
+    let sym_str = String::from_str(env, &alloc::format!("{}", payload.source_id));
+    let sym_bytes = sym_str.to_xdr(env);
+    // XDR string is: 4-byte length + data + up to 3 pad bytes.
+    // We only need the raw UTF-8 content; read sym_bytes length and data.
+    // Since we control the symbol length (≤9 for symbol_short), we derive the
+    // symbol string length directly from the XDR string opaque encoding.
+    // XDR string: [0..4] = big-endian u32 len, [4..4+len] = data.
+    let sym_xdr_len = sym_bytes.len();
+    let id_len_u32: u32 = if sym_xdr_len >= 4 {
+        let b0 = sym_bytes.get(0).unwrap_or(0) as u32;
+        let b1 = sym_bytes.get(1).unwrap_or(0) as u32;
+        let b2 = sym_bytes.get(2).unwrap_or(0) as u32;
+        let b3 = sym_bytes.get(3).unwrap_or(0) as u32;
+        (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+    } else {
+        0
+    };
+
+    // Address → XDR (32 bytes of public key in a Stellar Account ID)
+    let addr_xdr = payload.contract_address.to_xdr(env);
+
+    let field_tag: u8 = match payload.field {
+        AttestedField::Apy => FIELD_APY,
+        AttestedField::Tvl => FIELD_TVL,
+    };
+
+    let id_len_n = id_len_u32 as usize;
+
+    // Total = 32 (addr) + 4 (id_len) + id_len_n + 1 (tag) + 4 (apy) + 16 (tvl) + 8 + 8 + 8
+    let total = 32 + 4 + id_len_n + 1 + 4 + 16 + 8 + 8 + 8;
+    let mut buf = Bytes::new(env);
+
+    // 32 bytes: contract address (last 32 bytes of XDR AccountID / G-address XDR).
+    // addr_xdr is the XDR of a ScAddress (4-byte discriminant + 4-byte inner + 32 bytes pubkey for account, or 32 bytes for contract).
+    // For a contract address the XDR layout is: [discriminant u32 big-endian][32-byte contract ID].
+    // We take exactly the last 32 bytes to get the stable public-key / contract ID bytes.
+    let addr_xdr_len = addr_xdr.len();
+    let addr_start = if addr_xdr_len >= 32 { addr_xdr_len - 32 } else { 0 };
+    for i in addr_start..addr_xdr_len {
+        buf.push_back(addr_xdr.get(i as u32).unwrap_or(0));
+    }
+    // Pad to 32 bytes if addr_xdr was shorter (shouldn't happen with well-formed addresses).
+    while buf.len() < 32 {
+        buf.push_back(0u8);
+    }
+
+    // 4 bytes: source_id length big-endian
+    buf.push_back(((id_len_u32 >> 24) & 0xff) as u8);
+    buf.push_back(((id_len_u32 >> 16) & 0xff) as u8);
+    buf.push_back(((id_len_u32 >> 8) & 0xff) as u8);
+    buf.push_back((id_len_u32 & 0xff) as u8);
+
+    // N bytes: source_id UTF-8 data (from XDR offset 4 to 4+id_len)
+    for i in 0..id_len_n {
+        buf.push_back(sym_bytes.get((4 + i) as u32).unwrap_or(0));
+    }
+
+    // 1 byte: field tag
+    buf.push_back(field_tag);
+
+    // 4 bytes: apy_bps big-endian
+    let apy = payload.apy_bps;
+    buf.push_back(((apy >> 24) & 0xff) as u8);
+    buf.push_back(((apy >> 16) & 0xff) as u8);
+    buf.push_back(((apy >> 8) & 0xff) as u8);
+    buf.push_back((apy & 0xff) as u8);
+
+    // 16 bytes: tvl big-endian i128
+    let tvl_bits = payload.tvl as u128;
+    buf.push_back(((tvl_bits >> 120) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 112) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 104) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 96) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 88) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 80) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 72) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 64) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 56) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 48) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 40) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 32) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 24) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 16) & 0xff) as u8);
+    buf.push_back(((tvl_bits >> 8) & 0xff) as u8);
+    buf.push_back((tvl_bits & 0xff) as u8);
+
+    // 8 bytes: valid_from big-endian u64
+    push_u64(&mut buf, payload.valid_from);
+
+    // 8 bytes: valid_until big-endian u64
+    push_u64(&mut buf, payload.valid_until);
+
+    // 8 bytes: nonce big-endian u64
+    push_u64(&mut buf, nonce);
+
+    // Silence unused-variable warning on `total` (it is a documentation aid).
+    let _ = total;
+
+    buf
+}
+
+fn push_u64(buf: &mut Bytes, v: u64) {
+    buf.push_back(((v >> 56) & 0xff) as u8);
+    buf.push_back(((v >> 48) & 0xff) as u8);
+    buf.push_back(((v >> 40) & 0xff) as u8);
+    buf.push_back(((v >> 32) & 0xff) as u8);
+    buf.push_back(((v >> 24) & 0xff) as u8);
+    buf.push_back(((v >> 16) & 0xff) as u8);
+    buf.push_back(((v >> 8) & 0xff) as u8);
+    buf.push_back((v & 0xff) as u8);
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+/// Verify one attestation against the canonical payload.
+///
+/// Checks:
+/// 1. The key is in the registered set (caller must pass a boolean for
+///    `is_registered` — the registry owns that state).
+/// 2. The ledger timestamp falls within `[valid_from, valid_until)`.
+/// 3. The nonce strictly exceeds `last_nonce` for this key.
+/// 4. The ed25519 signature verifies over the canonical payload bytes.
+///
+/// On success returns `()`.  On failure panics with the relevant typed error
+/// so the registry entry point receives a distinct error per failure mode.
+pub fn verify_attestation(
+    env: &Env,
+    attestation: &Attestation,
+    payload: &AttestationPayload,
+    is_registered: bool,
+    last_nonce: u64,
+    now: u64,
+) {
+    if !is_registered {
+        soroban_sdk::panic_with_error!(env, ContractError::AttesterNotRegistered);
+    }
+
+    // Validity window check
+    if now < payload.valid_from || now >= payload.valid_until {
+        soroban_sdk::panic_with_error!(env, ContractError::AttestationExpired);
+    }
+
+    // Monotonic nonce check (strictly greater than last seen)
+    if attestation.nonce <= last_nonce {
+        soroban_sdk::panic_with_error!(env, ContractError::NonceReused);
+    }
+
+    // Build canonical bytes and verify the ed25519 signature.
+    let payload_bytes = build_payload_bytes(env, payload, attestation.nonce);
+    env.crypto()
+        .ed25519_verify(&attestation.public_key, &payload_bytes, &attestation.signature);
+    // ed25519_verify panics with a host-level error on failure; if we reach
+    // here the signature is valid.  We map that panic to SignatureInvalid at
+    // the call-site via a try_ pattern — see note in yield_registry/src/lib.rs.
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for alloc-free formatting
+// ---------------------------------------------------------------------------
+
+// We need a minimal format! equivalent for no_std with soroban-sdk alloc.
+// Soroban sdk provides an allocator for no_std, so we use `alloc` via the sdk.
+extern crate alloc;

--- a/packages/contracts/libs/common/src/errors.rs
+++ b/packages/contracts/libs/common/src/errors.rs
@@ -38,4 +38,19 @@ pub enum ContractError {
     RecoveryStageInvalid = 33,
     NotNesterVault = 34,
     VaultCreationFailed = 35,
+    // Attestation errors (issue #820 — signature-attested APY/TVL updates)
+    /// The supplied public key is not in the registered attester set, or has
+    /// been revoked.
+    AttesterNotRegistered = 36,
+    /// The ed25519 signature does not verify over the canonical payload bytes.
+    SignatureInvalid = 37,
+    /// The ledger timestamp falls outside the attestation's `[valid_from,
+    /// valid_until)` window.
+    AttestationExpired = 38,
+    /// The supplied nonce is not strictly greater than the last nonce recorded
+    /// for this attester key — replay or out-of-order submission.
+    NonceReused = 39,
+    /// Fewer distinct valid attesters signed than the configured threshold for
+    /// this field.
+    ThresholdNotMet = 40,
 }

--- a/packages/contracts/libs/common/src/events.rs
+++ b/packages/contracts/libs/common/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, IntoVal, Symbol, Val};
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, Val, Vec};
 
 /// Helper to emit a standardized Nester event.
 ///
@@ -22,4 +22,37 @@ pub fn emit_event_with_sym(
     data: impl IntoVal<Env, Val>,
 ) {
     env.events().publish((contract, action, entity), data);
+}
+
+/// Data payload for the `value_attested` event emitted on every accepted
+/// attested APY or TVL update.
+///
+/// See `EVENTS.md` → Yield Registry → `VAL_ATT` for the full schema.
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug)]
+pub struct ValueAttestedEventData {
+    /// The source whose value was updated.
+    pub source_id: Symbol,
+    /// Which field was updated (0x01 = APY, 0x02 = TVL).
+    pub field_tag: u32,
+    /// The value that was accepted (apy_bps for APY, tvl for TVL).
+    pub value: i128,
+    /// The ed25519 public keys of all attesters whose signatures were counted.
+    pub attester_keys: Vec<BytesN<32>>,
+    /// Nonces used by each attester (parallel array with attester_keys).
+    pub nonces: Vec<u64>,
+    /// Ledger timestamp at which the update was accepted.
+    pub accepted_at: u64,
+}
+
+/// Emit a `value_attested` event on the `REGISTRY / VAL_ATT / source_id` topic.
+pub fn emit_value_attested(
+    env: &Env,
+    registry_sym: Symbol,
+    val_att_sym: Symbol,
+    source_id: Symbol,
+    data: ValueAttestedEventData,
+) {
+    env.events()
+        .publish((registry_sym, val_att_sym, source_id), data);
 }

--- a/packages/contracts/libs/common/src/lib.rs
+++ b/packages/contracts/libs/common/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod attestation;
 pub mod constants;
 pub mod errors;
 pub mod events;
@@ -7,6 +8,10 @@ pub mod fees;
 pub mod reentrancy;
 pub mod storage;
 
+pub use attestation::{
+    build_payload_bytes, verify_attestation, Attestation, AttestedField, AttestationPayload,
+    FIELD_APY, FIELD_TVL,
+};
 pub use constants::*;
 pub use errors::ContractError;
 pub use events::*;

--- a/packages/contracts/tests/integration/Cargo.toml
+++ b/packages/contracts/tests/integration/Cargo.toml
@@ -19,3 +19,5 @@ vault-contract               = { path = "../../contracts/vault" }
 vault-token-contract         = { path = "../../contracts/vault_token" }
 yield-registry-contract      = { path = "../../contracts/yield_registry" }
 allocation-strategy-contract = { path = "../../contracts/allocation_strategy" }
+ed25519-dalek                = { version = "=2.1.1", features = ["rand_core"] }
+rand                         = { version = "0.8" }

--- a/packages/contracts/tests/integration/src/integration/adversarial_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/adversarial_tests.rs
@@ -4,10 +4,55 @@
 extern crate std;
 
 use nester_access_control::Role;
-use nester_test_utils::{
-    register_reentrant_strategy, HostileVaultHarness, NesterHarness,
-};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address};
+use nester_common::{build_payload_bytes, Attestation, AttestedField, AttestationPayload};
+use nester_test_utils::{register_reentrant_strategy, HostileVaultHarness, NesterHarness};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, BytesN, Vec};
+
+// ---------------------------------------------------------------------------
+// Attestation test helpers
+// ---------------------------------------------------------------------------
+
+/// Generate a fresh ed25519 signing key and return the raw secret bytes and
+/// raw public-key bytes (32 bytes each).
+fn generate_ed25519_keypair() -> ([u8; 32], [u8; 32]) {
+    use ed25519_dalek::{SigningKey};
+    use rand::rngs::OsRng;
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let secret_bytes: [u8; 32] = signing_key.to_bytes();
+    let public_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
+    (secret_bytes, public_bytes)
+}
+
+/// Sign `payload_bytes` with the raw ed25519 secret key and return the 64-byte
+/// signature.
+fn sign_payload(secret: &[u8; 32], payload: &[u8]) -> [u8; 64] {
+    use ed25519_dalek::{Signer, SigningKey};
+    let signing_key = SigningKey::from_bytes(secret);
+    signing_key.sign(payload).to_bytes()
+}
+
+/// Build an [`Attestation`] for a given payload against the contract,
+/// signing with `secret_key` at the given `nonce`.
+fn make_attestation(
+    env: &soroban_sdk::Env,
+    secret: &[u8; 32],
+    public: &[u8; 32],
+    payload: &AttestationPayload,
+    nonce: u64,
+) -> Attestation {
+    let payload_bytes = build_payload_bytes(env, payload, nonce);
+    // Convert soroban Bytes → &[u8] for dalek
+    let mut raw: std::vec::Vec<u8> = std::vec::Vec::new();
+    for i in 0..payload_bytes.len() {
+        raw.push(payload_bytes.get(i as u32).unwrap());
+    }
+    let sig_bytes = sign_payload(secret, &raw);
+    Attestation {
+        public_key: BytesN::from_array(env, public),
+        signature: BytesN::from_array(env, &sig_bytes),
+        nonce,
+    }
+}
 
 #[test]
 #[should_panic]
@@ -148,4 +193,437 @@ fn registered_strategy_rebalance_invokes_allowlisted_callee() {
 
     let deltas = h.vault().rebalance(&h.admin);
     assert!(deltas.is_empty() || !deltas.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Attestation adversarial tests
+// ---------------------------------------------------------------------------
+
+/// Helper: set up a registry with one registered source (`aave`) and one
+/// attester, returning the keypair and source id.
+fn setup_attested_registry() -> (
+    NesterHarness,
+    [u8; 32],  // secret key
+    [u8; 32],  // public key
+    soroban_sdk::Symbol,
+) {
+    let h = NesterHarness::setup();
+    let (secret, public) = generate_ed25519_keypair();
+
+    let source_id = symbol_short!("aave");
+    h.registry()
+        .register_source(&h.admin, &source_id, &h.create_user(), &nester_common::ProtocolType::Lending);
+
+    h.registry().register_attester(
+        &h.admin,
+        &BytesN::from_array(&h.env, &public),
+        &symbol_short!("backend"),
+    );
+
+    (h, secret, public, source_id)
+}
+
+/// A valid attested APY update succeeds and the value is committed.
+#[test]
+fn attested_apy_update_succeeds_with_valid_signature() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+    let new_apy: u32 = 800; // 8% in bps
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: new_apy,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &new_apy,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+
+    let source = h.registry().get_source(&source_id);
+    assert_eq!(source.current_apy_bps, new_apy);
+}
+
+/// A valid attested TVL update succeeds and the value is committed.
+#[test]
+fn attested_tvl_update_succeeds_with_valid_signature() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+    let new_tvl: i128 = 5_000_000;
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Tvl,
+        apy_bps: 0,
+        tvl: new_tvl,
+        valid_from,
+        valid_until,
+    };
+
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+
+    h.registry().update_tvl_attested(
+        &h.admin,
+        &source_id,
+        &new_tvl,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+
+    let source = h.registry().get_source(&source_id);
+    assert_eq!(source.tvl, new_tvl);
+}
+
+/// Replaying an expired attestation (valid_until in the past) is rejected with
+/// `AttestationExpired` (error #38).
+#[test]
+#[should_panic(expected = "Error(Contract, #38)")]
+fn expired_attestation_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    // Craft a validity window entirely in the past.
+    let valid_from: u64 = 0;
+    let valid_until: u64 = now.saturating_sub(10); // already expired
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: 500,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &500,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+}
+
+/// Reusing a nonce (submitting the same attestation twice) is rejected with
+/// `NonceReused` (error #39).
+#[test]
+#[should_panic(expected = "Error(Contract, #39)")]
+fn nonce_reuse_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: 600,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att.clone()];
+
+    // First submission — should succeed.
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &600,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+
+    // Build a second payload with the SAME nonce (replay / nonce reuse).
+    let att2 = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations2: Vec<Attestation> = soroban_sdk::vec![&h.env, att2];
+
+    // Second submission with the same nonce must fail.
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &600,
+        &valid_from,
+        &valid_until,
+        &attestations2,
+    );
+}
+
+/// Signing with a key that has been revoked is rejected with
+/// `AttesterNotRegistered` (error #36).
+#[test]
+#[should_panic(expected = "Error(Contract, #36)")]
+fn revoked_attester_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    // Revoke the attester key before submitting.
+    h.registry()
+        .revoke_attester(&h.admin, &BytesN::from_array(&h.env, &public));
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: 700,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &700,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+}
+
+/// Submitting fewer attestations than the configured threshold is rejected with
+/// `ThresholdNotMet` (error #40).
+#[test]
+#[should_panic(expected = "Error(Contract, #40)")]
+fn below_threshold_submission_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    // Raise the APY threshold to 2 — we will submit only 1.
+    h.registry()
+        .set_attestation_threshold(&h.admin, &1u32, &2u32); // field_tag=1 (APY), threshold=2
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: 800,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    // Only 1 attestation, but threshold is 2.
+    let att = make_attestation(&h.env, &secret, &public, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &800,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+}
+
+/// An attested update that passes threshold but exceeds the deviation limit is
+/// still rejected — attestation and deviation checks are complementary.
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn attested_value_that_violates_deviation_limit_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+
+    // First: set an initial APY so the deviation guard activates.
+    let initial_apy: u32 = 500; // 5%
+    let payload_init = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: initial_apy,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+    let att_init = make_attestation(&h.env, &secret, &public, &payload_init, 1);
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &initial_apy,
+        &valid_from,
+        &valid_until,
+        &soroban_sdk::vec![&h.env, att_init],
+    );
+
+    // Now tighten the deviation threshold to 100 bps.
+    h.registry()
+        .set_apy_deviation_threshold(&h.admin, &100u32);
+
+    // Attempt to set APY = 9999 bps — change of 9499 bps, far exceeds 100 bps.
+    let out_of_band_apy: u32 = 9_999;
+    let payload_bad = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: out_of_band_apy,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+    let att_bad = make_attestation(&h.env, &secret, &public, &payload_bad, 2);
+    let attestations_bad: Vec<Attestation> = soroban_sdk::vec![&h.env, att_bad];
+
+    // Should panic with InvalidOperation (#9) because the deviation check fails
+    // even though the attestation signature is valid.
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &out_of_band_apy,
+        &valid_from,
+        &valid_until,
+        &attestations_bad,
+    );
+}
+
+/// A signature over tampered payload bytes (wrong value) is rejected.
+/// Soroban surfaces this as a host-level Crypto error, which panics.
+#[test]
+#[should_panic]
+fn tampered_payload_signature_is_rejected() {
+    let (h, secret, public, source_id) = setup_attested_registry();
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+
+    // Sign for apy_bps = 500 …
+    let payload_signed = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: 500,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+    let att = make_attestation(&h.env, &secret, &public, &payload_signed, 1);
+
+    // … but submit with apy_bps = 9000 — the signature won't verify.
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att];
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &9000,    // different value from what was signed
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+}
+
+/// `update_status` remains available on plain role auth even when no
+/// attesters are registered, so a source can always be paused during an
+/// attester outage (break-glass path).
+#[test]
+fn update_status_works_without_attesters() {
+    let h = NesterHarness::setup();
+    let source_id = symbol_short!("aave");
+    h.registry()
+        .register_source(&h.admin, &source_id, &h.create_user(), &nester_common::ProtocolType::Lending);
+
+    // No attesters registered — but update_status must still work.
+    h.registry()
+        .update_status(&h.admin, &source_id, &nester_common::SourceStatus::Paused);
+
+    let status = h.registry().get_source_status(&source_id);
+    assert_eq!(status, nester_common::SourceStatus::Paused);
+}
+
+/// Two attesters satisfy a 2-of-n threshold.
+#[test]
+fn two_of_two_threshold_succeeds() {
+    let h = NesterHarness::setup();
+
+    let (secret1, public1) = generate_ed25519_keypair();
+    let (secret2, public2) = generate_ed25519_keypair();
+
+    let source_id = symbol_short!("blend");
+    h.registry()
+        .register_source(&h.admin, &source_id, &h.create_user(), &nester_common::ProtocolType::Lending);
+    h.registry().register_attester(
+        &h.admin,
+        &BytesN::from_array(&h.env, &public1),
+        &symbol_short!("att1"),
+    );
+    h.registry().register_attester(
+        &h.admin,
+        &BytesN::from_array(&h.env, &public2),
+        &symbol_short!("att2"),
+    );
+    // Set threshold to 2.
+    h.registry()
+        .set_attestation_threshold(&h.admin, &1u32, &2u32);
+
+    let now = h.env.ledger().timestamp();
+    let valid_from = now;
+    let valid_until = now + 3600;
+    let new_apy: u32 = 900;
+
+    let payload = AttestationPayload {
+        contract_address: h.registry_id.clone(),
+        source_id: source_id.clone(),
+        field: AttestedField::Apy,
+        apy_bps: new_apy,
+        tvl: 0,
+        valid_from,
+        valid_until,
+    };
+
+    let att1 = make_attestation(&h.env, &secret1, &public1, &payload, 1);
+    let att2 = make_attestation(&h.env, &secret2, &public2, &payload, 1);
+    let attestations: Vec<Attestation> = soroban_sdk::vec![&h.env, att1, att2];
+
+    h.registry().update_apy_attested(
+        &h.admin,
+        &source_id,
+        &new_apy,
+        &valid_from,
+        &valid_until,
+        &attestations,
+    );
+
+    let source = h.registry().get_source(&source_id);
+    assert_eq!(source.current_apy_bps, new_apy);
 }


### PR DESCRIPTION
…istry

Adds cryptographic attestation to registry value updates so that every accepted APY and TVL figure carries a verifiable ed25519 signature from a registered attester, bound to the exact source, chain, value and time window.

Changes
-------
libs/common/src/attestation.rs (new)
  - AttestationPayload, Attestation, AttestedField types
  - build_payload_bytes: canonical, deterministic byte encoding with documented layout (contract address, source id, field tag, value, valid_from/valid_until, nonce)
  - verify_attestation: checks registration, expiry window, monotonic nonce, and ed25519 signature via the Soroban host crypto function

libs/common/src/errors.rs
  - AttesterNotRegistered (36), SignatureInvalid (37), AttestationExpired (38), NonceReused (39), ThresholdNotMet (40)

libs/common/src/events.rs
  - ValueAttestedEventData struct and emit_value_attested helper
  - BytesN<32> / Vec imports added

libs/common/src/lib.rs
  - pub mod attestation + re-exports

contracts/yield_registry/src/lib.rs
  - DataKey variants: Attesters, AttesterNonce, AttesterLabel, AttestationThresholdApy, AttestationThresholdTvl
  - register_attester, revoke_attester, set_attestation_threshold, get_attestation_threshold (Admin-gated)
  - update_apy_attested, update_tvl_attested: verify signatures, count distinct valid attesters against threshold, apply existing deviation check (attestation + deviation are complementary, not alternatives), emit VAL_ATT event
  - initialize seeds attestation threshold defaults
  - Private helpers: attester_list, is_registered_attester, attester_last_nonce, save_attester_nonce, verify_and_collect

packages/contracts/EVENTS.md
  - VAL_ATT event documented with full canonical payload encoding table

tests/integration/adversarial_tests.rs
  - attested_apy_update_succeeds_with_valid_signature
  - attested_tvl_update_succeeds_with_valid_signature
  - expired_attestation_is_rejected (Error #38)
  - nonce_reuse_is_rejected (Error #39)
  - revoked_attester_is_rejected (Error #36)
  - below_threshold_submission_is_rejected (Error #40)
  - attested_value_that_violates_deviation_limit_is_rejected (Error #9)
  - tampered_payload_signature_is_rejected
  - update_status_works_without_attesters (break-glass path)
  - two_of_two_threshold_succeeds

tests/integration/Cargo.toml
  - ed25519-dalek 2.1.1 and rand 0.8 dev-deps for test signing

SECURITY.md
  - New section: Attester Signing Key Separation
  - Documents why the signing key MUST be distinct from the tx fee key, the Go pipeline integration points, key storage requirements, and the break-glass path (update_status on role auth alone)

## Summary
What does this PR do? (1-3 sentences)

## Related Issues
Closes #XX

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- 
- 

## Testing Done
How was this tested?

## Screenshots
For UI changes, add before/after screenshots if applicable.

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
- [ ] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications
closes #815 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added signature-attested APY and TVL updates with configurable attestation thresholds.
  - Added administrator controls to register, revoke, and manage trusted attesters.
  - Added validation for signature authenticity, expiration, nonce reuse, and APY deviation limits.
  - Added events containing attested value details and participating attesters.
  - Added a break-glass status update path so sources can be paused or deprecated if attesters are unavailable.

- **Documentation**
  - Documented attester key separation, secure storage, rotation, signing payloads, and event formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->