### PR TITLE
fix: repair dev CI baseline — Go test mocks + Python lint

### DIFF
--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -207,6 +207,25 @@ func (m *memorySavingsGoalRepo) SumGoalDeposits(_ context.Context, goalID uuid.U
 	return decimal.Zero, nil
 }
 
+func (m *memorySavingsGoalRepo) GetByVaultID(_ context.Context, vaultID uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	for _, g := range m.goals {
+		if g.VaultID != nil && *g.VaultID == vaultID {
+			return &g, nil
+		}
+	}
+	return nil, savingsgoal.ErrGoalNotFound
+}
+
+func (m *memorySavingsGoalRepo) CreditYieldBalance(_ context.Context, goalID uuid.UUID, amount decimal.Decimal) error {
+	g, ok := m.goals[goalID]
+	if !ok {
+		return savingsgoal.ErrGoalNotFound
+	}
+	g.YieldBalance = g.YieldBalance.Add(amount)
+	m.goals[goalID] = g
+	return nil
+}
+
 func (m *memorySavingsGoalRepo) SetShareToken(_ context.Context, goalID, userID uuid.UUID, token uuid.UUID) error {
 	g, ok := m.goals[goalID]
 	if !ok || g.UserID != userID {

--- a/apps/api/internal/service/savings_schedule_service_test.go
+++ b/apps/api/internal/service/savings_schedule_service_test.go
@@ -114,6 +114,12 @@ func (m *memoryGoalRepo) GetByID(_ context.Context, id uuid.UUID) (*savingsgoal.
 func (m *memoryGoalRepo) Update(context.Context, *savingsgoal.SavingsGoal) error { return nil }
 func (m *memoryGoalRepo) Delete(context.Context, uuid.UUID, uuid.UUID) error     { return nil }
 func (m *memoryGoalRepo) Restore(context.Context, uuid.UUID, uuid.UUID) error    { return nil }
+func (m *memoryGoalRepo) CreditYieldBalance(context.Context, uuid.UUID, decimal.Decimal) error {
+	return nil
+}
+func (m *memoryGoalRepo) GetByVaultID(context.Context, uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	return nil, savingsgoal.ErrGoalNotFound
+}
 func (m *memoryGoalRepo) GetByIDIncludingDeleted(_ context.Context, id uuid.UUID) (*savingsgoal.SavingsGoal, error) {
 	return m.GetByID(context.Background(), id)
 }

--- a/apps/intelligence/app/services/prometheus.py
+++ b/apps/intelligence/app/services/prometheus.py
@@ -14,12 +14,12 @@ from app.config import settings
 from app.models.coaching import CoachingRequest, CoachingResponse
 from app.models.explainability import DocumentUsed, ExplainabilityTrace, ToolInvocation
 from app.models.nudge import NudgeCopyResponse
-from app.models.preferences import ResponsePreferences
 from app.models.portfolio import (
     AllocationItem,
     PortfolioAnalysisResponse,
     PortfolioBreakdown,
 )
+from app.models.preferences import ResponsePreferences
 from app.models.recommendation import (
     ConfidenceLevel,
     Recommendation,

--- a/apps/intelligence/tests/test_coaching.py
+++ b/apps/intelligence/tests/test_coaching.py
@@ -98,7 +98,10 @@ async def test_generate_coaching_preference_wins_over_incidental_description_lan
     """A stored language preference is authoritative even when the goal's
     free-text description happens to be written in a different language.
     """
-    payload = '{"progress_assessment": "ok", "deposit_schedule": [], "nudges": [], "confidence": "high"}'
+    payload = (
+        '{"progress_assessment": "ok", "deposit_schedule": [], '
+        '"nudges": [], "confidence": "high"}'
+    )
     fake_client = FakeClient(payload)
     monkeypatch.setattr(prometheus, "get_client", lambda: fake_client)
     monkeypatch.setattr(prometheus.anthropic.types, "TextBlock", DummyTextBlock, raising=False)

--- a/apps/intelligence/tests/test_defillama_staleness.py
+++ b/apps/intelligence/tests/test_defillama_staleness.py
@@ -105,7 +105,10 @@ async def test_outage_after_ttl_expiry_serves_stale_data_on_non_200(client):
 async def test_outage_after_ttl_expiry_serves_stale_data_on_exception(client):
     await _prime_cache_and_expire_short_ttl(client)
 
-    with patch("aiohttp.ClientSession", return_value=_make_failing_session(Exception("network down"))):
+    with patch(
+        "aiohttp.ClientSession",
+        return_value=_make_failing_session(Exception("network down")),
+    ):
         result = await client.get_yield_pools(chain="Stellar")
 
     assert result, "expected stale fallback data, got empty list"

--- a/apps/intelligence/tests/test_prometheus_streaming_errors.py
+++ b/apps/intelligence/tests/test_prometheus_streaming_errors.py
@@ -6,7 +6,6 @@ with the generic "trouble connecting" catch-all, or propagating as a raw
 500 to the caller.
 """
 
-from types import SimpleNamespace
 from typing import Any
 
 import anthropic
@@ -66,7 +65,9 @@ def _stub_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_error_yields_friendly_retry_message(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_rate_limit_error_yields_friendly_retry_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     exc = _make_status_error(429)
     monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(exc))
 
@@ -80,7 +81,9 @@ async def test_rate_limit_error_yields_friendly_retry_message(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
-async def test_overloaded_error_yields_friendly_retry_message(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_overloaded_error_yields_friendly_retry_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     exc = _make_status_error(529)
     monkeypatch.setattr(prometheus, "get_client", lambda: FakeClient(exc))
 

--- a/apps/intelligence/tests/test_retrieval_relevance.py
+++ b/apps/intelligence/tests/test_retrieval_relevance.py
@@ -21,9 +21,15 @@ class RecordingDataSource:
 
     def __init__(self) -> None:
         self.called: set[str] = set()
-        self.vaults = [{"name": "Growth Vault", "balance_usd": 1200, "apy": 8.5, "yield_earned": 30}]
-        self.goals = [{"name": "Car", "target_amount": 5000, "current_amount": 1250, "progress_pct": 25}]
-        self.txs = [{"type": "deposit", "amount": 500, "currency": "USDC", "created_at": "2026-06-01"}]
+        self.vaults = [
+            {"name": "Growth Vault", "balance_usd": 1200, "apy": 8.5, "yield_earned": 30}
+        ]
+        self.goals = [
+            {"name": "Car", "target_amount": 5000, "current_amount": 1250, "progress_pct": 25}
+        ]
+        self.txs = [
+            {"type": "deposit", "amount": 500, "currency": "USDC", "created_at": "2026-06-01"}
+        ]
         self.available = [{"name": "Balanced", "apy": 10.0, "risk_tier": "medium"}]
         self.rates = [{"protocol": "aave", "apy": 6.5}]
 


### PR DESCRIPTION
## Problem

`dev` HEAD is red for two independent reasons, both in already-merged code. Neither is caused by any open PR, but every open PR inherits them — which is why the board currently shows failures in files those PRs never touched.

### 1. Go — test suite does not compile

Commit `9a0f074` ("Feat/goal level (#991)") added two methods to the `savingsgoal.Repository` interface:

- `CreditYieldBalance(ctx, goalID, amount) error`
- `GetByVaultID(ctx, vaultID) (*SavingsGoal, error)`

but did not update the in-memory test doubles implementing it. Production code still builds, so `go build ./...` stays green — only `go vet` / `go test` on `./internal/service/...` fail. That is why this slipped through.

### 2. Python — pre-existing ruff violations

`ruff check .` fails on dev with 8 violations: one unused import (F401) and seven over-length lines (E501), across four test modules. The Intelligence (Python) job lints the entire directory, so any PR touching `apps/intelligence` inherits them.

## Impact

Confirmed inherited by #987, #988, #993 and #1005. Each trial-merges onto dev and builds clean once these are fixed, so their red CI was never their own defect. #987 in particular was failing solely on lint errors in `test_prometheus_streaming_errors.py`, a file it does not touch.

## Fix

**Go** (2 files, +25):
- `memorySavingsGoalRepo`: real implementations backed by the existing `goals` map — `CreditYieldBalance` adds to `YieldBalance`, `GetByVaultID` scans for a matching `VaultID`, both returning `ErrGoalNotFound` on miss.
- `memoryGoalRepo`: stubs matching that mock's existing terse one-line style.

**Python** (5 files):
- Wrapped long signatures and literals, removed the unused `SimpleNamespace` import, reordered one import block. No behavioural change.

## Verification

```
go build ./...                 # exit 0
go vet ./internal/service/...  # exit 0, no output
go test ./...                  # all packages ok

ruff check .                   # All checks passed!
```

Recommend merging this first so the other PRs' CI results become trustworthy signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded in-memory savings goal/schedule test repositories to support retrieving goals by vault and (where applicable) crediting yield balances.
  * Updated and reformatted test payloads, fixtures, and patched session setup for coaching, staleness handling, retrieval relevance, and Prometheus streaming errors.

* **Chores / Style**
  * Minor import reordering and test cleanup to improve consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->