### PR TITLE
Fix: feat(api): yield source deactivation with graceful position migration (Auto-Generated)

### DIFF
--- a/apps/api/internal/domain/vault/deactivation.go
+++ b/apps/api/internal/domain/vault/deactivation.go
@@ -1,0 +1,182 @@
+package vault
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	AllocationStatusActive      = "active"
+	AllocationStatusDeactivated = "deactivated"
+)
+
+var (
+	ErrYieldSourceNotFound         = errors.New("yield source not found")
+	ErrYieldSourceDeactivated      = errors.New("yield source is deactivated")
+	ErrMigrationTargetRequired     = errors.New("migration target is required")
+	ErrMigrationTargetInactive     = errors.New("migration target is not active")
+	ErrMigrationSourceActive       = errors.New("migration source is still active")
+	ErrMigrationSourceEqualsTarget = errors.New("migration source and target must differ")
+	ErrMigrationAmountInvalid      = errors.New("migration amount must be greater than zero")
+	ErrMigrationAmountExceeded     = errors.New("migration amount exceeds source position")
+)
+
+// MigrationTarget describes an active allocation that can receive a position
+// migrated away from a deactivated yield source.
+type MigrationTarget struct {
+	Protocol string          `json:"protocol"`
+	Amount   decimal.Decimal `json:"amount"`
+	APY      decimal.Decimal `json:"apy"`
+}
+
+// MigrationGuide is the information needed by a caller to present a guided
+// migration flow for a deactivated source.
+type MigrationGuide struct {
+	SourceProtocol string            `json:"source_protocol"`
+	SourceAmount   decimal.Decimal   `json:"source_amount"`
+	Targets        []MigrationTarget `json:"targets"`
+}
+
+// DeactivateYieldSource marks a vault allocation as unavailable for new
+// deposits. Existing value remains in the allocation until it is migrated or
+// withdrawn. The operation is idempotent.
+func (v *Vault) DeactivateYieldSource(protocol string) error {
+	protocol = normalizeProtocol(protocol)
+	if protocol == "" {
+		return ErrYieldSourceNotFound
+	}
+
+	for i := range v.Allocations {
+		if normalizeProtocol(v.Allocations[i].Protocol) == protocol {
+			v.Allocations[i].Status = AllocationStatusDeactivated
+			return nil
+		}
+	}
+
+	return ErrYieldSourceNotFound
+}
+
+// CanAcceptDepositTo checks both vault capacity and whether the selected
+// yield source still accepts new deposits. An empty allocation status is
+// treated as active for backwards compatibility with existing allocations.
+func (v *Vault) CanAcceptDepositTo(protocol string, amount decimal.Decimal) error {
+	protocol = normalizeProtocol(protocol)
+	if protocol == "" {
+		return ErrYieldSourceNotFound
+	}
+
+	var allocation *Allocation
+	for i := range v.Allocations {
+		if normalizeProtocol(v.Allocations[i].Protocol) == protocol {
+			allocation = &v.Allocations[i]
+			break
+		}
+	}
+	if allocation == nil {
+		return ErrYieldSourceNotFound
+	}
+	if allocation.Status == AllocationStatusDeactivated {
+		return ErrYieldSourceDeactivated
+	}
+
+	return v.CanAcceptDeposit(amount)
+}
+
+// MigrationGuideFor returns active destinations for a deactivated source.
+// The returned guide is intentionally read-only data; callers must still
+// validate and apply a migration through MigrateYieldSourcePosition.
+func (v *Vault) MigrationGuideFor(sourceProtocol string) (MigrationGuide, error) {
+	sourceProtocol = normalizeProtocol(sourceProtocol)
+	if sourceProtocol == "" {
+		return MigrationGuide{}, ErrYieldSourceNotFound
+	}
+
+	var source *Allocation
+	for i := range v.Allocations {
+		if normalizeProtocol(v.Allocations[i].Protocol) == sourceProtocol {
+			source = &v.Allocations[i]
+			break
+		}
+	}
+	if source == nil {
+		return MigrationGuide{}, ErrYieldSourceNotFound
+	}
+	if source.Status != AllocationStatusDeactivated {
+		return MigrationGuide{}, ErrMigrationSourceActive
+	}
+
+	guide := MigrationGuide{
+		SourceProtocol: source.Protocol,
+		SourceAmount:   source.Amount,
+		Targets:        make([]MigrationTarget, 0),
+	}
+	for _, allocation := range v.Allocations {
+		if normalizeProtocol(allocation.Protocol) == sourceProtocol || allocation.Status == AllocationStatusDeactivated {
+			continue
+		}
+		guide.Targets = append(guide.Targets, MigrationTarget{
+			Protocol: allocation.Protocol,
+			Amount:   allocation.Amount,
+			APY:      allocation.APY,
+		})
+	}
+
+	return guide, nil
+}
+
+// MigrateYieldSourcePosition moves amount from a deactivated allocation to an
+// active allocation. Both allocations are updated together in memory, so a
+// caller can persist the resulting allocation set as one replacement.
+func (v *Vault) MigrateYieldSourcePosition(sourceProtocol, targetProtocol string, amount decimal.Decimal) error {
+	sourceProtocol = normalizeProtocol(sourceProtocol)
+	targetProtocol = normalizeProtocol(targetProtocol)
+	if sourceProtocol == "" {
+		return ErrYieldSourceNotFound
+	}
+	if targetProtocol == "" {
+		return ErrMigrationTargetRequired
+	}
+	if sourceProtocol == targetProtocol {
+		return ErrMigrationSourceEqualsTarget
+	}
+	if !amount.GreaterThan(decimal.Zero) {
+		return ErrMigrationAmountInvalid
+	}
+
+	sourceIndex := -1
+	targetIndex := -1
+	for i := range v.Allocations {
+		protocol := normalizeProtocol(v.Allocations[i].Protocol)
+		switch protocol {
+		case sourceProtocol:
+			sourceIndex = i
+		case targetProtocol:
+			targetIndex = i
+		}
+	}
+	if sourceIndex < 0 {
+		return ErrYieldSourceNotFound
+	}
+	if targetIndex < 0 {
+		return ErrMigrationTargetRequired
+	}
+	if v.Allocations[sourceIndex].Status != AllocationStatusDeactivated {
+		return ErrMigrationSourceActive
+	}
+	if v.Allocations[targetIndex].Status == AllocationStatusDeactivated {
+		return ErrMigrationTargetInactive
+	}
+	if amount.GreaterThan(v.Allocations[sourceIndex].Amount) {
+		return ErrMigrationAmountExceeded
+	}
+
+	v.Allocations[sourceIndex].Amount = v.Allocations[sourceIndex].Amount.Sub(amount)
+	v.Allocations[targetIndex].Amount = v.Allocations[targetIndex].Amount.Add(amount)
+	return nil
+}
+
+func normalizeProtocol(protocol string) string {
+	return strings.ToLower(strings.TrimSpace(protocol))
+}

