### PR TITLE
feat(api): per-vault configurable harvest frequency

### DIFF
--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -34,6 +34,7 @@ var (
 	ErrAllocationHasBalance = errors.New("allocation has non-zero balance; set force=true to remove")
 	ErrDuplicateProtocol    = errors.New("protocol already allocated")
 	ErrBelowMinDeposit      = errors.New("deposit amount is below the minimum required for this protocol")
+	ErrInvalidHarvestFrequency = errors.New("harvest frequency must be 'daily' or 'weekly'")
 	// ErrDuplicateTransaction is returned when a deposit/withdrawal insert
 	// collides with vault_transactions' UNIQUE transaction_hash index. A
 	// caller that generates its own idempotency-bearing hash (e.g. the
@@ -49,6 +50,15 @@ const (
 	// DefaultCapacityWarningThreshold is the percentage of capacity at which
 	// warnings are surfaced (80% by default).
 	DefaultCapacityWarningThreshold = 80.0
+)
+
+// HarvestFrequencyDaily and HarvestFrequencyWeekly are the supported cadences
+// for the per-vault harvest engine gate (#940). Smaller vaults default to
+// daily; larger vaults may prefer weekly to reduce cumulative gas spend.
+const (
+	HarvestFrequencyDaily   = "daily"
+	HarvestFrequencyWeekly  = "weekly"
+	DefaultHarvestFrequency = HarvestFrequencyDaily
 )
 
 type Vault struct {
@@ -68,6 +78,13 @@ type Vault struct {
 	// CapacityWarningPct is the percentage threshold at which capacity warnings
 	// are surfaced. Defaults to DefaultCapacityWarningThreshold (80%) when nil.
 	CapacityWarningPct  *float64         `json:"capacity_warning_pct,omitempty"`
+	// HarvestFrequency controls how often the harvest engine will consider this
+	// vault for a harvest: "daily" or "weekly". Defaults to
+	// DefaultHarvestFrequency when empty.
+	HarvestFrequency    string           `json:"harvest_frequency"`
+	// LastHarvestedAt is when the vault's yield was last harvested, used by the
+	// harvest engine to enforce HarvestFrequency. Nil means never harvested.
+	LastHarvestedAt     *time.Time       `json:"last_harvested_at,omitempty"`
 	LastSyncedAt        *time.Time       `json:"last_synced_at,omitempty"`
 	LastAPYAlertSentAt  *time.Time       `json:"last_apy_alert_sent_at,omitempty"`
 	DeletedAt           *time.Time       `json:"deleted_at,omitempty"`
@@ -144,6 +161,7 @@ type Repository interface {
 	UpdateVaultBalances(ctx context.Context, id uuid.UUID, totalDeposited decimal.Decimal, currentBalance decimal.Decimal) error
 	ReplaceAllocations(ctx context.Context, vaultID uuid.UUID, allocations []Allocation) error
 	UpdateVault(ctx context.Context, id uuid.UUID, contractAddress string, status VaultStatus) error
+	UpdateHarvestFrequency(ctx context.Context, id uuid.UUID, frequency string) error
 	RecordWithdrawal(ctx context.Context, vaultID uuid.UUID, record TransactionRecord) error
 	RecordHarvest(ctx context.Context, input HarvestRecordInput) error
 	RecordRebalance(ctx context.Context, input RebalanceRecordInput, withdrawRecord, depositRecord TransactionRecord) error
@@ -166,6 +184,20 @@ func (s VaultStatus) CanTransitionTo(next VaultStatus) bool {
 		return next == StatusActive || next == StatusClosed
 	default:
 		return false
+	}
+}
+
+// ParseHarvestFrequency validates a harvest frequency string, returning
+// ErrInvalidHarvestFrequency for anything other than "daily" or "weekly"
+// (case-insensitive, trimmed).
+func ParseHarvestFrequency(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case HarvestFrequencyDaily:
+		return HarvestFrequencyDaily, nil
+	case HarvestFrequencyWeekly:
+		return HarvestFrequencyWeekly, nil
+	default:
+		return "", ErrInvalidHarvestFrequency
 	}
 }
 

--- a/apps/api/internal/domain/vault/model_test.go
+++ b/apps/api/internal/domain/vault/model_test.go
@@ -192,6 +192,40 @@ func TestAllocationProtocolValidation(t *testing.T) {
 	}
 }
 
+func TestParseHarvestFrequencyValidValues(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"daily", HarvestFrequencyDaily},
+		{"DAILY", HarvestFrequencyDaily},
+		{"  daily  ", HarvestFrequencyDaily},
+		{"weekly", HarvestFrequencyWeekly},
+		{"WEEKLY", HarvestFrequencyWeekly},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseHarvestFrequency(tt.input)
+			if err != nil {
+				t.Fatalf("ParseHarvestFrequency(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.expected {
+				t.Fatalf("ParseHarvestFrequency(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseHarvestFrequencyInvalidValues(t *testing.T) {
+	for _, input := range []string{"", "monthly", "hourly", "biweekly"} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseHarvestFrequency(input); err != ErrInvalidHarvestFrequency {
+				t.Fatalf("ParseHarvestFrequency(%q) err = %v, want ErrInvalidHarvestFrequency", input, err)
+			}
+		})
+	}
+}
+
 func trimSpace(s string) string {
 	// Simple trim implementation for testing
 	start := 0

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -78,6 +78,7 @@ func (h *VaultHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/vaults/{id}/allocations", h.getAllocations)
 	mux.HandleFunc("POST /api/v1/vaults/{id}/harvest", h.harvestVault)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/harvest/preview", h.previewHarvest)
+	mux.HandleFunc("PATCH /api/v1/vaults/{id}/harvest-frequency", h.updateHarvestFrequency)
 	mux.HandleFunc("GET /api/v1/vaults/{id}/my-position", h.getMyPosition)
 	// GET /api/v1/vaults/{id}/projection is registered by ProjectionHandler
 	mux.HandleFunc("GET /api/v1/vaults/{id}/preview-deposit", h.previewDeposit)
@@ -100,6 +101,10 @@ func (h *VaultHandler) Register(mux *http.ServeMux) {
 
 type harvestVaultRequest struct {
 	Compound *bool `json:"compound"`
+}
+
+type updateHarvestFrequencyRequest struct {
+	HarvestFrequency string `json:"harvest_frequency"`
 }
 
 func (h *VaultHandler) createVault(w http.ResponseWriter, r *http.Request) {
@@ -305,6 +310,36 @@ func (h *VaultHandler) harvestVault(w http.ResponseWriter, r *http.Request) {
 			Data:      result,
 			Timestamp: time.Now().UTC(),
 		})
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(result))
+}
+
+// updateHarvestFrequency sets how often the harvest engine considers this
+// vault for a harvest ("daily" or "weekly"). Only the vault owner may change
+// it (#940).
+func (h *VaultHandler) updateHarvestFrequency(w http.ResponseWriter, r *http.Request) {
+	vaultID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("vault id must be a valid UUID"))
+		return
+	}
+
+	var req updateHarvestFrequencyRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+		return
+	}
+
+	userID, err := h.authenticatedUserID(w, r)
+	if err != nil {
+		return
+	}
+
+	result, err := h.service.UpdateHarvestFrequency(r.Context(), vaultID, userID, req.HarvestFrequency)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
 	}
 
 	response.WriteJSON(w, http.StatusOK, response.OK(result))
