### PR TITLE
feat(dapp): AI insight card dismissal persists across sessions

### DIFF
--- a/apps/dapp/frontend/__tests__/ai-insight-card.test.tsx
+++ b/apps/dapp/frontend/__tests__/ai-insight-card.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InsightCard, getInsightDismissKey } from "@/components/ai/insightCard";
+import { PrometheusInsightsCard } from "@/components/ai/prometheusInsightsCard";
+
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: () => ({ address: "GABC123456789" }),
+}));
+
+vi.mock("@/lib/api/intelligence", () => ({
+  intelligence: {
+    getPortfolioInsights: vi.fn().mockResolvedValue([
+      {
+        id: "insight-101",
+        title: "High Yield Opportunity",
+        body: "Consider switching to USDC Vault B for +1.5% APY.",
+        confidence: 0.85,
+      },
+      {
+        id: "insight-102",
+        title: "Weekly Read",
+        body: "Market yields remain stable.",
+        confidence: 0.9,
+      },
+    ]),
+  },
+}));
+
+describe("AI Insight Card Dismissal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists dismissal of InsightCard to localStorage and hides card", () => {
+    const key = getInsightDismissKey("insight-1", "Test Title");
+    expect(localStorage.getItem(key)).toBeNull();
+
+    const { rerender } = render(
+      <InsightCard
+        id="insight-1"
+        title="Test Title"
+        body="Test Body"
+        confidence={0.9}
+      />
+    );
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+
+    const dismissBtn = screen.getByRole("button", { name: /dismiss insight/i });
+    fireEvent.click(dismissBtn);
+
+    expect(localStorage.getItem(key)).toBe("true");
+    expect(screen.queryByText("Test Title")).not.toBeInTheDocument();
+
+    // Rerender/remount confirms it remains hidden
+    rerender(
+      <InsightCard
+        id="insight-1"
+        title="Test Title"
+        body="Test Body"
+        confidence={0.9}
+      />
+    );
+    expect(screen.queryByText("Test Title")).not.toBeInTheDocument();
+  });
+
+  it("persists dismissal of PrometheusInsightsCard to localStorage and hides card", async () => {
+    render(<PrometheusInsightsCard />);
+
+    const title = await screen.findByText("High Yield Opportunity");
+    expect(title).toBeInTheDocument();
+
+    const dismissBtn = screen.getByRole("button", { name: /dismiss insight/i });
+    fireEvent.click(dismissBtn);
+
+    expect(screen.queryByText("High Yield Opportunity")).not.toBeInTheDocument();
+    expect(screen.getByText("Insight dismissed.")).toBeInTheDocument();
+
+    const key = getInsightDismissKey("insight-101", "High Yield Opportunity");
+    expect(localStorage.getItem(key)).toBe("true");
+  });
+});

--- a/apps/dapp/frontend/components/ai/insightCard.tsx
+++ b/apps/dapp/frontend/components/ai/insightCard.tsx
@@ -1,23 +1,58 @@
 'use client'
 
 import Link from 'next/link'
-import { ChevronDown, ChevronUp, Sparkles } from 'lucide-react'
-import { useState } from 'react'
+import { ChevronDown, ChevronUp, Sparkles, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { type PortfolioInsight } from '@/lib/api/intelligence'
+
+export const INSIGHT_DISMISSAL_KEY_PREFIX = 'nester_ai_insight_dismissed_'
+
+export function getInsightDismissKey(id?: string, title?: string): string {
+  const keyIdentifier = id || title || 'unknown'
+  return `${INSIGHT_DISMISSAL_KEY_PREFIX}${keyIdentifier}`
+}
 
 interface InsightCardProps extends PortfolioInsight {
   /** Optional AI reasoning text shown in the expandable toggle. */
   reasoning?: string
+  /** Optional callback fired when card is dismissed */
+  onDismiss?: () => void
 }
 
 export function InsightCard({
+  id,
   title,
   body,
   confidence,
   action,
   reasoning,
+  onDismiss,
 }: InsightCardProps) {
   const [showReasoning, setShowReasoning] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  const storageKey = getInsightDismissKey(id, title)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const isDismissed = localStorage.getItem(storageKey) === 'true'
+      if (isDismissed) {
+        setDismissed(true)
+      }
+    }
+  }, [storageKey])
+
+  const handleDismiss = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, 'true')
+    }
+    setDismissed(true)
+    onDismiss?.()
+  }
+
+  if (dismissed) {
+    return null
+  }
 
   const confidencePct = Math.round(confidence * 100)
 