--- a/apps/api/internal/domain/vault/deactivation_test.go
+++ b/apps/api/internal/domain/vault/deactivation_test.go
@@ -1,0 +1,68 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestDeactivateYieldSourceBlocksDeposits(t *testing.T) {
+	v := Vault{
+		ID: uuid.New(),
+		Allocations: []Allocation{{
+			ID:       uuid.New(),
+			Protocol: "Aave",
+			Amount:   decimal.RequireFromString("100"),
+		}},
+	}
+
+	if err := v.DeactivateYieldSource("aave"); err != nil {
+		t.Fatalf("DeactivateYieldSource() error = %v", err)
+	}
+	if err := v.CanAcceptDepositTo("AAVE", decimal.RequireFromString("1")); err != ErrYieldSourceDeactivated {
+		t.Fatalf("CanAcceptDepositTo() error = %v, want %v", err, ErrYieldSourceDeactivated)
+	}
+}
+
+func TestMigrationGuideAndMigration(t *testing.T) {
+	v := Vault{
+		ID: uuid.New(),
+		Allocations: []Allocation{
+			{ID: uuid.New(), Protocol: "deprecated", Amount: decimal.RequireFromString("100"), Status: AllocationStatusDeactivated},
+			{ID: uuid.New(), Protocol: "aave", Amount: decimal.RequireFromString("25"), Status: AllocationStatusActive},
+		},
+	}
+
+	guide, err := v.MigrationGuideFor("DEPRECATED")
+	if err != nil {
+		t.Fatalf("MigrationGuideFor() error = %v", err)
+	}
+	if len(guide.Targets) != 1 || guide.Targets[0].Protocol != "aave" {
+		t.Fatalf("unexpected migration targets: %+v", guide.Targets)
+	}
+
+	if err := v.MigrateYieldSourcePosition("deprecated", "aave", decimal.RequireFromString("40")); err != nil {
+		t.Fatalf("MigrateYieldSourcePosition() error = %v", err)
+	}
+	if got := v.Allocations[0].Amount.String(); got != "60" {
+		t.Fatalf("source amount = %s, want 60", got)
+	}
+	if got := v.Allocations[1].Amount.String(); got != "65" {
+		t.Fatalf("target amount = %s, want 65", got)
+	}
+	if v.Allocations[0].Status != AllocationStatusDeactivated {
+		t.Fatal("source allocation should remain deactivated after migration")
+	}
+}
+
+func TestMigrationRejectsInactiveTarget(t *testing.T) {
+	v := Vault{Allocations: []Allocation{
+		{Protocol: "old", Amount: decimal.NewFromInt(10), Status: AllocationStatusDeactivated},
+		{Protocol: "new", Amount: decimal.Zero, Status: AllocationStatusDeactivated},
+	}}
+
+	if err := v.MigrateYieldSourcePosition("old", "new", decimal.NewFromInt(1)); err != ErrMigrationTargetInactive {
+		t.Fatalf("error = %v, want %v", err, ErrMigrationTargetInactive)
+	}
+}


### PR DESCRIPTION
Closes #948

This PR was generated by the DripTide AI coder and scoped strictly to issue #948.

### Changes
Added yield-source deactivation and migration workflow support to the vault domain, including deactivation errors, deposit gating, migration guidance, position migration, and tests covering the workflow.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #948` so the Drips Wave bot resolves the issue on merge._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Yield sources can now be deactivated, preventing new deposits.
  * Added migration guidance for moving funds from deactivated sources to active destinations.
  * Added validation for migration amounts, source and target status, and vault capacity.
  * Protocol names are handled consistently regardless of capitalization or surrounding spaces.

* **Tests**
  * Added coverage for deactivation, migration flows, and inactive migration targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->