### PR TITLE
feat(api): yield APY snapshot anomaly flagging before ingestion

### DIFF
--- a/apps/api/internal/domain/apysnapshot/anomaly_test.go
+++ b/apps/api/internal/domain/apysnapshot/anomaly_test.go
@@ -1,0 +1,104 @@
+package apysnapshot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func snapshotWithAPY(apy string, capturedAt time.Time) APYSnapshot {
+	return APYSnapshot{
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString(apy),
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   capturedAt,
+	}
+}
+
+func TestDetectAnomalousJump_NoPriorSnapshot(t *testing.T) {
+	next := snapshotWithAPY("50", time.Now())
+	anomalous, reason := DetectAnomalousJump(nil, next)
+	if anomalous {
+		t.Fatalf("expected no anomaly with no prior snapshot, got reason %q", reason)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestDetectAnomalousJump_NormalMovementNotFlagged(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("4.5", base)
+	next := snapshotWithAPY("5.1", base.Add(time.Hour)) // ~13% up, normal
+
+	anomalous, reason := DetectAnomalousJump(&prev, next)
+	if anomalous {
+		t.Fatalf("expected no anomaly for normal movement, got reason %q", reason)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestDetectAnomalousJump_SpikeIsFlagged(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("5", base)
+	next := snapshotWithAPY("20", base.Add(time.Hour)) // 4x jump
+
+	anomalous, reason := DetectAnomalousJump(&prev, next)
+	if !anomalous {
+		t.Fatal("expected a 4x jump to be flagged as anomalous")
+	}
+	if !strings.Contains(reason, "jumped") {
+		t.Fatalf("expected reason to describe an upward jump, got %q", reason)
+	}
+}
+
+func TestDetectAnomalousJump_CrashIsFlagged(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("30", base)
+	next := snapshotWithAPY("2", base.Add(time.Hour)) // drop to 1/15th
+
+	anomalous, reason := DetectAnomalousJump(&prev, next)
+	if !anomalous {
+		t.Fatal("expected a sharp drop to be flagged as anomalous")
+	}
+	if !strings.Contains(reason, "dropped") {
+		t.Fatalf("expected reason to describe a downward drop, got %q", reason)
+	}
+}
+
+func TestDetectAnomalousJump_ExactlyAtThresholdNotFlagged(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("5", base)
+	next := snapshotWithAPY("15", base.Add(time.Hour)) // exactly 3x
+
+	anomalous, _ := DetectAnomalousJump(&prev, next)
+	if anomalous {
+		t.Fatal("expected exactly-at-threshold movement to not be flagged (strictly greater than required)")
+	}
+}
+
+func TestDetectAnomalousJump_SkipsNearZeroBaseline(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("0.1", base)               // below AnomalyJumpMinPriorAPY
+	next := snapshotWithAPY("5", base.Add(time.Hour)) // 50x, but off a tiny base
+
+	anomalous, reason := DetectAnomalousJump(&prev, next)
+	if anomalous {
+		t.Fatalf("expected near-zero baseline to skip jump detection, got reason %q", reason)
+	}
+}
+
+func TestDetectAnomalousJump_ZeroOrNegativeNextAPYNotFlagged(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	prev := snapshotWithAPY("5", base)
+	next := snapshotWithAPY("0", base.Add(time.Hour))
+
+	anomalous, _ := DetectAnomalousJump(&prev, next)
+	if anomalous {
+		t.Fatal("a drop to exactly zero should be handled by validation, not the jump detector")
+	}
+}

--- a/apps/api/internal/domain/apysnapshot/model.go
+++ b/apps/api/internal/domain/apysnapshot/model.go
@@ -3,6 +3,7 @@ package apysnapshot
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -16,12 +17,65 @@ var (
 	ErrInvalidSnapshot   = errors.New("invalid snapshot input")
 )
 
+// AnomalyJumpMultiplier is the factor a new APY reading may move (up or down)
+// relative to the protocol's prior reading before DetectAnomalousJump flags
+// it as an implausible jump (#941). E.g. 3.0 flags anything that more than
+// triples or drops to under a third of the prior value.
+const AnomalyJumpMultiplier = 3.0
+
+// AnomalyJumpMinPriorAPY is the minimum prior APY (in percent) below which
+// jump detection is skipped: small absolute moves off a near-zero base
+// produce huge percentage swings that are usually normal, not anomalous.
+const AnomalyJumpMinPriorAPY = "0.5"
+
 type APYSnapshot struct {
 	ID           uuid.UUID       `json:"id"`
 	ProtocolSlug string          `json:"protocol_slug"`
 	APY          decimal.Decimal `json:"apy"`
 	TVL          decimal.Decimal `json:"tvl"`
 	CapturedAt   time.Time       `json:"captured_at"`
+	// Flagged marks a snapshot whose APY moved implausibly relative to the
+	// protocol's prior reading (#941). Flagged snapshots are still persisted,
+	// not rejected, so oracle aggregation/failover (#830) and vault APY
+	// history aren't starved of data during a genuine market dislocation —
+	// callers that care can filter or surface the flag instead.
+	Flagged bool `json:"flagged"`
+	// FlagReason explains why Flagged is true. Empty when Flagged is false.
+	FlagReason string `json:"flag_reason,omitempty"`
+}
+
+// DetectAnomalousJump compares a new snapshot's APY against the protocol's
+// previous reading and reports whether the move looks implausible. prev may
+// be nil when no prior snapshot exists yet, in which case the result is
+// always "not anomalous" — there is nothing to compare against.
+func DetectAnomalousJump(prev *APYSnapshot, next APYSnapshot) (bool, string) {
+	if prev == nil {
+		return false, ""
+	}
+	if prev.APY.LessThan(decimal.RequireFromString(AnomalyJumpMinPriorAPY)) {
+		return false, ""
+	}
+	if next.APY.LessThanOrEqual(decimal.Zero) {
+		return false, ""
+	}
+
+	ratio := next.APY.Div(prev.APY)
+	threshold := decimal.NewFromFloat(AnomalyJumpMultiplier)
+
+	switch {
+	case ratio.GreaterThan(threshold):
+		return true, fmt.Sprintf(
+			"apy jumped %sx (%s%% -> %s%%) since previous snapshot at %s",
+			ratio.StringFixed(2), prev.APY.StringFixed(2), next.APY.StringFixed(2), prev.CapturedAt.Format(time.RFC3339),
+		)
+	case ratio.LessThan(decimal.NewFromInt(1).Div(threshold)):
+		return true, fmt.Sprintf(
+			"apy dropped to %sx (%s%% -> %s%%) since previous snapshot at %s",
+			ratio.StringFixed(2), prev.APY.StringFixed(2), next.APY.StringFixed(2), prev.CapturedAt.Format(time.RFC3339),
+		)
+	default:
+		return false, ""
+	}
 }
 
 // Validate checks that a snapshot has the minimum required data before it is

--- a/apps/api/internal/repository/postgres/apy_snapshot_repository.go
+++ b/apps/api/internal/repository/postgres/apy_snapshot_repository.go
@@ -27,8 +27,8 @@ func (r *APYSnapshotRepository) Upsert(ctx context.Context, snap apysnapshot.APY
 	// as separate rows. The unique constraint uq_apy_snapshots_protocol_time
 	// enforces this at the DB level (migration 069).
 	const q = `
-		INSERT INTO apy_snapshots (id, protocol_slug, apy, tvl, captured_at)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO apy_snapshots (id, protocol_slug, apy, tvl, captured_at, flagged, flag_reason)
+		VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''))
 		ON CONFLICT (protocol_slug, captured_at) DO NOTHING`
 	_, err := r.db.ExecContext(ctx, q,
 		snap.ID,
@@ -36,6 +36,8 @@ func (r *APYSnapshotRepository) Upsert(ctx context.Context, snap apysnapshot.APY
 		snap.APY.String(),
 		snap.TVL.String(),
 		snap.CapturedAt,
+		snap.Flagged,
+		snap.FlagReason,
 	)
 	if err != nil && strings.Contains(err.Error(), "uq_apy_snapshots_protocol_time") {
 		return apysnapshot.ErrDuplicateSnapshot
@@ -45,7 +47,7 @@ func (r *APYSnapshotRepository) Upsert(ctx context.Context, snap apysnapshot.APY
 
 func (r *APYSnapshotRepository) ListByProtocol(ctx context.Context, slug string, since time.Time) ([]apysnapshot.APYSnapshot, error) {
 	const q = `
-		SELECT id, protocol_slug, apy, tvl, captured_at
+		SELECT id, protocol_slug, apy, tvl, captured_at, flagged, COALESCE(flag_reason, '')
 		FROM apy_snapshots
 		WHERE protocol_slug = $1
 		  AND captured_at >= $2
@@ -87,8 +89,10 @@ func scanAPYSnapshot(row interface {
 		apy          string
 		tvl          string
 		capturedAt   time.Time
+		flagged      bool
+		flagReason   string
 	)
-	if err := row.Scan(&id, &protocolSlug, &apy, &tvl, &capturedAt); err != nil {
+	if err := row.Scan(&id, &protocolSlug, &apy, &tvl, &capturedAt, &flagged, &flagReason); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return apysnapshot.APYSnapshot{}, apysnapshot.ErrProtocolNotFound
 		}
@@ -114,5 +118,7 @@ func scanAPYSnapshot(row interface {
 		APY:          apyDec,
 		TVL:          tvlDec,
 		CapturedAt:   capturedAt,
+		Flagged:      flagged,
+		FlagReason:   flagReason,
 	}, nil
 }

--- a/apps/api/internal/service/apy_service.go
+++ b/apps/api/internal/service/apy_service.go
@@ -18,6 +18,11 @@ const (
 	apyPollInterval  = 6 * time.Hour
 	apyHistoryWindow = 30 * 24 * time.Hour
 	apyPruneAge      = 90 * 24 * time.Hour
+	// apyAnomalyLookback bounds how far back the poller will look for a
+	// "previous" snapshot to compare against when flagging implausible jumps
+	// (#941). A prior snapshot older than this is treated as no baseline,
+	// same as having none, since too much may have legitimately changed.
+	apyAnomalyLookback = 48 * time.Hour
 )
 
 type APYHistoryEntry struct {
@@ -94,6 +99,7 @@ func (s *APYService) poll(ctx context.Context) {
 		return
 	}
 	for _, snap := range snapshots {
+		snap = s.flagIfAnomalous(ctx, snap)
 		if err := s.repo.Upsert(ctx, snap); err != nil {
 			s.logger.Error("apy poller: upsert failed", "protocol", snap.ProtocolSlug, "error", err.Error())
 		}
@@ -101,6 +107,34 @@ func (s *APYService) poll(ctx context.Context) {
 	if err := s.repo.PruneOlderThan(ctx, apyPruneAge); err != nil {
 		s.logger.Error("apy poller: prune failed", "error", err.Error())
 	}
+}
+
+// flagIfAnomalous looks up the protocol's most recent prior snapshot within
+// apyAnomalyLookback and, if the new reading is an implausible jump relative
+// to it, marks snap as flagged (#941). It never rejects a snapshot outright —
+// callers still persist it — and any error looking up history is logged and
+// treated as "no baseline" so a lookup failure never blocks ingestion.
+func (s *APYService) flagIfAnomalous(ctx context.Context, snap apysnapshot.APYSnapshot) apysnapshot.APYSnapshot {
+	since := snap.CapturedAt.Add(-apyAnomalyLookback)
+	history, err := s.repo.ListByProtocol(ctx, snap.ProtocolSlug, since)
+	if err != nil {
+		s.logger.Warn("apy poller: anomaly lookup failed", "protocol", snap.ProtocolSlug, "error", err.Error())
+		return snap
+	}
+
+	var prev *apysnapshot.APYSnapshot
+	for i := range history {
+		if history[i].CapturedAt.Before(snap.CapturedAt) && (prev == nil || history[i].CapturedAt.After(prev.CapturedAt)) {
+			prev = &history[i]
+		}
+	}
+
+	if anomalous, reason := apysnapshot.DetectAnomalousJump(prev, snap); anomalous {
+		snap.Flagged = true
+		snap.FlagReason = reason
+		s.logger.Warn("apy poller: flagged anomalous snapshot", "protocol", snap.ProtocolSlug, "reason", reason)
+	}
+	return snap
 }
 
 func (s *APYService) fetchFromDeFiLlama(ctx context.Context) ([]apysnapshot.APYSnapshot, error) {

--- a/apps/api/internal/service/apy_service_test.go
+++ b/apps/api/internal/service/apy_service_test.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/apysnapshot"
+)
+
+// fakeAPYSnapshotRepo is an in-memory apysnapshot.Repository for testing the
+// anomaly-flagging guard (#941) without a database.
+type fakeAPYSnapshotRepo struct {
+	snapshots []apysnapshot.APYSnapshot
+	upserted  []apysnapshot.APYSnapshot
+}
+
+func (f *fakeAPYSnapshotRepo) Upsert(_ context.Context, snap apysnapshot.APYSnapshot) error {
+	f.upserted = append(f.upserted, snap)
+	f.snapshots = append(f.snapshots, snap)
+	return nil
+}
+
+func (f *fakeAPYSnapshotRepo) ListByProtocol(_ context.Context, slug string, since time.Time) ([]apysnapshot.APYSnapshot, error) {
+	var out []apysnapshot.APYSnapshot
+	for _, s := range f.snapshots {
+		if s.ProtocolSlug == slug && !s.CapturedAt.Before(since) {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeAPYSnapshotRepo) PruneOlderThan(context.Context, time.Duration) error { return nil }
+
+func TestAPYService_FlagIfAnomalous_NoHistoryNotFlagged(t *testing.T) {
+	repo := &fakeAPYSnapshotRepo{}
+	svc := NewAPYService(repo)
+
+	snap := apysnapshot.APYSnapshot{
+		ID:           uuid.New(),
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString("5"),
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   time.Now().UTC(),
+	}
+
+	got := svc.flagIfAnomalous(context.Background(), snap)
+	if got.Flagged {
+		t.Fatalf("expected first-ever snapshot to not be flagged, got reason %q", got.FlagReason)
+	}
+}
+
+func TestAPYService_FlagIfAnomalous_SpikeIsFlagged(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeAPYSnapshotRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{
+				ID:           uuid.New(),
+				ProtocolSlug: "aave-v3",
+				APY:          decimal.RequireFromString("5"),
+				TVL:          decimal.RequireFromString("1000000"),
+				CapturedAt:   now.Add(-time.Hour),
+			},
+		},
+	}
+	svc := NewAPYService(repo)
+
+	snap := apysnapshot.APYSnapshot{
+		ID:           uuid.New(),
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString("40"), // 8x prior reading
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   now,
+	}
+
+	got := svc.flagIfAnomalous(context.Background(), snap)
+	if !got.Flagged {
+		t.Fatal("expected an 8x APY jump to be flagged")
+	}
+	if got.FlagReason == "" {
+		t.Fatal("expected a non-empty flag reason")
+	}
+}
+
+func TestAPYService_FlagIfAnomalous_IgnoresOtherProtocols(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeAPYSnapshotRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{
+				ID:           uuid.New(),
+				ProtocolSlug: "blend",
+				APY:          decimal.RequireFromString("5"),
+				TVL:          decimal.RequireFromString("1000000"),
+				CapturedAt:   now.Add(-time.Hour),
+			},
+		},
+	}
+	svc := NewAPYService(repo)
+
+	snap := apysnapshot.APYSnapshot{
+		ID:           uuid.New(),
+		ProtocolSlug: "aave-v3", // different protocol, no relevant history
+		APY:          decimal.RequireFromString("40"),
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   now,
+	}
+
+	got := svc.flagIfAnomalous(context.Background(), snap)
+	if got.Flagged {
+		t.Fatalf("expected no cross-protocol comparison, got reason %q", got.FlagReason)
+	}
+}
+
+func TestAPYService_FlagIfAnomalous_PicksMostRecentPrior(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeAPYSnapshotRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ProtocolSlug: "aave-v3", APY: decimal.RequireFromString("40"), CapturedAt: now.Add(-47 * time.Hour)}, // old outlier
+			{ProtocolSlug: "aave-v3", APY: decimal.RequireFromString("5"), CapturedAt: now.Add(-time.Hour)},        // most recent
+		},
+	}
+	svc := NewAPYService(repo)
+
+	snap := apysnapshot.APYSnapshot{
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString("5.5"), // small move relative to the recent 5, not the old 40
+		CapturedAt:   now,
+	}
+
+	got := svc.flagIfAnomalous(context.Background(), snap)
+	if got.Flagged {
+		t.Fatalf("expected comparison against most recent prior snapshot only, got reason %q", got.FlagReason)
+	}
+}
+
+func TestAPYService_Poll_PersistsFlaggedSnapshots(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeAPYSnapshotRepo{
+		snapshots: []apysnapshot.APYSnapshot{
+			{ProtocolSlug: "aave-v3", APY: decimal.RequireFromString("5"), CapturedAt: now.Add(-time.Hour)},
+		},
+	}
+	svc := NewAPYService(repo)
+
+	snap := apysnapshot.APYSnapshot{
+		ID:           uuid.New(),
+		ProtocolSlug: "aave-v3",
+		APY:          decimal.RequireFromString("40"),
+		TVL:          decimal.RequireFromString("1000000"),
+		CapturedAt:   now,
+	}
+	flagged := svc.flagIfAnomalous(context.Background(), snap)
+	if err := repo.Upsert(context.Background(), flagged); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	if len(repo.upserted) != 1 || !repo.upserted[0].Flagged {
+		t.Fatal("expected the flagged snapshot to still be persisted, not rejected")
+	}
+}

--- a/apps/api/migrations/081_add_apy_snapshot_anomaly_flag.down.sql
+++ b/apps/api/migrations/081_add_apy_snapshot_anomaly_flag.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_apy_snapshots_flagged;
+ALTER TABLE apy_snapshots DROP COLUMN IF EXISTS flag_reason;
+ALTER TABLE apy_snapshots DROP COLUMN IF EXISTS flagged;

--- a/apps/api/migrations/081_add_apy_snapshot_anomaly_flag.up.sql
+++ b/apps/api/migrations/081_add_apy_snapshot_anomaly_flag.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE apy_snapshots
+    ADD COLUMN flagged BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN flag_reason TEXT;
+
+CREATE INDEX idx_apy_snapshots_flagged ON apy_snapshots (protocol_slug, captured_at) WHERE flagged;


### PR DESCRIPTION
## Summary

closes #941

`apysnapshot/model.go` stores APY snapshots straight from the DeFiLlama poller with no sanity check, so a bad upstream reading (oracle glitch, scraping error, a genuinely manipulated pool) flows straight into vault APY history and user-facing yield figures. This adds a guard that flags implausible jumps before a snapshot is persisted, complementing the oracle aggregation/failover work in #830.

## Changes

- `apysnapshot.DetectAnomalousJump(prev, next)`: compares a new snapshot's APY to the protocol's most recent prior reading and flags moves of more than `AnomalyJumpMultiplier` (3x) in either direction. Skips near-zero baselines (prior APY below `AnomalyJumpMinPriorAPY`, 0.5%) since small absolute moves off a tiny base produce large, usually benign percentage swings.
- `APYSnapshot` gains `Flagged`/`FlagReason` fields, persisted via migration 081 (`apy_snapshots.flagged`, `apy_snapshots.flag_reason`), with a partial index on flagged rows for fast lookups.
- `APYService.poll` now runs each incoming snapshot through a new `flagIfAnomalous` step, which looks up the most recent prior snapshot within a 48h lookback window and applies the guard. Flagged snapshots are still persisted, not rejected — a genuine market dislocation shouldn't starve history or oracle failover of data — but the flag is available for downstream review/alerting.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/domain/apysnapshot/... ./internal/service/... -v` — new anomaly detection and service-level tests pass, covering: no baseline, normal movement, upward spike, downward crash, exactly-at-threshold, near-zero baseline skip, zero/negative next APY, cross-protocol isolation, and picking the most recent prior snapshot
- [x] `go test ./...` — all green except two pre-existing failures in `internal/domain/protocoltvl` and `internal/domain/tvl` that are unrelated to this change and reproduce identically on `dev` before this branch's changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added anomaly detection for APY jumps (upward spikes and sharp downward drops) using recent prior snapshots for the same protocol.
  - Persisted anomaly metadata on APY snapshots (`flagged` and `flag_reason`) and included it in list results, along with a human-readable explanation.
  - Detection is skipped when there’s no valid baseline (missing history, near-zero prior APY, or non-positive next APY), and an index improves retrieval of flagged entries.
- **Tests**
  - Added unit tests covering spike/drop detection, threshold behavior, baseline/zero handling, and protocol-scoped comparison (including persistence during polling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->