### PR TITLE
feat: tone preferences, explainability trace, goal soft-delete, timezone reminder fix

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -756,6 +756,19 @@ func run() error {
 	defer cancelRecurring()
 	go recurringDepositJob.Run(recurringCtx)
 
+	// Savings goal soft-delete recovery purge (#924): hard-deletes goals
+	// whose deleted_at is older than savingsgoal.SavingsGoalRecoveryWindow.
+	// Runs daily; leader-elected like the other sweep jobs to avoid every
+	// instance racing to purge the same rows.
+	savingsGoalPurgeJob := scheduler.NewSavingsGoalPurgeJob(
+		savingsGoalRepo,
+		baseLogger.WithGroup("savings-goal-purge"),
+	)
+	savingsGoalPurgeJob.SetLeaderChecker(schedulerLeadership)
+	savingsGoalPurgeCtx, cancelSavingsGoalPurge := context.WithCancel(context.Background())
+	defer cancelSavingsGoalPurge()
+	go savingsGoalPurgeJob.Run(savingsGoalPurgeCtx, 24*time.Hour)
+
 	jobWorker := jobqueue.NewWorker(
 		jobQueueRepo,
 		jobqueue.Config{

--- a/apps/api/internal/domain/savingsgoal/model.go
+++ b/apps/api/internal/domain/savingsgoal/model.go
@@ -30,7 +30,19 @@ var (
 	// or below MinTargetAmount (#692). Defined here so handlers don't have to
 	// import the vault domain to classify amount validation failures.
 	ErrInvalidAmount = errors.New("invalid target amount")
+	// ErrGoalNotDeleted is returned by Restore when the goal has no deleted_at
+	// set (#924): nothing to restore.
+	ErrGoalNotDeleted = errors.New("savings goal is not deleted")
+	// ErrRecoveryWindowExpired is returned by Restore when the goal was
+	// deleted more than SavingsGoalRecoveryWindow ago (#924): it may already
+	// have been (or is about to be) permanently purged.
+	ErrRecoveryWindowExpired = errors.New("savings goal recovery window has expired")
 )
+
+// SavingsGoalRecoveryWindow is how long a soft-deleted savings goal (#924)
+// remains restorable via POST /savings-goals/{id}/restore before the
+// scheduled purge job (see internal/scheduler) hard-deletes it permanently.
+const SavingsGoalRecoveryWindow = 30 * 24 * time.Hour
 
 // MinTargetAmount is the smallest meaningful goal target (#692). Values above
 // zero but below this (e.g. 0.000000001) are rejected as no-op goals.
@@ -163,11 +175,11 @@ func isEmojiRange(r rune) bool {
 		(r >= 0x1F900 && r <= 0x1F9FF) || // supplemental symbols
 		(r >= 0x1FA00 && r <= 0x1FA6F) || // chess symbols
 		(r >= 0x1FA70 && r <= 0x1FAFF) || // symbols and pictographs extended
-		(r >= 0x2600 && r <= 0x26FF) ||   // misc symbols
-		(r >= 0x2700 && r <= 0x27BF) ||   // dingbats
-		r == 0xFE0F ||                     // variation selector-16
+		(r >= 0x2600 && r <= 0x26FF) || // misc symbols
+		(r >= 0x2700 && r <= 0x27BF) || // dingbats
+		r == 0xFE0F || // variation selector-16
 		(r >= 0x1F1E0 && r <= 0x1F1FF) || // flags
-		(r >= 0x200D && r <= 0x200D)       // zero-width joiner
+		(r >= 0x200D && r <= 0x200D) // zero-width joiner
 }
 
 func ParseCategory(value string) (GoalCategory, error) {
@@ -188,18 +200,18 @@ func ParseCategory(value string) (GoalCategory, error) {
 }
 
 type SavingsGoal struct {
-	ID            uuid.UUID       `json:"id"`
-	UserID        uuid.UUID       `json:"user_id"`
-	VaultID       *uuid.UUID      `json:"vault_id,omitempty"`
-	TargetAmount  decimal.Decimal `json:"target_amount"`
-	Currency      string          `json:"currency"`
-	Deadline      time.Time       `json:"deadline"`
-	Description   string          `json:"description,omitempty"`
+	ID           uuid.UUID       `json:"id"`
+	UserID       uuid.UUID       `json:"user_id"`
+	VaultID      *uuid.UUID      `json:"vault_id,omitempty"`
+	TargetAmount decimal.Decimal `json:"target_amount"`
+	Currency     string          `json:"currency"`
+	Deadline     time.Time       `json:"deadline"`
+	Description  string          `json:"description,omitempty"`
 	// Name is a user-supplied display label (#738). Defaults to first 50 chars of Description.
-	Name  string `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 	// Emoji is a single Unicode emoji icon (#738).
-	Emoji string `json:"emoji,omitempty"`
-	Category      GoalCategory    `json:"category"`
+	Emoji    string       `json:"emoji,omitempty"`
+	Category GoalCategory `json:"category"`
 	// Icon is an optional icon identifier (e.g. lucide icon name) displayed in the UI.
 	// When blank the UI falls back to the category default via DefaultIconForCategory.
 	Icon string `json:"icon,omitempty"`
@@ -207,42 +219,47 @@ type SavingsGoal struct {
 	// When blank the UI falls back to the category default.
 	Color string `json:"color,omitempty"`
 	// Status is one of "active", "paused", "completed" (#718, #716).
-	Status             string          `json:"status"`
-	CurrentAmount      decimal.Decimal `json:"current_amount"`
-	ProgressPct        float64         `json:"progress_pct"`
-	NotifiedMilestones []int           `json:"-"`
-	DeadlineRemindersSent []int        `json:"-"`
-	CreatedAt          time.Time       `json:"created_at"`
-	UpdatedAt          time.Time       `json:"updated_at"`
+	Status                string          `json:"status"`
+	CurrentAmount         decimal.Decimal `json:"current_amount"`
+	ProgressPct           float64         `json:"progress_pct"`
+	NotifiedMilestones    []int           `json:"-"`
+	DeadlineRemindersSent []int           `json:"-"`
+	CreatedAt             time.Time       `json:"created_at"`
+	UpdatedAt             time.Time       `json:"updated_at"`
 	// Completion fields (#716).
-	CompletedAt     *time.Time `json:"completed_at,omitempty"`
-	CompletionAction string    `json:"completion_action,omitempty"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+	CompletionAction string     `json:"completion_action,omitempty"`
 	// Velocity stats (#714).
-	AvgWeeklyDeposit       decimal.Decimal `json:"avg_weekly_deposit"`
+	AvgWeeklyDeposit        decimal.Decimal `json:"avg_weekly_deposit"`
 	ProjectedDaysToComplete *int            `json:"projected_days_to_completion,omitempty"`
-	OnTrack                bool            `json:"on_track"`
+	OnTrack                 bool            `json:"on_track"`
 	// Sharing fields.
-	ShareToken      *uuid.UUID `json:"share_token,omitempty"`
-	ShareEnabledAt  *time.Time `json:"share_enabled_at,omitempty"`
-	IsShared        bool       `json:"is_shared"`
+	ShareToken     *uuid.UUID `json:"share_token,omitempty"`
+	ShareEnabledAt *time.Time `json:"share_enabled_at,omitempty"`
+	IsShared       bool       `json:"is_shared"`
 	// On-chain linkage (#807). OnchainGoalID is nil until asynchronous
 	// registration against the savings_goal contract succeeds.
-	OnchainGoalID  *string `json:"onchain_goal_id,omitempty"`
-	OnchainStatus  *string `json:"onchain_status,omitempty"`
+	OnchainGoalID *string `json:"onchain_goal_id,omitempty"`
+	OnchainStatus *string `json:"onchain_status,omitempty"`
+	// DeletedAt is set when the user deletes the goal (#924). The goal is
+	// hidden from all normal reads while set, but remains restorable via
+	// Restore until SavingsGoalRecoveryWindow elapses, after which the
+	// scheduled purge job hard-deletes it.
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // SharedGoalView is the read-only public projection of a savings goal exposed
 // via the unauthenticated share link. It deliberately omits user PII.
 type SharedGoalView struct {
-	Name        string          `json:"name"`
-	Emoji       string          `json:"emoji,omitempty"`
-	TargetAmount decimal.Decimal `json:"target_amount"`
-	Currency    string          `json:"currency"`
+	Name          string          `json:"name"`
+	Emoji         string          `json:"emoji,omitempty"`
+	TargetAmount  decimal.Decimal `json:"target_amount"`
+	Currency      string          `json:"currency"`
 	CurrentAmount decimal.Decimal `json:"current_amount"`
-	ProgressPct float64         `json:"progress_pct"`
-	Deadline    time.Time       `json:"deadline"`
-	Category    GoalCategory    `json:"category"`
-	Status      string          `json:"status"`
+	ProgressPct   float64         `json:"progress_pct"`
+	Deadline      time.Time       `json:"deadline"`
+	Category      GoalCategory    `json:"category"`
+	Status        string          `json:"status"`
 }
 
 // GoalDeposit records a single allocation in a multi-goal deposit split (#719).
@@ -295,6 +312,20 @@ type Repository interface {
 	// UpdateOnchainLink persists the result of asynchronously registering the
 	// goal against the savings_goal contract (#807).
 	UpdateOnchainLink(ctx context.Context, goalID uuid.UUID, onchainGoalID, onchainStatus string) error
+	// Restore clears deleted_at, undoing a soft delete (#924). Returns
+	// ErrGoalNotFound if no matching row exists for id/userID at all (deleted
+	// or not); callers should have already validated the recovery window.
+	Restore(ctx context.Context, id, userID uuid.UUID) error
+	// GetByIDIncludingDeleted looks up a goal by ID regardless of its
+	// deleted_at value (#924), so Restore can check the recovery window
+	// against a goal GetByID would otherwise filter out.
+	GetByIDIncludingDeleted(ctx context.Context, id uuid.UUID) (*SavingsGoal, error)
+	// ListDeletedOlderThan returns soft-deleted goals whose deleted_at is
+	// older than cutoff (#924), for the scheduled hard-delete purge job.
+	ListDeletedOlderThan(ctx context.Context, cutoff time.Time) ([]SavingsGoal, error)
+	// HardDelete permanently removes a goal row (#924). Used only by the
+	// recovery-window purge job, never from a user-facing request path.
+	HardDelete(ctx context.Context, id uuid.UUID) error
 }
 
 // categoryIconDefaults maps each GoalCategory to a default icon name and color

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -29,6 +29,7 @@ type SavingsGoalManager interface {
 	ListPaginated(ctx context.Context, userID uuid.UUID, filter service.SavingsGoalListFilter) ([]savingsgoal.SavingsGoal, int, error)
 	Update(ctx context.Context, userID, goalID uuid.UUID, in service.UpdateSavingsGoalInput) (savingsgoal.SavingsGoal, error)
 	Delete(ctx context.Context, userID, goalID uuid.UUID) error
+	Restore(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error)
 	Pause(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
 	Resume(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error)
@@ -77,6 +78,8 @@ func (h *SavingsGoalHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/users/savings-goals/{id}", h.get)
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}", h.update)
 	mux.HandleFunc("DELETE /api/v1/users/savings-goals/{id}", h.delete)
+	// #924 soft-delete recovery
+	mux.HandleFunc("POST /api/v1/users/savings-goals/{id}/restore", h.restore)
 	// #718 pause/resume
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/pause", h.pause)
 	mux.HandleFunc("PATCH /api/v1/users/savings-goals/{id}/resume", h.resume)
@@ -432,6 +435,25 @@ func (h *SavingsGoalHandler) delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// restore undoes a soft delete within the recovery window (#924).
+func (h *SavingsGoalHandler) restore(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+	goalID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("goal id must be a valid UUID"))
+		return
+	}
+	goal, err := h.svc.Restore(r.Context(), userID, goalID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, response.OK(goal))
+}
+
 func (h *SavingsGoalHandler) pause(w http.ResponseWriter, r *http.Request) {
 	userID, ok := h.authenticatedUserID(w, r)
 	if !ok {
@@ -659,6 +681,10 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_PAUSED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrGoalArchived):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_ARCHIVED", err.Error()))
+	case errors.Is(err, savingsgoal.ErrGoalNotDeleted):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "GOAL_NOT_DELETED", err.Error()))
+	case errors.Is(err, savingsgoal.ErrRecoveryWindowExpired):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "RECOVERY_WINDOW_EXPIRED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrUnauthorized):
 		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "vault does not belong to you"))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -162,8 +162,26 @@ func (m *mockSavingsGoalService) Delete(_ context.Context, userID, goalID uuid.U
 	if !ok || g.UserID != userID {
 		return savingsgoal.ErrGoalNotFound
 	}
-	delete(m.goals, goalID)
+	now := time.Now().UTC()
+	g.DeletedAt = &now
+	m.goals[goalID] = g
 	return nil
+}
+
+func (m *mockSavingsGoalService) Restore(_ context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[goalID]
+	if !ok || g.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if g.DeletedAt == nil {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotDeleted
+	}
+	if time.Since(*g.DeletedAt) > savingsgoal.SavingsGoalRecoveryWindow {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrRecoveryWindowExpired
+	}
+	g.DeletedAt = nil
+	m.goals[goalID] = g
+	return g, nil
 }
 
 func (m *mockSavingsGoalService) Summary(_ context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error) {
@@ -341,6 +359,104 @@ func TestSavingsGoalHandler_CRUD(t *testing.T) {
 	defer listResp.Body.Close()
 	if listResp.StatusCode != http.StatusOK {
 		t.Fatalf("list status = %d, want 200", listResp.StatusCode)
+	}
+}
+
+// TestSavingsGoalHandler_DeleteThenRestore covers the #924 soft-delete +
+// restore round trip: DELETE marks the goal deleted, and POST .../restore
+// clears it and returns the goal within the recovery window.
+func TestSavingsGoalHandler_DeleteThenRestore(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: userID},
+	}}
+	h := NewSavingsGoalHandler(svc, nil)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/users/savings-goals/"+goalID.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", resp.StatusCode)
+	}
+	if svc.goals[goalID].DeletedAt == nil {
+		t.Fatalf("expected goal DeletedAt to be set after delete")
+	}
+
+	restoreResp, err := http.Post(server.URL+"/api/v1/users/savings-goals/"+goalID.String()+"/restore", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restoreResp.Body.Close()
+	if restoreResp.StatusCode != http.StatusOK {
+		t.Fatalf("restore status = %d, want 200", restoreResp.StatusCode)
+	}
+	if svc.goals[goalID].DeletedAt != nil {
+		t.Fatalf("expected goal DeletedAt to be cleared after restore")
+	}
+}
+
+// TestSavingsGoalHandler_Restore_ExpiredWindowReturnsConflict covers a
+// restore attempt after SavingsGoalRecoveryWindow has elapsed (#924): the
+// mock service's Restore returns ErrRecoveryWindowExpired, which the handler
+// must map to 409.
+func TestSavingsGoalHandler_Restore_ExpiredWindowReturnsConflict(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	longAgo := time.Now().UTC().Add(-31 * 24 * time.Hour)
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: userID, DeletedAt: &longAgo},
+	}}
+	h := NewSavingsGoalHandler(svc, nil)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/api/v1/users/savings-goals/"+goalID.String()+"/restore", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("restore status = %d, want 409", resp.StatusCode)
+	}
+}
+
+// TestSavingsGoalHandler_Restore_NotDeletedReturnsConflict covers restoring a
+// goal that was never deleted (#924).
+func TestSavingsGoalHandler_Restore_NotDeletedReturnsConflict(t *testing.T) {
+	userID := uuid.New()
+	goalID := uuid.New()
+	svc := &mockSavingsGoalService{goals: map[uuid.UUID]savingsgoal.SavingsGoal{
+		goalID: {ID: goalID, UserID: userID},
+	}}
+	h := NewSavingsGoalHandler(svc, nil)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/api/v1/users/savings-goals/"+goalID.String()+"/restore", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("restore status = %d, want 409", resp.StatusCode)
 	}
 }
 

