### PR TITLE
fix(dev): wire seed.sql into make dev and make it re-runnable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,17 @@ services:
       retries: 5
       start_period: 15s
 
+  seed:
+    image: postgres:16-alpine
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: nester_dev_password
+    volumes:
+      - ./scripts/seed.sql:/seed.sql:ro
+    command: ["psql", "-h", "postgres", "-U", "nester", "-d", "nester_dev", "-v", "ON_ERROR_STOP=1", "-f", "/seed.sql"]
+
   frontend:
     build:
       context: ./apps/dapp/frontend

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -101,7 +101,8 @@ INSERT INTO vaults (id, user_id, contract_address, total_deposited, current_bala
     ('550e8400-e29b-41d4-a716-446655440011',
      '550e8400-e29b-41d4-a716-446655440001',
      'CCLQBFQKIIASLN7MXDQFAUXHQXPKR5ZVGKIMKNBZMKWL4LNKQXQXQAB',
-     5000.00, 5150.25, 'USDC', 'active');
+     5000.00, 5150.25, 'USDC', 'active')
+ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO allocations (id, vault_id, protocol, amount, apy, allocated_at) VALUES
     ('550e8400-e29b-41d4-a716-446655440020',
@@ -112,7 +113,8 @@ INSERT INTO allocations (id, vault_id, protocol, amount, apy, allocated_at) VALU
      'Aave', 4000.00, 7.2500, NOW()),
     ('550e8400-e29b-41d4-a716-446655440022',
      '550e8400-e29b-41d4-a716-446655440011',
-     'Compound', 5000.00, 6.8000, NOW());
+     'Compound', 5000.00, 6.8000, NOW())
+ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO settlements (
     id, user_id, vault_id, amount, currency, fiat_currency, fiat_amount,
@@ -141,4 +143,5 @@ INSERT INTO settlements (
      200.00, 'USDC', 'NGN', 330000.00, 1650.00,
      'bank_transfer', 'paystack', '9876543210', 'Test User', '058',
      'fiat_dispatched',
-     NOW() - INTERVAL '1 hour', NULL);
+     NOW() - INTERVAL '1 hour', NULL)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

Closes #608.

Investigation found the `users` INSERT in `scripts/seed.sql` **already** matches the post-007 schema — `wallet_address`, `display_name`, `kyc_status`, no `email`/`name` — and already grants the test user an `admin` row in `user_roles`. Diffed byte-for-byte against `Suncrest-Labs/nester`'s current `dev` branch to confirm: identical.

What's actually broken is that `docker-compose.yml`/`Makefile` never execute `scripts/seed.sql` at all — the README claims the database is "seeded automatically," but nothing wires it in, so a fresh `make dev` never gets any seed data despite the file itself being correct.

## Changes

- **`docker-compose.yml`**: add a one-shot `seed` service (`postgres:16-alpine` + `psql`) that runs `scripts/seed.sql` against the dev database once the `api` service reports healthy (which only happens after its auto-migrations complete), so seeding always runs against the final post-migration schema.
- **`scripts/seed.sql`**: add `ON CONFLICT (id) DO NOTHING` to the `vaults`, `allocations`, and `settlements` INSERTs (matching the pattern already used for `users`/`user_roles`/`system_state`), so re-running `make dev` against a persisted volume doesn't fail on duplicate keys — since seeding now happens on every run.

## Test plan

- [x] Applied all 79 migrations in `apps/api/migrations` in order to a fresh Postgres volume (mirrors `RUN_MIGRATIONS=true`)
- [x] Ran `scripts/seed.sql` against the migrated schema — succeeds, `INSERT 0 1`/`INSERT 0 2`/`INSERT 0 3` as expected
- [x] Ran `scripts/seed.sql` a second time — succeeds with `INSERT 0 0` across the board (idempotent, no duplicate-key errors)
- [x] Verified seeded `users` row has `wallet_address`, `display_name`, `kyc_status` populated
- [x] Verified `user_roles` has exactly one `admin` row for the test user, unchanged across the second seed run
- [x] Confirmed `email`/`name` are not referenced anywhere in `scripts/seed.sql`
- [x] `docker compose config` validates the updated compose file

Note: `make dev`'s full `docker compose up --build` currently fails to build the `api` image on an unrelated, pre-existing issue — `Dockerfile.dev` runs `go install github.com/air-verse/air@latest`, and current `air` requires Go ≥1.26 while the image pins Go 1.25.11. That's a Dockerfile toolchain-pinning bug, unrelated to seed.sql/#608, so it's left out of this PR; happy to file a separate issue for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated database seeding service for local development environments.
  * Seed data now loads after the API is ready.

* **Bug Fixes**
  * Re-running database seeds no longer fails when records with matching IDs already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->