### PR TITLE
fix(ci): move staging-secret guard out of the job-level if in load-soak

### DIFF
--- a/.github/workflows/load-soak.yml
+++ b/.github/workflows/load-soak.yml
@@ -12,12 +12,28 @@ jobs:
   soak:
     name: k6 soak (staging)
     runs-on: ubuntu-latest
-    # A missing secret must never cause a test to fall back to localhost or production.
-    if: ${{ secrets.STAGING_LOAD_API_BASE_URL != '' }}
     environment: staging
     steps:
       - uses: actions/checkout@v4
+
+      # A missing secret must never cause a test to fall back to localhost or
+      # production. The `secrets` context is not available in a job-level `if`,
+      # so the guard has to live in a step: this sets configured=true/false and
+      # every later step keys off it.
+      - name: Check staging target is configured
+        id: guard
+        env:
+          API_BASE_URL: ${{ secrets.STAGING_LOAD_API_BASE_URL }}
+        run: |
+          if [ -z "$API_BASE_URL" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::STAGING_LOAD_API_BASE_URL is not set — skipping the soak run."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run isolated staging soak
+        if: steps.guard.outputs.configured == 'true'
         env:
           API_BASE_URL: ${{ secrets.STAGING_LOAD_API_BASE_URL }}
           INTELLIGENCE_BASE_URL: ${{ secrets.STAGING_LOAD_INTELLIGENCE_BASE_URL }}

--- a/apps/api/internal/cache/cache_test.go
+++ b/apps/api/internal/cache/cache_test.go
@@ -244,22 +244,46 @@ func TestGetOrCompute_Redis_TTLIsJittered(t *testing.T) {
 	ctx := context.Background()
 	ns := "it-jitter"
 
-	base := 10 * time.Second
+	// The jitter window is ±10% of the base, so TTLs are drawn from
+	// [9s, 11s] at sub-second resolution. Sample with PTTL (milliseconds)
+	// rather than TTL (whole seconds) — second-resolution rounding collapses
+	// that window onto {9s, 10s, 11s} and makes identical samples common
+	// enough to flake.
+	const (
+		base           = 10 * time.Second
+		jitterFraction = 0.10
+		samples        = 20
+	)
+	minTTL := time.Duration(float64(base) * (1 - jitterFraction))
+	maxTTL := time.Duration(float64(base) * (1 + jitterFraction))
+
 	seen := map[time.Duration]bool{}
-	for i := 0; i < 5; i++ {
+	for i := 0; i < samples; i++ {
 		id := uniqueID(t)
 		_, err := cache.GetOrCompute(ctx, c, cache.Options{Namespace: ns, ID: id, HardTTL: base},
 			func(context.Context) (int, error) { return 1, nil })
 		require.NoError(t, err)
 
-		ttl := rc.TTL(ctx, "cache:v1:"+ns+":"+id).Val()
+		ttl := rc.PTTL(ctx, "cache:v1:"+ns+":"+id).Val()
 		_ = c.Invalidate(context.Background(), ns, id)
-		seen[ttl.Round(time.Second)] = true
+
+		// Every TTL must land inside the jitter window (allowing a small
+		// slack for the round-trip elapsed between SET and PTTL).
+		assert.GreaterOrEqual(t, ttl, minTTL-time.Second,
+			"TTL %v below the jitter window [%v, %v]", ttl, minTTL, maxTTL)
+		assert.LessOrEqual(t, ttl, maxTTL,
+			"TTL %v above the jitter window [%v, %v]", ttl, minTTL, maxTTL)
+
+		seen[ttl] = true
 	}
-	// Not a strict proof of randomness, but across 5 runs with a ±10% jitter
-	// window we expect at least one distinct TTL bucket, i.e. it isn't a
-	// hardcoded constant.
-	assert.Greater(t, len(seen), 1, "expected jittered TTLs to vary across calls, got identical TTL every time: %v", seen)
+
+	// A constant (unjittered) TTL yields a single distinct value. With 20
+	// samples drawn from a continuous 2s-wide window at ms resolution, a
+	// working jitter yields many; requiring well over half guards against a
+	// hardcoded TTL without being sensitive to occasional ms-level collisions.
+	assert.Greater(t, len(seen), samples/2,
+		"expected jittered TTLs to vary across calls, got %d distinct values in %d samples: %v",
+		len(seen), samples, seen)
 }
 
 func TestGetOrCompute_Redis_ServesStaleWhileRevalidating(t *testing.T) {


### PR DESCRIPTION
Part of #996.

## Problem

The nightly soak has **never run**. Every trigger produces a `startup_failure` with zero jobs:

```yaml
jobs:
  soak:
    if: ${{ secrets.STAGING_LOAD_API_BASE_URL != '' }}   # ← invalid here
```

The `secrets` context is **not available in a job-level `if`**. GitHub rejects the workflow while building the run graph, before any job is created. The repo's own YAML tooling flags it:

```
Unrecognized named-value: 'secrets'
```

Every recent run confirms it — `31345252845`, `31344999919`, `31344730261`, `31344360393`, `31344120260`: all `failure`, all zero jobs.

## Correction to #996

That issue reports `load-soak.yml` and `contract-audit.yml` as one bug — "fail to parse". They are **two unrelated bugs** that happen to share a symptom:

| Workflow | Cause | Fix |
|---|---|---|
| `contract-audit.yml` | Genuine YAML syntax error (unindented heredoc) | #1024 |
| `load-soak.yml` | **Parses fine.** Invalid context reference | this PR |

`load-soak.yml` passes `yaml.safe_load` without complaint — the failure is semantic, not syntactic.

## Fix

The original intent is correct and preserved: *a missing secret must never cause a test to fall back to localhost or production.*

Move the check into a step, where `secrets` **is** available:

```yaml
      - name: Check staging target is configured
        id: guard
        env:
          API_BASE_URL: ${{ secrets.STAGING_LOAD_API_BASE_URL }}
        run: |
          if [ -z "$API_BASE_URL" ]; then
            echo "configured=false" >> "$GITHUB_OUTPUT"
            echo "::notice::STAGING_LOAD_API_BASE_URL is not set — skipping the soak run."
          else
            echo "configured=true" >> "$GITHUB_OUTPUT"
          fi

      - name: Run isolated staging soak
        if: steps.guard.outputs.configured == 'true'
```

An unconfigured repo now **skips with a notice** rather than running against the wrong target — same safety property, expressed where the context actually resolves.

The artifact upload keeps `if: always()` and finds no summary file on a skipped run; `if-no-files-found` is already `warn`.

## Verification

- File parses (`yaml.safe_load`)
- No job-level `if` references `secrets` anywhere in the file
- Step guards resolve as intended:

| Step | `if` |
|---|---|
| `actions/checkout@v4` | — |
| Check staging target is configured | — |
| Run isolated staging soak | `steps.guard.outputs.configured == 'true'` |
| `actions/upload-artifact@v4` | `always()` |

## Note

This makes the workflow *start*. Since it has never executed, its first real run may surface further issues in `tests/load/soak.js` or the k6 setup — separate from the startup failure fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load-soak workflow handling when the staging API URL is unavailable, clearly skipping the soak instead of failing unexpectedly.

* **Tests**
  * Strengthened cache expiration testing with more precise timing checks and broader sampling to better validate TTL jitter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->