### PR TITLE
fix(contracts): degrade deviation-rejected yield sources

### DIFF
--- a/packages/contracts/contracts/yield_registry/src/lib.rs
+++ b/packages/contracts/contracts/yield_registry/src/lib.rs
@@ -117,6 +117,7 @@ pub struct SourceMigrationEventData {
     pub migration_completed_at: u64,
 }
 
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -635,12 +636,15 @@ impl YieldRegistryContract {
         let mut source = get_source_or_panic(&env, &id);
 
         // Deviation guard: reject single-update jumps that are implausible.
-        // Threshold is read from storage so it can be tuned by an admin.
+        // Threshold is read from storage so it can be tuned by an admin. Do
+        // not panic here: a panic would roll back the failure accounting and
+        // let a source report rejected values indefinitely without degrading.
         let last_apy = source.current_apy_bps;
         if last_apy != 0 {
             let deviation = new_apy_bps.abs_diff(last_apy);
             if deviation > apy_deviation_threshold(&env) {
-                panic_with_error!(env, ContractError::InvalidOperation);
+                record_failure(&env, &id, &mut source, &caller);
+                return;
             }
         }
 
@@ -1059,7 +1063,6 @@ impl YieldRegistryContract {
         }
     }
 }
-
 
 // ---------------------------------------------------------------------------
 // Private helpers

--- a/packages/contracts/contracts/yield_registry/src/test.rs
+++ b/packages/contracts/contracts/yield_registry/src/test.rs
@@ -419,9 +419,7 @@ fn test_apy_update_exceeds_threshold_rejected() {
     client.update_apy(&admin, &aave_id(&env), &1_000);
 
     // +6000 bps exceeds the 5000-bps threshold and must be rejected.
-    assert!(client
-        .try_update_apy(&admin, &aave_id(&env), &7_000)
-        .is_err());
+    client.update_apy(&admin, &aave_id(&env), &7_000);
 
     // The rejected update must not have mutated stored state.
     assert_eq!(
@@ -430,6 +428,7 @@ fn test_apy_update_exceeds_threshold_rejected() {
             .current_apy_bps,
         1_000
     );
+    assert_eq!(client.get_source_failure_count(&aave_id(&env)), 1);
 }
 
 #[test]
@@ -460,9 +459,13 @@ fn test_admin_can_override_deviation_guard() {
     client.update_apy(&admin, &aave_id(&env), &1_000);
 
     // Sanity: the guarded path rejects this jump (dev 7000 > 5000).
-    assert!(client
-        .try_update_apy(&admin, &aave_id(&env), &8_000)
-        .is_err());
+    client.update_apy(&admin, &aave_id(&env), &8_000);
+    assert_eq!(
+        client
+            .get_source_performance(&aave_id(&env))
+            .current_apy_bps,
+        1_000
+    );
 
     // The admin emergency override bypasses the guard.
     client.update_apy_override(&admin, &aave_id(&env), &8_000);
@@ -500,9 +503,7 @@ fn test_apy_update_at_exact_threshold_boundary() {
     client.update_apy(&admin, &aave_id(&env), &1_000);
 
     // One bps PAST the threshold (dev 5001) is rejected — leaves state at 1000.
-    assert!(client
-        .try_update_apy(&admin, &aave_id(&env), &6_001)
-        .is_err());
+    client.update_apy(&admin, &aave_id(&env), &6_001);
     assert_eq!(
         client
             .get_source_performance(&aave_id(&env))
@@ -539,9 +540,7 @@ fn test_threshold_is_configurable_from_storage() {
     assert_eq!(client.get_apy_deviation_threshold(), 1_000);
 
     // A +1500 jump passed under the default 5000 but now exceeds the new 1000.
-    assert!(client
-        .try_update_apy(&admin, &aave_id(&env), &2_500)
-        .is_err());
+    client.update_apy(&admin, &aave_id(&env), &2_500);
     assert_eq!(
         client
             .get_source_performance(&aave_id(&env))
@@ -580,6 +579,39 @@ fn test_set_threshold_above_max_apy_rejected() {
 
     // Threshold cannot exceed the absolute APY ceiling (MAX_APY_BPS = 10000).
     client.set_apy_deviation_threshold(&admin, &10_001);
+}
+
+#[test]
+fn consecutive_deviation_rejections_require_explicit_recovery() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let id = aave_id(&env);
+    register_default(&client, &env, &admin, &id);
+
+    client.set_apy_deviation_threshold(&admin, &100);
+    client.set_failure_threshold(&admin, &2);
+    client.update_apy(&admin, &id, &500);
+
+    // The configured threshold is the tolerated failure count, so the next
+    // failure crosses it and degrades the source.
+    for expected_count in 1..=3 {
+        client.update_apy(&admin, &id, &900);
+        assert_eq!(client.get_source_failure_count(&id), expected_count);
+    }
+
+    assert_eq!(client.get_source_status(&id), SourceStatus::Degraded);
+    assert_eq!(client.get_active_sources().len(), 0);
+    assert_eq!(client.get_source_performance(&id).current_apy_bps, 500);
+
+    // A subsequent valid reading may update performance, but must not make
+    // the source eligible for allocation again without an admin decision.
+    client.update_apy(&admin, &id, &550);
+    assert_eq!(client.get_source_status(&id), SourceStatus::Degraded);
+    assert_eq!(client.get_active_sources().len(), 0);
+
+    client.recover_source(&admin, &id);
+    assert_eq!(client.get_source_status(&id), SourceStatus::Active);
+    assert_eq!(client.get_active_sources().len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  This PR ensures APY readings rejected for exceeding the deviation bound increment the yield source’s failure counter. Repeated
  rejected readings degrade the source and exclude it from allocation until an admin explicitly recovers it.

  ## Related Issues

  Closes #1079

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation

  ## Changes Made

  - Record a source failure when an APY update exceeds the configured deviation threshold while preserving the last accepted APY.
  - Add regression coverage confirming consecutive rejected readings degrade the source, exclude it from active sources, and
    require explicit admin recovery.

  ## Testing Done

  Ran the yield registry contract test suite:

  cargo test -p yield-registry-contract

  All 49 tests passed.

  ## Screenshots

  Not applicable; this PR contains no UI changes.

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated for changes
  - [x] Documentation updated if needed
  - [x] No secrets or credentials in the code
  - [x] Smart contract changes reviewed for security implications