### PR TITLE
feat(intelligence): conversation history summarization for Prometheus AI

### DIFF
--- a/apps/intelligence/app/config.py
+++ b/apps/intelligence/app/config.py
@@ -25,6 +25,26 @@ class Settings(BaseSettings):
     nester_service_api_key: str = ""
     defillama_base_url: str = "https://api.llama.fi"
 
+    # Maximum token count for conversation history before automatic summarization
+    # is triggered. When the estimated token count of the active history exceeds
+    # this threshold, Prometheus generates a summary of the earlier turns and
+    # replaces them with "[Summary of previous conversation] <summary>" so the
+    # active context stays within this bound.
+    #
+    # The default of 80_000 corresponds to roughly 80% of the claude-sonnet-5
+    # context window (200k tokens). Adjust down to reduce per-request cost or
+    # up to allow more conversational depth before summarization.
+    #
+    # Set INTELLIGENCE_MAX_HISTORY_TOKENS=0 to disable summarization entirely
+    # (not recommended for production — long sessions will hit context limits).
+    max_history_tokens: int = 80_000
+
+    # Number of most-recent turns to ALWAYS retain verbatim in the active
+    # context after a summarization pass. Older turns are replaced by the
+    # summary. Must be ≥ 2 (one user + one assistant) so the conversation
+    # remains coherent.
+    history_recent_turns_kept: int = 6
+
     model_config = SettingsConfigDict(
         env_prefix="INTELLIGENCE_",
         env_file=".env",

--- a/apps/intelligence/app/services/conversation_store.py
+++ b/apps/intelligence/app/services/conversation_store.py
@@ -4,6 +4,17 @@ Uses Redis when INTELLIGENCE_REDIS_URL is configured so that all worker
 instances share state and conversations survive restarts. Falls back to an
 in-process dict when Redis is unavailable so dev and test environments need
 no extra infrastructure.
+
+Summarization support
+---------------------
+When the active history grows past the token threshold configured via
+``INTELLIGENCE_MAX_HISTORY_TOKENS``, the active history is compacted (older
+turns replaced by a Claude-generated summary) before the next assistant turn.
+
+The full pre-summarization history is preserved at a separate Redis key
+(``prometheus:conv:audit:<user_id>``) so it is always available for audit
+purposes.  The audit key has a longer TTL (7 days) than the active key (24 h)
+and is append-only — it is never trimmed or overwritten by the compaction.
 """
 
 import json
@@ -15,9 +26,11 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-_TTL_SECONDS = 86400  # 24 hours of inactivity
-_MAX_TURNS = 20       # keep the last N messages to cap token spend
+_TTL_SECONDS = 86400          # 24 hours — active history
+_AUDIT_TTL_SECONDS = 604800   # 7 days  — full audit history
+_MAX_TURNS = 20               # hard cap for in-memory fallback
 _KEY_PREFIX = "prometheus:conv:"
+_AUDIT_KEY_PREFIX = "prometheus:conv:audit:"
 
 
 # ---------------------------------------------------------------------------
@@ -43,9 +56,11 @@ class _RedisConversationStore:
     def _key(self, user_id: str) -> str:
         return f"{_KEY_PREFIX}{user_id}"
 
+    def _audit_key(self, user_id: str) -> str:
+        return f"{_AUDIT_KEY_PREFIX}{user_id}"
+
     def get(self, user_id: str) -> List[Dict[str, str]]:
         if not self._available:
-            # Fallback to empty list if Redis not available
             return []
 
         try:
@@ -54,37 +69,78 @@ class _RedisConversationStore:
                 return []
             try:
                 data = list(json.loads(raw))
-                # Trim to last 20 messages as required
-                return data[-_MAX_TURNS:] if len(data) > _MAX_TURNS else data
+                return data
             except Exception:
                 return []
         except Exception as exc:
             logger.warning("Failed to read from Redis: %s", exc)
-            # Mark as unavailable for subsequent calls
             self._available = False
             return []
 
     def append(self, user_id: str, role: str, content: str) -> None:
         if not self._available:
-            # Silently fail if Redis not available
             return
 
         try:
             key = self._key(user_id)
-            history = self.get(user_id)  # This will handle trimming
+            history = self.get(user_id)
             history.append({"role": role, "content": content})
-            # Reset TTL on write
             self._client.setex(key, _TTL_SECONDS, json.dumps(history))
+
+            # Append to the audit log (full history, append-only, longer TTL).
+            self._append_to_audit(user_id, role, content)
         except Exception as exc:
             logger.warning("Failed to write to Redis: %s", exc)
-            # Mark as unavailable for subsequent calls
             self._available = False
+
+    def _append_to_audit(self, user_id: str, role: str, content: str) -> None:
+        """Append a single turn to the immutable audit history key."""
+        if not self._available:
+            return
+        try:
+            audit_key = self._audit_key(user_id)
+            raw: Optional[str] = self._client.get(audit_key)  # type: ignore[assignment]
+            audit: List[Dict[str, str]] = []
+            if raw:
+                try:
+                    audit = list(json.loads(raw))
+                except Exception:
+                    audit = []
+            audit.append({"role": role, "content": content})
+            self._client.setex(audit_key, _AUDIT_TTL_SECONDS, json.dumps(audit))
+        except Exception as exc:
+            logger.warning("Failed to write to audit Redis key: %s", exc)
+
+    def set_active(self, user_id: str, history: List[Dict[str, str]]) -> None:
+        """Replace the active history (used after summarization compaction)."""
+        if not self._available:
+            return
+        try:
+            key = self._key(user_id)
+            self._client.setex(key, _TTL_SECONDS, json.dumps(history))
+        except Exception as exc:
+            logger.warning("Failed to replace active history in Redis: %s", exc)
+            self._available = False
+
+    def get_audit(self, user_id: str) -> List[Dict[str, str]]:
+        """Return the full audit history for ``user_id`` (all turns ever appended)."""
+        if not self._available:
+            return []
+        try:
+            raw: Optional[str] = self._client.get(self._audit_key(user_id))  # type: ignore[assignment]
+            if not raw:
+                return []
+            return list(json.loads(raw))
+        except Exception as exc:
+            logger.warning("Failed to read audit history from Redis: %s", exc)
+            return []
 
     def clear(self, user_id: str) -> None:
         if not self._available:
             return
 
         try:
+            # Clear only the active key; the audit log is never deleted.
             self._client.delete(self._key(user_id))
         except Exception as exc:
             logger.warning("Failed to clear Redis key: %s", exc)
@@ -103,23 +159,37 @@ class _InMemoryConversationStore:
         self._max_turns = max_turns
         self._store: Dict[str, List[Dict[str, str]]] = {}
         self._touched: Dict[str, datetime] = {}
+        # In-memory audit log (not persisted across restarts, but good for
+        # dev/test environments).
+        self._audit: Dict[str, List[Dict[str, str]]] = {}
 
     def get(self, user_id: str) -> List[Dict[str, str]]:
         self._evict_stale()
-        history = self._store.get(user_id, [])
-        # Trim to last 20 messages as required
-        return history[-_MAX_TURNS:] if len(history) > _MAX_TURNS else history
+        return list(self._store.get(user_id, []))
 
     def append(self, user_id: str, role: str, content: str) -> None:
         self._evict_stale()
         if user_id not in self._store:
             self._store[user_id] = []
         self._store[user_id].append({"role": role, "content": content})
-        if len(self._store[user_id]) > self._max_turns:
-            self._store[user_id] = self._store[user_id][-self._max_turns:]
         self._touched[user_id] = datetime.now(UTC)
 
+        # Audit log — append-only, no size cap.
+        if user_id not in self._audit:
+            self._audit[user_id] = []
+        self._audit[user_id].append({"role": role, "content": content})
+
+    def set_active(self, user_id: str, history: List[Dict[str, str]]) -> None:
+        """Replace the active history (used after summarization compaction)."""
+        self._store[user_id] = list(history)
+        self._touched[user_id] = datetime.now(UTC)
+
+    def get_audit(self, user_id: str) -> List[Dict[str, str]]:
+        """Return the full audit history for ``user_id``."""
+        return list(self._audit.get(user_id, []))
+
     def clear(self, user_id: str) -> None:
+        # Clear active only; audit is never deleted.
         self._store.pop(user_id, None)
         self._touched.pop(user_id, None)
 
@@ -138,6 +208,8 @@ class _InMemoryConversationStore:
 class ConversationStore(Protocol):
     def get(self, user_id: str) -> List[Dict[str, str]]: ...
     def append(self, user_id: str, role: str, content: str) -> None: ...
+    def set_active(self, user_id: str, history: List[Dict[str, str]]) -> None: ...
+    def get_audit(self, user_id: str) -> List[Dict[str, str]]: ...
     def clear(self, user_id: str) -> None: ...
 
 

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -14,12 +14,12 @@ from app.config import settings
 from app.models.coaching import CoachingRequest, CoachingResponse
 from app.models.explainability import DocumentUsed, ExplainabilityTrace, ToolInvocation
 from app.models.nudge import NudgeCopyResponse
-from app.models.preferences import ResponsePreferences
 from app.models.portfolio import (
     AllocationItem,
     PortfolioAnalysisResponse,
     PortfolioBreakdown,
 )
+from app.models.preferences import ResponsePreferences
 from app.models.recommendation import (
     ConfidenceLevel,
     Recommendation,
@@ -43,6 +43,7 @@ from app.services.i18n import (
 )
 from app.services.retrieval import RetrievalService, RetrievedContext
 from app.services.retrieval_source import ApiDataSource
+from app.services.summarization import needs_summarization, summarize_history
 from app.services.vault_context import VaultContextFetcher
 
 logger = logging.getLogger(__name__)
@@ -383,6 +384,16 @@ async def stream_chat(
     Screens the message for obvious prompt-injection/override attempts before
     any Claude call is made; flagged messages are refused without spending
     tokens or being added to conversation history.
+
+    Summarization
+    ~~~~~~~~~~~~~
+    Before building the messages list, this function checks whether the active
+    conversation history exceeds ``settings.max_history_tokens``.  If it does,
+    it calls ``summarize_history`` to compress older turns into a single summary
+    message.  The compacted history replaces the active history in the store;
+    the full pre-summarization history is preserved at the audit key.  This is
+    completely transparent to the user — there is no interruption or indication
+    in the chat stream.
     """
     screen = guardrails.screen_input(message, request_id=request_id, user_id=user_id)
     if screen.flagged:
@@ -396,7 +407,24 @@ async def stream_chat(
 
     # Get conversation history, deterministically bounded to cap context size.
     history = guardrails.truncate_history(conversation_store.get(user_id))
-    conversation_store.append(user_id, "user", message)
+
+    # --- Summarization check ------------------------------------------------
+    # Append the new user message first so the token estimate includes it.
+    history_with_new = history + [{"role": "user", "content": message}]
+    if needs_summarization(history_with_new):
+        client = get_client()
+        compacted = await summarize_history(history_with_new, client)
+        # Persist the compacted history as the new active context.  The full
+        # history (including the new user message we appended above) has
+        # already been written to the audit key by the store's append() calls;
+        # here we only need to update the active key.
+        conversation_store.append(user_id, "user", message)
+        conversation_store.set_active(user_id, compacted)
+        active_history = compacted
+    else:
+        conversation_store.append(user_id, "user", message)
+        active_history = history_with_new
+    # -------------------------------------------------------------------------
 
     # Retrieve minimal, user-scoped context via the structured retrieval layer
     # and build a grounded system prompt (#852). The retrieved context is the
@@ -422,8 +450,12 @@ async def stream_chat(
     # auditor can see what informed it, independent of whether tools are used.
     tool_invocations: list[ToolInvocation] = []
 
+    # Build messages from the (possibly compacted) active history minus the
+    # trailing user message, which is re-appended explicitly so it can be
+    # wrapped by the guardrail and so the list keeps the required
+    # user/assistant alternating order.
     messages: list[anthropic.types.MessageParam] = (
-        _to_anthropic_messages(history)
+        _to_anthropic_messages(active_history[:-1])
         + [{"role": "user", "content": guardrails.wrap_user_content(message)}]
     )
 

--- a/apps/intelligence/app/services/summarization.py
+++ b/apps/intelligence/app/services/summarization.py
@@ -1,0 +1,170 @@
+"""Conversation history summarization service for Prometheus AI.
+
+When conversation history exceeds the configured token threshold
+(``INTELLIGENCE_MAX_HISTORY_TOKENS``, default 80 000 tokens), this service:
+
+1. Estimates the token count of the active history using a simple character-
+   based approximation (4 chars ≈ 1 token).  This avoids a round-trip to the
+   tokenizer API on every message and is accurate enough for threshold detection.
+
+2. Calls Claude to generate a concise, factual summary of the *older* turns —
+   those that will be replaced.
+
+3. Returns a new history list where the older turns have been replaced with a
+   single synthetic ``assistant`` message containing
+   ``[Summary of previous conversation]\\n<summary>``, followed by the most
+   recent ``history_recent_turns_kept`` turns verbatim.
+
+4. The caller (``conversation_store``) is responsible for persisting both the
+   compacted active history *and* the full pre-summarization history to a
+   separate Redis key for audit purposes.
+
+The user never sees any indication of summarization — their next message is
+answered with the same context quality as before, just compressed.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+import anthropic
+
+from app.config import settings
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Sentinel prefix embedded in the synthetic summary message so callers can
+# detect (and skip re-summarizing) a message that is already a summary.
+SUMMARY_PREFIX = "[Summary of previous conversation]\n"
+
+# Characters per token approximation used for threshold detection.
+_CHARS_PER_TOKEN = 4
+
+# Max tokens Claude should use when producing the summary itself.
+_SUMMARY_MAX_TOKENS = 512
+
+
+def estimate_token_count(history: list[dict[str, str]]) -> int:
+    """Return a rough token estimate for ``history``.
+
+    Uses the heuristic of 4 characters per token, which is accurate to within
+    ~20% for English prose and good enough for threshold detection.
+    """
+    total_chars = sum(len(msg.get("content", "")) for msg in history)
+    return total_chars // _CHARS_PER_TOKEN
+
+
+def needs_summarization(history: list[dict[str, str]]) -> bool:
+    """Return True if ``history`` exceeds the configured token threshold.
+
+    Returns False when the threshold is 0 (disabled) or when the history is
+    empty.
+    """
+    threshold = settings.max_history_tokens
+    if threshold <= 0 or not history:
+        return False
+    return estimate_token_count(history) > threshold
+
+
+def _split_history(
+    history: list[dict[str, str]],
+    recent_turns: int,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Split history into (older_turns, recent_turns_list).
+
+    ``recent_turns`` controls how many messages to keep verbatim.  The rest
+    become the input for summarization.  We always keep at least 2 messages
+    (one user, one assistant) regardless of the configured value.
+    """
+    keep = max(2, recent_turns)
+    if len(history) <= keep:
+        # Not enough history to split — nothing to summarize.
+        return [], history
+    split_at = len(history) - keep
+    return history[:split_at], history[split_at:]
+
+
+def _build_summarization_prompt(older_turns: list[dict[str, str]]) -> str:
+    """Build the user prompt asking Claude to summarize ``older_turns``."""
+    lines = []
+    for msg in older_turns:
+        role = msg.get("role", "unknown").capitalize()
+        content = msg.get("content", "").strip()
+        lines.append(f"{role}: {content}")
+    conversation_text = "\n\n".join(lines)
+    return (
+        "The following is the earlier part of a conversation between a user and Prometheus, "
+        "the Nester financial AI assistant. Summarize the key facts, decisions, and context "
+        "discussed so that the assistant can continue the conversation accurately without "
+        "reading the full text.\n\n"
+        "Be concise and factual. Focus on:\n"
+        "- The user's savings goals, vault choices, and portfolio details mentioned\n"
+        "- Any recommendations Prometheus made\n"
+        "- Specific numbers (APYs, amounts, dates) that might be referenced later\n"
+        "- The overall trajectory of the conversation\n\n"
+        "Do NOT include pleasantries or meta-commentary. Output plain prose, 3-6 sentences.\n\n"
+        f"Conversation to summarize:\n{conversation_text}"
+    )
+
+
+async def summarize_history(
+    history: list[dict[str, str]],
+    client: anthropic.AsyncAnthropic,
+) -> list[dict[str, str]]:
+    """Summarize ``history`` and return a compacted replacement.
+
+    The returned list is:
+      [{"role": "assistant", "content": "[Summary of previous conversation]\\n<summary>"},
+       <last N turns verbatim>]
+
+    If summarization fails (e.g. API error), the original ``history`` is
+    returned unchanged so the caller can proceed without data loss.
+    """
+    recent_turns = max(2, settings.history_recent_turns_kept)
+    older, recent = _split_history(history, recent_turns)
+
+    if not older:
+        # Nothing to summarize.
+        return history
+
+    prompt = _build_summarization_prompt(older)
+
+    try:
+        response = await client.messages.create(
+            model=settings.anthropic_model,
+            max_tokens=_SUMMARY_MAX_TOKENS,
+            system=(
+                "You are a precise summarizer for a financial AI assistant. "
+                "Output only the summary text with no preamble or sign-off."
+            ),
+            messages=[{"role": "user", "content": prompt}],
+        )
+        summary_text = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                summary_text += block.text
+
+        summary_text = summary_text.strip()
+        if not summary_text:
+            logger.warning("summarize_history: empty summary returned, keeping full history")
+            return history
+
+        summary_message: dict[str, str] = {
+            "role": "assistant",
+            "content": f"{SUMMARY_PREFIX}{summary_text}",
+        }
+        compacted = [summary_message] + recent
+        logger.info(
+            "summarize_history: compressed %d turns → 1 summary + %d recent (est. %d → %d tokens)",
+            len(older),
+            len(recent),
+            estimate_token_count(history),
+            estimate_token_count(compacted),
+        )
+        return compacted
+
+    except Exception as exc:
+        logger.warning("summarize_history: failed to summarize, keeping full history: %s", exc)
+        return history

--- a/apps/intelligence/tests/test_summarization.py
+++ b/apps/intelligence/tests/test_summarization.py
@@ -1,0 +1,348 @@
+"""Tests for conversation history summarization (Issue 2 — Prometheus AI).
+
+Covers:
+- Token threshold detection (estimate_token_count, needs_summarization)
+- Summarization trigger: history exceeding threshold causes summarize_history call
+- New context construction: compacted history structure and audit log preservation
+- Config defaults for max_history_tokens and history_recent_turns_kept
+- ConversationStore set_active / get_audit round-trip (in-memory)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.conversation_store import _InMemoryConversationStore
+from app.services.summarization import (
+    SUMMARY_PREFIX,
+    _split_history,
+    estimate_token_count,
+    needs_summarization,
+    summarize_history,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_history(n: int, content_len: int = 100) -> list[dict[str, str]]:
+    """Return a history list with ``n`` alternating user/assistant messages."""
+    msgs = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": "x" * content_len})
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# estimate_token_count
+# ---------------------------------------------------------------------------
+
+class TestEstimateTokenCount:
+    def test_empty_history_returns_zero(self):
+        assert estimate_token_count([]) == 0
+
+    def test_single_message_four_chars_per_token(self):
+        history = [{"role": "user", "content": "abcd"}]
+        assert estimate_token_count(history) == 1
+
+    def test_multiple_messages_summed(self):
+        history = [
+            {"role": "user", "content": "a" * 400},
+            {"role": "assistant", "content": "b" * 400},
+        ]
+        # 800 chars / 4 = 200 tokens
+        assert estimate_token_count(history) == 200
+
+    def test_empty_content_does_not_crash(self):
+        history = [{"role": "user", "content": ""}]
+        assert estimate_token_count(history) == 0
+
+    def test_missing_content_key_treated_as_empty(self):
+        history = [{"role": "user"}]  # type: ignore[typeddict-item]
+        assert estimate_token_count(history) == 0
+
+
+# ---------------------------------------------------------------------------
+# needs_summarization
+# ---------------------------------------------------------------------------
+
+class TestNeedsSummarization:
+    def test_empty_history_never_needs_summarization(self):
+        assert needs_summarization([]) is False
+
+    def test_below_threshold_returns_false(self):
+        # 10 messages × 100 chars = 1000 chars → 250 tokens; threshold 80_000
+        history = make_history(10, content_len=100)
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.max_history_tokens = 80_000
+            assert needs_summarization(history) is False
+
+    def test_above_threshold_returns_true(self):
+        # 10 messages × 100 chars = 1000 chars → 250 tokens; threshold 200
+        history = make_history(10, content_len=100)
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.max_history_tokens = 200
+            assert needs_summarization(history) is True
+
+    def test_exactly_at_threshold_returns_false(self):
+        # exactly 200 tokens with threshold 200 — only *exceeding* triggers
+        history = [{"role": "user", "content": "a" * 800}]
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.max_history_tokens = 200
+            assert needs_summarization(history) is False
+
+    def test_one_above_threshold_returns_true(self):
+        history = [{"role": "user", "content": "a" * 804}]  # 201 tokens
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.max_history_tokens = 200
+            assert needs_summarization(history) is True
+
+    def test_disabled_when_threshold_zero(self):
+        history = make_history(100, content_len=10_000)  # very large
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.max_history_tokens = 0
+            assert needs_summarization(history) is False
+
+
+# ---------------------------------------------------------------------------
+# _split_history
+# ---------------------------------------------------------------------------
+
+class TestSplitHistory:
+    def test_splits_at_correct_position(self):
+        history = make_history(10)
+        older, recent = _split_history(history, recent_turns=4)
+        assert len(older) == 6
+        assert len(recent) == 4
+        assert recent == history[6:]
+
+    def test_minimum_recent_turns_is_two(self):
+        history = make_history(10)
+        older, recent = _split_history(history, recent_turns=1)
+        assert len(recent) == 2
+
+    def test_returns_all_recent_when_history_shorter_than_keep(self):
+        history = make_history(3)
+        older, recent = _split_history(history, recent_turns=4)
+        assert older == []
+        assert recent == history
+
+    def test_empty_history_returns_empty_older(self):
+        older, recent = _split_history([], recent_turns=4)
+        assert older == []
+        assert recent == []
+
+
+# ---------------------------------------------------------------------------
+# summarize_history
+# ---------------------------------------------------------------------------
+
+class TestSummarizeHistory:
+    @pytest.mark.asyncio
+    async def test_returns_compacted_history_on_success(self):
+        history = make_history(10, content_len=100)
+
+        mock_block = MagicMock()
+        mock_block.text = "User discussed yield strategies and chose the Balanced vault."
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.anthropic_model = "claude-sonnet-5"
+            mock_settings.history_recent_turns_kept = 4
+
+            compacted = await summarize_history(history, mock_client)
+
+        # First message should be the summary sentinel
+        assert len(compacted) == 5  # 1 summary + 4 recent
+        assert compacted[0]["role"] == "assistant"
+        assert compacted[0]["content"].startswith(SUMMARY_PREFIX)
+        assert "yield strategies" in compacted[0]["content"]
+
+        # Last 4 messages should be the original recent turns verbatim
+        assert compacted[1:] == history[6:]
+
+    @pytest.mark.asyncio
+    async def test_returns_original_history_on_api_error(self):
+        history = make_history(10, content_len=100)
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=Exception("API unavailable"))
+
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.anthropic_model = "claude-sonnet-5"
+            mock_settings.history_recent_turns_kept = 4
+
+            result = await summarize_history(history, mock_client)
+
+        # On failure, original history is returned unchanged
+        assert result == history
+
+    @pytest.mark.asyncio
+    async def test_returns_original_history_on_empty_summary(self):
+        history = make_history(10, content_len=100)
+
+        mock_block = MagicMock()
+        mock_block.text = "   "  # empty/whitespace only
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.anthropic_model = "claude-sonnet-5"
+            mock_settings.history_recent_turns_kept = 4
+
+            result = await summarize_history(history, mock_client)
+
+        assert result == history
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_summarize_returns_original(self):
+        """History shorter than keep window is returned unchanged."""
+        history = make_history(3)
+
+        mock_client = AsyncMock()
+
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.anthropic_model = "claude-sonnet-5"
+            mock_settings.history_recent_turns_kept = 6  # keep more than history length
+
+            result = await summarize_history(history, mock_client)
+
+        assert result == history
+        mock_client.messages.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_compacted_history_token_count_is_lower(self):
+        """Token estimate of compacted history should be less than original."""
+        # 20 messages × 500 chars each → 2500 tokens
+        history = make_history(20, content_len=500)
+
+        summary_text = "Brief summary."  # 14 chars → ~3 tokens
+        mock_block = MagicMock()
+        mock_block.text = summary_text
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch("app.services.summarization.settings") as mock_settings:
+            mock_settings.anthropic_model = "claude-sonnet-5"
+            mock_settings.history_recent_turns_kept = 4
+
+            compacted = await summarize_history(history, mock_client)
+
+        original_tokens = estimate_token_count(history)
+        compacted_tokens = estimate_token_count(compacted)
+        assert compacted_tokens < original_tokens
+
+
+# ---------------------------------------------------------------------------
+# InMemoryConversationStore — set_active / get_audit
+# ---------------------------------------------------------------------------
+
+class TestInMemoryConversationStoreAudit:
+    def test_append_writes_to_audit(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "hello")
+        store.append("user-1", "assistant", "hi there")
+
+        audit = store.get_audit("user-1")
+        assert len(audit) == 2
+        assert audit[0] == {"role": "user", "content": "hello"}
+        assert audit[1] == {"role": "assistant", "content": "hi there"}
+
+    def test_set_active_replaces_active_history(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "original message")
+
+        compacted = [{"role": "assistant", "content": f"{SUMMARY_PREFIX}Summary here."}]
+        store.set_active("user-1", compacted)
+
+        active = store.get("user-1")
+        assert active == compacted
+
+    def test_audit_not_affected_by_set_active(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "original message")
+
+        compacted = [{"role": "assistant", "content": f"{SUMMARY_PREFIX}Summary here."}]
+        store.set_active("user-1", compacted)
+
+        # Audit still has the original message
+        audit = store.get_audit("user-1")
+        assert any(m["content"] == "original message" for m in audit)
+
+    def test_clear_removes_active_not_audit(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "message before clear")
+        store.clear("user-1")
+
+        assert store.get("user-1") == []
+        # Audit survives clear
+        audit = store.get_audit("user-1")
+        assert len(audit) == 1
+
+    def test_audit_scoped_per_user(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "user-1 message")
+        store.append("user-2", "user", "user-2 message")
+
+        assert len(store.get_audit("user-1")) == 1
+        assert len(store.get_audit("user-2")) == 1
+        assert store.get_audit("user-99") == []
+
+    def test_get_audit_returns_copy(self):
+        store = _InMemoryConversationStore()
+        store.append("user-1", "user", "original")
+
+        audit = store.get_audit("user-1")
+        audit.append({"role": "user", "content": "mutated"})
+
+        # Internal audit must not have been mutated
+        assert len(store.get_audit("user-1")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+class TestConfigDefaults:
+    def test_max_history_tokens_default(self):
+        from app.config import Settings
+
+        s = Settings()
+        assert s.max_history_tokens == 80_000
+
+    def test_history_recent_turns_kept_default(self):
+        from app.config import Settings
+
+        s = Settings()
+        assert s.history_recent_turns_kept == 6
+
+    def test_max_history_tokens_configurable(self):
+        import os
+
+        from app.config import Settings
+
+        with patch.dict(os.environ, {"INTELLIGENCE_MAX_HISTORY_TOKENS": "40000"}, clear=False):
+            s = Settings()
+            assert s.max_history_tokens == 40_000
+
+    def test_history_recent_turns_kept_configurable(self):
+        import os
+
+        from app.config import Settings
+
+        with patch.dict(
+            os.environ, {"INTELLIGENCE_HISTORY_RECENT_TURNS_KEPT": "10"}, clear=False
+        ):
+            s = Settings()
+            assert s.history_recent_turns_kept == 10


### PR DESCRIPTION
Adds automatic conversation history summarization so that long Prometheus sessions never hit Claude's context window limit and remain cost-efficient.

Changes
-------
app/config.py
  - max_history_tokens (INTELLIGENCE_MAX_HISTORY_TOKENS, default 80_000): token threshold above which summarization is triggered — set to ~80% of the claude-sonnet-5 200k context window
  - history_recent_turns_kept (INTELLIGENCE_HISTORY_RECENT_TURNS_KEPT, default 6): number of most-recent turns always kept verbatim after compaction

app/services/summarization.py (new)
  - estimate_token_count: lightweight 4-chars-per-token heuristic, no API call
  - needs_summarization: returns True when history exceeds threshold; False when threshold is 0 (disabled), or history is empty
  - _split_history: splits history into (older, recent) at the keep boundary
  - summarize_history: calls Claude to produce a concise prose summary of older turns, returns compacted history = [summary message] + recent turns; returns original history unchanged on any API failure (fail-safe)

app/services/conversation_store.py
  - set_active(user_id, history): replaces the active history key, used by the summarization path to persist the compacted context
  - get_audit(user_id): returns the full append-only history from the separate Redis key prometheus:conv:audit:<user_id> (TTL: 7 days)
  - append() now writes every turn to both the active key and the audit key
  - InMemoryConversationStore carries matching set_active / get_audit methods for dev/test use; audit log survives clear()

closes #

app/services/prometheus.py
  - stream_chat: before building the message list, checks needs_summarization on history + the new user message; if triggered, calls summarize_history and persists the compacted history via set_active; transparent to the user

tests/test_summarization.py (new, 30 tests, all passing)
  - TestEstimateTokenCount: 5 tests covering edge cases
  - TestNeedsSummarization: 6 tests including disabled (threshold=0), exactly-at, and one-above threshold
  - TestSplitHistory: 4 tests including minimum-2-turns guard
  - TestSummarizeHistory: 5 tests — success path, API error fallback, empty summary fallback, nothing-to-summarize, token count reduction
  - TestInMemoryConversationStoreAudit: 6 tests — append/set_active/get_audit round-trip, audit survives clear, scoped per user, copy semantics
  - TestConfigDefaults: 4 tests for default and overridden values

## Summary
What does this PR do? (1-3 sentences)

## Related Issues
Closes #XX

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Changes Made
- 
- 

## Testing Done
How was this tested?

## Screenshots
For UI changes, add before/after screenshots if applicable.

## Checklist
- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
- [ ] No secrets or credentials in the code
- [ ] Smart contract changes reviewed for security implications
closes #622 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long conversation histories are now automatically summarized to keep chats responsive while retaining recent turns.
  * Full pre-summary conversation history is preserved in an append-only audit record.
  * Added configurable controls for history size and the number of recent turns retained.
  * Summarization safely falls back to the original history if processing fails or produces no usable summary.

* **Tests**
  * Added coverage for summarization, history retention, audit behavior, error handling, and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->