@@ -39,10 +74,21 @@ export function InsightCard({
           </div>
           <p className="text-sm font-medium text-foreground">{title}</p>
         </div>
-        {/* Confidence badge */}
-        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${badgeClass}`}>
-          {confidencePct}% confidence
-        </span>
+        <div className="flex items-center gap-2">
+          {/* Confidence badge */}
+          <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${badgeClass}`}>
+            {confidencePct}% confidence
+          </span>
+          {/* Dismiss button */}
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss insight"
+            className="rounded-lg p-1 text-foreground/40 hover:bg-secondary hover:text-foreground transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* Body */}

--- a/apps/dapp/frontend/components/ai/prometheusInsightsCard.tsx
+++ b/apps/dapp/frontend/components/ai/prometheusInsightsCard.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Sparkles } from 'lucide-react'
+import { Sparkles, X } from 'lucide-react'
 import { intelligence, type PortfolioInsight } from '@/lib/api/intelligence'
 import { useWallet } from '@/components/wallet-provider'
+import { getInsightDismissKey } from './insightCard'
 
 export function PrometheusInsightsCard() {
   const { address } = useWallet()
   const [insights, setInsights] = useState<PortfolioInsight[]>([])
   const [loading, setLoading] = useState(true)
+  const [dismissed, setDismissed] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -34,6 +36,27 @@ export function PrometheusInsightsCard() {
 
   const latest = useMemo(() => insights[0], [insights])
   const weeklySummary = useMemo(() => insights[1], [insights])
+
+  const storageKey = useMemo(() => {
+    return latest ? getInsightDismissKey(latest.id, latest.title) : ''
+  }, [latest])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && storageKey) {
+      if (localStorage.getItem(storageKey) === 'true') {
+        setDismissed(true)
+      } else {
+        setDismissed(false)
+      }
+    }
+  }, [storageKey])
+
+  const handleDismiss = () => {
+    if (typeof window !== 'undefined' && storageKey) {
+      localStorage.setItem(storageKey, 'true')
+    }
+    setDismissed(true)
+  }
 
   const openChat = (prompt?: string) => {
     if (typeof window === 'undefined') return
@@ -71,14 +94,24 @@ export function PrometheusInsightsCard() {
         </button>
       </div>
 
-      {latest ? (
-        <div className="rounded-xl border border-black/[0.06] dark:border-white/[0.06] bg-black/[0.015] dark:bg-white/[0.015] p-4">
-          <p className="text-[12px] font-medium text-black dark:text-white">{latest.title}</p>
+      {latest && !dismissed ? (
+        <div className="relative rounded-xl border border-black/[0.06] dark:border-white/[0.06] bg-black/[0.015] dark:bg-white/[0.015] p-4">
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss insight"
+            className="absolute top-3 right-3 rounded-lg p-1 text-black/40 dark:text-white/40 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+          <p className="pr-6 text-[12px] font-medium text-black dark:text-white">{latest.title}</p>
           <p className="mt-1.5 text-[12px] leading-relaxed text-black/60 dark:text-white/60">{latest.body}</p>
           <p className="mt-2 text-[10px] text-black/45 dark:text-white/45">Confidence: {Math.round(latest.confidence * 100)}%</p>
         </div>
       ) : (
-        <p className="text-[12px] text-black/50 dark:text-white/50">No insight available yet. Ask Prometheus to generate one.</p>
+        <p className="text-[12px] text-black/50 dark:text-white/50">
+          {dismissed ? 'Insight dismissed.' : 'No insight available yet. Ask Prometheus to generate one.'}
+        </p>
       )}
 
       <div className="mt-4 rounded-xl border border-black/[0.06] dark:border-white/[0.06] bg-white dark:bg-[#100F0F] p-4">

--- a/apps/dapp/frontend/lib/api/intelligence.ts
+++ b/apps/dapp/frontend/lib/api/intelligence.ts
@@ -88,6 +88,7 @@ export interface MarketContextSignal {
 }
 
 export interface PortfolioInsight {
+  id?: string
   title: string
   body: string
   confidence: number


### PR DESCRIPTION
 I have completed issue #938 and pushed the changes to your repository.

  ### Changes Implemented in Ai-insight-card:

  1. **insightCard.tsx**:
      • Added a dismiss (X) button control in the header next to the confidence badge.
      • Added localStorage persistence under key nester_ai_insight_dismissed_<id|title>.
      • On initial mount and user click, checks/persists the dismissal flag so dismissed insights do not reappear
      across logins or session reloads.
  2. **prometheusInsightsCard.tsx**:
      • Added dismiss (X) button control on the Prometheus insight card.
      • Tied dismissal persistence to localStorage via getInsightDismissKey(latest.id, latest.title).
      • If dismissed, renders an 'Insight dismissed.' state and prevents the dismissed insight instance from showing
      upon future page reloads or logins.
  3. **intelligence.ts** & **ai-insight-card.test.tsx**:
      • Added optional id?: string to PortfolioInsight type.
      • Added unit tests covering dismissal behavior and localStorage persistence.
closes #938 