### PR TITLE
fix(ci): repair failing gates, dev image, and the never-running database tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,9 +364,20 @@ jobs:
       - name: Test (unit)
         run: go test -race -timeout 120s -count=1 -short ./...
 
-      - name: Test (integration)
-        run: go test -race -timeout 120s -count=1 -run Integration ./...
-        continue-on-error: true
+      # Database-backed tests gate on TEST_DATABASE_DSN (the convention in
+      # internal/db and internal/repository/postgres), not DATABASE_URL, so
+      # without this variable every one of them silently skipped — and the
+      # step was continue-on-error, so it never gated a merge either. Scoped
+      # to this step so the unit run above stays DB-free and parallel.
+      #
+      # -p 1: the tests share one database and each wipes the public schema
+      # before applying the full migration chain, so packages must not run
+      # concurrently. No -run filter: DB-gated tests whose names lack
+      # "Integration" (internal/audit, internal/stellar backfill) must run too.
+      - name: Test (database integration)
+        env:
+          TEST_DATABASE_DSN: postgres://nester:nester@localhost:5432/nester_test?sslmode=disable
+        run: go test -race -timeout 900s -count=1 -p 1 ./...
 
 
   contracts:

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,5 +1,8 @@
-FROM golang:1.25.11-alpine
-RUN go install github.com/air-verse/air@latest
+# Must be >= the `go` directive in go.mod or `go mod download` refuses to run.
+FROM golang:1.25.13-alpine
+# Pinned: air v1.67.2+ requires Go >= 1.26, so an unpinned @latest silently
+# broke this image when upstream released. Bump deliberately with the base image.
+RUN go install github.com/air-verse/air@v1.67.1
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/suncrestlabs/nester/apps/api
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/apps/api/internal/audit/audit.go
+++ b/apps/api/internal/audit/audit.go
@@ -181,7 +181,12 @@ func (s *auditService) LogAction(
 		return nil, err
 	}
 
-	now := time.Now().UTC()
+	// Truncated to microseconds before it is hashed: created_at is a
+	// timestamptz, which stores microsecond precision, and VerifyChain
+	// recomputes the hash from the value read back. Hashing the nanosecond
+	// value would make every entry fail verification as soon as it was
+	// written, which is exactly what happened.
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	serialData := CanonicalSerialize(nextSeq, now, actor, action, target, detailHash, prevHash)
 	entryHash := HashData(serialData)
 
@@ -309,12 +314,33 @@ func (s *auditService) VerifyChain(ctx context.Context, fromSeq, toSeq int64) (b
 }
 
 func (s *auditService) RedactEntry(ctx context.Context, seq int64, redactKeys []string) error {
+	redacted, err := s.redactDetail(ctx, seq, redactKeys)
+	if err != nil || !redacted {
+		return err
+	}
+
+	// Logged only after redactDetail has returned and released s.mu:
+	// LogAction takes the same mutex, and sync.Mutex is not reentrant, so
+	// calling it while still holding the lock deadlocked every redaction
+	// and, because the lock was never released, every audit write after it.
+	_, _ = s.LogAction(ctx, nil, "system", "redaction", fmt.Sprintf("audit_logs:sequence:%d", seq), map[string]any{
+		"target_sequence": seq,
+		"redacted_fields": redactKeys,
+	}, nil, nil, nil)
+
+	return nil
+}
+
+// redactDetail performs the redaction under the service mutex and commits it.
+// It reports whether anything was actually redacted so the caller can skip
+// the follow-up audit entry when nothing changed.
+func (s *auditService) redactDetail(ctx context.Context, seq int64, redactKeys []string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
+		return false, fmt.Errorf("begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -330,15 +356,15 @@ func (s *auditService) RedactEntry(ctx context.Context, seq int64, redactKeys []
 
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return fmt.Errorf("audit log entry not found: sequence %d", seq)
+			return false, fmt.Errorf("audit log entry not found: sequence %d", seq)
 		}
-		return fmt.Errorf("query audit log entry: %w", err)
+		return false, fmt.Errorf("query audit log entry: %w", err)
 	}
 
 	// 2. Parse the detail map
 	var detailMap map[string]any
 	if err := json.Unmarshal(detailJSON, &detailMap); err != nil {
-		return fmt.Errorf("unmarshal detail for redaction: %w", err)
+		return false, fmt.Errorf("unmarshal detail for redaction: %w", err)
 	}
 
 	// 3. Redact the fields