@@ -701,7 +736,7 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
 	case errors.Is(err, vault.ErrUserNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("user"))
-	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation):
+	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation), errors.Is(err, vault.ErrInvalidHarvestFrequency):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	case errors.Is(err, vault.ErrBelowMinDeposit):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -285,6 +285,17 @@ func (r *handlerRepository) UpdateVault(_ context.Context, id uuid.UUID, contrac
 	return nil
 }
 
+func (r *handlerRepository) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
+	model, ok := r.vaults[id]
+	if !ok {
+		return vault.ErrVaultNotFound
+	}
+	model.HarvestFrequency = frequency
+	model.UpdatedAt = time.Now().UTC()
+	r.vaults[id] = cloneHandlerVault(model)
+	return nil
+}
+
 func (r *handlerRepository) RecordHarvest(_ context.Context, input vault.HarvestRecordInput) error {
 	model, ok := r.vaults[input.VaultID]
 	if !ok {

--- a/apps/api/internal/harvest/adapters.go
+++ b/apps/api/internal/harvest/adapters.go
@@ -65,11 +65,13 @@ func toVaultYield(v vault.Vault) VaultYield {
 		accrued = v.CurrentBalance.Sub(v.TotalDeposited)
 	}
 	return VaultYield{
-		VaultID:         v.ID,
-		UserID:          v.UserID,
-		ContractAddress: v.ContractAddress,
-		Currency:        v.Currency,
-		AccruedYield:    accrued,
+		VaultID:          v.ID,
+		UserID:           v.UserID,
+		ContractAddress:  v.ContractAddress,
+		Currency:         v.Currency,
+		AccruedYield:     accrued,
+		HarvestFrequency: v.HarvestFrequency,
+		LastHarvestedAt:  v.LastHarvestedAt,
 	}
 }
 

--- a/apps/api/internal/harvest/decision.go
+++ b/apps/api/internal/harvest/decision.go
@@ -24,7 +24,32 @@ const (
 	ReasonNoYield Reason = "no_yield"
 	// ReasonBelowThreshold: yield is positive but does not cover gas + margin.
 	ReasonBelowThreshold Reason = "below_threshold"
+	// ReasonNotDue: the vault's configured harvest frequency has not elapsed
+	// since its last harvest (#940).
+	ReasonNotDue Reason = "not_due"
 )
+
+// FrequencyDuration maps a per-vault harvest frequency (#940) to the minimum
+// interval that must elapse between harvests. Unrecognized values fall back
+// to the daily cadence.
+func FrequencyDuration(frequency string) time.Duration {
+	switch frequency {
+	case "weekly":
+		return 7 * 24 * time.Hour
+	default:
+		return 24 * time.Hour
+	}
+}
+
+// DueForHarvest reports whether enough time has elapsed since lastHarvestedAt
+// for frequency to permit another harvest. A nil lastHarvestedAt (never
+// harvested) is always due.
+func DueForHarvest(now time.Time, frequency string, lastHarvestedAt *time.Time) bool {
+	if lastHarvestedAt == nil {
+		return true
+	}
+	return now.Sub(*lastHarvestedAt) >= FrequencyDuration(frequency)
+}
 
 // GatingInput carries the economics of a single harvest decision. All amounts
 // are in the vault's settlement currency (e.g. USDC), same scale as the ledger.

--- a/apps/api/internal/harvest/decision_test.go
+++ b/apps/api/internal/harvest/decision_test.go
@@ -59,3 +59,48 @@ func TestEstimateNextHarvest(t *testing.T) {
 		t.Fatal("expected undefined estimate for zero rate")
 	}
 }
