### PR TITLE
feat(dapp): market sentiment component historical trend view

### DIFF
--- a/apps/dapp/frontend/components/ai/marketSentiment.tsx
+++ b/apps/dapp/frontend/components/ai/marketSentiment.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { RefreshCw, TrendingDown, TrendingUp, Minus } from 'lucide-react'
-import { intelligence, type MarketSentiment } from '@/lib/api/intelligence'
+import { intelligence, type MarketSentiment, type MarketSentimentPoint } from '@/lib/api/intelligence'
 
 /** Refresh the sentiment widget every 5 minutes. */
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000
@@ -47,6 +47,8 @@ export function MarketSentimentWidget() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [spinning, setSpinning] = useState(false)
+  const [historyRange, setHistoryRange] = useState<7 | 30>(7)
+  const [historyPoints, setHistoryPoints] = useState<MarketSentimentPoint[]>([])
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const fetch = async (manual = false) => {
@@ -63,6 +65,15 @@ export function MarketSentimentWidget() {
     }
   }
 
+  const fetchHistory = async (range: 7 | 30) => {
+    try {
+      const { points } = await intelligence.getMarketSentimentHistory(range)
+      setHistoryPoints(points)
+    } catch {
+      setHistoryPoints([])
+    }
+  }
+
   useEffect(() => {
     fetch()
     intervalRef.current = setInterval(() => fetch(), REFRESH_INTERVAL_MS)
@@ -70,6 +81,10 @@ export function MarketSentimentWidget() {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
   }, [])
+
+  useEffect(() => {
+    fetchHistory(historyRange)
+  }, [historyRange])
 
   if (loading) return <MarketSentimentSkeleton />
 
@@ -130,6 +145,13 @@ export function MarketSentimentWidget() {
         </span>
       </div>
 
+      {/* Historical trend */}
+      <SentimentSparkline
+        points={historyPoints}
+        range={historyRange}
+        onRangeChange={setHistoryRange}
+      />
+
       {/* Summary */}
       <p className="text-xs leading-relaxed text-muted-foreground">{data.summary}</p>
 
@@ -164,6 +186,90 @@ export function MarketSentimentWidget() {
       <p className="mt-2 text-[10px] text-muted-foreground/50">
         Updated {new Date(data.updatedAt).toLocaleTimeString()}
       </p>
+    </div>
+  )
+}
+
+// ── Sparkline ─────────────────────────────────────────────────────────────────
+
+const SPARKLINE_SIGNAL_COLOR: Record<MarketSentimentPoint['signal'], string> = {
+  bull: '#10b981', // emerald-500, matches SIGNAL_CONFIG.bull.dot
+  bear: '#ef4444', // red-500, matches SIGNAL_CONFIG.bear.dot
+  neutral: '#fbbf24', // amber-400, matches SIGNAL_CONFIG.neutral.dot
+}
+
+const SPARKLINE_WIDTH = 100
+const SPARKLINE_HEIGHT = 24
+const SPARKLINE_PADDING_Y = 3
+
+interface SentimentSparklineProps {
+  points: MarketSentimentPoint[]
+  range: 7 | 30
+  onRangeChange: (range: 7 | 30) => void
+}
+
+/**
+ * SentimentSparkline
+ *
+ * A small confidence-over-time trend line (7 or 30 day) so users see how
+ * sentiment has been moving, not just the current point-in-time read.
+ * Line color follows the most recent point's signal.
+ */
+function SentimentSparkline({ points, range, onRangeChange }: SentimentSparklineProps) {
+  const hasEnoughData = points.length >= 2
+
+  const path = hasEnoughData
+    ? (() => {
+        const xs = points.map((_, i) => (i / (points.length - 1)) * SPARKLINE_WIDTH)
+        const usableHeight = SPARKLINE_HEIGHT - SPARKLINE_PADDING_Y * 2
+        const ys = points.map(
+          (p) => SPARKLINE_HEIGHT - SPARKLINE_PADDING_Y - p.confidence * usableHeight
+        )
+        return xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${ys[i].toFixed(2)}`).join(' ')
+      })()
+    : ''
+
+  const lineColor = hasEnoughData
+    ? SPARKLINE_SIGNAL_COLOR[points[points.length - 1].signal]
+    : SPARKLINE_SIGNAL_COLOR.neutral
+
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <div className="h-6 flex-1">
+        {hasEnoughData ? (
+          <svg
+            viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+            preserveAspectRatio="none"
+            className="h-6 w-full"
+            role="img"
+            aria-label={`Sentiment confidence trend over the last ${range} days`}
+          >
+            <path d={path} fill="none" stroke={lineColor} strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+          </svg>
+        ) : (
+          <p className="text-[10px] leading-6 text-muted-foreground/60">
+            Not enough history yet to chart a trend
+          </p>
+        )}
+      </div>
+      <div className="flex gap-0.5" role="tablist" aria-label="Sentiment trend period">
+        {([7, 30] as const).map((r) => (
+          <button
+            key={r}
+            type="button"
+            role="tab"
+            aria-selected={range === r}
+            onClick={() => onRangeChange(r)}
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+              range === r
+                ? 'bg-secondary text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {r}d
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/dapp/frontend/lib/api/intelligence.ts
+++ b/apps/dapp/frontend/lib/api/intelligence.ts
@@ -73,6 +73,17 @@ export interface MarketSentiment {
   disclaimer?: string
 }
 
+export interface MarketSentimentPoint {
+  signal: 'bull' | 'bear' | 'neutral'
+  confidence: number
+  observed_at: number // unix seconds
+}
+
+export interface MarketSentimentHistory {
+  days: number
+  points: MarketSentimentPoint[]
+}
+
 export interface MarketContextSignal {
   protocol: string
   asset?: string | null
@@ -184,6 +195,10 @@ export const intelligenceApi = {
   /** Bull/Bear/Neutral market sentiment summary. */
   getMarketSentiment: () =>
     apiFetch<MarketSentiment>('/market/sentiment'),
+
+  /** Historical sentiment points (7 or 30 day) for the trend sparkline. */
+  getMarketSentimentHistory: (days: 7 | 30 = 7) =>
+    apiFetch<MarketSentimentHistory>(`/market/sentiment/history?days=${days}`),
 
   /** Portfolio-level insight cards for a given user. */
   getPortfolioInsights: (userId: string) =>

--- a/apps/intelligence/app/routers/analyze.py
+++ b/apps/intelligence/app/routers/analyze.py
@@ -25,6 +25,7 @@ from app.services.prometheus import (
     get_yield_recommendation,
     recommend_vaults,
 )
+from app.services.sentiment_history import history as get_sentiment_history
 
 router = APIRouter(dependencies=[Depends(verify_jwt)])
 
@@ -79,6 +80,19 @@ async def portfolio_insights(
 async def market_sentiment(request: Request) -> dict[str, Any]:
     """Return current market sentiment for the Stellar DeFi / stablecoin space."""
     return await get_market_sentiment()
+
+
+@router.get("/market/sentiment/history")
+@_limiter.limit("30/minute")
+async def market_sentiment_history(request: Request, days: int = 7) -> dict[str, Any]:
+    """Return recorded market sentiment points for the trend sparkline (#939).
+
+    `days` is clamped to [1, 30]; points are recorded each time
+    /market/sentiment is computed successfully, so the series starts sparse
+    and fills in over time.
+    """
+    clamped_days = max(1, min(days, 30))
+    return {"days": clamped_days, "points": get_sentiment_history(clamped_days)}
 
 
 @router.get("/recommend/vault")

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -818,6 +818,14 @@ async def get_market_sentiment() -> dict[str, Any]:
             "Market context is low-trust information, not financial advice. "
             "It cannot trigger fund movements."
         )
+
+        signal = result.get("signal")
+        confidence = result.get("confidence")
+        if isinstance(signal, str) and isinstance(confidence, (int, float)):
+            from app.services.sentiment_history import record as record_sentiment
+
+            record_sentiment(signal, float(confidence))
+
         return result
     except Exception:
         logger.exception("Failed to get market sentiment")

--- a/apps/intelligence/app/services/sentiment_history.py
+++ b/apps/intelligence/app/services/sentiment_history.py
@@ -1,0 +1,85 @@
+"""Historical market sentiment tracking for the trend sparkline (#939).
+
+Each time /market/sentiment is computed successfully, the resulting
+signal/confidence is recorded here. The router exposes the recorded points so
+the dapp can render a 7/30 day trend alongside the current point-in-time
+read, instead of just the latest value.
+
+Storage mirrors the pattern in coingecko.py: Redis when available (durable
+across restarts, shared across replicas), falling back to an in-memory list
+scoped to this process otherwise.
+"""
+
+import json
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_REDIS_KEY = "market_sentiment_history"
+_RETENTION_SECONDS = 30 * 24 * 60 * 60  # keep 30 days of points
+_MEM_CAP = 500  # in-memory fallback cap, well above 30 days at a 6h poll cadence
+
+_redis_client: Any = None
+_redis_available: bool = False
+_mem_history: list[dict[str, Any]] = []
+
+
+def _get_redis() -> Any:
+    global _redis_client, _redis_available
+    if _redis_client is not None:
+        return _redis_client if _redis_available else None
+    try:
+        import redis as _redis
+
+        from app.config import settings
+
+        _redis_client = _redis.from_url(settings.redis_url, decode_responses=True)
+        _redis_client.ping()
+        _redis_available = True
+        logger.info("sentiment history: redis connected")
+    except Exception as exc:
+        logger.warning("sentiment history: redis unavailable (%s), using in-memory", exc)
+        _redis_available = False
+    return _redis_client if _redis_available else None
+
+
+def record(signal: str, confidence: float, observed_at: float | None = None) -> None:
+    """Append one sentiment data point."""
+    ts = observed_at if observed_at is not None else time.time()
+    entry = {"signal": signal, "confidence": confidence, "observed_at": ts}
+
+    r = _get_redis()
+    if r is not None:
+        try:
+            r.zadd(_REDIS_KEY, {json.dumps(entry): ts})
+            r.zremrangebyscore(_REDIS_KEY, 0, ts - _RETENTION_SECONDS)
+            return
+        except Exception as exc:
+            logger.warning("sentiment history: redis record failed (%s)", exc)
+
+    _mem_history.append(entry)
+    cutoff = ts - _RETENTION_SECONDS
+    _mem_history[:] = [e for e in _mem_history if e["observed_at"] >= cutoff]
+    if len(_mem_history) > _MEM_CAP:
+        del _mem_history[: len(_mem_history) - _MEM_CAP]
+
+
+def history(days: int) -> list[dict[str, Any]]:
+    """Return recorded points from the last `days` days, oldest first."""
+    cutoff = time.time() - days * 24 * 60 * 60
+
+    r = _get_redis()
+    if r is not None:
+        try:
+            raw = r.zrangebyscore(_REDIS_KEY, cutoff, "+inf")
+            points = [json.loads(item) for item in raw]
+            points.sort(key=lambda e: e["observed_at"])
+            return points
+        except Exception as exc:
+            logger.warning("sentiment history: redis read failed (%s)", exc)
+
+    points = [e for e in _mem_history if e["observed_at"] >= cutoff]
+    points.sort(key=lambda e: e["observed_at"])
+    return points

--- a/apps/intelligence/tests/test_sentiment_history.py
+++ b/apps/intelligence/tests/test_sentiment_history.py
@@ -1,0 +1,80 @@
+"""Unit tests for the market sentiment history tracker (#939)."""
+
+import time
+
+import pytest
+
+from app.services import sentiment_history
+
+
+@pytest.fixture(autouse=True)
+def clear_history(monkeypatch):
+    # Force the in-memory fallback path so tests don't depend on a real Redis
+    # instance being reachable.
+    monkeypatch.setattr(sentiment_history, "_get_redis", lambda: None)
+    sentiment_history._mem_history.clear()
+    yield
+    sentiment_history._mem_history.clear()
+
+
+def test_record_and_history_round_trip():
+    # history() filters relative to the real clock, so observed_at values must
+    # be recent (within the query window) for the point to be returned.
+    now = time.time()
+    sentiment_history.record("bull", 0.8, observed_at=now)
+
+    points = sentiment_history.history(days=30)
+
+    assert len(points) == 1
+    assert points[0]["signal"] == "bull"
+    assert points[0]["confidence"] == 0.8
+    assert points[0]["observed_at"] == now
+
+
+def test_history_returns_points_oldest_first():
+    now = time.time()
+    sentiment_history.record("bear", 0.5, observed_at=now - 30)
+    sentiment_history.record("bull", 0.9, observed_at=now - 90)
+    sentiment_history.record("neutral", 0.4, observed_at=now - 60)
+
+    points = sentiment_history.history(days=30)
+
+    assert [p["observed_at"] for p in points] == [now - 90, now - 60, now - 30]
+
+
+def test_history_excludes_points_outside_window():
+    day = 24 * 60 * 60
+    now = time.time()
+    sentiment_history.record("bull", 0.7, observed_at=now - 40 * day)  # older than a 30d window
+    sentiment_history.record("bear", 0.6, observed_at=now - 5 * day)
+
+    points = sentiment_history.history(days=30)
+
+    assert len(points) == 1
+    assert points[0]["signal"] == "bear"
+
+
+def test_history_days_clamped_by_caller_not_by_history_itself():
+    # history() itself trusts the days argument as given; clamping to [1, 30]
+    # is the router's responsibility (tested via the endpoint).
+    now = time.time()
+    sentiment_history.record("bull", 0.7, observed_at=now - 1)
+
+    assert len(sentiment_history.history(days=1)) == 1
+    assert len(sentiment_history.history(days=7)) == 1
+
+
+def test_record_prunes_entries_older_than_retention():
+    now = 2_000_000.0
+    stale = now - sentiment_history._RETENTION_SECONDS - 1
+    sentiment_history.record("bull", 0.7, observed_at=stale)
+    sentiment_history.record("bear", 0.6, observed_at=now)
+
+    # The second record() call prunes anything older than the retention
+    # window relative to its own observed_at.
+    assert len(sentiment_history._mem_history) == 1
+    assert sentiment_history._mem_history[0]["signal"] == "bear"
+
+
+def test_history_empty_when_nothing_recorded():
+    assert sentiment_history.history(days=7) == []


### PR DESCRIPTION
## Summary

closes #939

`components/ai/marketSentiment.tsx` showed current sentiment only. This adds a small 7/30 day sparkline so users see the trend, not just a point-in-time read.

## Changes

- `app/services/sentiment_history.py` (intelligence service): records each successfully computed sentiment (signal + confidence) with a timestamp. Backed by Redis when available, following the same pattern already used by `coingecko.py`'s cache, with an in-memory fallback when Redis isn't reachable. Retains 30 days of points.
- Wired recording into `prometheus.get_market_sentiment`'s success path — only real, successfully computed reads are recorded, not the "service unavailable" neutral fallback.
- New endpoint `GET /api/v1/market/sentiment/history?days=7|30` in `analyze.py`, with `days` clamped to `[1, 30]`.
- Dapp: `intelligence.getMarketSentimentHistory(days)` client method, and a `SentimentSparkline` sub-component in `marketSentiment.tsx` rendering an inline SVG confidence trend line with a 7d/30d toggle. Line color follows the most recent point's signal (bull/bear/neutral), and it falls back to a muted "Not enough history yet to chart a trend" message when fewer than 2 points are available (e.g. right after this ships, before history has accumulated).

## Test plan

- [x] `pytest` in `apps/intelligence` — 195 passed, including 6 new tests for `sentiment_history.py` (record/history round trip, chronological ordering, retention pruning, window filtering, empty state)
- [x] `ruff check` — clean
- [x] `tsc --noEmit` on the dapp frontend — no errors
- [x] Manual review of the sparkline rendering logic for the "not enough history" and single-signal-color paths