@@ -352,13 +378,13 @@ func (s *auditService) RedactEntry(ctx context.Context, seq int64, redactKeys []
 
 	if !redactedAny {
 		// Nothing to redact, complete successfully
-		return nil
+		return false, nil
 	}
 
 	// 4. Serialize the redacted detail (keys sorted automatically by Go JSON marshal)
 	newDetailBytes, err := json.Marshal(detailMap)
 	if err != nil {
-		return fmt.Errorf("marshal redacted detail: %w", err)
+		return false, fmt.Errorf("marshal redacted detail: %w", err)
 	}
 
 	// 5. Update DB row: replace detail payload, flag as redacted, but KEEP the original detail_hash!
@@ -368,24 +394,16 @@ func (s *auditService) RedactEntry(ctx context.Context, seq int64, redactKeys []
 		WHERE sequence = $2
 	`, json.RawMessage(newDetailBytes), seq)
 	if err != nil {
-		return fmt.Errorf("update redacted audit log entry: %w", err)
+		return false, fmt.Errorf("update redacted audit log entry: %w", err)
 	}
 
-	// 6. Log the redaction action itself as a new audit entry to make it auditable
-	// Note: to avoid infinite recursion or lock deadlock, we insert it directly in this txn.
-	// But wait, the audit trail of the redaction needs a sequence number!
-	// It's cleaner to commit this transaction first, and then log the redaction as a new audit action.
+	// 6. Commit here; the redaction is recorded as its own audit entry by
+	// the caller once this function has released the mutex.
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit redaction: %w", err)
+		return false, fmt.Errorf("commit redaction: %w", err)
 	}
 
-	// Log the redaction action separately (acquires mu/lock and logs normally)
-	_, _ = s.LogAction(ctx, nil, "system", "redaction", fmt.Sprintf("audit_logs:sequence:%d", seq), map[string]any{
-		"target_sequence": seq,
-		"redacted_fields": redactKeys,
-	}, nil, nil, nil)
-
-	return nil
+	return true, nil
 }
 
 func (s *auditService) AnchorLatestEntry(ctx context.Context) (string, error) {

--- a/apps/api/internal/handler/portfolio_handler_integration_test.go
+++ b/apps/api/internal/handler/portfolio_handler_integration_test.go
@@ -57,8 +57,10 @@ func TestPortfolioHandlerSummaryIntegration(t *testing.T) {
 	if _, err := vaultService.UpdateAllocations(context.Background(), service.UpdateAllocationsInput{
 		VaultID: vaultA.ID,
 		Allocations: []vault.Allocation{
-			{Protocol: "aave", Amount: decimal.RequireFromString("60.00"), APY: decimal.RequireFromString("4.00"), AllocatedAt: time.Now().UTC()},
-			{Protocol: "compound", Amount: decimal.RequireFromString("60.00"), APY: decimal.RequireFromString("6.00"), AllocatedAt: time.Now().UTC().Add(time.Second)},
+			// Allocation amounts are percentage weights and must sum to 100;
+			// the summary totals below come from the recorded deposits.
+			{Protocol: "aave", Amount: decimal.RequireFromString("50.00"), APY: decimal.RequireFromString("4.00"), AllocatedAt: time.Now().UTC()},
+			{Protocol: "compound", Amount: decimal.RequireFromString("50.00"), APY: decimal.RequireFromString("6.00"), AllocatedAt: time.Now().UTC().Add(time.Second)},
 		},
 	}); err != nil {
 		t.Fatalf("UpdateAllocations(vaultA) error = %v", err)
@@ -83,8 +85,8 @@ func TestPortfolioHandlerSummaryIntegration(t *testing.T) {
 	if _, err := vaultService.UpdateAllocations(context.Background(), service.UpdateAllocationsInput{
 		VaultID: vaultB.ID,
 		Allocations: []vault.Allocation{
-			{Protocol: "angle", Amount: decimal.RequireFromString("100.00"), APY: decimal.RequireFromString("3.25"), AllocatedAt: time.Now().UTC()},
-			{Protocol: "yield", Amount: decimal.RequireFromString("130.50"), APY: decimal.RequireFromString("5.10"), AllocatedAt: time.Now().UTC().Add(time.Second)},
+			{Protocol: "angle", Amount: decimal.RequireFromString("40.00"), APY: decimal.RequireFromString("3.25"), AllocatedAt: time.Now().UTC()},
+			{Protocol: "yield", Amount: decimal.RequireFromString("60.00"), APY: decimal.RequireFromString("5.10"), AllocatedAt: time.Now().UTC().Add(time.Second)},
 		},
 	}); err != nil {
 		t.Fatalf("UpdateAllocations(vaultB) error = %v", err)

--- a/apps/api/internal/handler/vault_handler_integration_test.go
+++ b/apps/api/internal/handler/vault_handler_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 func TestVaultHandlerIntegrationCreateGetListAndErrors(t *testing.T) {
@@ -56,10 +57,7 @@ func TestVaultHandlerIntegrationCreateGetListAndErrors(t *testing.T) {
 		t.Fatalf("expected 201, got %d", response.StatusCode)
 	}
 
-	var created vault.Vault
-	if err := json.NewDecoder(response.Body).Decode(&created); err != nil {
-		t.Fatalf("decode create response: %v", err)
-	}
+	created := decodeAPIData[vault.Vault](t, response.Body)
 
 	if _, err := vaultService.RecordDeposit(context.Background(), service.RecordDepositInput{
 		VaultID: created.ID,
@@ -92,10 +90,7 @@ func TestVaultHandlerIntegrationCreateGetListAndErrors(t *testing.T) {
 	}
 	defer getResponse.Body.Close()
 
-	var fetched vault.Vault
-	if err := json.NewDecoder(getResponse.Body).Decode(&fetched); err != nil {
-		t.Fatalf("decode get response: %v", err)
-	}
+	fetched := decodeAPIData[vault.Vault](t, getResponse.Body)
 	if len(fetched.Allocations) != 2 {
 		t.Fatalf("expected 2 allocations, got %d", len(fetched.Allocations))
 	}
@@ -106,10 +101,7 @@ func TestVaultHandlerIntegrationCreateGetListAndErrors(t *testing.T) {
 	}
 	defer listResponse.Body.Close()
 
-	var listed []vault.Vault
-	if err := json.NewDecoder(listResponse.Body).Decode(&listed); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
+	listed := decodeAPIData[[]vault.Vault](t, listResponse.Body)
 	if len(listed) != 1 {
 		t.Fatalf("expected 1 listed vault, got %d", len(listed))
 	}
@@ -152,54 +144,9 @@ func openHandlerIntegrationDB(t *testing.T) *sql.DB {
 
 func applyHandlerIntegrationMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-
-	// Wipe every table in the public schema before applying. The docker
-	// volume persists across container restarts, so tables created in prior
-	// runs must be dropped to avoid non-idempotent CREATE TABLE statements
-	// (e.g. 006_create_settlements_table) failing on the second run. CASCADE
-	// pulls in dependent objects; schema_migrations and any tables outside
-	// the public schema are untouched.
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-
-	// 033 must run BEFORE 023: 033 renames vault_transactions.tx_hash →
-	// transaction_hash, and 023 creates the UNIQUE INDEX on that column. 035
-	// is a byte-identical duplicate of 033 whose non-idempotent RENAME COLUMN
-	// would fail on re-runs, so it is intentionally skipped.
-	// 010 and 020 are deliberately omitted: they DROP users.email and RENAME
-	// users.name → display_name, which would break the seed helpers that
-	// INSERT into users (id, email, name). Apply either via a separate,
-	// opt-in helper if user-profile tests are extended.
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"007_add_vault_deleted_at.up.sql",
-		"008_add_vault_transactions.up.sql",
-		"014_add_missing_columns.up.sql",
-		"027_user_profile_fields.up.sql",
-		"033_update_vault_transactions.up.sql",
-		"023_vault_transactions_hash_unique.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
 }
 
 func resetHandlerIntegrationTables(t *testing.T, db *sql.DB) {
@@ -215,9 +162,9 @@ func seedHandlerIntegrationUser(t *testing.T, db *sql.DB) uuid.UUID {
 
 	userID := uuid.New()
 	if _, err := db.Exec(
-		`INSERT INTO users (id, email, name) VALUES ($1, $2, $3)`,
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
 		userID.String(),
-		userID.String()+"@example.com",
+		"G"+userID.String(), // final schema: wallet_address NOT NULL UNIQUE, email dropped by 010
 		"Handler Integration User",
 	); err != nil {
 		t.Fatalf("seed user failed: %v", err)
@@ -257,10 +204,7 @@ func TestVaultHandlerDepositAndWithdrawIntegration(t *testing.T) {
 		t.Fatalf("expected 201, got %d", response.StatusCode)
 	}
 
-	var created vault.Vault
-	if err := json.NewDecoder(response.Body).Decode(&created); err != nil {
-		t.Fatalf("decode create response: %v", err)
-	}
+	created := decodeAPIData[vault.Vault](t, response.Body)
 
 	// Test: Deposit to vault
 	depositResponse, err := http.Post(
@@ -277,10 +221,7 @@ func TestVaultHandlerDepositAndWithdrawIntegration(t *testing.T) {
 		t.Fatalf("expected 201 for deposit, got %d", depositResponse.StatusCode)
 	}
 
-	var depositedVault vault.Vault
-	if err := json.NewDecoder(depositResponse.Body).Decode(&depositedVault); err != nil {
-		t.Fatalf("decode deposit response: %v", err)
-	}
+	depositedVault := decodeAPIData[vault.Vault](t, depositResponse.Body)
 
 	if depositedVault.TotalDeposited.Cmp(decimal.RequireFromString("100.50")) != 0 {
 		t.Fatalf("expected total_deposited 100.50, got %v", depositedVault.TotalDeposited)
@@ -301,10 +242,7 @@ func TestVaultHandlerDepositAndWithdrawIntegration(t *testing.T) {
 		t.Fatalf("expected 200 for withdraw, got %d", withdrawResponse.StatusCode)
 	}
 
-	var withdrawnVault vault.Vault
-	if err := json.NewDecoder(withdrawResponse.Body).Decode(&withdrawnVault); err != nil {
-		t.Fatalf("decode withdraw response: %v", err)
-	}
+	withdrawnVault := decodeAPIData[vault.Vault](t, withdrawResponse.Body)
 
 	if withdrawnVault.CurrentBalance.Cmp(decimal.RequireFromString("50.50")) != 0 {
 		t.Fatalf("expected current_balance 50.50 after withdrawal, got %v", withdrawnVault.CurrentBalance)

--- a/apps/api/internal/repository/postgres/activity_repository.go
+++ b/apps/api/internal/repository/postgres/activity_repository.go
@@ -56,9 +56,14 @@ func (r *ActivityRepository) List(ctx context.Context, userID uuid.UUID, filter 
 		args = append(args, keysetArgs...)
 	}
 
+	// Each arm projects user_id: buildActivityWhere filters the unioned feed
+	// by it, and a CTE column that is not projected cannot be referenced in
+	// the outer WHERE. Without it every call failed with "column user_id
+	// does not exist". The per-arm $1 predicates stay so each source table
+	// is narrowed before the union rather than after.
 	query := fmt.Sprintf(`
 		WITH activity_feed AS (
-			SELECT vt.id, vt.type AS type, vt.amount, v.currency,
+			SELECT vt.id, vt.user_id, vt.type AS type, vt.amount, v.currency,
 			       'completed'::text AS status, vt.created_at,
 			       vt.vault_id, COALESCE(v.name, v.currency || ' Vault') AS vault_name,
 			       COALESCE(vt.transaction_hash, '') AS ref, vt.search_vector AS search_vector
@@ -68,7 +73,7 @@ func (r *ActivityRepository) List(ctx context.Context, userID uuid.UUID, filter 
 
 			UNION ALL
 
-			SELECT s.id, 'settlement' AS type, s.amount, s.currency,
+			SELECT s.id, s.user_id, 'settlement' AS type, s.amount, s.currency,
 			       CASE s.status
 			           WHEN 'confirmed' THEN 'completed'
 			           WHEN 'failed' THEN 'failed'
@@ -82,7 +87,7 @@ func (r *ActivityRepository) List(ctx context.Context, userID uuid.UUID, filter 
 
 			UNION ALL
 
-			SELECT yh.id, 'yield_earned' AS type, yh.amount, yh.currency,
+			SELECT yh.id, yh.user_id, 'yield_earned' AS type, yh.amount, yh.currency,
 			       'completed'::text AS status, yh.harvested_at AS created_at,
 			       yh.vault_id, COALESCE(v.name, v.currency || ' Vault') AS vault_name,
 			       COALESCE(yh.tx_hash, '') AS ref, to_tsvector('english', '') AS search_vector

--- a/apps/api/internal/repository/postgres/activity_repository_test.go
+++ b/apps/api/internal/repository/postgres/activity_repository_test.go
@@ -144,9 +144,35 @@ func TestActivityRepositoryIntegration_FullTextSearchUsesGIN(t *testing.T) {
 		t.Fatalf("search %q got %+v, want exactly the deposit with memo containing 'paycheck'", "paycheck", items)
 	}
 
-	rows, err := db.QueryContext(context.Background(),
-		`EXPLAIN (FORMAT JSON) SELECT id FROM vault_transactions WHERE user_id = $1 AND search_vector @@ plainto_tsquery('english', $2)`,
-		userID.String(), "paycheck",
+	// The index must exist in the real schema.
+	var indexDef string
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT indexdef FROM pg_indexes WHERE tablename = 'vault_transactions' AND indexname = 'idx_vault_transactions_search_vector'`,
+	).Scan(&indexDef); err != nil {
+		t.Fatalf("GIN index idx_vault_transactions_search_vector is missing: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(indexDef), "using gin") {
+		t.Fatalf("idx_vault_transactions_search_vector is not a GIN index: %s", indexDef)
+	}
+
+	// And it must be usable for the full-text predicate. The plan is checked
+	// on the search predicate alone with sequential scans disabled for the
+	// transaction: with a handful of fixture rows the planner otherwise
+	// prefers either a seq scan or the (user_id, ...) btree with a filter,
+	// and neither choice says anything about whether the GIN index works.
+	// Only the index's existence and usability are deterministic; which
+	// index wins on a three-row table is a cost estimate, not a contract.
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(context.Background(), `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+	rows, err := tx.QueryContext(context.Background(),
+		`EXPLAIN (FORMAT JSON) SELECT id FROM vault_transactions WHERE search_vector @@ plainto_tsquery('english', $1)`,
+		"paycheck",
 	)
 	if err != nil {
 		t.Fatalf("EXPLAIN query failed: %v", err)
@@ -158,7 +184,7 @@ func TestActivityRepositoryIntegration_FullTextSearchUsesGIN(t *testing.T) {
 			t.Fatalf("scan EXPLAIN output: %v", err)
 		}
 	}
-	if !strings.Contains(plan, "idx_vault_transactions_search_vector") && !strings.Contains(strings.ToLower(plan), "bitmap index scan") {
+	if !strings.Contains(plan, "idx_vault_transactions_search_vector") {
 		t.Fatalf("expected the search_vector GIN index to be used, got plan: %s", plan)
 	}
 	var parsed []map[string]any

--- a/apps/api/internal/repository/postgres/deterioration_integration_test.go
+++ b/apps/api/internal/repository/postgres/deterioration_integration_test.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -11,6 +10,8 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/deterioration"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 // applyDeteriorationIntegrationMigrations wipes and applies only the
@@ -20,33 +21,9 @@ import (
 // themselves.
 func applyDeteriorationIntegrationMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"030_create_vault_rebalances.up.sql",
-		"051_create_protocol_tvl_snapshots.up.sql",
-		"094_create_deterioration_actions.up.sql",
-	} {
-		path := filepath.Join("..", "..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "..", "migrations"))
 }
 
 func TestProtocolTVLRepository_ListSince_Integration(t *testing.T) {

--- a/apps/api/internal/repository/postgres/job_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/job_repository_integration_test.go
@@ -120,7 +120,7 @@ func TestJobRepository_LeaseExpiryReclaim(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	_, _, err := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "recover"})
+	_, _, err := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "recover", RunAt: now})
 	if err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}

--- a/apps/api/internal/repository/postgres/job_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/job_repository_integration_test.go
@@ -45,10 +45,15 @@ func TestJobRepository_EnqueueDequeueComplete(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
+	// RunAt is pinned to the same instant the dequeue below uses as its
+	// cursor. Left unset, Enqueue stamps time.Now() a few microseconds after
+	// `now` was captured, and next_run_at <= now is then false on any clock
+	// with sub-millisecond resolution.
 	job, created, err := repo.Enqueue(ctx, jobqueue.EnqueueInput{
 		Type:          "harvest",
 		Payload:       json.RawMessage(`{"vault_id":"v1"}`),
 		CorrelationID: "corr-1",
+		RunAt:         now,
 	})
 	if err != nil || !created {
 		t.Fatalf("enqueue: created=%v err=%v", created, err)
@@ -146,7 +151,7 @@ func TestJobRepository_RetryAndDeadLetter(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	job, _, _ := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "flaky", MaxAttempts: 2})
+	job, _, _ := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "flaky", MaxAttempts: 2, RunAt: now})
 	leased, _ := repo.Dequeue(ctx, jobqueue.DequeueParams{Type: "flaky", Limit: 1, Lease: time.Minute, Now: now})
 	if len(leased) != 1 {
 		t.Fatal("expected one leased job")
@@ -185,7 +190,7 @@ func TestJobRepository_HeartbeatExtendsLease(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 
-	job, _, _ := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "long"})
+	job, _, _ := repo.Enqueue(ctx, jobqueue.EnqueueInput{Type: "long", RunAt: now})
 	leased, _ := repo.Dequeue(ctx, jobqueue.DequeueParams{Type: "long", Limit: 1, Lease: time.Second, Now: now})
 	if len(leased) != 1 {
 		t.Fatal("expected one leased job")

--- a/apps/api/internal/repository/postgres/performance_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/performance_repository_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +12,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 // applyPerformanceMigrations applies the minimal set of migrations needed for
@@ -21,45 +22,9 @@ import (
 // non-idempotent statements (notably 006_create_settlements_table).
 func applyPerformanceMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-	// 033 must run BEFORE 023: 033 renames vault_transactions.tx_hash →
-	// transaction_hash, and 023 creates the UNIQUE INDEX on that column. 035
-	// is a byte-identical duplicate of 033 whose non-idempotent RENAME COLUMN
-	// would fail on re-runs, so it is intentionally skipped. 007 is required
-	// by TestAPYRefresherIntegration_OneTick which queries vaults.deleted_at;
-	// 031_create_vault_tvl_snapshots is required by TestTVLTrackerIntegration_OneTick.
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"007_add_vault_deleted_at.up.sql",
-		"008_add_vault_transactions.up.sql",
-		"014_add_missing_columns.up.sql",
-		"018_create_vault_performance.up.sql",
-		"031_create_vault_tvl_snapshots.up.sql",
-		"033_update_vault_transactions.up.sql",
-		"023_vault_transactions_hash_unique.up.sql",
-	} {
-		path := filepath.Join("..", "..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "..", "migrations"))
 }
 
 // newTestSnapshot returns a minimal valid snapshot for the given vault.

--- a/apps/api/internal/repository/postgres/recurring_deposit_integration_test.go
+++ b/apps/api/internal/repository/postgres/recurring_deposit_integration_test.go
@@ -89,15 +89,9 @@ func (d *directGoalProgressChecker) IsGoalPausedOrArchived(ctx context.Context, 
 
 func applySavingsScheduleMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
+	// The base helper now applies the complete migration chain, so the
+	// per-feature additions this function used to layer on are covered.
 	applyIntegrationMigrations(t, db)
-	for _, name := range []string{
-		"026_create_savings_goals.up.sql",
-		"037_add_savings_goal_category.up.sql",
-		"039_create_savings_schedules.up.sql",
-		"053_add_savings_goal_vault_id.up.sql",
-	} {
-		applyMigrationFile(t, db, name)
-	}
 }
 
 func applyMigrationFile(t *testing.T, db *sql.DB, name string) {
@@ -148,7 +142,10 @@ func TestRecurringDepositJobIntegration(t *testing.T) {
 	vaultRepo := NewVaultRepository(db)
 	goalRepo := NewSavingsGoalRepository(db)
 
-	past := time.Now().UTC().Add(-2 * time.Hour)
+	// Truncated to microseconds: timestamptz stores microsecond precision,
+	// so a nanosecond-precision Go value would not round-trip and the exact
+	// comparison against the computed next run below would fail.
+	past := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Microsecond)
 	schedule := &savingsschedule.SavingsSchedule{
 		ID:        uuid.New(),
 		UserID:    userID,
@@ -244,7 +241,7 @@ func TestRecurringDepositJobIntegration_SecondOccurrenceSucceeds(t *testing.T) {
 	vaultRepo := NewVaultRepository(db)
 	goalRepo := NewSavingsGoalRepository(db)
 
-	occurrence1 := time.Now().UTC().Add(-8 * 24 * time.Hour) // due a week+ago
+	occurrence1 := time.Now().UTC().Add(-8 * 24 * time.Hour).Truncate(time.Microsecond) // due a week+ago; µs for timestamptz round-trip
 	schedule := &savingsschedule.SavingsSchedule{
 		ID:        uuid.New(),
 		UserID:    userID,

--- a/apps/api/internal/repository/postgres/transaction_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/transaction_repository_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +12,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 // applyTransactionMigrations applies the minimal set of migrations needed for
@@ -22,35 +23,9 @@ import (
 // 003_create_transactions_table.
 func applyTransactionMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"003_create_transactions_table.up.sql",
-		"014_add_missing_columns.up.sql",
-		"009_add_confirmed_at_to_transactions.up.sql",
-	} {
-		path := filepath.Join("..", "..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "..", "migrations"))
 }
 
 // newTestTransaction returns a pending deposit transaction for the given vault.

--- a/apps/api/internal/repository/postgres/vault_repository_extended_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_extended_integration_test.go
@@ -151,11 +151,18 @@ func TestVaultRepositoryIntegrationAllocationPersistence(t *testing.T) {
 		t.Fatalf("fetched %d allocations, want 2", len(fetched.Allocations))
 	}
 
+	// GetVault returns allocations newest-first (ORDER BY allocated_at DESC),
+	// so match each fetched row to its fixture by ID rather than by position.
+	expectedByID := make(map[uuid.UUID]vault.Allocation, len(allocations))
+	for _, a := range allocations {
+		expectedByID[a.ID] = a
+	}
+
 	// Verify each allocation
 	for i, alloc := range fetched.Allocations {
-		expected := allocations[i]
-		if alloc.ID != expected.ID {
-			t.Fatalf("allocation[%d] ID = %v, want %v", i, alloc.ID, expected.ID)
+		expected, ok := expectedByID[alloc.ID]
+		if !ok {
+			t.Fatalf("allocation[%d] ID = %v not among the inserted fixtures", i, alloc.ID)
 		}
 		if alloc.VaultID != expected.VaultID {
 			t.Fatalf("allocation[%d] VaultID = %v, want %v", i, alloc.VaultID, expected.VaultID)

--- a/apps/api/internal/repository/postgres/vault_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 func TestVaultRepositoryIntegrationCRUD(t *testing.T) {
@@ -225,58 +227,9 @@ func openIntegrationDB(t *testing.T) *sql.DB {
 
 func applyIntegrationMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-
-	// Wipe every table in the public schema before applying. The docker
-	// volume persists across container restarts, so tables created in prior
-	// runs must be dropped to avoid non-idempotent CREATE TABLE statements
-	// (e.g. 006_create_settlements_table) failing on the second run. CASCADE
-	// pulls in dependent objects; schema_migrations and any tables outside
-	// the public schema are untouched.
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-
-	// 033 must run BEFORE 023: 033 renames vault_transactions.tx_hash →
-	// transaction_hash, and 023 creates the UNIQUE INDEX on that column. 035
-	// is a byte-identical duplicate of 033 whose non-idempotent RENAME COLUMN
-	// would fail on re-runs, so it is intentionally skipped.
-	// 010 and 020 are deliberately omitted: they DROP users.email and RENAME
-	// users.name → display_name, which would break the seed helpers that
-	// INSERT into users (id, email, name). Apply either via a separate,
-	// opt-in helper if user-profile tests are extended.
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"007_add_vault_deleted_at.up.sql",
-		"008_add_vault_transactions.up.sql",
-		"014_add_missing_columns.up.sql",
-		"027_user_profile_fields.up.sql",
-		"033_update_vault_transactions.up.sql",
-		"023_vault_transactions_hash_unique.up.sql",
-		"036_allow_harvest_transaction_type.up.sql",
-		"042_create_yield_harvests.up.sql",
-		"074_add_vault_name_description_search.up.sql",
-		"075_add_vault_transactions_memo_search.up.sql",
-	} {
-		path := filepath.Join("..", "..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "..", "migrations"))
 }
 
 func resetIntegrationTables(t *testing.T, db *sql.DB) {
@@ -292,9 +245,9 @@ func seedIntegrationUser(t *testing.T, db *sql.DB) uuid.UUID {
 
 	userID := uuid.New()
 	if _, err := db.Exec(
-		`INSERT INTO users (id, email, name) VALUES ($1, $2, $3)`,
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
 		userID.String(),
-		userID.String()+"@example.com",
+		"G"+userID.String(), // final schema: wallet_address NOT NULL UNIQUE, email dropped by 010
 		"Integration User",
 	); err != nil {
 		t.Fatalf("seed user failed: %v", err)

--- a/apps/api/internal/service/savings_goal_lifecycle_integration_test.go
+++ b/apps/api/internal/service/savings_goal_lifecycle_integration_test.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"database/sql"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,29 +21,9 @@ import (
 // token, vault linking, auto-compound) so GetByID/List round-trip cleanly.
 func applySavingsGoalLifecycleMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
+	// The base helper now applies the complete migration chain, so the
+	// per-feature additions this function used to layer on are covered.
 	applySavingsGoalIntegrationMigrations(t, db)
-	for _, name := range []string{
-		"026_create_savings_goals.up.sql",
-		"029_create_device_tokens.up.sql",
-		"037_add_savings_goal_category.up.sql",
-		"038_add_savings_goal_notified_milestones.up.sql",
-		"040_savings_goal_velocity_pause_completion.up.sql",
-		"041_add_savings_goal_archived_status.up.sql",
-		"045_add_savings_goal_name_emoji.up.sql",
-		"052_add_savings_goal_share_token.up.sql",
-		"053_add_savings_goal_icon_color.up.sql",
-		"054_add_savings_goal_vault_id.up.sql",
-		"095_add_savings_goal_auto_compound.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
 }
 
 // TestSavingsGoalDepositMilestoneCompletionLifecycle_Integration exercises the

--- a/apps/api/internal/service/savings_goal_milestone_integration_test.go
+++ b/apps/api/internal/service/savings_goal_milestone_integration_test.go
@@ -17,48 +17,22 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 func applySavingsGoalMilestoneMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
+	// The base helper now applies the complete migration chain, so the
+	// per-feature additions this function used to layer on are covered.
 	applySavingsGoalIntegrationMigrations(t, db)
-	for _, name := range []string{
-		"026_create_savings_goals.up.sql",
-		"029_create_device_tokens.up.sql",
-		"037_add_savings_goal_category.up.sql",
-		"038_add_savings_goal_notified_milestones.up.sql",
-		"053_add_savings_goal_vault_id.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
 }
 
 func applySavingsGoalIntegrationMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"004_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"007_update_users_table.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
 }
 
 func openSavingsGoalIntegrationDB(t *testing.T) *sql.DB {
@@ -83,9 +57,9 @@ func seedSavingsGoalIntegrationUser(t *testing.T, db *sql.DB) uuid.UUID {
 
 	userID := uuid.New()
 	if _, err := db.Exec(
-		`INSERT INTO users (id, email, name) VALUES ($1, $2, $3)`,
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
 		userID.String(),
-		userID.String()+"@example.com",
+		"G"+userID.String(), // final schema: wallet_address NOT NULL UNIQUE, email dropped by 010
 		"Integration User",
 	); err != nil {
 		t.Fatalf("seed user failed: %v", err)

--- a/apps/api/internal/service/savings_goal_vault_integration_test.go
+++ b/apps/api/internal/service/savings_goal_vault_integration_test.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"database/sql"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,22 +16,9 @@ import (
 
 func applySavingsGoalVaultMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
+	// The base helper now applies the complete migration chain, so the
+	// per-feature additions this function used to layer on are covered.
 	applySavingsGoalIntegrationMigrations(t, db)
-	for _, name := range []string{
-		"026_create_savings_goals.up.sql",
-		"037_add_savings_goal_category.up.sql",
-		"038_add_savings_goal_notified_milestones.up.sql",
-		"053_add_savings_goal_vault_id.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
 }
 
 // TestSavingsGoalVaultLinking_Integration exercises the full persistence path

--- a/apps/api/internal/service/vault_service_yield_cycle_integration_test.go
+++ b/apps/api/internal/service/vault_service_yield_cycle_integration_test.go
@@ -20,6 +20,8 @@ import (
 	performancedomain "github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
 	performancesvc "github.com/suncrestlabs/nester/apps/api/internal/service/performance"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 // TestVaultServiceFullYieldCycleIntegration proves that deposit, performance
@@ -269,57 +271,9 @@ func openYieldCycleDB(t *testing.T) *sql.DB {
 
 func applyYieldCycleMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-	// Wipe every table in the public schema before applying so re-runs against
-	// a reused DB don't trip on non-idempotent statements from earlier
-	// migrations.
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-	// Migration ordering notes (also required for production):
-	//  - 008 creates vault_transactions with the `tx_hash` column.
-	//  - 033 renames `tx_hash` → `transaction_hash` and adds the fee columns.
-	//  - 023 builds a UNIQUE INDEX on `transaction_hash`, so it MUST run after
-	//    033. Numeric ordering (008→023→033) fails on a fresh DB because 023
-	//    would reference a column that does not exist yet. We pin 033 before
-	//    023 here to keep the integration test self-contained on a fresh DB.
-	//  - 035 is intentionally skipped (byte-identical duplicate of 033 which
-	//    would re-run the non-idempotent RENAME COLUMN and fail).
-	//  - 036 widens vault_transactions.type CHECK to allow 'harvest' rows
-	//    produced by RecordHarvest.
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"005_create_allocations_table.up.sql",
-		"006_create_settlements_table.up.sql",
-		"007_add_vault_deleted_at.up.sql",
-		"008_add_vault_transactions.up.sql",
-		"014_add_missing_columns.up.sql",
-		"016_add_indices_and_constraints.up.sql",
-		"018_create_vault_performance.up.sql",
-		// 033 BEFORE 023 — see ordering note above.
-		"033_update_vault_transactions.up.sql",
-		"023_vault_transactions_hash_unique.up.sql",
-		"036_allow_harvest_transaction_type.up.sql",
-	} {
-		// Test file lives at apps/api/internal/service/ → migrations are two
-		// directories up at apps/api/migrations.
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("apply migration %q: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
 }
 
 func resetYieldCycleTables(t *testing.T, db *sql.DB) {
@@ -342,9 +296,9 @@ func seedYieldCycleUser(t *testing.T, db *sql.DB) uuid.UUID {
 	t.Helper()
 	userID := uuid.New()
 	if _, err := db.Exec(
-		`INSERT INTO users (id, email, name) VALUES ($1, $2, $3)`,
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
 		userID.String(),
-		userID.String()+"@example.com",
+		"G"+userID.String(), // final schema: wallet_address NOT NULL UNIQUE, email dropped by 010
 		"Yield Cycle Integration User",
 	); err != nil {
 		t.Fatalf("seed user failed: %v", err)

--- a/apps/api/internal/stellar/backfill_integration_test.go
+++ b/apps/api/internal/stellar/backfill_integration_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/backfill"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
 // openBackfillIntegrationDB and applyBackfillIntegrationMigrations mirror
@@ -39,37 +41,9 @@ func openBackfillIntegrationDB(t *testing.T) *sql.DB {
 
 func applyBackfillIntegrationMigrations(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`
-		DO $$
-		DECLARE r record;
-		BEGIN
-			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
-			END LOOP;
-		END$$;
-	`); err != nil {
-		t.Fatalf("drop tables: %v", err)
-	}
-	for _, name := range []string{
-		"001_create_users_table.up.sql",
-		"002_create_vaults_table.up.sql",
-		"028_create_processed_events_table.up.sql",
-		"030_create_vault_rebalances.up.sql",
-		"063_create_penalty_events.up.sql",
-		"064_create_vault_rebalance_legs.up.sql",
-		"065_create_vault_rebalance_completions.up.sql",
-		"092_create_backfill_runs.up.sql",
-		"093_add_ledger_sequence_to_derived_events.up.sql",
-	} {
-		path := filepath.Join("..", "..", "migrations", name)
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		if _, err := db.Exec(string(contents)); err != nil {
-			t.Fatalf("applying migration %q failed: %v", name, err)
-		}
-	}
+	// The full migration chain in numeric order — see testutil.ApplyAllMigrations
+	// for why no per-test subset is used.
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
 }
 
 func countPenaltyEvents(t *testing.T, db *sql.DB, contractID string) int {

--- a/apps/api/internal/testutil/migrations.go
+++ b/apps/api/internal/testutil/migrations.go
@@ -1,0 +1,82 @@
+// Package testutil provides shared helpers for database-backed integration
+// tests.
+//
+// It exists because every integration test previously carried its own
+// hand-curated list of migration files, and those lists rotted: whenever a
+// migration was added, renamed, or corrected, tests that were not running in
+// CI (they gate on TEST_DATABASE_DSN, which CI did not set) silently drifted
+// until the whole suite failed on a fresh database. Applying the complete
+// chain in numeric order — exactly what golang-migrate does in production —
+// makes the schema under test the schema the code actually runs against, and
+// removes the lists that rotted.
+package testutil
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ApplyAllMigrations wipes every table in the public schema and applies every
+// up-migration in migrationsDir in ascending numeric order.
+//
+// The wipe makes the helper idempotent across test functions and across runs
+// against a persistent database: several migrations create tables without
+// IF NOT EXISTS guards, so re-applying onto leftovers from a prior run would
+// fail. Only tables are dropped because the migration set creates only
+// tables, indexes, and constraints — no types, functions, triggers, or
+// extensions (verified against the full set; revisit if that changes).
+//
+// The full chain is applied rather than a per-test subset deliberately. The
+// numeric order is the production order, and the resulting schema is the one
+// production code targets — including later migrations that drop or rename
+// columns earlier ones created. Seed helpers must therefore insert the FINAL
+// shape of each table, not the shape it had when some early migration
+// created it.
+func ApplyAllMigrations(t *testing.T, db *sql.DB, migrationsDir string) {
+	t.Helper()
+
+	if _, err := db.Exec(`
+		DO $$
+		DECLARE r record;
+		BEGIN
+			FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+				EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
+			END LOOP;
+		END$$;
+	`); err != nil {
+		t.Fatalf("drop tables: %v", err)
+	}
+
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatalf("read migrations dir %q: %v", migrationsDir, err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".up.sql") {
+			names = append(names, entry.Name())
+		}
+	}
+	// Lexicographic order equals numeric order here: every file carries a
+	// fixed-width zero-padded prefix (001_..., 023_..., 100_...).
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		t.Fatalf("no up-migrations found in %q", migrationsDir)
+	}
+
+	for _, name := range names {
+		contents, err := os.ReadFile(filepath.Join(migrationsDir, name))
+		if err != nil {
+			t.Fatalf("read migration %q: %v", name, err)
+		}
+		if _, err := db.Exec(string(contents)); err != nil {
+			t.Fatalf("applying migration %q failed: %v", name, err)
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,11 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - ./apps/intelligence/.env
+      # Optional: a fresh clone has no .env yet, and a hard requirement here
+      # makes every `docker compose` command fail to parse — even ones that
+      # never start this service.
+      - path: ./apps/intelligence/.env
+        required: false
     environment:
       INTELLIGENCE_REDIS_URL: redis://redis:6379/0
     depends_on:


### PR DESCRIPTION
## Summary

Fixes every failing CI gate, the broken dev image, and the DB integration tests that had never actually run in CI. Eight commits, each independently revertible.

**CI**
- govulncheck: six stdlib advisories fixed in go1.25.13 → bump `go.mod`
- The DB integration step set the wrong env var (`DATABASE_URL`; tests gate on `TEST_DATABASE_DSN`) and was `continue-on-error`, so it gated nothing. Now runs with `-p 1` and gates.

**Production bugs** (hidden until those tests ran)
- `GET /api/v1/activity` failed on every call — CTE didn't project `user_id`
- Audit tamper-evidence could never verify — hashed a ns timestamp, stored µs
- Every audit redaction deadlocked — `RedactEntry` re-took its own mutex

**Tests**
- 13 helpers each hand-curated a migration subset; all had rotted. Replaced with one `testutil.ApplyAllMigrations` applying the full chain in numeric order (all 100 verified to replay cleanly). Fixed the seeds, envelope decoding, weight sums, timestamp precision, and ordering assumptions that surfaced.

**Dev env**
- `Dockerfile.dev`: base image < go.mod; `air@latest` now needs Go >= 1.26 → pin both
- `docker compose` failed to parse on a fresh clone → `env_file` optional

## Notes
- Audit entries already in prod keep ns-derived hashes and will still fail `VerifyChain`; re-hashing would defeat the chain. Maintainer decision.
- `contract-audit.yml` untouched — its old failures predate #1024, which fixed it.
- First commit is identical to #1065's second; they rebase cleanly either way.

## Verification
Full suite against real Postgres 16 + Redis 7 locally; CI 21/21 including the DB step under `-race`.