+
+func TestFrequencyDuration(t *testing.T) {
+	tests := []struct {
+		frequency string
+		want      time.Duration
+	}{
+		{"daily", 24 * time.Hour},
+		{"weekly", 7 * 24 * time.Hour},
+		{"", 24 * time.Hour},
+		{"monthly", 24 * time.Hour},
+	}
+	for _, tt := range tests {
+		if got := FrequencyDuration(tt.frequency); got != tt.want {
+			t.Errorf("FrequencyDuration(%q) = %v, want %v", tt.frequency, got, tt.want)
+		}
+	}
+}
+
+func TestDueForHarvest(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	if !DueForHarvest(now, "daily", nil) {
+		t.Error("never-harvested vault should always be due")
+	}
+
+	almostADayAgo := now.Add(-23 * time.Hour)
+	if DueForHarvest(now, "daily", &almostADayAgo) {
+		t.Error("daily vault harvested 23h ago should not be due")
+	}
+
+	overADayAgo := now.Add(-25 * time.Hour)
+	if !DueForHarvest(now, "daily", &overADayAgo) {
+		t.Error("daily vault harvested 25h ago should be due")
+	}
+
+	sixDaysAgo := now.Add(-6 * 24 * time.Hour)
+	if DueForHarvest(now, "weekly", &sixDaysAgo) {
+		t.Error("weekly vault harvested 6 days ago should not be due")
+	}
+
+	eightDaysAgo := now.Add(-8 * 24 * time.Hour)
+	if !DueForHarvest(now, "weekly", &eightDaysAgo) {
+		t.Error("weekly vault harvested 8 days ago should be due")
+	}
+}

--- a/apps/api/internal/harvest/engine.go
+++ b/apps/api/internal/harvest/engine.go
@@ -31,6 +31,12 @@ type VaultYield struct {
 	// AccrualRatePerHour is the recent yield accrual rate, used only to estimate
 	// the next harvest time for user-facing status. Zero means "unknown".
 	AccrualRatePerHour decimal.Decimal
+	// HarvestFrequency is the vault owner's configured cadence ("daily" or
+	// "weekly", #940). Empty is treated as the default (daily).
+	HarvestFrequency string
+	// LastHarvestedAt is when this vault's yield was last harvested. Nil means
+	// never harvested, so the frequency gate always lets it through.
+	LastHarvestedAt *time.Time
 }
 
 // VaultSource lists vaults eligible for harvest evaluation.
