### PR TITLE
feat: Claude rate-limit handling, retrieval tests, defillama staleness guard, AI opt-out

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -798,6 +798,7 @@ func run() error {
 		prometheusClient,
 		nudgeNotificationDispatcher,
 		baseLogger.WithGroup("goal-coaching"),
+		nudgeHistoryRepo,
 	)
 	goalCoachingCtx, cancelGoalCoaching := context.WithCancel(context.Background())
 	defer cancelGoalCoaching()

--- a/apps/api/internal/domain/intelligence/model.go
+++ b/apps/api/internal/domain/intelligence/model.go
@@ -83,6 +83,12 @@ type PortfolioContext struct {
 type CoachingRequest struct {
 	Goal      SavingsGoalContext `json:"goal"`
 	Portfolio PortfolioContext   `json:"portfolio"`
+	// AIInsightsEnabled (#935): explicit opt-out flag, defaulted to true via
+	// omitempty so on-demand (user-initiated) coaching requests that don't
+	// set it are unaffected. Scheduled/batch callers that already checked
+	// the user's nudges_enabled preference should set this explicitly so
+	// the intelligence service enforces it too, independent of the caller.
+	AIInsightsEnabled *bool `json:"ai_insights_enabled,omitempty"`
 }
 
 // DepositScheduleItem mirrors the intelligence service's DepositScheduleItem model.

--- a/apps/api/internal/service/goal_coaching_scheduler.go
+++ b/apps/api/internal/service/goal_coaching_scheduler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/nudge"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
 	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
 )
