### PR TITLE
fix(contracts): prevent performance fee holder dilution

### DIFF
--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -2158,9 +2158,9 @@ impl VaultContract {
     /// Steps (issue #518):
     ///  1. Calculate accrued yield since last harvest.
     ///  2. Deduct performance fee — only on net positive yield, never on impairment.
-    ///  3. Send the fee portion to the treasury contract.
-    ///  4. Compound the net yield: mint new vault-token shares at the current price
-    ///     and credit them to `user`, then increase TotalAssets accordingly.
+    ///  3. Burn fee-equivalent shares from `user` and send that value to the
+    ///     treasury, preserving the exchange rate for every other holder.
+    ///  4. Leave the net yield compounded in `user`'s remaining shares.
     ///  5. Update `LastHarvestAt` timestamp for `user`.
     ///
     /// Returns a zero-filled `HarvestResult` with `compounded: false` when the
@@ -2211,8 +2211,23 @@ impl VaultContract {
             .checked_sub(performance_fee)
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::ArithmeticOverflow));
 
-        // Transfer performance fee to treasury.
+        // Charge the performance fee against the harvesting user only. Yield
+        // is already reflected in TotalAssets and therefore in the value of
+        // the user's existing shares. Minting more shares for that same yield,
+        // or reducing assets without reducing supply, would dilute passive
+        // holders. Burning enough of the user's shares to cover the fee before
+        // transferring it reduces assets and supply together. Rounding the
+        // share charge up assigns any dust to the fee payer, never to holders
+        // who did not harvest.
         if performance_fee > 0 {
+            let fee_shares = conversion::assets_to_shares_up(
+                performance_fee,
+                get_net_total_assets(&env),
+                vault_token_client(&env).total_supply(),
+            )
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
+            let _ = vault_token_client(&env).burn_for_withdrawal(&user, &fee_shares);
+
             let token_address = self::VaultContract::get_token(env.clone());
             transfer_tokens(
                 &env,
@@ -2242,20 +2257,6 @@ impl VaultContract {
             // no-op when no referral contract is configured.
             notify_referral_of_fee(&env, &user, performance_fee, principal);
         }
-
-        // Compound net yield: mint new shares for the user at the current price.
-        // The gross yield was already added to TotalAssets by report_yield, so
-        // only the fee reduction above affects TotalAssets here.
-        let new_shares = if net_yield > 0 {
-            let s = vault_token_client(&env).mint_for_deposit(&user, &net_yield);
-            // mint_for_deposit increments vault token's total_assets by net_yield, but
-            // that amount was already tracked by report_yield — sync back to the correct value.
-            sync_vault_token_total_assets(&env);
-            s
-        } else {
-            0
-        };
-        let _ = new_shares; // shares minted internally; user balance updated by vault token
 
         // Reset per-user pending yield to zero and record harvest timestamp.
         set_user_yield(&env, &user, 0);

--- a/packages/contracts/contracts/vault/src/test.rs
+++ b/packages/contracts/contracts/vault/src/test.rs
@@ -1370,10 +1370,11 @@ fn test_harvest_basic() {
     assert!(result.compounded);
     assert_eq!(result.user, user);
 
-    // new_share_balance must be >= shares before harvest (net yield minted new shares)
+    // Yield was already reflected in the existing shares. Harvest charges the
+    // fee by burning only the harvesting user's fee-equivalent shares.
     assert!(
-        result.new_share_balance >= shares_before,
-        "share balance should have grown after compounding"
+        result.new_share_balance < shares_before,
+        "only fee-equivalent shares should be burned from the harvesting user"
     );
 
     // Performance fee must have been sent to treasury (not sitting in accrued fees)
@@ -1604,8 +1605,7 @@ fn test_harvest_impairment_no_fee_charged() {
 }
 
 #[test]
-fn test_harvest_new_share_balance_increases() {
-    // After harvest, user's share balance should be greater than before
+fn harvest_fee_burns_only_the_harvesting_users_shares() {
     let (env, admin, token, vault, _treasury) = setup();
     let user = Address::generate(&env);
     let deposit = 1_000 * XLM;
@@ -1617,18 +1617,57 @@ fn test_harvest_new_share_balance_increases() {
     vault.grant_role(&admin, &admin, &Role::Manager);
     vault.report_yield(&admin, &(500 * XLM));
 
-    let shares_before = vault.get_shares(&admin);
-    let result = vault.harvest(&admin);
+    let shares_before = vault.get_shares(&user);
+    let result = vault.harvest(&user);
 
     assert!(
-        result.new_share_balance >= shares_before,
-        "share balance must not decrease after harvest with positive yield"
+        result.new_share_balance < shares_before,
+        "the performance fee must be charged in the harvesting user's shares"
     );
     assert_eq!(
         result.new_share_balance,
-        vault.get_shares(&admin),
+        vault.get_shares(&user),
         "new_share_balance in result must match on-chain balance"
     );
+}
+
+#[test]
+fn performance_fee_does_not_dilute_passive_holders() {
+    let (env, admin, token, vault, treasury) = setup();
+    let harvester = Address::generate(&env);
+    let passive_holder = Address::generate(&env);
+    let deposit = 1_000 * XLM;
+    let yield_amount = 200 * XLM;
+
+    mint(&token, &harvester, deposit);
+    mint(&token, &passive_holder, deposit);
+    vault.deposit(&harvester, &deposit, &0);
+    vault.deposit(&passive_holder, &deposit, &0);
+
+    vault.grant_role(&admin, &admin, &Role::Manager);
+    mint(&token, &vault.address, yield_amount);
+    vault.report_yield(&admin, &yield_amount);
+
+    let passive_value_before = vault.get_balance(&passive_holder);
+    let share_price_before = vault.share_price();
+    let treasury_before = token::Client::new(&env, &token.address).balance(&treasury);
+
+    let result = vault.harvest(&harvester);
+
+    let share_price_after = vault.share_price();
+    let passive_value_after = vault.get_balance(&passive_holder);
+    let treasury_after = token::Client::new(&env, &token.address).balance(&treasury);
+
+    assert!(result.performance_fee > 0, "the regression must exercise a fee");
+    assert!(
+        share_price_after >= share_price_before,
+        "one user's performance fee must not lower the exchange rate"
+    );
+    assert!(
+        passive_value_after >= passive_value_before,
+        "a passive holder must not lose value when another user harvests"
+    );
+    assert_eq!(treasury_after - treasury_before, result.performance_fee);
 }
 
 #[test]

--- a/packages/contracts/tests/integration/src/integration/property_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/property_tests.rs
@@ -15,8 +15,9 @@
 extern crate std;
 
 use proptest::prelude::*;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::Address;
 
+use nester_access_control::Role;
 use nester_test_utils::NesterHarness;
 
 const STROOP: i128 = 1;
@@ -28,6 +29,7 @@ enum VaultOp {
     Deposit { user_idx: usize, amount: i128 },
     Withdraw { user_idx: usize, shares: i128 },
     ReportYield { amount: i128 },
+    ReportLoss { amount: i128 },
 }
 
 fn amount_strategy() -> impl Strategy<Value = i128> {
@@ -52,6 +54,9 @@ fn op_strategy(num_users: usize) -> impl Strategy<Value = VaultOp> {
             shares,
         }),
         (0..10_000_i128).prop_map(|amount| VaultOp::ReportYield {
+            amount: amount * XLM / 100,
+        }),
+        (1..1_000_i128).prop_map(|amount| VaultOp::ReportLoss {
             amount: amount * XLM / 100,
         }),
     ]
@@ -193,12 +198,10 @@ proptest! {
                         continue;
                     }
 
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().deposit(&users[user_idx], &amount, &0)
-                    }));
+                    let result = h.vault().try_deposit(&users[user_idx], &amount, &0);
 
-                    if let Ok(shares) = result {
-                        let model_shares = model.deposit(user_idx, amount);
+                    if result.is_ok() {
+                        model.deposit(user_idx, amount);
                         prop_assert!(
                             model.check_conservation(),
                             "share balance consistency violated after deposit"
@@ -206,16 +209,18 @@ proptest! {
                     }
                 }
                 VaultOp::Withdraw { user_idx, shares } => {
-                    if shares == 0 {
+                    let owned = h.token().balance(&users[user_idx]);
+                    let actual_shares = shares.min(owned);
+                    if actual_shares == 0 {
                         continue;
                     }
 
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().withdraw(&users[user_idx], &shares, &0)
-                    }));
+                    let result = h
+                        .vault()
+                        .try_withdraw(&users[user_idx], &actual_shares, &0);
 
                     if let Ok(_) = result {
-                        model.withdraw(user_idx, shares);
+                        model.withdraw(user_idx, actual_shares);
                         prop_assert!(
                             model.check_conservation(),
                             "share balance consistency violated after withdraw"
@@ -227,28 +232,18 @@ proptest! {
                         model.report_yield(amount);
                     }
                 }
+                VaultOp::ReportLoss { amount } => model.report_yield(-amount),
             }
         }
 
         prop_assert!(model.check_conservation(), "final share balance consistency");
     }
 