@@ -194,6 +200,10 @@ func (e *Engine) TriggerVault(ctx context.Context, vaultID uuid.UUID) (bool, err
 // evaluateAndEnqueue applies the gate to one vault and enqueues an idempotent
 // harvest job when it clears. Returns whether a harvest was enqueued.
 func (e *Engine) evaluateAndEnqueue(ctx context.Context, v VaultYield) (bool, error) {
+	if !DueForHarvest(e.clock(), v.HarvestFrequency, v.LastHarvestedAt) {
+		return false, nil
+	}
+
 	fee, err := e.gas.HarvestFee(ctx, v.Currency)
 	if err != nil {
 		return false, fmt.Errorf("estimate gas fee: %w", err)
@@ -290,6 +300,11 @@ func (e *Engine) SimulateHarvest(ctx context.Context, vaultID uuid.UUID) (Simula
 		GasFee:       fee,
 		Margin:       e.cfg.Margin,
 	})
+
+	if !DueForHarvest(e.clock(), v.HarvestFrequency, v.LastHarvestedAt) {
+		decision.Harvest = false
+		decision.Reason = ReasonNotDue
+	}
 
 	// If network is congested, the harvest would be deferred (not enqueued).
 	wouldHarvest := decision.Harvest && !congested

--- a/apps/api/internal/harvest/engine_test.go
+++ b/apps/api/internal/harvest/engine_test.go
@@ -117,6 +117,40 @@ func TestEngine_SkipsBelowThreshold(t *testing.T) {
 	}
 }
 
+func TestEngine_SkipsNotDueForFrequency(t *testing.T) {
+	v := vaultYield("10") // would clear the economic gate...
+	recent := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC)
+	v.HarvestFrequency = "daily"
+	v.LastHarvestedAt = &recent
+	vs := &fakeVaultSource{list: []VaultYield{v}}
+	q := newFakeEnqueuer()
+	e := newEngine(t, vs, &fakeGas{fee: decimal.RequireFromString("2")}, q)
+	e.clock = func() time.Time { return recent.Add(2 * time.Hour) } // only 2h since last harvest
+
+	e.tick(context.Background())
+
+	if len(q.calls) != 0 {
+		t.Fatalf("daily vault harvested 2h ago should not be due; enqueued %d jobs", len(q.calls))
+	}
+}
+
+func TestEngine_HarvestsWhenFrequencyElapsed(t *testing.T) {
+	v := vaultYield("10")
+	past := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	v.HarvestFrequency = "daily"
+	v.LastHarvestedAt = &past
+	vs := &fakeVaultSource{list: []VaultYield{v}}
+	q := newFakeEnqueuer()
+	e := newEngine(t, vs, &fakeGas{fee: decimal.RequireFromString("2")}, q)
+	e.clock = func() time.Time { return past.Add(48 * time.Hour) }
+
+	e.tick(context.Background())
+
+	if len(q.calls) != 1 {
+		t.Fatalf("daily vault harvested 48h ago should be due; enqueued %d jobs, want 1", len(q.calls))
+	}
+}
+
 func TestEngine_DefersWhenCongested(t *testing.T) {
 	v := vaultYield("100")
 	vs := &fakeVaultSource{list: []VaultYield{v}}

--- a/apps/api/internal/harvest/status.go
+++ b/apps/api/internal/harvest/status.go
@@ -63,6 +63,12 @@ func (e *Engine) statusFor(ctx context.Context, v VaultYield) (Status, error) {
 		Margin:       e.cfg.Margin,
 	})
 