@@ -30,10 +31,11 @@ type GoalCoachingClient interface {
 // coaching notification for every active savings goal (#112 "AI coaching
 // message generated weekly per goal").
 type GoalCoachingScheduler struct {
-	repo       GoalCoachingRepository
-	coaching   GoalCoachingClient
-	dispatcher *notifications.Dispatcher
-	logger     *slog.Logger
+	repo        GoalCoachingRepository
+	coaching    GoalCoachingClient
+	dispatcher  *notifications.Dispatcher
+	logger      *slog.Logger
+	prefChecker nudge.PreferenceChecker
 }
 
 func NewGoalCoachingScheduler(
@@ -41,11 +43,18 @@ func NewGoalCoachingScheduler(
 	coaching GoalCoachingClient,
 	dispatcher *notifications.Dispatcher,
 	logger *slog.Logger,
+	prefChecker nudge.PreferenceChecker,
 ) *GoalCoachingScheduler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &GoalCoachingScheduler{repo: repo, coaching: coaching, dispatcher: dispatcher, logger: logger}
+	return &GoalCoachingScheduler{
+		repo:        repo,
+		coaching:    coaching,
+		dispatcher:  dispatcher,
+		logger:      logger,
+		prefChecker: prefChecker,
+	}
 }
 
 // Run ticks every `interval` (weekly in production) until ctx is cancelled,
@@ -85,10 +94,30 @@ func (s *GoalCoachingScheduler) tick(ctx context.Context) {
 }
 
 func (s *GoalCoachingScheduler) sendCoaching(ctx context.Context, goal savingsgoal.SavingsGoal) {
+	// Opt-out (#935): some users don't want AI-driven nudges/insights.
+	// Checked before any intelligence-service call is made — mirrors
+	// nudge_engine_service.go's prefChecker gate for the same preference.
+	// Also passed through explicitly on the request below so the
+	// intelligence service enforces the same preference independent of
+	// this check (defense in depth, not just "trust the caller skipped it").
+	enabled := true
+	if s.prefChecker != nil {
+		var err error
+		enabled, err = s.prefChecker.NudgesEnabled(ctx, goal.UserID)
+		if err != nil {
+			s.logger.Warn("goal coaching: failed to check nudges preference", "goal_id", goal.ID.String(), "error", err.Error())
+			return
+		}
+		if !enabled {
+			return
+		}
+	}
+
 	targetAmount, _ := goal.TargetAmount.Float64()
 	currentAmount, _ := goal.CurrentAmount.Float64()
 
 	result, err := s.coaching.GetGoalCoaching(ctx, intelligence.CoachingRequest{
+		AIInsightsEnabled: &enabled,
 		Goal: intelligence.SavingsGoalContext{
 			ID:            goal.ID.String(),
 			TargetAmount:  targetAmount,

--- a/apps/api/internal/service/goal_coaching_scheduler_test.go
+++ b/apps/api/internal/service/goal_coaching_scheduler_test.go
@@ -41,6 +41,16 @@ func (fakePreferenceStore) Get(_ context.Context, _ uuid.UUID) (notifications.Pr
 	return notifications.DefaultPreferences(), nil
 }
 
+// fakeNudgePreferenceChecker implements nudge.PreferenceChecker for tests.
+type fakeNudgePreferenceChecker struct {
+	enabled bool
+	err     error
+}
+
+func (f fakeNudgePreferenceChecker) NudgesEnabled(_ context.Context, _ uuid.UUID) (bool, error) {
+	return f.enabled, f.err
+}
+
 type recordingChannel struct {
 	mu        sync.Mutex
 	delivered []notifications.Notification
@@ -86,6 +96,7 @@ func TestGoalCoachingScheduler_TickSendsOnePerActiveGoal(t *testing.T) {
 		}},
 		dispatcher,
 		nil,
+		fakeNudgePreferenceChecker{enabled: true},
 	)
 
 	scheduler.tick(t.Context())
@@ -120,6 +131,7 @@ func TestGoalCoachingScheduler_TickSkipsGoalOnCoachingError(t *testing.T) {
 		fakeGoalCoachingClient{err: context.DeadlineExceeded},
 		dispatcher,
 		nil,
+		fakeNudgePreferenceChecker{enabled: true},
 	)
 
 	scheduler.tick(t.Context())
@@ -130,6 +142,72 @@ func TestGoalCoachingScheduler_TickSkipsGoalOnCoachingError(t *testing.T) {
 }
 
 func TestGoalCoachingScheduler_TickNoopWithoutDependencies(t *testing.T) {
-	scheduler := NewGoalCoachingScheduler(nil, nil, nil, nil)
+	scheduler := NewGoalCoachingScheduler(nil, nil, nil, nil, nil)
 	scheduler.tick(t.Context()) // must not panic
+}
+
+func TestGoalCoachingScheduler_SkipsGoalWhenUserOptedOut(t *testing.T) {
+	userID := uuid.New()
+	goal := savingsgoal.SavingsGoal{ID: uuid.New(), UserID: userID, Currency: "USDC"}
+
+	channel := &recordingChannel{}
+	dispatcher := notifications.New([]notifications.Channel{channel}, fakePreferenceStore{}, nil)
+	client := &fakeGoalCoachingClient{resp: &intelligence.CoachingResponse{ProgressAssessment: "should not be sent"}}
+
+	scheduler := NewGoalCoachingScheduler(
+		fakeGoalCoachingRepo{goals: []savingsgoal.SavingsGoal{goal}},
+		client,
+		dispatcher,
+		nil,
+		fakeNudgePreferenceChecker{enabled: false},
+	)
+
+	scheduler.tick(t.Context())
+
+	if len(channel.all()) != 0 {
+		t.Fatalf("expected no notifications delivered for an opted-out user, got %d", len(channel.all()))
+	}
+}
+
+func TestGoalCoachingScheduler_PassesOptOutFlagThroughToIntelligenceRequest(t *testing.T) {
+	userID := uuid.New()
+	goal := savingsgoal.SavingsGoal{ID: uuid.New(), UserID: userID, Currency: "USDC"}
+
+	channel := &recordingChannel{}
+	dispatcher := notifications.New([]notifications.Channel{channel}, fakePreferenceStore{}, nil)
+	client := &recordingGoalCoachingClient{
+		resp: &intelligence.CoachingResponse{ProgressAssessment: "hi"},
+	}
+
+	scheduler := NewGoalCoachingScheduler(
+		fakeGoalCoachingRepo{goals: []savingsgoal.SavingsGoal{goal}},
+		client,
+		dispatcher,
+		nil,
+		fakeNudgePreferenceChecker{enabled: true},
+	)
+
+	scheduler.tick(t.Context())
+
+	if len(client.requests) != 1 {
+		t.Fatalf("expected 1 coaching request, got %d", len(client.requests))
+	}
+	req := client.requests[0]
+	if req.AIInsightsEnabled == nil || !*req.AIInsightsEnabled {
+		t.Errorf("AIInsightsEnabled = %v, want pointer to true", req.AIInsightsEnabled)
+	}
+}
+
+// recordingGoalCoachingClient captures every request it's called with, so a
+// test can assert on the fields sent to the intelligence service (not just
+// the response side-effects).
+type recordingGoalCoachingClient struct {
+	resp     *intelligence.CoachingResponse
+	err      error
+	requests []intelligence.CoachingRequest
+}
+
+func (f *recordingGoalCoachingClient) GetGoalCoaching(_ context.Context, req intelligence.CoachingRequest) (*intelligence.CoachingResponse, error) {
+	f.requests = append(f.requests, req)
+	return f.resp, f.err
 }

--- a/apps/intelligence/app/models/coaching.py
+++ b/apps/intelligence/app/models/coaching.py
@@ -25,6 +25,14 @@ class PortfolioContext(BaseModel):
 class CoachingRequest(BaseModel):
     goal: SavingsGoalContext
     portfolio: PortfolioContext
+    # Opt-out (#935): callers that already know the user has disabled
+    # AI-driven nudges/insights set this to False so the intelligence
+    # service refuses to generate anything, as a second layer of
+    # enforcement independent of the caller's own check. Defaults True so
+    # existing/on-demand callers that don't set it (an explicit,
+    # user-initiated "get my coaching" request, which opt-out doesn't
+    # apply to) are unaffected.
+    ai_insights_enabled: bool = True
 
 
 class DepositScheduleItem(BaseModel):

--- a/apps/intelligence/app/services/defillama.py
+++ b/apps/intelligence/app/services/defillama.py
@@ -14,6 +14,17 @@ _TTL_PROTOCOLS = 900  # 15 min
 _TTL_POOLS = 900
 _TTL_HISTORY = 900
 
+# Staleness guard (#931): every successful fetch also writes a "last known
+# good" copy under a much longer TTL. If a live fetch fails *and* the normal
+# (short-TTL) cache has already expired, that stale copy is served instead of
+# an empty list — a DefiLlama outage then degrades to slightly-out-of-date
+# yield data instead of the AI having no yield data to reference at all.
+# Capped at 24h: past that, the data is old enough that presenting it as
+# current would be misleading, so it's better to fall back to empty (the
+# existing failure behavior) than serve day-plus-old numbers silently.
+_TTL_STALE_FALLBACK = 24 * 3600
+_STALE_KEY_SUFFIX = ":stale"
+
 _redis_client: Any = None
 _redis_available: bool = False
 _mem_cache: dict[str, tuple[Any, float]] = {}
@@ -63,6 +74,32 @@ def _cache_set(key: str, value: Any, ttl: int) -> None:
     _mem_cache[key] = (value, time.monotonic() + ttl)
 
 
+def _cache_set_with_stale_fallback(key: str, value: Any, ttl: int) -> None:
+    """Write the normal (short-TTL) cache entry plus a long-TTL "last known
+    good" copy for the staleness guard to fall back on."""
+    _cache_set(key, value, ttl)
+    _cache_set(key + _STALE_KEY_SUFFIX, value, _TTL_STALE_FALLBACK)
+
+
+def _cache_get_stale(key: str) -> Optional[Any]:
+    """Read the long-TTL "last known good" copy, ignoring the normal cache's
+    TTL entirely — used only as an outage fallback, never on the hot path."""
+    return _cache_get(key + _STALE_KEY_SUFFIX)
+
+
+def _stale_fallback_or_empty(key: str, what: str) -> list[Any]:
+    stale = _cache_get_stale(key)
+    if stale is not None:
+        logger.warning(
+            "defillama %s: live fetch failed, serving last-known-good cached data "
+            "(up to %ds old) instead of empty",
+            what,
+            _TTL_STALE_FALLBACK,
+        )
+        return list(stale)
+    return []
+
+
 class DeFiLlamaClient:
     def __init__(self, base_url: str = _DEFILLAMA_BASE, yields_url: str = _YIELDS_BASE):
         self.base_url = base_url.rstrip("/")
@@ -82,11 +119,11 @@ class DeFiLlamaClient:
                 ) as resp:
                     if resp.status != 200:
                         logger.warning("defillama /protocols returned %s", resp.status)
-                        return []
+                        return _stale_fallback_or_empty(key, "get_stellar_protocols")
                     data = await resp.json()
         except Exception as exc:
             logger.warning("defillama get_stellar_protocols failed: %s", exc)
-            return []
+            return _stale_fallback_or_empty(key, "get_stellar_protocols")
 
         stellar = [
             {
@@ -99,7 +136,7 @@ class DeFiLlamaClient:
             for p in data
             if "stellar" in [c.lower() for c in (p.get("chains") or [])]
         ]
-        _cache_set(key, stellar, _TTL_PROTOCOLS)
+        _cache_set_with_stale_fallback(key, stellar, _TTL_PROTOCOLS)
         return stellar
 
     async def get_yield_pools(self, chain: str = "Stellar") -> list[dict[str, Any]]:
@@ -116,11 +153,11 @@ class DeFiLlamaClient:
                 ) as resp:
                     if resp.status != 200:
                         logger.warning("defillama /pools returned %s", resp.status)
-                        return []
+                        return _stale_fallback_or_empty(key, "get_yield_pools")
                     data = await resp.json()
         except Exception as exc:
             logger.warning("defillama get_yield_pools failed: %s", exc)
-            return []
+            return _stale_fallback_or_empty(key, "get_yield_pools")
 
         pools = [
             {
@@ -138,7 +175,7 @@ class DeFiLlamaClient:
             for p in data.get("data", [])
             if p.get("chain", "").lower() == chain.lower()
         ]
-        _cache_set(key, pools, _TTL_POOLS)
+        _cache_set_with_stale_fallback(key, pools, _TTL_POOLS)
         return pools
 
     async def get_pool_history(self, pool_id: str) -> list[dict[str, Any]]:
@@ -155,11 +192,11 @@ class DeFiLlamaClient:
                 ) as resp:
                     if resp.status != 200:
                         logger.warning("defillama /chart/%s returned %s", pool_id, resp.status)
-                        return []
+                        return _stale_fallback_or_empty(key, "get_pool_history")
                     data = await resp.json()
         except Exception as exc:
             logger.warning("defillama get_pool_history failed: %s", exc)
-            return []
+            return _stale_fallback_or_empty(key, "get_pool_history")
 
         history = [
             {
@@ -169,7 +206,7 @@ class DeFiLlamaClient:
             }
             for entry in data.get("data", [])
         ]
-        _cache_set(key, history, _TTL_HISTORY)
+        _cache_set_with_stale_fallback(key, history, _TTL_HISTORY)
         return history
 
 

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -610,6 +610,28 @@ async def stream_chat(
                     yield "data: [DONE]\n\n"
                     return
 
+        except anthropic.APIStatusError as exc:
+            # 429 (rate-limited) and 529 (Anthropic overloaded) are both
+            # transient, caller-should-retry-shortly conditions — give the
+            # user a distinct message from a hard failure instead of the
+            # generic "trouble connecting" catch-all below (#928).
+            if exc.status_code in (429, 529):
+                logger.warning(
+                    "Anthropic rate-limit/overload for user %s (status %s)",
+                    user_id,
+                    exc.status_code,
+                )
+                yield (
+                    "data: Prometheus is receiving a lot of requests right now. "
+                    "Please wait a moment and try again.\n\n"
+                )
+            else:
+                logger.exception(
+                    "Anthropic API error for user %s (status %s)", user_id, exc.status_code
+                )
+                yield "data: Sorry, I had trouble connecting. Please try again.\n\n"
+            yield "data: [DONE]\n\n"
+            return
         except Exception:
             logger.exception("Anthropic streaming error for user %s", user_id)
             yield "data: Sorry, I had trouble connecting. Please try again.\n\n"
@@ -640,6 +662,18 @@ async def generate_coaching(
 ) -> CoachingResponse:
     """Generate deposit schedule and progress assessment for a savings goal."""
     from app.models.coaching import DepositScheduleItem
+
+    if not request.ai_insights_enabled:
+        # Opt-out (#935): the caller has told us this user disabled
+        # AI-driven nudges/insights. Refuse to spend any tokens generating
+        # content for them, independent of whether the caller already
+        # skipped calling us for the same reason.
+        return CoachingResponse(
+            progress_assessment="",
+            deposit_schedule=[],
+            nudges=[],
+            confidence="low",
+        )
 
     goal = request.goal
     portfolio = request.portfolio

--- a/apps/intelligence/tests/test_coaching.py
+++ b/apps/intelligence/tests/test_coaching.py
@@ -52,3 +52,59 @@ async def test_generate_coaching_returns_structured_schedule(monkeypatch):
     assert len(result.deposit_schedule) == 1
     assert result.deposit_schedule[0].amount_usdc == 100
     assert "on track" in result.progress_assessment
+
+
+@pytest.mark.asyncio
+async def test_generate_coaching_respects_opt_out_flag(monkeypatch):
+    """#935: ai_insights_enabled=False must refuse generation without ever
+    calling Claude — the intelligence service's own enforcement layer,
+    independent of whether the caller (the Go API) already checked."""
+
+    def _unexpected_call() -> FakeClient:
+        raise AssertionError("get_client() should not be called when opted out")
+
+    monkeypatch.setattr(prometheus, "get_client", _unexpected_call)
+
+    result = await prometheus.generate_coaching(
+        CoachingRequest(
+            goal=SavingsGoalContext(
+                target_amount=1000,
+                currency="USDC",
+                deadline="2026-12-31T00:00:00Z",
+                current_amount=200,
+                progress_pct=20,
+            ),
+            portfolio=PortfolioContext(total_balance_usd=500),
+            ai_insights_enabled=False,
+        )
+    )
+
+    assert result.progress_assessment == ""
+    assert result.deposit_schedule == []
+    assert result.nudges == []
+
+
+@pytest.mark.asyncio
+async def test_generate_coaching_defaults_to_enabled_when_flag_omitted(monkeypatch):
+    """Existing/on-demand callers that don't set ai_insights_enabled at all
+    (an explicit, user-initiated request — opt-out doesn't apply) must be
+    unaffected by the new field."""
+    payload = (
+        '{"progress_assessment": "You are on track.", '
+        '"deposit_schedule": [], "nudges": [], "confidence": "high"}'
+    )
+    monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(payload))
+    monkeypatch.setattr(prometheus.anthropic.types, "TextBlock", DummyTextBlock, raising=False)
+
+    request = CoachingRequest(
+        goal=SavingsGoalContext(
+            target_amount=1000,
+            currency="USDC",
+            deadline="2026-12-31T00:00:00Z",
+        ),
+        portfolio=PortfolioContext(),
+    )
+    assert request.ai_insights_enabled is True
+
+    result = await prometheus.generate_coaching(request)
+    assert "on track" in result.progress_assessment

--- a/apps/intelligence/tests/test_defillama_staleness.py
+++ b/apps/intelligence/tests/test_defillama_staleness.py
@@ -1,0 +1,137 @@
+"""Tests for the DefiLlama staleness guard (#931).
+
+Confirms that once a live fetch has succeeded and populated the cache, a
+subsequent DefiLlama outage (non-200 or a raised exception) after the normal
+short-TTL cache entry has expired falls back to the last-known-good data
+instead of an empty list — so an AI response that references yield data
+degrades to slightly-stale numbers instead of having none at all.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.defillama import DeFiLlamaClient, _mem_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_mem_cache():
+    _mem_cache.clear()
+    yield
+    _mem_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return DeFiLlamaClient(
+        base_url="https://api.llama.fi",
+        yields_url="https://yields.llama.fi",
+    )
+
+
+_POOLS_RESPONSE = {
+    "data": [
+        {
+            "pool": "abc-123",
+            "project": "blend",
+            "symbol": "USDC",
+            "apy": 9.5,
+            "apyBase": 8.0,
+            "apyReward": 1.5,
+            "tvlUsd": 2_000_000,
+            "apyPct7d": 0.3,
+            "il7d": None,
+            "chain": "Stellar",
+        },
+    ]
+}
+
+
+def _make_mock_response(status: int, json_data: object) -> MagicMock:
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=json_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+    return mock_resp
+
+
+def _make_session(mock_resp: MagicMock) -> MagicMock:
+    session = AsyncMock()
+    session.get = MagicMock(return_value=mock_resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_failing_session(exc: Exception) -> MagicMock:
+    session = AsyncMock()
+    session.get = MagicMock(side_effect=exc)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+async def _prime_cache_and_expire_short_ttl(client: DeFiLlamaClient) -> None:
+    """Populate both the normal cache and the stale fallback via one
+    successful fetch, then simulate the short-TTL entry expiring (an
+    outage happening *after* the normal cache would already be a miss)
+    without waiting out the real 15-minute TTL."""
+    mock_resp = _make_mock_response(200, _POOLS_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_yield_pools(chain="Stellar")
+    assert result  # sanity: the priming fetch actually returned data
+
+    # Expire only the short-TTL entry, leaving the long-TTL stale copy intact
+    # — mirrors real behavior (different TTLs), without sleeping in a test.
+    key = "defillama:pools:stellar"
+    del _mem_cache[key]
+    assert key + ":stale" in _mem_cache
+
+
+@pytest.mark.asyncio
+async def test_outage_after_ttl_expiry_serves_stale_data_on_non_200(client):
+    await _prime_cache_and_expire_short_ttl(client)
+
+    mock_resp = _make_mock_response(500, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_yield_pools(chain="Stellar")
+
+    assert result, "expected stale fallback data, got empty list"
+    assert result[0]["project"] == "blend"
+
+
+@pytest.mark.asyncio
+async def test_outage_after_ttl_expiry_serves_stale_data_on_exception(client):
+    await _prime_cache_and_expire_short_ttl(client)
+
+    with patch("aiohttp.ClientSession", return_value=_make_failing_session(Exception("network down"))):
+        result = await client.get_yield_pools(chain="Stellar")
+
+    assert result, "expected stale fallback data, got empty list"
+    assert result[0]["project"] == "blend"
+
+
+@pytest.mark.asyncio
+async def test_outage_with_no_prior_successful_fetch_still_returns_empty(client):
+    # No priming fetch — nothing to fall back to, so behavior must be
+    # unchanged from before the staleness guard: an empty list, not an error.
+    mock_resp = _make_mock_response(500, {})
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)):
+        result = await client.get_yield_pools(chain="Stellar")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_stale_fallback_is_not_used_when_a_fresh_cache_entry_exists(client):
+    # Prime the cache and do NOT expire it — the fresh, non-stale path
+    # should serve normally and never even attempt a live fetch, let alone
+    # need the fallback.
+    mock_resp = _make_mock_response(200, _POOLS_RESPONSE)
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_resp)) as mock_session:
+        await client.get_yield_pools(chain="Stellar")
+        result = await client.get_yield_pools(chain="Stellar")
+
+    assert mock_session.call_count == 1
+    assert result[0]["project"] == "blend"

--- a/apps/intelligence/tests/test_prometheus_streaming_errors.py
+++ b/apps/intelligence/tests/test_prometheus_streaming_errors.py
@@ -1,0 +1,118 @@
+"""Tests for stream_chat's handling of Claude API rate-limit/overload errors (#928).
+
+Confirms that a 429 (rate-limited) or 529 (overloaded) response from Claude
+surfaces as a distinct, friendly SSE message rather than being lumped in
+with the generic "trouble connecting" catch-all, or propagating as a raw
+500 to the caller.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import anthropic
+import httpx
+import pytest
+
+from app.services import prometheus
+from app.services.retrieval import RetrievedContext
+
+
+class RaisingStream:
+    """Fake `client.messages.stream(...)` context manager that raises on entry."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> "RaisingStream":
+        raise self._exc
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class FakeMessages:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def stream(self, **kwargs: Any) -> RaisingStream:
+        return RaisingStream(self._exc)
+
+
+class FakeClient:
+    def __init__(self, exc: Exception) -> None:
+        self.messages = FakeMessages(exc)
+
+
+class FakeRetrievalService:
+    async def retrieve(self, user_id: str, message: str) -> RetrievedContext:
+        return RetrievedContext()
+
+
+def _make_status_error(status_code: int) -> anthropic.APIStatusError:
+    response = httpx.Response(status_code, request=httpx.Request("POST", "http://x"))
+    return anthropic.APIStatusError("boom", response=response, body=None)
+
+
+async def _collect(agen: Any) -> list[str]:
+    return [chunk async for chunk in agen]
+
+
+@pytest.fixture(autouse=True)
+def _stub_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prometheus, "get_retrieval_service", lambda: FakeRetrievalService())
+    # Conversation store is a simple in-memory dict-backed store — no live
+    # dependency to stub, but keep each test isolated from prior test state.
+    prometheus.conversation_store.clear("user-1")
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_yields_friendly_retry_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    exc = _make_status_error(429)
+    monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(exc))
+
+    chunks = await _collect(prometheus.stream_chat("user-1", "What's my balance?"))
+
+    joined = "".join(chunks)
+    assert "receiving a lot of requests" in joined
+    assert "data: [DONE]" in joined
+    # Must not fall through to the generic connection-error message.
+    assert "trouble connecting" not in joined
+
+
+@pytest.mark.asyncio
+async def test_overloaded_error_yields_friendly_retry_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    exc = _make_status_error(529)
+    monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(exc))
+
+    chunks = await _collect(prometheus.stream_chat("user-1", "What's my balance?"))
+
+    joined = "".join(chunks)
+    assert "receiving a lot of requests" in joined
+    assert "data: [DONE]" in joined
+    assert "trouble connecting" not in joined
+
+
+@pytest.mark.asyncio
+async def test_other_api_status_error_uses_generic_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    exc = _make_status_error(400)
+    monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(exc))
+
+    chunks = await _collect(prometheus.stream_chat("user-1", "What's my balance?"))
+
+    joined = "".join(chunks)
+    assert "trouble connecting" in joined
+    assert "receiving a lot of requests" not in joined
+    assert "data: [DONE]" in joined
+
+
+@pytest.mark.asyncio
+async def test_non_api_exception_still_falls_back_to_generic_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(RuntimeError("boom")))
+
+    chunks = await _collect(prometheus.stream_chat("user-1", "What's my balance?"))
+
+    joined = "".join(chunks)
+    assert "trouble connecting" in joined
+    assert "data: [DONE]" in joined

--- a/apps/intelligence/tests/test_retrieval_relevance.py
+++ b/apps/intelligence/tests/test_retrieval_relevance.py
@@ -1,0 +1,139 @@
+"""Tests for retrieval.py's relevance filtering and empty-result fallback (#930).
+
+`RetrievalService.retrieve` gates which sections get fetched/included by the
+intents `route_query` matches — that's this codebase's relevance filter (it
+doesn't do numeric relevance scoring; a section is either routed-in or not).
+These tests cover the two things #930 calls out that test_retrieval.py
+(added alongside #852) didn't: that *irrelevant* sections are actually
+excluded (not just that empty sources produce no data), and that a query
+matching only one intent doesn't pull in unrelated data.
+"""
+
+import pytest
+
+from app.services.retrieval import Intent, RetrievalService, route_query
+
+
+class RecordingDataSource:
+    """Records which source methods were actually called, so a test can
+    assert an irrelevant one was never even fetched — not just that its
+    section is absent from the output."""
+
+    def __init__(self) -> None:
+        self.called: set[str] = set()
+        self.vaults = [{"name": "Growth Vault", "balance_usd": 1200, "apy": 8.5, "yield_earned": 30}]
+        self.goals = [{"name": "Car", "target_amount": 5000, "current_amount": 1250, "progress_pct": 25}]
+        self.txs = [{"type": "deposit", "amount": 500, "currency": "USDC", "created_at": "2026-06-01"}]
+        self.available = [{"name": "Balanced", "apy": 10.0, "risk_tier": "medium"}]
+        self.rates = [{"protocol": "aave", "apy": 6.5}]
+
+    async def user_vaults(self, user_id: str):
+        self.called.add("user_vaults")
+        return self.vaults
+
+    async def savings_goals(self, user_id: str):
+        self.called.add("savings_goals")
+        return self.goals
+
+    async def recent_transactions(self, user_id: str):
+        self.called.add("recent_transactions")
+        return self.txs
+
+    async def available_vaults(self):
+        self.called.add("available_vaults")
+        return self.available
+
+    async def market_rates(self):
+        self.called.add("market_rates")
+        return self.rates
+
+
+class TestRelevanceFiltering:
+    @pytest.mark.asyncio
+    async def test_goal_only_query_excludes_transactions_and_yield_landscape(self) -> None:
+        src = RecordingDataSource()
+        svc = RetrievalService(src)
+        await svc.retrieve("user-1", "how is my car goal going?")
+
+        assert "savings_goals" in src.called
+        # POSITIONS is always fetched (Intent.GENERAL is always routed in
+        # alongside whatever else matched — see route_query), but sources
+        # only relevant to *other* intents must not be fetched at all.
+        assert "recent_transactions" not in src.called
+        assert "available_vaults" not in src.called
+        assert "market_rates" not in src.called
+
+    @pytest.mark.asyncio
+    async def test_transactions_only_query_excludes_goals_and_yield_landscape(self) -> None:
+        src = RecordingDataSource()
+        svc = RetrievalService(src)
+        await svc.retrieve("user-1", "show me my last deposits")
+
+        assert "recent_transactions" in src.called
+        assert "savings_goals" not in src.called
+        assert "available_vaults" not in src.called
+        assert "market_rates" not in src.called
+
+    @pytest.mark.asyncio
+    async def test_multi_intent_query_pulls_only_the_matched_sections(self) -> None:
+        # A message that matches both GOALS and TRANSACTIONS keywords should
+        # fetch both, but still not the unrelated YIELD_LANDSCAPE source.
+        src = RecordingDataSource()
+        svc = RetrievalService(src)
+        await svc.retrieve("user-1", "how is my car goal doing, and what were my last deposits?")
+
+        assert "savings_goals" in src.called
+        assert "recent_transactions" in src.called
+        assert "available_vaults" not in src.called
+        assert "market_rates" not in src.called
+
+    @pytest.mark.asyncio
+    async def test_yield_landscape_query_excludes_goals_and_transactions(self) -> None:
+        src = RecordingDataSource()
+        svc = RetrievalService(src)
+        await svc.retrieve("user-1", "which is the best vault right now?")
+
+        assert "available_vaults" in src.called
+        assert "market_rates" in src.called
+        assert "savings_goals" not in src.called
+        assert "recent_transactions" not in src.called
+
+
+class TestEmptyResultFallback:
+    @pytest.mark.asyncio
+    async def test_matched_but_empty_source_yields_no_section_for_that_intent(self) -> None:
+        # Goals intent matches, but the user has none — the section (and its
+        # citation) must be omitted rather than rendered empty.
+        src = RecordingDataSource()
+        src.goals = []
+        svc = RetrievalService(src)
+        ctx = await svc.retrieve("user-1", "how is my car goal doing?")
+
+        assert not any("Savings Goals" in s for s in ctx.sections)
+        assert not any(c.source == "goals" for c in ctx.citations)
+
+    @pytest.mark.asyncio
+    async def test_all_sources_empty_falls_back_to_no_data_message(self) -> None:
+        src = RecordingDataSource()
+        src.vaults = []
+        src.goals = []
+        src.txs = []
+        src.available = []
+        src.rates = []
+        svc = RetrievalService(src)
+        ctx = await svc.retrieve("user-1", "how am I doing overall?")
+
+        assert not ctx.has_data
+        assert ctx.sections == []
+        assert ctx.citations == []
+        assert "No user data" in ctx.to_prompt_block()
+
+    @pytest.mark.asyncio
+    async def test_unmatched_query_still_defaults_to_positions_scope(self) -> None:
+        # route_query's documented fallback: an unrecognized message defaults
+        # to POSITIONS + GENERAL, not an empty intent set.
+        intents = route_query("what's the weather like today?")
+        assert Intent.POSITIONS in intents
+        assert Intent.GENERAL in intents
+        assert Intent.GOALS not in intents
+        assert Intent.TRANSACTIONS not in intents


### PR DESCRIPTION
## Changes

- **#928**: `stream_chat` (`apps/intelligence/app/services/prometheus.py`) caught every Claude error identically with a generic "trouble connecting" message. Added a specific `anthropic.APIStatusError` handler that distinguishes 429 (rate-limited) / 529 (overloaded) with a clearer "Prometheus is receiving a lot of requests right now, please wait a moment" message, while other API status errors and non-API exceptions keep the existing generic fallback. Note: neither `chat.py` nor `ws_chat.py` were ever surfacing a raw 500 for this — `stream_chat` already caught everything — the gap was that the message didn't distinguish the specific, actionable rate-limit/overload case from a hard failure.
- **#930**: added `tests/test_retrieval_relevance.py`. `retrieval.py`'s "relevance filtering" is intent-based section gating (`route_query` determines which of GOALS/TRANSACTIONS/YIELD_LANDSCAPE/POSITIONS actually get fetched), not numeric relevance scoring — the new tests confirm sections *not* matched by a query's intents are never even fetched (not just absent from the output), across single-intent, multi-intent, and empty-result-fallback cases. `tests/test_retrieval.py` (from #852) already covered routing and basic empty-fallback; this fills the specific "excluded, not just empty" gap.
- **#931**: `defillama.py` already had a TTL cache (redis + in-memory fallback); added the actual staleness guard the issue is about. Every successful fetch now also writes a long-TTL (24h) "last known good" copy; a live-fetch failure (non-200 or exception) after the short-TTL entry has expired now serves that stale copy instead of an empty list, so a DefiLlama outage degrades to slightly-stale yield data instead of the AI having none to reference. Capped at 24h — past that, serving the data as current would be misleading, so it falls back to the pre-existing empty-list behavior.
- **#935**: `goal_coaching_scheduler.go`'s weekly AI goal-coaching job iterated every active goal and called the intelligence service unconditionally — no opt-out check at all, unlike `nudge_engine_service.go`'s existing `NudgesEnabled` gate for generic nudges. Added the same `nudge.PreferenceChecker` gate before any intelligence-service call, and added an explicit `ai_insights_enabled` field to `CoachingRequest` (both the Go struct and the intelligence service's Pydantic model) so the intelligence service also refuses to generate content when told a user opted out — enforcement independent of the caller, not just "trust the API already checked." Defaults to enabled so on-demand (user-initiated) coaching requests, which opt-out doesn't apply to, are unaffected.

## Test plan

- [x] `apps/intelligence`: full suite run locally in a fresh `uv venv` — **212 passed**, including all new/changed tests
- [ ] `apps/api` (Go): **no Go toolchain was available** in the environment this was authored in, so `main.go`, `goal_coaching_scheduler.go`, `model.go`, and their test changes could not be compiled or run locally. Reviewed by hand for correctness — `nudgeHistoryRepo` (already constructed in `main.go`) implements `nudge.PreferenceChecker`; the new `recordingGoalCoachingClient` test double satisfies `GoalCoachingClient` via a pointer receiver. Please confirm with `go build ./... && go test ./...` (or CI) before merging.

Closes #928
Closes #930
Closes #931
Closes #935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI insights opt-out for scheduled coaching and coaching requests.
  * Improved chat error messages for rate limits and service overloads.
  * Added fallback to recently cached market data during temporary data-provider outages.
  * Improved retrieval relevance by limiting results to information related to the request.

* **Bug Fixes**
  * Prevented coaching notifications from being sent when AI insights are disabled.
  * Preserved previously available market data when live requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->