-    // TODO(#1029): this property fails on a real inconsistency, not a flake.
-    // ReferenceModel::withdraw moves the 10% performance fee out of
-    // total_assets while total_shares is unchanged, so share price drops for
-    // the remaining holders (observed 10002000 -> 10000000). Whether the model,
-    // the contract, or the invariant is wrong is a vault fee-accounting
-    // question tracked in #1029, which closes by removing this ignore.
-    //
-    // The test could not run at all until the register_source arity error in
-    // adversarial_tests.rs was fixed, so this has never passed or failed in CI
-    // before. Ignoring it lets the other 263 workspace tests execute.
     #[test]
-    #[ignore = "see #1029: performance fee dilutes remaining holders"]
-    fn prop_share_price_non_decreasing_with_positive_yield(ops in prop::collection::vec(op_strategy(2), 1..30)) {
+    fn prop_share_price_non_decreasing_except_real_loss(ops in prop::collection::vec(op_strategy(2), 1..30)) {
         let (h, users) = setup_harness_with_users(2);
-        let mut model = ReferenceModel::new(2);
-        let mut prev_price = XLM;
+        h.vault().grant_role(&h.admin, &h.admin, &Role::Manager);
+        let mut prev_price = h.vault().share_price();
 
         for op in ops {
             match op {
@@ -257,13 +252,10 @@ proptest! {
                         continue;
                     }
 
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().deposit(&users[user_idx], &amount, &0)
-                    }));
+                    let result = h.vault().try_deposit(&users[user_idx], &amount, &0);
 
                     if let Ok(_) = result {
-                        model.deposit(user_idx, amount);
-                        let current_price = model.share_price();
+                        let current_price = h.vault().share_price();
                         prop_assert!(
                             current_price >= prev_price,
                             "share price decreased: {} -> {}",
@@ -274,22 +266,36 @@ proptest! {
                     }
                 }
                 VaultOp::Withdraw { user_idx, shares } => {
-                    if shares == 0 {
+                    let actual_shares = shares.min(h.token().balance(&users[user_idx]));
+                    if actual_shares == 0 {
                         continue;
                     }
 
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().withdraw(&users[user_idx], &shares, &0)
-                    }));
+                    let result = h
+                        .vault()
+                        .try_withdraw(&users[user_idx], &actual_shares, &0);
 
                     if let Ok(_) = result {
-                        model.withdraw(user_idx, shares);
+                        let current_price = h.vault().share_price();
+                        // With no shares left there are no remaining holders;
+                        // share_price() intentionally returns its 1.0 bootstrap
+                        // value, so monotonicity is not meaningful in that state.
+                        if h.token().total_supply() > 0 {
+                            prop_assert!(
+                                current_price >= prev_price,
+                                "share price decreased after withdrawal: {} -> {}",
+                                prev_price,
+                                current_price
+                            );
+                        }
+                        prev_price = current_price;
                     }
                 }
                 VaultOp::ReportYield { amount } => {
-                    if amount > 0 {
-                        model.report_yield(amount);
-                        let current_price = model.share_price();
+                    if amount > 0 && h.token().total_supply() > 0 {
+                        h.mint_deposit_tokens(&h.vault_id, amount);
+                        h.vault().report_yield(&h.admin, &amount);
+                        let current_price = h.vault().share_price();
                         prop_assert!(
                             current_price >= prev_price,
                             "share price decreased after yield: {} -> {}",
@@ -297,6 +303,15 @@ proptest! {
                             current_price
                         );
                         prev_price = current_price;
+                    }
+                }
+                VaultOp::ReportLoss { amount } => {
+                    // A real impairment is the sole operation allowed to lower
+                    // the exchange rate. Whether the sanity guard accepts or
+                    // rejects it, establish the resulting price as the new base.
+                    if h.token().total_supply() > 0 {
+                        h.vault().report_yield(&h.admin, &(-amount));
+                        prev_price = h.vault().share_price();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

  This PR prevents performance fees charged during harvest from diluting passive vault shareholders. Fee-equivalent shares are now
  burned from the harvesting user, while net yield remains compounded in their remaining shares.

  ## Related Issues

  Closes #1078

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation

  ## Changes Made

  - Charge performance fees by burning fee-equivalent shares from the harvesting user before transferring the fee to the treasury.
  - Document the chosen fee mechanism and its rounding behavior in the contract.
  - Add a regression test proving another user’s harvest cannot reduce a passive holder’s share price or value.
  - Update existing harvest fee tests for the corrected share accounting.
  - Re-enable and correct the property test covering randomized deposits, yield accruals, losses, and withdrawals.

  ## Testing Done

  Ran the complete vault contract and integration test suites:

  cargo test -p vault-contract
  cargo test -p nester-integration-tests

  Results:

  - Vault contract: 124 passed.
  - Integration tests: 74 passed.
  - No ignored integration tests.

  ## Screenshots

  Not applicable; this PR contains no UI changes.

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated for changes
  - [x] Documentation updated if needed
  - [x] No secrets or credentials in the code
  - [x] Smart contract changes reviewed for security implications