### PR TITLE
fix(api): drop unused decimal import in risk_service

### DIFF
--- a/apps/api/internal/services/risk_service.go
+++ b/apps/api/internal/services/risk_service.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 )
 


### PR DESCRIPTION
`apps/api/internal/services/risk_service.go` imports `github.com/shopspring/decimal` but never uses it, so the package does not compile:

```
internal/services/risk_service.go:12:2: "github.com/shopspring/decimal" imported and not used
```

This came in with #884. One-line removal; `go build ./...` is clean afterwards.