--- a/apps/api/internal/handler/savings_goal_template_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_template_handler_test.go
@@ -43,6 +43,9 @@ func (m *mockGoalTemplateService) Update(ctx context.Context, userID, goalID uui
 func (m *mockGoalTemplateService) Delete(ctx context.Context, userID, goalID uuid.UUID) error {
 	return nil
 }
+func (m *mockGoalTemplateService) Restore(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	return savingsgoal.SavingsGoal{}, nil
+}
 func (m *mockGoalTemplateService) Summary(ctx context.Context, userID uuid.UUID) (savingsgoal.SavingsGoalsSummary, error) {
 	return savingsgoal.SavingsGoalsSummary{}, nil
 }

--- a/apps/api/internal/repository/postgres/savings_goal_repository.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository.go
@@ -76,8 +76,8 @@ func (r *SavingsGoalRepository) GetByShareToken(ctx context.Context, token uuid.
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
 		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
-		       share_token, share_enabled_at, onchain_goal_id, onchain_status
-		FROM savings_goals WHERE share_token = $1
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
+		FROM savings_goals WHERE share_token = $1 AND deleted_at IS NULL
 	`, token)
 	g, err := scanSavingsGoalWithShare(row)
 	if err != nil {
@@ -94,9 +94,9 @@ func (r *SavingsGoalRepository) ListByUser(ctx context.Context, userID uuid.UUID
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
 		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
-		       share_token, share_enabled_at, onchain_goal_id, onchain_status
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
 		FROM savings_goals
-		WHERE user_id = $1
+		WHERE user_id = $1 AND deleted_at IS NULL
 	`
 	args := []any{userID}
 	if category != "" {
@@ -131,7 +131,28 @@ func (r *SavingsGoalRepository) GetByID(ctx context.Context, id uuid.UUID) (*sav
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
 		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
-		       share_token, share_enabled_at, onchain_goal_id, onchain_status
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
+		FROM savings_goals WHERE id = $1 AND deleted_at IS NULL
+	`, id)
+	g, err := scanSavingsGoalWithShare(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, savingsgoal.ErrGoalNotFound
+		}
+		return nil, err
+	}
+	return &g, nil
+}
+
+// GetByIDIncludingDeleted looks up a goal regardless of deleted_at (#924),
+// so Restore can inspect a soft-deleted goal's deleted_at to enforce the
+// recovery window.
+func (r *SavingsGoalRepository) GetByIDIncludingDeleted(ctx context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
+		       status, completed_at, completion_action, name, emoji,
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
 		FROM savings_goals WHERE id = $1
 	`, id)
 	g, err := scanSavingsGoalWithShare(row)
@@ -149,7 +170,7 @@ func (r *SavingsGoalRepository) Update(ctx context.Context, goal *savingsgoal.Sa
 		UPDATE savings_goals
 		SET target_amount = $1, currency = $2, deadline = $3, description = $4, category = $5,
 		    vault_id = $6, name = $7, emoji = $8, updated_at = NOW()
-		WHERE id = $9 AND user_id = $10
+		WHERE id = $9 AND user_id = $10 AND deleted_at IS NULL
 	`, goal.TargetAmount.String(), goal.Currency, goal.Deadline, nullSQLString(goal.Description),
 		string(goal.Category), nullUUID(goal.VaultID), nullSQLString(goal.Name), nullSQLString(goal.Emoji),
 		goal.ID, goal.UserID)
@@ -163,16 +184,82 @@ func (r *SavingsGoalRepository) Update(ctx context.Context, goal *savingsgoal.Sa
 	return nil
 }
 
-// Delete soft-archives the goal instead of destroying the row (#685): it
-// stamps archived_at and moves the goal to the archived status. Already
-// archived goals are not matched, so a repeat DELETE surfaces as
+// Delete soft-deletes the goal by stamping deleted_at instead of destroying
+// the row (#924). This is distinct from Archive (#684/#685, which flips
+// status to 'archived' via UpdateStatus): a deleted goal is hidden from all
+// normal reads (GetByID/ListByUser/GetByShareToken/ListActiveApproachingDeadline
+// all filter on deleted_at IS NULL) but remains restorable via Restore for
+// SavingsGoalRecoveryWindow, after which the scheduled purge job hard-deletes
+// it. Already-deleted goals are not matched, so a repeat DELETE surfaces as
 // ErrGoalNotFound (404) and no row is ever permanently removed via this path.
 func (r *SavingsGoalRepository) Delete(ctx context.Context, id, userID uuid.UUID) error {
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE savings_goals
-		SET archived_at = NOW(), status = 'archived', updated_at = NOW()
-		WHERE id = $1 AND user_id = $2 AND status <> 'archived'
+		SET deleted_at = NOW(), updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
 	`, id, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+// Restore clears deleted_at, undoing a soft delete (#924). The caller
+// (service layer) is responsible for enforcing the recovery window before
+// calling this — Restore itself only guards against restoring a goal that
+// isn't actually deleted or doesn't belong to userID.
+func (r *SavingsGoalRepository) Restore(ctx context.Context, id, userID uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE savings_goals
+		SET deleted_at = NULL, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NOT NULL
+	`, id, userID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return savingsgoal.ErrGoalNotFound
+	}
+	return nil
+}
+
+// ListDeletedOlderThan returns soft-deleted goals whose deleted_at predates
+// cutoff (#924), for the scheduled purge job to hard-delete.
+func (r *SavingsGoalRepository) ListDeletedOlderThan(ctx context.Context, cutoff time.Time) ([]savingsgoal.SavingsGoal, error) {
+	query := `
+		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
+		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
+		       status, completed_at, completion_action, name, emoji,
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
+		FROM savings_goals
+		WHERE deleted_at IS NOT NULL AND deleted_at < $1
+	`
+	rows, err := r.db.QueryContext(ctx, query, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var goals []savingsgoal.SavingsGoal
+	for rows.Next() {
+		g, err := scanSavingsGoalWithShare(rows)
+		if err != nil {
+			return nil, err
+		}
+		goals = append(goals, g)
+	}
+	return goals, rows.Err()
+}
+
+// HardDelete permanently removes a goal row (#924). Only called by the
+// recovery-window purge job after SavingsGoalRecoveryWindow has elapsed.
+func (r *SavingsGoalRepository) HardDelete(ctx context.Context, id uuid.UUID) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM savings_goals WHERE id = $1 AND deleted_at IS NOT NULL`, id)
 	if err != nil {
 		return err
 	}
@@ -243,9 +330,10 @@ func (r *SavingsGoalRepository) ListActiveApproachingDeadline(ctx context.Contex
 		SELECT id, user_id, vault_id, target_amount, currency, deadline, description, category,
 		       notified_milestones, deadline_reminders_sent, created_at, updated_at,
 		       status, completed_at, completion_action, name, emoji,
-		       share_token, share_enabled_at, onchain_goal_id, onchain_status
+		       share_token, share_enabled_at, onchain_goal_id, onchain_status, deleted_at
 		FROM savings_goals
 		WHERE (status = 'active' OR status IS NULL OR status = '')
+		  AND deleted_at IS NULL
 		  AND deadline BETWEEN NOW() AND NOW() + ($1 || ' days')::INTERVAL
 	`
 	rows, err := r.db.QueryContext(ctx, query, maxDays)
@@ -472,12 +560,13 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 		shareToken                                sql.NullString
 		shareEnabledAt                            sql.NullTime
 		onchainGoalID, onchainStatus              sql.NullString
+		deletedAt                                 sql.NullTime
 	)
 	if err := row.Scan(
 		&id, &userID, &vaultID, &targetStr, &currency, &deadline, &description, &category,
 		&notifiedMilestones, &deadlineReminders, &createdAt, &updatedAt,
 		&status, &completedAt, &completionAction, &name, &emoji,
-		&shareToken, &shareEnabledAt, &onchainGoalID, &onchainStatus,
+		&shareToken, &shareEnabledAt, &onchainGoalID, &onchainStatus, &deletedAt,
 	); err != nil {
 		return savingsgoal.SavingsGoal{}, err
 	}
@@ -530,6 +619,11 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 	if onchainStatus.Valid {
 		onchainStatusPtr = &onchainStatus.String
 	}
+	var deletedAtPtr *time.Time
+	if deletedAt.Valid {
+		t := deletedAt.Time
+		deletedAtPtr = &t
+	}
 	return savingsgoal.SavingsGoal{
 		ID:                    parsedID,
 		UserID:                parsedUserID,
@@ -553,6 +647,7 @@ func scanSavingsGoalWithShare(row savingsGoalScanner) (savingsgoal.SavingsGoal, 
 		IsShared:              shareTokenPtr != nil,
 		OnchainGoalID:         onchainGoalIDPtr,
 		OnchainStatus:         onchainStatusPtr,
+		DeletedAt:             deletedAtPtr,
 	}, nil
 }
 

--- a/apps/api/internal/repository/postgres/savings_goal_repository_test.go
+++ b/apps/api/internal/repository/postgres/savings_goal_repository_test.go
@@ -14,8 +14,8 @@ import (
 
 const softDeleteQuery = `
 		UPDATE savings_goals
-		SET archived_at = NOW(), status = 'archived', updated_at = NOW()
-		WHERE id = $1 AND user_id = $2 AND status <> 'archived'
+		SET deleted_at = NOW(), updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
 	`
 
 func TestSavingsGoalDeleteSoftArchivesRow(t *testing.T) {
@@ -52,7 +52,7 @@ func TestSavingsGoalDeleteAlreadyArchivedReturnsNotFound(t *testing.T) {
 	goalID := uuid.New()
 	userID := uuid.New()
 
-	// The status <> 'archived' guard means an already-archived (or missing)
+	// The deleted_at IS NULL guard means an already-deleted (or missing)
 	// goal matches zero rows.
 	mock.ExpectExec(regexp.QuoteMeta(softDeleteQuery)).
 		WithArgs(goalID, userID).
@@ -61,6 +61,108 @@ func TestSavingsGoalDeleteAlreadyArchivedReturnsNotFound(t *testing.T) {
 	err = repository.Delete(context.Background(), goalID, userID)
 	if !errors.Is(err, savingsgoal.ErrGoalNotFound) {
 		t.Fatalf("Delete() error = %v, want ErrGoalNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+const restoreQuery = `
+		UPDATE savings_goals
+		SET deleted_at = NULL, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2 AND deleted_at IS NOT NULL
+	`
+
+func TestSavingsGoalRestoreClearsDeletedAt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+	userID := uuid.New()
+
+	mock.ExpectExec(regexp.QuoteMeta(restoreQuery)).
+		WithArgs(goalID, userID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repository.Restore(context.Background(), goalID, userID); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSavingsGoalRestoreNotDeletedReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+	userID := uuid.New()
+
+	// The deleted_at IS NOT NULL guard means a goal that was never deleted
+	// (or doesn't exist / isn't owned by userID) matches zero rows.
+	mock.ExpectExec(regexp.QuoteMeta(restoreQuery)).
+		WithArgs(goalID, userID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repository.Restore(context.Background(), goalID, userID)
+	if !errors.Is(err, savingsgoal.ErrGoalNotFound) {
+		t.Fatalf("Restore() error = %v, want ErrGoalNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+const hardDeleteQuery = `DELETE FROM savings_goals WHERE id = $1 AND deleted_at IS NOT NULL`
+
+func TestSavingsGoalHardDeleteRemovesRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+
+	mock.ExpectExec(regexp.QuoteMeta(hardDeleteQuery)).
+		WithArgs(goalID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repository.HardDelete(context.Background(), goalID); err != nil {
+		t.Fatalf("HardDelete() error = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSavingsGoalHardDeleteNotDeletedReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewSavingsGoalRepository(db)
+	goalID := uuid.New()
+
+	mock.ExpectExec(regexp.QuoteMeta(hardDeleteQuery)).
+		WithArgs(goalID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repository.HardDelete(context.Background(), goalID)
+	if !errors.Is(err, savingsgoal.ErrGoalNotFound) {
+		t.Fatalf("HardDelete() error = %v, want ErrGoalNotFound", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)

--- a/apps/api/internal/scheduler/savings_goal_purge.go
+++ b/apps/api/internal/scheduler/savings_goal_purge.go
@@ -1,0 +1,93 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+// SavingsGoalPurgeRepository is the subset of savingsgoal.Repository the
+// purge job needs to find and permanently remove expired soft-deletes (#924).
+type SavingsGoalPurgeRepository interface {
+	ListDeletedOlderThan(ctx context.Context, cutoff time.Time) ([]savingsgoal.SavingsGoal, error)
+	HardDelete(ctx context.Context, id uuid.UUID) error
+}
+
+// SavingsGoalPurgeJob periodically hard-deletes savings goals whose
+// deleted_at is older than savingsgoal.SavingsGoalRecoveryWindow (#924),
+// permanently removing rows the recovery window has expired for. Mirrors
+// GoalCoachingScheduler's tick-on-a-timer shape (see goal_coaching_scheduler.go).
+type SavingsGoalPurgeJob struct {
+	repo   SavingsGoalPurgeRepository
+	logger *slog.Logger
+	clock  func() time.Time
+	leader LeaderChecker
+}
+
+// NewSavingsGoalPurgeJob constructs the purge job. logger may be nil.
+func NewSavingsGoalPurgeJob(repo SavingsGoalPurgeRepository, logger *slog.Logger) *SavingsGoalPurgeJob {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	return &SavingsGoalPurgeJob{
+		repo:   repo,
+		logger: logger,
+		clock:  func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetClock overrides the job's clock (tests only).
+func (j *SavingsGoalPurgeJob) SetClock(clock func() time.Time) { j.clock = clock }
+
+// SetLeaderChecker wires leader election. Not money-moving, but running the
+// sweep from multiple instances is still harmless-but-wasteful, so it's
+// classified the same as the other sweep jobs: a nil checker means "always
+// leader" (single-instance deployments, existing tests).
+func (j *SavingsGoalPurgeJob) SetLeaderChecker(l LeaderChecker) { j.leader = l }
+
+func (j *SavingsGoalPurgeJob) isLeader() bool {
+	return j.leader == nil || j.leader.IsLeader()
+}
+
+// Run ticks every `interval` until ctx is cancelled, purging expired
+// soft-deletes on each tick. A tick also fires once immediately on start.
+func (j *SavingsGoalPurgeJob) Run(ctx context.Context, interval time.Duration) {
+	j.Tick(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			j.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single purge pass. Exported for tests.
+func (j *SavingsGoalPurgeJob) Tick(ctx context.Context) {
+	if j.repo == nil || !j.isLeader() {
+		return
+	}
+
+	cutoff := j.clock().Add(-savingsgoal.SavingsGoalRecoveryWindow)
+	expired, err := j.repo.ListDeletedOlderThan(ctx, cutoff)
+	if err != nil {
+		j.logger.Error("savings goal purge: list expired soft-deletes failed", "error", err.Error())
+		return
+	}
+
+	for _, goal := range expired {
+		if err := j.repo.HardDelete(ctx, goal.ID); err != nil {
+			j.logger.Warn("savings goal purge: hard delete failed", "goal_id", goal.ID.String(), "error", err.Error())
+			continue
+		}
+		j.logger.Info("savings goal purge: hard deleted expired soft-delete", "goal_id", goal.ID.String())
+	}
+}

--- a/apps/api/internal/scheduler/savings_goal_purge_test.go
+++ b/apps/api/internal/scheduler/savings_goal_purge_test.go
@@ -1,0 +1,113 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+)
+
+// fakeSavingsGoalPurgeRepo is an in-memory stand-in for the repository
+// methods SavingsGoalPurgeJob needs, so its tick logic can be exercised
+// without a database (#924).
+type fakeSavingsGoalPurgeRepo struct {
+	goals            []savingsgoal.SavingsGoal
+	hardDeleted      []uuid.UUID
+	listCutoffs      []time.Time
+	hardDeleteErrFor map[uuid.UUID]error
+}
+
+func (f *fakeSavingsGoalPurgeRepo) ListDeletedOlderThan(_ context.Context, cutoff time.Time) ([]savingsgoal.SavingsGoal, error) {
+	f.listCutoffs = append(f.listCutoffs, cutoff)
+	var out []savingsgoal.SavingsGoal
+	for _, g := range f.goals {
+		if g.DeletedAt != nil && g.DeletedAt.Before(cutoff) {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSavingsGoalPurgeRepo) HardDelete(_ context.Context, id uuid.UUID) error {
+	if err, ok := f.hardDeleteErrFor[id]; ok {
+		return err
+	}
+	f.hardDeleted = append(f.hardDeleted, id)
+	return nil
+}
+
+func TestSavingsGoalPurgeJob_HardDeletesExpiredSoftDeletes(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+
+	expiredID := uuid.New()
+	expiredDeletedAt := now.Add(-31 * 24 * time.Hour) // past the 30-day window
+	withinWindowID := uuid.New()
+	withinWindowDeletedAt := now.Add(-5 * 24 * time.Hour) // still recoverable
+	notDeletedID := uuid.New()
+
+	repo := &fakeSavingsGoalPurgeRepo{
+		goals: []savingsgoal.SavingsGoal{
+			{ID: expiredID, DeletedAt: &expiredDeletedAt},
+			{ID: withinWindowID, DeletedAt: &withinWindowDeletedAt},
+			{ID: notDeletedID},
+		},
+	}
+
+	job := NewSavingsGoalPurgeJob(repo, nil)
+	job.SetClock(func() time.Time { return now })
+
+	job.Tick(context.Background())
+
+	if len(repo.hardDeleted) != 1 || repo.hardDeleted[0] != expiredID {
+		t.Fatalf("expected only the expired goal (%s) to be hard-deleted, got %v", expiredID, repo.hardDeleted)
+	}
+}
+
+func TestSavingsGoalPurgeJob_UsesRecoveryWindowAsCutoff(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	repo := &fakeSavingsGoalPurgeRepo{}
+
+	job := NewSavingsGoalPurgeJob(repo, nil)
+	job.SetClock(func() time.Time { return now })
+
+	job.Tick(context.Background())
+
+	if len(repo.listCutoffs) != 1 {
+		t.Fatalf("expected exactly one ListDeletedOlderThan call, got %d", len(repo.listCutoffs))
+	}
+	wantCutoff := now.Add(-savingsgoal.SavingsGoalRecoveryWindow)
+	if !repo.listCutoffs[0].Equal(wantCutoff) {
+		t.Fatalf("cutoff = %v, want %v", repo.listCutoffs[0], wantCutoff)
+	}
+}
+
+// fakePurgeLeaderChecker lets the "not leader" skip path be exercised
+// deterministically, mirroring recurring_deposit_test.go's leadership tests.
+type fakePurgeLeaderChecker struct {
+	leader bool
+}
+
+func (f fakePurgeLeaderChecker) IsLeader() bool { return f.leader }
+
+func TestSavingsGoalPurgeJob_SkipsTickWhenNotLeader(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	expiredID := uuid.New()
+	expiredDeletedAt := now.Add(-31 * 24 * time.Hour)
+
+	repo := &fakeSavingsGoalPurgeRepo{
+		goals: []savingsgoal.SavingsGoal{{ID: expiredID, DeletedAt: &expiredDeletedAt}},
+	}
+
+	job := NewSavingsGoalPurgeJob(repo, nil)
+	job.SetClock(func() time.Time { return now })
+	job.SetLeaderChecker(fakePurgeLeaderChecker{leader: false})
+
+	job.Tick(context.Background())
+
+	if len(repo.hardDeleted) != 0 {
+		t.Fatalf("expected no hard deletes while not leader, got %v", repo.hardDeleted)
+	}
+}

--- a/apps/api/internal/service/nudge_engine_service.go
+++ b/apps/api/internal/service/nudge_engine_service.go
@@ -153,7 +153,13 @@ func (s *NudgeEngineService) evaluate(ctx context.Context, userID uuid.UUID, hin
 		return err
 	}
 
-	dedupKey := fmt.Sprintf("%s-%s-%s", best.Candidate.Type, userID, now.Format("2006-01-02"))
+	// Dedup on the user's local calendar date, not the server's UTC date
+	// (#923): a user whose timezone offset places them ahead of or behind
+	// UTC (e.g. UTC+14 or UTC-11) can have their local calendar day span a
+	// UTC day boundary. Keying on now.UTC()'s date let two scheduler ticks
+	// that fall on the same local day but different UTC days both pass the
+	// dedup check, double-firing the reminder.
+	dedupKey := fmt.Sprintf("%s-%s-%s", best.Candidate.Type, userID, localCalendarDate(now, s.userTimezone(ctx, userID)))
 	if err := s.historyRepo.RecordDispatch(ctx, nudge.DispatchRecord{
 		ID:         uuid.New(),
 		UserID:     userID,
@@ -204,6 +210,32 @@ func (s *NudgeEngineService) gatherCandidates(ctx context.Context, userID uuid.U
 	}
 
 	return candidates
+}
+
+// userTimezone looks up the user's saved IANA timezone (#078_add_user_timezone)
+// for local-date computations. Falls back to "UTC" if the user can't be
+// loaded or hasn't set one, matching the default the users table itself uses.
+func (s *NudgeEngineService) userTimezone(ctx context.Context, userID uuid.UUID) string {
+	if s.userRepo == nil {
+		return "UTC"
+	}
+	u, err := s.userRepo.GetByID(ctx, userID)
+	if err != nil || u == nil || u.Timezone == "" {
+		return "UTC"
+	}
+	return u.Timezone
+}
+
+// localCalendarDate returns now's calendar date (YYYY-MM-DD) in the given
+// IANA timezone. Falls back to UTC if the timezone can't be loaded, so a bad
+// or unknown zone degrades to the old (safe, if imprecise) behavior rather
+// than erroring the whole dispatch.
+func localCalendarDate(now time.Time, timezone string) string {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	return now.In(loc).Format("2006-01-02")
 }
 
 func (s *NudgeEngineService) lastDepositAt(ctx context.Context, userID uuid.UUID) time.Time {

--- a/apps/api/internal/service/nudge_engine_service_test.go
+++ b/apps/api/internal/service/nudge_engine_service_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLocalCalendarDate_CrossesUTCBoundary is a regression test for #923: the
+// deadline reminder dedup key must be derived from the user's local calendar
+// date, not the server's UTC date. A user in a timezone far ahead of (or
+// behind) UTC can have their local day fall on a different calendar date than
+// UTC at the same instant. If the dedup key used UTC's date, two scheduler
+// ticks that occur on the same local calendar day but straddle the UTC day
+// boundary would produce two different dedup keys and double-send the
+// reminder.
+func TestLocalCalendarDate_CrossesUTCBoundary(t *testing.T) {
+	// 23:30 UTC on 2026-07-28 is already 2026-07-29 in Kiritimati (UTC+14).
+	utcMoment := time.Date(2026, 7, 28, 23, 30, 0, 0, time.UTC)
+
+	utcDate := utcMoment.UTC().Format("2006-01-02")
+	localDate := localCalendarDate(utcMoment, "Pacific/Kiritimati")
+
+	if utcDate == localDate {
+		t.Fatalf("expected UTC date (%s) and local Kiritimati date (%s) to differ across the boundary, test setup is invalid", utcDate, localDate)
+	}
+	if localDate != "2026-07-29" {
+		t.Fatalf("expected local date 2026-07-29 for UTC+14 user, got %s", localDate)
+	}
+
+	// A second tick an hour later is still 2026-07-29 UTC, but is now also
+	// 2026-07-29 in Kiritimati -- the two ticks fall on the same local
+	// calendar day and must dedup to the same key.
+	secondTick := utcMoment.Add(90 * time.Minute)
+	if got := localCalendarDate(secondTick, "Pacific/Kiritimati"); got != localDate {
+		t.Fatalf("expected both ticks within the same local calendar day to produce the same dedup date, got %s and %s", localDate, got)
+	}
+}
+
+// TestLocalCalendarDate_NegativeOffsetCrossesBoundary covers the opposite
+// extreme: a user far behind UTC (e.g. UTC-11) whose local day starts later
+// than UTC's, so a tick just after UTC midnight is still "yesterday" locally.
+func TestLocalCalendarDate_NegativeOffsetCrossesBoundary(t *testing.T) {
+	// 00:30 UTC on 2026-07-29 is still 2026-07-28 in Pago Pago (UTC-11).
+	utcMoment := time.Date(2026, 7, 29, 0, 30, 0, 0, time.UTC)
+
+	utcDate := utcMoment.UTC().Format("2006-01-02")
+	localDate := localCalendarDate(utcMoment, "Pacific/Pago_Pago")
+
+	if utcDate == localDate {
+		t.Fatalf("expected UTC date (%s) and local Pago Pago date (%s) to differ across the boundary, test setup is invalid", utcDate, localDate)
+	}
+	if localDate != "2026-07-28" {
+		t.Fatalf("expected local date 2026-07-28 for UTC-11 user, got %s", localDate)
+	}
+}
+
+// TestLocalCalendarDate_UnknownTimezoneFallsBackToUTC ensures a bad/unknown
+// IANA zone name degrades to UTC rather than panicking or erroring the whole
+// dispatch path.
+func TestLocalCalendarDate_UnknownTimezoneFallsBackToUTC(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	got := localCalendarDate(now, "Not/A_Real_Zone")
+	want := now.UTC().Format("2006-01-02")
+	if got != want {
+		t.Fatalf("expected fallback to UTC date %s, got %s", want, got)
+	}
+}

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -419,8 +419,37 @@ func (s *SavingsGoalService) Update(ctx context.Context, userID, goalID uuid.UUI
 	return s.EnrichProgress(ctx, *goal)
 }
 
+// Delete soft-deletes the goal (#924): it stamps deleted_at rather than
+// destroying the row, leaving a SavingsGoalRecoveryWindow-long window during
+// which Restore can undo it before the scheduled purge job hard-deletes it.
 func (s *SavingsGoalService) Delete(ctx context.Context, userID, goalID uuid.UUID) error {
 	return s.repo.Delete(ctx, goalID, userID)
+}
+
+// Restore undoes a soft delete (#924), provided the goal was deleted less
+// than SavingsGoalRecoveryWindow ago. Returns ErrGoalNotFound if the goal
+// doesn't exist or isn't owned by userID, ErrGoalNotDeleted if it was never
+// deleted, and ErrRecoveryWindowExpired once the window has elapsed (the
+// goal may already be gone, or about to be purged).
+func (s *SavingsGoalService) Restore(ctx context.Context, userID, goalID uuid.UUID) (savingsgoal.SavingsGoal, error) {
+	goal, err := s.repo.GetByIDIncludingDeleted(ctx, goalID)
+	if err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	if goal.UserID != userID {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotFound
+	}
+	if goal.DeletedAt == nil {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrGoalNotDeleted
+	}
+	if time.Since(*goal.DeletedAt) > savingsgoal.SavingsGoalRecoveryWindow {
+		return savingsgoal.SavingsGoal{}, savingsgoal.ErrRecoveryWindowExpired
+	}
+	if err := s.repo.Restore(ctx, goalID, userID); err != nil {
+		return savingsgoal.SavingsGoal{}, err
+	}
+	goal.DeletedAt = nil
+	return s.EnrichProgress(ctx, *goal)
 }
 
 func (s *SavingsGoalService) ListContributions(ctx context.Context, userID, goalID uuid.UUID, params listquery.PageParams) ([]savingsgoal.GoalContribution, int, string, error) {

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -51,6 +51,9 @@ func (m *memorySavingsGoalRepo) ListByUser(_ context.Context, userID uuid.UUID, 
 		if g.UserID != userID {
 			continue
 		}
+		if g.DeletedAt != nil {
+			continue
+		}
 		if category != "" && string(g.Category) != category {
 			continue
 		}
@@ -64,7 +67,7 @@ func (m *memorySavingsGoalRepo) ListByUser(_ context.Context, userID uuid.UUID, 
 
 func (m *memorySavingsGoalRepo) GetByID(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	g, ok := m.goals[id]
-	if !ok {
+	if !ok || g.DeletedAt != nil {
 		return nil, savingsgoal.ErrGoalNotFound
 	}
 	return &g, nil
@@ -80,7 +83,46 @@ func (m *memorySavingsGoalRepo) Update(_ context.Context, goal *savingsgoal.Savi
 
 func (m *memorySavingsGoalRepo) Delete(_ context.Context, id, userID uuid.UUID) error {
 	g, ok := m.goals[id]
-	if !ok || g.UserID != userID {
+	if !ok || g.UserID != userID || g.DeletedAt != nil {
+		return savingsgoal.ErrGoalNotFound
+	}
+	now := time.Now().UTC()
+	g.DeletedAt = &now
+	m.goals[id] = g
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) Restore(_ context.Context, id, userID uuid.UUID) error {
+	g, ok := m.goals[id]
+	if !ok || g.UserID != userID || g.DeletedAt == nil {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.DeletedAt = nil
+	m.goals[id] = g
+	return nil
+}
+
+func (m *memorySavingsGoalRepo) GetByIDIncludingDeleted(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	g, ok := m.goals[id]
+	if !ok {
+		return nil, savingsgoal.ErrGoalNotFound
+	}
+	return &g, nil
+}
+
+func (m *memorySavingsGoalRepo) ListDeletedOlderThan(_ context.Context, cutoff time.Time) ([]savingsgoal.SavingsGoal, error) {
+	var out []savingsgoal.SavingsGoal
+	for _, g := range m.goals {
+		if g.DeletedAt != nil && g.DeletedAt.Before(cutoff) {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+func (m *memorySavingsGoalRepo) HardDelete(_ context.Context, id uuid.UUID) error {
+	g, ok := m.goals[id]
+	if !ok || g.DeletedAt == nil {
 		return savingsgoal.ErrGoalNotFound
 	}
 	delete(m.goals, id)
@@ -1463,5 +1505,162 @@ func TestSavingsGoalService_Update_RejectsOverlongName(t *testing.T) {
 	_, err = svc.Update(ctx, userID, goal.ID, UpdateSavingsGoalInput{Name: &long})
 	if !errors.Is(err, savingsgoal.ErrInvalidGoal) {
 		t.Fatalf("Update(101-char name) error = %v, want ErrInvalidGoal", err)
+	}
+}
+
+// TestSavingsGoalService_Delete_HidesGoalFromReads covers the #924
+// soft-delete: after Delete, GetByID/ListByUser must no longer surface the
+// goal (deleted_at IS NULL filtering), even though the row still exists.
+func TestSavingsGoalService_Delete_HidesGoalFromReads(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := svc.Delete(ctx, userID, goal.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if _, err := svc.Get(ctx, userID, goal.ID); !errors.Is(err, savingsgoal.ErrGoalNotFound) {
+		t.Fatalf("Get() after delete error = %v, want ErrGoalNotFound", err)
+	}
+
+	goals, err := svc.List(ctx, userID, "", "", false)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	for _, g := range goals {
+		if g.ID == goal.ID {
+			t.Fatalf("expected deleted goal %s to be excluded from List()", goal.ID)
+		}
+	}
+}
+
+// TestSavingsGoalService_Restore_WithinWindowUndeletesGoal covers restoring a
+// goal deleted less than SavingsGoalRecoveryWindow ago (#924).
+func TestSavingsGoalService_Restore_WithinWindowUndeletesGoal(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := svc.Delete(ctx, userID, goal.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	restored, err := svc.Restore(ctx, userID, goal.ID)
+	if err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+	if restored.DeletedAt != nil {
+		t.Fatalf("expected restored goal DeletedAt to be nil, got %v", restored.DeletedAt)
+	}
+
+	if _, err := svc.Get(ctx, userID, goal.ID); err != nil {
+		t.Fatalf("Get() after restore error = %v, want nil", err)
+	}
+}
+
+// TestSavingsGoalService_Restore_AfterWindowReturnsExpiredError covers
+// attempting to restore a goal deleted more than SavingsGoalRecoveryWindow
+// ago (#924): Restore must refuse, not silently undelete it.
+func TestSavingsGoalService_Restore_AfterWindowReturnsExpiredError(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := svc.Delete(ctx, userID, goal.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Back-date deleted_at past the recovery window directly in the fake repo.
+	g := repo.goals[goal.ID]
+	expired := time.Now().UTC().Add(-(savingsgoal.SavingsGoalRecoveryWindow + time.Hour))
+	g.DeletedAt = &expired
+	repo.goals[goal.ID] = g
+
+	_, err = svc.Restore(ctx, userID, goal.ID)
+	if !errors.Is(err, savingsgoal.ErrRecoveryWindowExpired) {
+		t.Fatalf("Restore() after window error = %v, want ErrRecoveryWindowExpired", err)
+	}
+}
+
+// TestSavingsGoalService_Restore_NeverDeletedReturnsNotDeletedError covers
+// calling Restore on a goal that was never soft-deleted (#924).
+func TestSavingsGoalService_Restore_NeverDeletedReturnsNotDeletedError(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	_, err = svc.Restore(ctx, userID, goal.ID)
+	if !errors.Is(err, savingsgoal.ErrGoalNotDeleted) {
+		t.Fatalf("Restore() on non-deleted goal error = %v, want ErrGoalNotDeleted", err)
+	}
+}
+
+// TestSavingsGoalService_Restore_WrongUserReturnsNotFound ensures Restore
+// doesn't leak/act on another user's deleted goal (#924).
+func TestSavingsGoalService_Restore_WrongUserReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	repo := newMemorySavingsGoalRepo()
+	svc := NewSavingsGoalService(repo, nil, nil)
+
+	goal, err := svc.Create(ctx, userID, CreateSavingsGoalInput{
+		TargetAmount: decimal.NewFromInt(1000),
+		Currency:     "USDC",
+		Deadline:     testDeadline(),
+		Name:         "Emergency fund",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := svc.Delete(ctx, userID, goal.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if _, err := svc.Restore(ctx, otherUserID, goal.ID); !errors.Is(err, savingsgoal.ErrGoalNotFound) {
+		t.Fatalf("Restore() by wrong user error = %v, want ErrGoalNotFound", err)
 	}
 }

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -113,6 +113,14 @@ func (m *memoryGoalRepo) GetByID(_ context.Context, id uuid.UUID) (*savingsgoal.
 }
 func (m *memoryGoalRepo) Update(context.Context, *savingsgoal.SavingsGoal) error { return nil }
 func (m *memoryGoalRepo) Delete(context.Context, uuid.UUID, uuid.UUID) error     { return nil }
+func (m *memoryGoalRepo) Restore(context.Context, uuid.UUID, uuid.UUID) error    { return nil }
+func (m *memoryGoalRepo) GetByIDIncludingDeleted(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	return m.GetByID(context.Background(), id)
+}
+func (m *memoryGoalRepo) ListDeletedOlderThan(context.Context, time.Time) ([]savingsgoal.SavingsGoal, error) {
+	return nil, nil
+}
+func (m *memoryGoalRepo) HardDelete(context.Context, uuid.UUID) error { return nil }
 func (m *memoryGoalRepo) SumVaultBalance(context.Context, uuid.UUID, string) (decimal.Decimal, error) {
 	return decimal.Zero, nil
 }

--- a/apps/api/migrations/081_add_savings_goal_soft_delete.down.sql
+++ b/apps/api/migrations/081_add_savings_goal_soft_delete.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_savings_goals_deleted_at;
+
+ALTER TABLE savings_goals
+    DROP COLUMN IF EXISTS deleted_at;

--- a/apps/api/migrations/081_add_savings_goal_soft_delete.up.sql
+++ b/apps/api/migrations/081_add_savings_goal_soft_delete.up.sql
@@ -1,0 +1,10 @@
+-- #924: real soft-delete for savings goals with a 30-day recovery window.
+-- deleted_at is distinct from the existing archived_at/status='archived'
+-- pair (#685, #684): archiving is a user-visible lifecycle state the user
+-- can toggle back and forth, while deleted_at marks a goal the user deleted
+-- and hides it from all normal reads until either restored or permanently
+-- purged by the recovery-window scheduler.
+ALTER TABLE savings_goals
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_savings_goals_deleted_at ON savings_goals(deleted_at) WHERE deleted_at IS NOT NULL;

--- a/apps/intelligence/app/models/explainability.py
+++ b/apps/intelligence/app/models/explainability.py
@@ -1,0 +1,36 @@
+"""Pydantic models for AI explainability traces (#925).
+
+An `ExplainabilityTrace` is a structured record of what informed an
+AI-suggested action or answer: which retrieved data sections were used,
+which tools were invoked (and with what outcome), and a short human-readable
+summary of the reasoning. It is built alongside a chat response so a user (or
+an auditor) can see why Prometheus said what it said, without inspecting raw
+logs.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DocumentUsed(BaseModel):
+    """One retrieved, user-scoped data section that informed the response."""
+
+    source: str
+    detail: str
+
+
+class ToolInvocation(BaseModel):
+    """One tool call made while producing the response."""
+
+    tool_name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    status: str  # "executed" | "proposed" | "failed" | "rejected"
+
+
+class ExplainabilityTrace(BaseModel):
+    """Structured explanation of what informed an AI-suggested action or answer."""
+
+    documents_used: list[DocumentUsed] = Field(default_factory=list)
+    tools_invoked: list[ToolInvocation] = Field(default_factory=list)
+    reasoning_summary: str = ""

--- a/apps/intelligence/app/models/preferences.py
+++ b/apps/intelligence/app/models/preferences.py
@@ -1,0 +1,27 @@
+"""Pydantic models for per-user AI response tone/style preferences (#927).
+
+Prometheus lets a user choose how it talks to them: how long answers are
+(concise vs detailed) and how formal the voice is (casual vs formal). These
+are threaded into system-prompt construction in `app.services.claude` so the
+same underlying facts get reworded to match the user's taste, without
+changing the grounding/scope rules in the base system prompt.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+ResponseLength = Literal["concise", "detailed"]
+ResponseTone = Literal["casual", "formal"]
+
+
+class ResponsePreferences(BaseModel):
+    """A user's saved preference for how Prometheus should style its replies.
+
+    Defaults match Prometheus's existing baseline voice (warm/casual, and
+    reasoned/detailed answers per the base SYSTEM_PROMPT), so a user with no
+    preference on file sees no behavior change.
+    """
+
+    response_length: ResponseLength = "detailed"
+    response_tone: ResponseTone = "casual"

--- a/apps/intelligence/app/routers/ws_chat.py
+++ b/apps/intelligence/app/routers/ws_chat.py
@@ -7,6 +7,7 @@ import jwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from app.config import settings
+from app.models.preferences import ResponsePreferences
 from app.services import guardrails
 from app.services.prometheus import stream_chat
 
@@ -79,7 +80,17 @@ async def websocket_chat(websocket: WebSocket) -> None:
                 continue
 
             request_id = str(uuid.uuid4())
-            async for chunk in stream_chat(user_id, message, request_id=request_id):
+            raw_preferences = data.get("preferences")
+            preferences: Optional[ResponsePreferences] = None
+            if isinstance(raw_preferences, dict):
+                try:
+                    preferences = ResponsePreferences(**raw_preferences)
+                except Exception:
+                    preferences = None
+
+            async for chunk in stream_chat(
+                user_id, message, request_id=request_id, preferences=preferences
+            ):
                 # Strip SSE "data: " prefix — WS clients get raw text
                 if chunk.startswith("data: "):
                     chunk = chunk[6:].rstrip("\n")

--- a/apps/intelligence/app/services/claude.py
+++ b/apps/intelligence/app/services/claude.py
@@ -1,5 +1,72 @@
+"""Claude client and per-user tone/style prompt helpers (#927).
+
+Prometheus's base persona and scope rules live in
+`app.services.prometheus.SYSTEM_PROMPT`. This module builds an additional,
+optional instruction block from a user's saved `ResponsePreferences` (response
+length and tone) and appends it to a system prompt, so the same underlying
+facts get reworded to match the user's taste without touching the base
+persona, grounding, or trust-boundary rules.
+"""
+
 import anthropic
 
 from app.config import settings
+from app.models.preferences import ResponsePreferences
 
 client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+
+
+_LENGTH_INSTRUCTIONS: dict[str, str] = {
+    "concise": (
+        "Keep answers short: 1-3 sentences where possible, no more than one "
+        "short paragraph. Skip preamble and get straight to the point."
+    ),
+    "detailed": (
+        "Give thorough answers: explain the reasoning behind a recommendation "
+        "and any relevant context, using multiple short paragraphs when useful."
+    ),
+}
+
+_TONE_INSTRUCTIONS: dict[str, str] = {
+    "casual": (
+        "Use a warm, casual, conversational tone, like a knowledgeable friend. "
+        "Contractions are fine."
+    ),
+    "formal": (
+        "Use a professional, formal tone. Avoid slang and contractions, and "
+        "write in complete, precise sentences."
+    ),
+}
+
+
+def build_tone_instructions(preferences: ResponsePreferences | None) -> str:
+    """Render a preferences-driven instruction block for the system prompt.
+
+    Returns an empty string when no preferences are supplied, so callers with
+    no preference on file get the base prompt unchanged.
+    """
+    if preferences is None:
+        return ""
+
+    length_line = _LENGTH_INSTRUCTIONS.get(
+        preferences.response_length, _LENGTH_INSTRUCTIONS["detailed"]
+    )
+    tone_line = _TONE_INSTRUCTIONS.get(
+        preferences.response_tone, _TONE_INSTRUCTIONS["casual"]
+    )
+    return (
+        "\n\n## User tone preference (applies to this response only)\n"
+        f"- Length: {length_line}\n"
+        f"- Tone: {tone_line}"
+    )
+
+
+def apply_tone_preferences(
+    system_prompt: str, preferences: ResponsePreferences | None
+) -> str:
+    """Append the user's tone/length preference instructions to a system prompt.
+
+    A no-op (returns `system_prompt` unchanged) when `preferences` is None.
+    """
+    block = build_tone_instructions(preferences)
+    return system_prompt + block if block else system_prompt

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -12,7 +12,9 @@ import anthropic
 
 from app.config import settings
 from app.models.coaching import CoachingRequest, CoachingResponse
+from app.models.explainability import DocumentUsed, ExplainabilityTrace, ToolInvocation
 from app.models.nudge import NudgeCopyResponse
+from app.models.preferences import ResponsePreferences
 from app.models.portfolio import (
     AllocationItem,
     PortfolioAnalysisResponse,
@@ -26,11 +28,12 @@ from app.models.recommendation import (
     VaultRecommendationResponse,
 )
 from app.services import guardrails
+from app.services.claude import apply_tone_preferences
 from app.services.coingecko import get_client as get_coingecko_client
 from app.services.conversation_store import store as conversation_store
 from app.services.defillama import get_client as get_defillama_client
 from app.services.grounding import build_grounded_system_prompt, validate_grounding
-from app.services.retrieval import RetrievalService
+from app.services.retrieval import RetrievalService, RetrievedContext
 from app.services.retrieval_source import ApiDataSource
 from app.services.vault_context import VaultContextFetcher
 
@@ -318,8 +321,45 @@ def _to_anthropic_messages(
 # ---------------------------------------------------------------------------
 
 
+def build_explainability_trace(
+    retrieved: RetrievedContext,
+    tool_invocations: list[ToolInvocation],
+) -> ExplainabilityTrace:
+    """Build a structured explanation of what informed a chat response (#925).
+
+    `retrieved` supplies the retrieval citations (documents used); recording
+    them here, rather than re-deriving them, keeps the trace consistent with
+    what actually grounded the answer per `grounding.build_grounded_system_prompt`.
+    `tool_invocations` is the ordered list of tool calls made this turn.
+    """
+    documents_used = [
+        DocumentUsed(source=c.source, detail=c.detail) for c in retrieved.citations
+    ]
+
+    if documents_used:
+        reasoning_summary = "Answer grounded in: " + "; ".join(
+            f"{d.source} ({d.detail})" for d in documents_used
+        )
+    else:
+        reasoning_summary = "No user-scoped data was retrieved for this query."
+
+    if tool_invocations:
+        reasoning_summary += " Tools used: " + ", ".join(
+            f"{t.tool_name} ({t.status})" for t in tool_invocations
+        )
+
+    return ExplainabilityTrace(
+        documents_used=documents_used,
+        tools_invoked=tool_invocations,
+        reasoning_summary=reasoning_summary,
+    )
+
+
 async def stream_chat(
-    user_id: str, message: str, request_id: str = ""
+    user_id: str,
+    message: str,
+    request_id: str = "",
+    preferences: ResponsePreferences | None = None,
 ) -> AsyncIterator[str]:
     """Yield SSE-formatted data strings for a streaming Claude response.
 
@@ -354,6 +394,14 @@ async def stream_chat(
     retrieval_service = get_retrieval_service()
     retrieved = await retrieval_service.retrieve(user_id, message)
     dynamic_system_prompt = build_grounded_system_prompt(SYSTEM_PROMPT, retrieved)
+    # Per-user tone/length preference (#927): rewords the same grounded facts
+    # to match the user's saved taste, without altering the persona, scope,
+    # or grounding rules above.
+    dynamic_system_prompt = apply_tone_preferences(dynamic_system_prompt, preferences)
+
+    # Explainability trace (#925): built alongside the response so a user or
+    # auditor can see what informed it, independent of whether tools are used.
+    tool_invocations: list[ToolInvocation] = []
 
     messages: list[anthropic.types.MessageParam] = (
         _to_anthropic_messages(history)
@@ -512,6 +560,13 @@ async def stream_chat(
                                         status="executed",
                                         result=res,
                                     )
+                                    tool_invocations.append(
+                                        ToolInvocation(
+                                            tool_name=tool.name,
+                                            arguments=args.model_dump(mode="json"),
+                                            status="executed",
+                                        )
+                                    )
                                     wrapped = guardrails.wrap_context_block(
                                         f"{tool.name}_result", json.dumps(res)
                                     )
@@ -530,6 +585,13 @@ async def stream_chat(
                                         consequential=False,
                                         status="failed",
                                         error_message=str(e),
+                                    )
+                                    tool_invocations.append(
+                                        ToolInvocation(
+                                            tool_name=tool.name,
+                                            arguments=args.model_dump(mode="json"),
+                                            status="failed",
+                                        )
                                     )
                                     tool_results.append({
                                         "type": "tool_result",
@@ -567,6 +629,13 @@ async def stream_chat(
                                     consequential=True,
                                     status="proposed",
                                 )
+                                tool_invocations.append(
+                                    ToolInvocation(
+                                        tool_name=tool.name,
+                                        arguments=args.model_dump(mode="json"),
+                                        status="proposed",
+                                    )
+                                )
 
                                 r = _get_redis()
                                 if r:
@@ -582,6 +651,10 @@ async def stream_chat(
                                 }
                                 pending_payload = json.dumps(pending_evt)
                                 yield f"event: pending_confirmation\ndata: {pending_payload}\n\n"
+                                trace = build_explainability_trace(retrieved, tool_invocations)
+                                yield (
+                                    f"event: explainability\ndata: {trace.model_dump_json()}\n\n"
+                                )
                                 yield "data: [DONE]\n\n"
                                 return
 
@@ -607,6 +680,8 @@ async def stream_chat(
                             user_id,
                             unsupported,
                         )
+                    trace = build_explainability_trace(retrieved, tool_invocations)
+                    yield f"event: explainability\ndata: {trace.model_dump_json()}\n\n"
                     yield "data: [DONE]\n\n"
                     return
 

--- a/apps/intelligence/tests/test_claude_tone_preferences.py
+++ b/apps/intelligence/tests/test_claude_tone_preferences.py
@@ -1,0 +1,66 @@
+"""Tests for per-user AI response tone/style preferences (#927)."""
+
+from app.models.preferences import ResponsePreferences
+from app.services.claude import apply_tone_preferences, build_tone_instructions
+
+
+def test_build_tone_instructions_none_is_empty() -> None:
+    assert build_tone_instructions(None) == ""
+
+
+def test_apply_tone_preferences_none_is_noop() -> None:
+    base = "BASE PROMPT"
+    assert apply_tone_preferences(base, None) == base
+
+
+def test_default_preferences_produce_detailed_casual_instructions() -> None:
+    prefs = ResponsePreferences()
+    assert prefs.response_length == "detailed"
+    assert prefs.response_tone == "casual"
+
+    block = build_tone_instructions(prefs)
+    assert "thorough" in block.lower()
+    assert "casual" in block.lower()
+
+
+def test_concise_preference_differs_from_detailed() -> None:
+    concise = build_tone_instructions(
+        ResponsePreferences(response_length="concise", response_tone="casual")
+    )
+    detailed = build_tone_instructions(
+        ResponsePreferences(response_length="detailed", response_tone="casual")
+    )
+    assert concise != detailed
+    assert "short" in concise.lower()
+    assert "thorough" in detailed.lower()
+
+
+def test_formal_preference_differs_from_casual() -> None:
+    formal = build_tone_instructions(
+        ResponsePreferences(response_length="concise", response_tone="formal")
+    )
+    casual = build_tone_instructions(
+        ResponsePreferences(response_length="concise", response_tone="casual")
+    )
+    assert formal != casual
+    assert "professional" in formal.lower()
+    assert "warm" in casual.lower()
+
+
+def test_apply_tone_preferences_appends_to_base_prompt() -> None:
+    base = "You are Prometheus."
+    prefs = ResponsePreferences(response_length="concise", response_tone="formal")
+    result = apply_tone_preferences(base, prefs)
+    assert result.startswith(base)
+    assert "concise" not in result.lower() or "short" in result.lower()
+    assert "professional" in result.lower()
+
+
+def test_all_four_combinations_are_distinct() -> None:
+    combos = [
+        ResponsePreferences(response_length=length, response_tone=tone)
+        for length in ("concise", "detailed")
+        for tone in ("casual", "formal")
+    ]
+    blocks = {build_tone_instructions(p) for p in combos}
+    assert len(blocks) == 4

--- a/apps/intelligence/tests/test_explainability.py
+++ b/apps/intelligence/tests/test_explainability.py
@@ -1,0 +1,69 @@
+"""Tests for the Prometheus explainability trace (#925)."""
+
+from app.models.explainability import DocumentUsed, ExplainabilityTrace, ToolInvocation
+from app.services.prometheus import build_explainability_trace
+from app.services.retrieval import Citation, RetrievedContext
+
+
+def test_trace_with_no_documents_or_tools() -> None:
+    ctx = RetrievedContext()
+    trace = build_explainability_trace(ctx, [])
+
+    assert isinstance(trace, ExplainabilityTrace)
+    assert trace.documents_used == []
+    assert trace.tools_invoked == []
+    assert "no user-scoped data" in trace.reasoning_summary.lower()
+
+
+def test_trace_includes_retrieval_citations_as_documents_used() -> None:
+    ctx = RetrievedContext(
+        sections=["### Your Vaults\n- Balanced: $100 balance"],
+        citations=[Citation(source="positions", detail="1 active vault(s) on your account")],
+    )
+    trace = build_explainability_trace(ctx, [])
+
+    assert len(trace.documents_used) == 1
+    doc = trace.documents_used[0]
+    assert isinstance(doc, DocumentUsed)
+    assert doc.source == "positions"
+    assert doc.detail == "1 active vault(s) on your account"
+    assert "positions" in trace.reasoning_summary
+
+
+def test_trace_includes_tool_invocations() -> None:
+    ctx = RetrievedContext()
+    invocations = [
+        ToolInvocation(tool_name="get_vault_apy", arguments={"vault_id": "v1"}, status="executed"),
+    ]
+    trace = build_explainability_trace(ctx, invocations)
+
+    assert trace.tools_invoked == invocations
+    assert "get_vault_apy" in trace.reasoning_summary
+    assert "executed" in trace.reasoning_summary
+
+
+def test_trace_combines_documents_and_tools_in_summary() -> None:
+    ctx = RetrievedContext(
+        sections=["### Your Savings Goals\n- Car: 100/1000 saved (10% complete)"],
+        citations=[Citation(source="goals", detail="1 savings goal(s)")],
+    )
+    invocations = [
+        ToolInvocation(tool_name="propose_rebalance", arguments={}, status="proposed"),
+    ]
+    trace = build_explainability_trace(ctx, invocations)
+
+    assert len(trace.documents_used) == 1
+    assert len(trace.tools_invoked) == 1
+    assert "goals" in trace.reasoning_summary
+    assert "propose_rebalance" in trace.reasoning_summary
+
+
+def test_explainability_trace_serializes_to_json() -> None:
+    trace = ExplainabilityTrace(
+        documents_used=[DocumentUsed(source="positions", detail="1 vault")],
+        tools_invoked=[ToolInvocation(tool_name="t", arguments={"a": 1}, status="executed")],
+        reasoning_summary="test",
+    )
+    payload = trace.model_dump_json()
+    assert "positions" in payload
+    assert "t" in payload


### PR DESCRIPTION
- **#927** — Added per-user AI response tone/style preference (`response_length`: concise/detailed, `response_tone`: casual/formal) threaded into system prompt construction in `apps/intelligence/app/services/claude.py`.
- **#925** — Added a structured explainability trace (documents used, tools invoked, reasoning summary) returned alongside chat responses in `apps/intelligence/app/services/prometheus.py`, built from the existing tool-use (#858) and RAG grounding (#852) data.
- **#924** — Added soft-delete with a 30-day recovery window for savings goals: `deleted_at` column + migration, restore endpoint, reads filter out soft-deleted goals, and a scheduled job hard-deletes goals past the recovery window.
- **#923** — Fixed duplicate deadline reminder sends across timezones: the dedup key in `nudge_engine_service.go` was keyed on server UTC date instead of the user's local calendar date, so users near a UTC day boundary (e.g. UTC+14, UTC-11) could get double-fired. Now keyed on local date derived from the user's saved timezone.

## Test plan
- [x] `apps/intelligence`: `python -m pytest` — 224 passed (includes new tests for #927, #925)
- [x] `apps/api`: `go build ./... && go vet ./... && go test ./...` — all pass, including new repository/service/handler/scheduler tests for #924 and new timezone regression tests for #923 (UTC+14 Pacific/Kiritimati, UTC-11 Pacific/Pago_Pago, unknown-timezone fallback)
- Pre-existing failures: none observed; nothing out of scope was skipped.

Closes #927
Closes #925
Closes #924
Closes #923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Savings goals can now be restored within the recovery window after deletion; expired deleted goals are permanently purged.
  * AI chat supports concise/detailed and casual/formal response preferences.
  * Chat responses now include explainability details covering referenced information and tool activity.
* **Bug Fixes**
  * Reminder deduplication now respects each user’s local calendar date, improving behavior across time zones.
* **Tests**
  * Added coverage for savings goal recovery, AI preferences, explainability, and time-zone edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->