+	due := DueForHarvest(e.clock(), v.HarvestFrequency, v.LastHarvestedAt)
+	if !due {
+		decision.Harvest = false
+		decision.Reason = ReasonNotDue
+	}
+
 	status := Status{
 		VaultID:      v.VaultID,
 		PendingYield: v.AccruedYield,

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -24,10 +24,14 @@ func NewVaultRepository(db *sql.DB) *VaultRepository {
 }
 
 func (r *VaultRepository) CreateVault(ctx context.Context, model vault.Vault) (vault.Vault, error) {
+	if model.HarvestFrequency == "" {
+		model.HarvestFrequency = vault.DefaultHarvestFrequency
+	}
+
 	query := `
 		INSERT INTO vaults (
-			id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING created_at, updated_at
 	`
 
@@ -43,6 +47,7 @@ func (r *VaultRepository) CreateVault(ctx context.Context, model vault.Vault) (v
 		string(model.Status),
 		model.YieldEarned.String(),
 		model.FeesPaid.String(),
+		model.HarvestFrequency,
 	).Scan(&model.CreatedAt, &model.UpdatedAt); err != nil {
 		return vault.Vault{}, mapRepositoryError(err)
 	}
@@ -52,7 +57,7 @@ func (r *VaultRepository) CreateVault(ctx context.Context, model vault.Vault) (v
 
 func (r *VaultRepository) GetVault(ctx context.Context, id uuid.UUID) (vault.Vault, error) {
 	query := `
-		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, last_synced_at, deleted_at, created_at, updated_at
+		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency, last_harvested_at, last_synced_at, deleted_at, created_at, updated_at
 		FROM vaults
 		WHERE id = $1 AND deleted_at IS NULL
 	`
@@ -89,7 +94,7 @@ func (r *VaultRepository) ListUserVaults(
 	offset := (filter.Page - 1) * filter.PerPage
 
 	listQuery := fmt.Sprintf(`
-		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, last_synced_at, deleted_at, created_at, updated_at
+		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency, last_harvested_at, last_synced_at, deleted_at, created_at, updated_at
 		FROM vaults
 		WHERE %s
 		ORDER BY %s %s
@@ -142,7 +147,7 @@ func (r *VaultRepository) ListVaults(ctx context.Context, filter vault.ListFilte
 
 	args = append(args, filter.Limit, filter.Offset)
 	listQuery := fmt.Sprintf(`
-		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, last_synced_at, deleted_at, created_at, updated_at
+		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency, last_harvested_at, last_synced_at, deleted_at, created_at, updated_at
 		FROM vaults
 		WHERE %s
 		ORDER BY created_at DESC
@@ -173,7 +178,7 @@ func (r *VaultRepository) ListVaults(ctx context.Context, filter vault.ListFilte
 // by the performance tracker so it can iterate live vaults each tick.
 func (r *VaultRepository) ListActive(ctx context.Context) ([]vault.Vault, error) {
 	const query = `
-		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, created_at, updated_at
+		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency, last_harvested_at, last_synced_at, deleted_at, created_at, updated_at
 		FROM vaults
 		WHERE deleted_at IS NULL AND status = 'active'
 		ORDER BY created_at ASC
@@ -406,6 +411,32 @@ func (r *VaultRepository) UpdateVault(ctx context.Context, id uuid.UUID, contrac
 	return nil
 }
 
+// UpdateHarvestFrequency sets the vault's harvest cadence, used by the harvest
+// engine to gate how often it considers this vault for a harvest (#940).
+func (r *VaultRepository) UpdateHarvestFrequency(ctx context.Context, id uuid.UUID, frequency string) error {
+	result, err := r.db.ExecContext(
+		ctx,
+		`UPDATE vaults
+		 SET harvest_frequency = $2, updated_at = NOW()
+		 WHERE id = $1 AND deleted_at IS NULL`,
+		id.String(),
+		frequency,
+	)
+	if err != nil {
+		return mapRepositoryError(err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return vault.ErrVaultNotFound
+	}
+
+	return nil
+}
+
 // RecordWithdrawal decrements current_balance atomically and writes a ledger
 // entry. It does NOT touch total_deposited (deposits are never reversed).
 func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, record vault.TransactionRecord) error {
@@ -480,6 +511,7 @@ func (r *VaultRepository) RecordHarvest(ctx context.Context, input vault.Harvest
 			     current_balance = current_balance + $2::numeric,
 			     yield_earned = GREATEST(yield_earned - ($2::numeric + $3::numeric), 0),
 			     fees_paid = fees_paid + $3::numeric,
+			     last_harvested_at = NOW(),
 			     updated_at = NOW()
 			 WHERE id = $1 AND deleted_at IS NULL`,
 			input.VaultID.String(),
@@ -503,6 +535,7 @@ func (r *VaultRepository) RecordHarvest(ctx context.Context, input vault.Harvest
 			 SET current_balance = current_balance - $2::numeric,
 			     yield_earned = GREATEST(yield_earned - ($2::numeric + $3::numeric), 0),
 			     fees_paid = fees_paid + $3::numeric,
+			     last_harvested_at = NOW(),
 			     updated_at = NOW()
 			 WHERE id = $1 AND deleted_at IS NULL`,
 			input.VaultID.String(),
@@ -809,19 +842,21 @@ type queryer interface {
 
 func scanVault(row scanner) (vault.Vault, error) {
 	var (
-		id              string
-		userID          string
-		totalDeposited  string
-		currentBalance  string
-		contractAddress string
-		currency        string
-		status          string
-		yieldEarned     string
-		feesPaid        string
-		lastSyncedAt    sql.NullTime
-		deletedAt       sql.NullTime
-		createdAt       time.Time
-		updatedAt       time.Time
+		id               string
+		userID           string
+		totalDeposited   string
+		currentBalance   string
+		contractAddress  string
+		currency         string
+		status           string
+		yieldEarned      string
+		feesPaid         string
+		harvestFrequency string
+		lastHarvestedAt  sql.NullTime
+		lastSyncedAt     sql.NullTime
+		deletedAt        sql.NullTime
+		createdAt        time.Time
+		updatedAt        time.Time
 	)
 
 	if err := row.Scan(
@@ -834,6 +869,8 @@ func scanVault(row scanner) (vault.Vault, error) {
 		&status,
 		&yieldEarned,
 		&feesPaid,
+		&harvestFrequency,
+		&lastHarvestedAt,
 		&lastSyncedAt,
 		&deletedAt,
 		&createdAt,
@@ -868,6 +905,12 @@ func scanVault(row scanner) (vault.Vault, error) {
 	parsedYield, _ := decimal.NewFromString(yieldEarned)
 	parsedFees, _ := decimal.NewFromString(feesPaid)
 
+	var lastHarvestedAtPtr *time.Time
+	if lastHarvestedAt.Valid {
+		t := lastHarvestedAt.Time
+		lastHarvestedAtPtr = &t
+	}
+
 	var lastSyncedAtPtr *time.Time
 	if lastSyncedAt.Valid {
 		t := lastSyncedAt.Time
@@ -881,19 +924,21 @@ func scanVault(row scanner) (vault.Vault, error) {
 	}
 
 	return vault.Vault{
-		ID:              parsedID,
-		UserID:          parsedUserID,
-		ContractAddress: contractAddress,
-		TotalDeposited:  parsedDeposited,
-		CurrentBalance:  parsedBalance,
-		Currency:        currency,
-		Status:          vault.VaultStatus(status),
-		YieldEarned:     parsedYield,
-		FeesPaid:        parsedFees,
-		LastSyncedAt:    lastSyncedAtPtr,
-		DeletedAt:       deletedAtPtr,
-		CreatedAt:       createdAt,
-		UpdatedAt:       updatedAt,
+		ID:               parsedID,
+		UserID:           parsedUserID,
+		ContractAddress:  contractAddress,
+		TotalDeposited:   parsedDeposited,
+		CurrentBalance:   parsedBalance,
+		Currency:         currency,
+		Status:           vault.VaultStatus(status),
+		YieldEarned:      parsedYield,
+		FeesPaid:         parsedFees,
+		HarvestFrequency: harvestFrequency,
+		LastHarvestedAt:  lastHarvestedAtPtr,
+		LastSyncedAt:     lastSyncedAtPtr,
+		DeletedAt:        deletedAtPtr,
+		CreatedAt:        createdAt,
+		UpdatedAt:        updatedAt,
 	}, nil
 }
 

--- a/apps/api/internal/repository/postgres/vault_repository_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_test.go
@@ -35,8 +35,8 @@ func TestCreateVaultMapsForeignKeyViolationToUserNotFound(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
 		INSERT INTO vaults (
-			id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING created_at, updated_at
 	`)).
 		WillReturnError(&pgconn.PgError{Code: "23503", ConstraintName: "vaults_user_id_fkey"})
@@ -99,14 +99,14 @@ func TestGetVaultLoadsAllocations(t *testing.T) {
 	createdAt := time.Now().UTC()
 
 	mock.ExpectQuery(regexp.QuoteMeta(`
-		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, last_synced_at, deleted_at, created_at, updated_at
+		SELECT id, user_id, contract_address, total_deposited, current_balance, currency, status, yield_earned, fees_paid, harvest_frequency, last_harvested_at, last_synced_at, deleted_at, created_at, updated_at
 		FROM vaults
 		WHERE id = $1 AND deleted_at IS NULL
 	`)).
 		WithArgs(vaultID.String()).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "user_id", "contract_address", "total_deposited", "current_balance", "currency", "status", "yield_earned", "fees_paid", "last_synced_at", "deleted_at", "created_at", "updated_at",
-		}).AddRow(vaultID.String(), userID.String(), "CA-001", "100.00", "105.50", "USDC", "active", "0", "0", nil, nil, createdAt, createdAt))
+			"id", "user_id", "contract_address", "total_deposited", "current_balance", "currency", "status", "yield_earned", "fees_paid", "harvest_frequency", "last_harvested_at", "last_synced_at", "deleted_at", "created_at", "updated_at",
+		}).AddRow(vaultID.String(), userID.String(), "CA-001", "100.00", "105.50", "USDC", "active", "0", "0", "daily", nil, nil, nil, createdAt, createdAt))
 
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, vault_id, protocol, amount, apy, status, allocated_at, updated_at FROM allocations WHERE vault_id = $1 ORDER BY allocated_at DESC`)).
 		WithArgs(vaultID.String()).

--- a/apps/api/internal/service/admin_rebalance_service_test.go
+++ b/apps/api/internal/service/admin_rebalance_service_test.go
@@ -116,6 +116,9 @@ func (rebalanceVaultRepo) ReplaceAllocations(context.Context, uuid.UUID, []vault
 func (rebalanceVaultRepo) UpdateVault(context.Context, uuid.UUID, string, vault.VaultStatus) error {
 	return nil
 }
+func (rebalanceVaultRepo) UpdateHarvestFrequency(context.Context, uuid.UUID, string) error {
+	return nil
+}
 func (rebalanceVaultRepo) RecordWithdrawal(context.Context, uuid.UUID, vault.TransactionRecord) error {
 	return nil
 }

--- a/apps/api/internal/service/allocation_service_test.go
+++ b/apps/api/internal/service/allocation_service_test.go
@@ -82,6 +82,9 @@ func (r *allocationVaultRepository) ReplaceAllocations(_ context.Context, _ uuid
 func (r *allocationVaultRepository) UpdateVault(context.Context, uuid.UUID, string, vault.VaultStatus) error {
 	return nil
 }
+func (r *allocationVaultRepository) UpdateHarvestFrequency(context.Context, uuid.UUID, string) error {
+	return nil
+}
 func (r *allocationVaultRepository) RecordWithdrawal(context.Context, uuid.UUID, vault.TransactionRecord) error {
 	return nil
 }

--- a/apps/api/internal/service/performance/service_test.go
+++ b/apps/api/internal/service/performance/service_test.go
@@ -44,6 +44,10 @@ func (s *stubVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, contr
 	return errors.New("not implemented")
 }
 
+func (s *stubVaultRepository) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
+	return errors.New("not implemented")
+}
+
 func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -242,6 +242,15 @@ func (m *memoryVaultRepo) UpdateVault(_ context.Context, id uuid.UUID, addr stri
 	m.vaults[id] = v
 	return nil
 }
+func (m *memoryVaultRepo) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
+	v, ok := m.vaults[id]
+	if !ok {
+		return vault.ErrVaultNotFound
+	}
+	v.HarvestFrequency = frequency
+	m.vaults[id] = v
+	return nil
+}
 func (m *memoryVaultRepo) RecordWithdrawal(context.Context, uuid.UUID, vault.TransactionRecord) error {
 	return nil
 }

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -413,6 +413,34 @@ func (s *VaultService) UpdateVault(ctx context.Context, input UpdateVaultInput) 
 	return s.repository.GetVault(ctx, input.VaultID)
 }
 
+// UpdateHarvestFrequency sets how often the harvest engine considers this
+// vault for a harvest ("daily" or "weekly"), letting owners trade off
+// harvest latency against cumulative gas spend on a per-vault basis (#940).
+func (s *VaultService) UpdateHarvestFrequency(ctx context.Context, vaultID uuid.UUID, userID uuid.UUID, frequency string) (vault.Vault, error) {
+	if vaultID == uuid.Nil {
+		return vault.Vault{}, vault.ErrInvalidVault
+	}
+
+	parsed, err := vault.ParseHarvestFrequency(frequency)
+	if err != nil {
+		return vault.Vault{}, err
+	}
+
+	existing, err := s.repository.GetVault(ctx, vaultID)
+	if err != nil {
+		return vault.Vault{}, err
+	}
+	if existing.UserID != userID {
+		return vault.Vault{}, vault.ErrVaultForbidden
+	}
+
+	if err := s.repository.UpdateHarvestFrequency(ctx, vaultID, parsed); err != nil {
+		return vault.Vault{}, err
+	}
+
+	return s.repository.GetVault(ctx, vaultID)
+}
+
 // CloseVault transitions a vault to the closed status. Unless Force is set, it
 // rejects vaults that still hold a balance.
 func (s *VaultService) CloseVault(ctx context.Context, input CloseVaultInput) (vault.Vault, error) {

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -64,6 +64,40 @@ func TestVaultServiceRecordDepositAndUpdateAllocations(t *testing.T) {
 	}
 }
 
+func TestVaultServiceUpdateHarvestFrequency(t *testing.T) {
+	userID := uuid.New()
+	repository := newMemoryVaultRepository(userID)
+	service := NewVaultService(repository)
+
+	created, err := service.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CA123",
+		Currency:        "usdc",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+	if created.HarvestFrequency != vault.HarvestFrequencyDaily {
+		t.Fatalf("new vault harvest frequency = %q, want default %q", created.HarvestFrequency, vault.HarvestFrequencyDaily)
+	}
+
+	updated, err := service.UpdateHarvestFrequency(context.Background(), created.ID, userID, "weekly")
+	if err != nil {
+		t.Fatalf("UpdateHarvestFrequency() error = %v", err)
+	}
+	if updated.HarvestFrequency != vault.HarvestFrequencyWeekly {
+		t.Fatalf("harvest frequency = %q, want %q", updated.HarvestFrequency, vault.HarvestFrequencyWeekly)
+	}
+
+	if _, err := service.UpdateHarvestFrequency(context.Background(), created.ID, userID, "monthly"); err != vault.ErrInvalidHarvestFrequency {
+		t.Fatalf("invalid frequency err = %v, want ErrInvalidHarvestFrequency", err)
+	}
+
+	if _, err := service.UpdateHarvestFrequency(context.Background(), created.ID, uuid.New(), "weekly"); err != vault.ErrVaultForbidden {
+		t.Fatalf("non-owner err = %v, want ErrVaultForbidden", err)
+	}
+}
+
 func TestVaultServiceCreateVaultReturnsUserNotFound(t *testing.T) {
 	service := NewVaultService(newMemoryVaultRepository())
 
@@ -246,6 +280,9 @@ func (r *memoryVaultRepository) CreateVault(_ context.Context, model vault.Vault
 		return vault.Vault{}, vault.ErrUserNotFound
 	}
 
+	if model.HarvestFrequency == "" {
+		model.HarvestFrequency = vault.DefaultHarvestFrequency
+	}
 	now := time.Now().UTC()
 	model.CreatedAt = now
 	model.UpdatedAt = now
@@ -355,6 +392,17 @@ func (r *memoryVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, con
 	}
 	model.ContractAddress = contractAddress
 	model.Status = status
+	model.UpdatedAt = time.Now().UTC()
+	r.vaults[id] = cloneVault(model)
+	return nil
+}
+
+func (r *memoryVaultRepository) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
+	model, ok := r.vaults[id]
+	if !ok {
+		return vault.ErrVaultNotFound
+	}
+	model.HarvestFrequency = frequency
 	model.UpdatedAt = time.Now().UTC()
 	r.vaults[id] = cloneVault(model)
 	return nil

--- a/apps/api/internal/services/risk_service_test.go
+++ b/apps/api/internal/services/risk_service_test.go
@@ -45,6 +45,10 @@ func (s *stubVaultRepository) UpdateVault(_ context.Context, id uuid.UUID, contr
 	return errors.New("not implemented")
 }
 
+func (s *stubVaultRepository) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
+	return errors.New("not implemented")
+}
+
 func (s *stubVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	return errors.New("not implemented")
 }
@@ -108,6 +112,10 @@ func (s *stubVaultRepositoryWithCount) ReplaceAllocations(_ context.Context, vau
 }
 
 func (s *stubVaultRepositoryWithCount) UpdateVault(_ context.Context, id uuid.UUID, contractAddress string, status vault.VaultStatus) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubVaultRepositoryWithCount) UpdateHarvestFrequency(_ context.Context, id uuid.UUID, frequency string) error {
 	return errors.New("not implemented")
 }
 

--- a/apps/api/migrations/080_add_vault_harvest_frequency.down.sql
+++ b/apps/api/migrations/080_add_vault_harvest_frequency.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE vaults DROP CONSTRAINT IF EXISTS vaults_harvest_frequency_check;
+ALTER TABLE vaults DROP COLUMN IF EXISTS last_harvested_at;
+ALTER TABLE vaults DROP COLUMN IF EXISTS harvest_frequency;

--- a/apps/api/migrations/080_add_vault_harvest_frequency.up.sql
+++ b/apps/api/migrations/080_add_vault_harvest_frequency.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE vaults
+    ADD COLUMN harvest_frequency TEXT NOT NULL DEFAULT 'daily',
+    ADD COLUMN last_harvested_at TIMESTAMPTZ;
+
+ALTER TABLE vaults
+    ADD CONSTRAINT vaults_harvest_frequency_check
+    CHECK (harvest_frequency IN ('daily', 'weekly'));


### PR DESCRIPTION
## Summary

closes #940

The harvest engine (#845) currently evaluates every vault on a single global tick interval, so a small vault and a large one pay the same harvest cadence regardless of their gas-cost tradeoffs. This adds a per-vault configurable harvest frequency (daily or weekly).

## Changes

- Migration 080 adds `harvest_frequency` (default `daily`) and `last_harvested_at` columns to `vaults`, with a check constraint restricting the value to `daily`/`weekly`.
- `vault.ParseHarvestFrequency` validates the frequency string; `vault.Repository` gains an `UpdateHarvestFrequency` method, implemented in the Postgres repository.
- The harvest engine's `evaluateAndEnqueue`, `SimulateHarvest`, and `statusFor` paths now apply a `DueForHarvest` gate (in addition to the existing economic gate), computed from the vault's configured frequency and `last_harvested_at`. A new `ReasonNotDue` explains the decision in status/simulation responses.
- `RecordHarvest` now stamps `last_harvested_at = NOW()` on both the compounded and non-compounded update paths.
- New endpoint: `PATCH /api/v1/vaults/{id}/harvest-frequency`, restricted to the vault owner, backed by a new `VaultService.UpdateHarvestFrequency`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all green except two pre-existing failures in `internal/domain/protocoltvl` and `internal/domain/tvl` that are unrelated to this change and reproduce identically on `dev` before this branch's changes
- [x] Added unit tests: `ParseHarvestFrequency` validation, `FrequencyDuration`/`DueForHarvest` table tests, engine-level tests for the new gate (`TestEngine_SkipsNotDueForFrequency`, `TestEngine_HarvestsWhenFrequencyElapsed`), and a service-level `TestVaultServiceUpdateHarvestFrequency` covering the happy path, invalid frequency, and ownership check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable vault harvest frequencies: daily or weekly.
  * Added an endpoint to update a vault’s harvest frequency.
  * New vaults default to daily harvesting.
  * Harvests are now automatically skipped until the configured interval has elapsed.
  * Vault status reflects when the next harvest is due.

* **Bug Fixes**
  * Harvest timestamps are recorded after successful harvest activity.
  * Invalid harvest frequency values now return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->