### PR TITLE
fix(test): remove race in TestSavingsGoalMilestoneIntegration

### DIFF
--- a/apps/api/internal/service/savings_goal_milestone_integration_test.go
+++ b/apps/api/internal/service/savings_goal_milestone_integration_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,18 +130,18 @@ func TestSavingsGoalMilestoneIntegration(t *testing.T) {
 		t.Fatalf("progress_pct = %v, want >= 50", enriched.ProgressPct)
 	}
 
-	deadlineWait := time.After(2 * time.Second)
-	for {
-		if push.CallCount() >= 1 && persistence.Count() >= 1 {
-			break
-		}
-		select {
-		case <-deadlineWait:
-			t.Fatalf("timed out waiting for notification; push=%d persisted=%d", push.CallCount(), persistence.Count())
-		default:
-			time.Sleep(20 * time.Millisecond)
-		}
-	}
+	// Crossing 0% -> 50% trips two milestones, 25 and 50, and
+	// notifyMilestonesAsync dispatches one detached goroutine per milestone.
+	// They race, so waiting for "at least one notification" can return as soon
+	// as the 25% one lands and leave the 50% assertions below reading state
+	// that has not been written yet. Wait for the specific condition this test
+	// actually asserts on instead of for a count.
+	waitFor(t, 10*time.Second, func() bool {
+		return pushCallForMilestone(push, 50) && persistence.Count() >= 2
+	}, func() string {
+		return fmt.Sprintf("push=%d persisted=%d calls=%+v",
+			push.CallCount(), persistence.Count(), push.SnapshotCalls())
+	})
 
 	stored, err := goalRepo.GetByID(ctx, goal.ID)
 	if err != nil {
@@ -164,4 +165,39 @@ func TestSavingsGoalMilestoneIntegration(t *testing.T) {
 	if !found50 {
 		t.Fatalf("push calls = %+v, want 50%% milestone notification", calls)
 	}
+}
+
+// waitFor polls until done returns true or the timeout elapses.
+//
+// Polling rather than a fixed sleep because the work being waited on is a
+// detached goroutine with no completion signal to synchronise on; describe is
+// only evaluated on failure, so the message reports the state at the moment
+// the wait gave up rather than a stale snapshot.
+func waitFor(t *testing.T, timeout time.Duration, done func() bool, describe func() string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if done() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for notifications; %s", timeout, describe())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// pushCallForMilestone reports whether a push for the given milestone has been
+// recorded. Matched on the payload rather than the title so the check does not
+// break when copy is reworded.
+func pushCallForMilestone(push *notifications.RecordingPushSender, milestone int) bool {
+	for _, call := range push.SnapshotCalls() {
+		if value, ok := call.Payload["milestone"]; ok {
+			if asInt, ok := value.(int); ok && asInt == milestone {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

`TestSavingsGoalMilestoneIntegration` is flaky. Its wait condition does not match its assertions, so it fails intermittently — reproduced at **2 failures in 25 local runs** against a real Postgres.

This matters now rather than later: #1066 made the database integration step gating. Before that it was `continue-on-error` with the wrong env var, so the step never actually ran and this flake merged silently (it surfaced on #1054, unrelated to that change). A flaky test in a now-gating step will intermittently block merges for everyone.

## The bug

Crossing 0% → 50% progress trips **two** milestones, 25 and 50, and `notifyMilestonesAsync` dispatches one detached goroutine per milestone. They race.

The wait loop broke as soon as `push.CallCount() >= 1`, which the 25% notification satisfies on its own:

```go
if push.CallCount() >= 1 && persistence.Count() >= 1 {
    break
}
```

The assertions that follow require the **50%** push and **both** milestones persisted. Whenever the 25% goroutine won the race, the test read state that had not been written yet:

```
push calls = [{Title:Great start! ... milestone:25}], want 50% milestone notification
```

## The fix

Wait for the condition the test actually asserts on — a push carrying milestone 50, plus both notifications persisted — instead of a count that any single notification satisfies.

Matching on the payload rather than the title, so the check survives copy changes.

Timeout raised 2s → 10s. The old value was tight for two round-trips under `-race` on a loaded runner, and a longer ceiling costs nothing on the passing path since the wait returns as soon as the condition holds.

## Verification

Against a local Postgres 16 with `TEST_DATABASE_DSN` set:

| | Result |
|---|---|
| Previous code | **2 failures / 25 runs** |
| This change | **65 / 65 pass** |
| Full DB suite (`go test -p 1 ./...`) | pass |
| `go build` / `go vet` | pass |

## Scope

One test file. No production code changed.

`TestSavingsGoalDepositMilestoneCompletionLifecycle_Integration` uses the same polling shape, but waits for `>= 4` and asserts on exactly four milestones — its condition does match its assertions. Confirmed stable 15/15 and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of savings goal milestone notification tests.
  * Added clearer timeout diagnostics when milestone notifications or persistence records are not received as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->