### PR TITLE
Fix: bug(api): vault position rounding drift over many small deposits (Auto-Generated)

### DIFF
--- a/apps/api/internal/domain/vault/position.go
+++ b/apps/api/internal/domain/vault/position.go
@@ -38,7 +38,10 @@ func ComputeSharePrice(v Vault) decimal.Decimal {
 	if v.TotalDeposited.IsZero() || v.TotalDeposited.Sign() <= 0 {
 		return decimal.NewFromInt(1)
 	}
-	return v.CurrentBalance.Div(v.TotalDeposited).Round(8)
+	// Keep the full decimal precision here. Rounding the share price before it
+	// is multiplied by a user's shares can create material valuation drift for
+	// large positions, especially after many small deposits and harvests.
+	return v.CurrentBalance.Div(v.TotalDeposited)
 }
 
 // BuildUserVaultPosition aggregates user transactions and applies live vault pricing.

--- a/apps/api/internal/domain/vault/position_test.go
+++ b/apps/api/internal/domain/vault/position_test.go
@@ -100,3 +100,62 @@ func TestBuildUserVaultPositionAccountsForWithdrawals(t *testing.T) {
 		t.Fatalf("expected pnl -160 after withdrawal, got %s", position.UnrealizedPnLUSDC)
 	}
 }
+
+func TestBuildUserVaultPositionManySmallDepositsAndHarvestsLimitRoundingDrift(t *testing.T) {
+	const operationCount = 5000
+
+	vaultID := uuid.New()
+	userID := uuid.New()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	oneMillion := decimal.RequireFromString("1000000")
+	depositAmount := decimal.RequireFromString("0.01")
+	harvestAmount := decimal.RequireFromString("0.000001")
+
+	v := Vault{
+		ID:             vaultID,
+		TotalDeposited: oneMillion,
+		CurrentBalance: oneMillion,
+	}
+	initialShares := oneMillion
+	txns := []VaultTransaction{{
+		VaultID:              vaultID,
+		UserID:               &userID,
+		Type:                 "deposit",
+		Amount:               oneMillion,
+		SharesMintedOrBurned: &initialShares,
+		CreatedAt:            at,
+	}}
+	sharesHeld := initialShares
+
+	for i := 1; i <= operationCount; i++ {
+		// Apply a small harvest before each deposit and mint shares at the
+		// unrounded live price used by the ledger.
+		v.CurrentBalance = v.CurrentBalance.Add(harvestAmount)
+		sharePrice := v.CurrentBalance.Div(v.TotalDeposited)
+		shares := depositAmount.Div(sharePrice)
+
+		at = at.Add(time.Minute)
+		txns = append(txns, VaultTransaction{
+			VaultID:              vaultID,
+			UserID:               &userID,
+			Type:                 "deposit",
+			Amount:               depositAmount,
+			SharesMintedOrBurned: &shares,
+			CreatedAt:            at,
+		})
+		sharesHeld = sharesHeld.Add(shares)
+		v.TotalDeposited = v.TotalDeposited.Add(depositAmount)
+		v.CurrentBalance = v.CurrentBalance.Add(depositAmount)
+	}
+
+	position := BuildUserVaultPosition(v, userID, txns)
+	got, err := decimal.NewFromString(position.CurrentValueUSDC)
+	if err != nil {
+		t.Fatalf("parse current value %q: %v", position.CurrentValueUSDC, err)
+	}
+	expected := sharesHeld.Mul(v.CurrentBalance.Div(v.TotalDeposited)).Round(positionDecimalPlaces)
+	epsilon := decimal.RequireFromString("0.000001")
+	if got.Sub(expected).Abs().GreaterThan(epsilon) {
+		t.Fatalf("current value drifted: got %s, expected %s, epsilon %s", got, expected, epsilon)
+	}
+}


### PR DESCRIPTION
Closes #947

This PR was generated by the DripTide AI coder and scoped strictly to issue #947.

### Changes
Removed intermediate rounding from ComputeSharePrice so cumulative position valuation retains the decimal precision of the underlying vault balance and deposits. Added a 5,000-operation regression test covering repeated small deposits and harvests and asserting valuation drift remains within one micro-USDC.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #947` so the Drips Wave bot resolves the issue on merge._