### PR TITLE
test(contracts): add share accounting invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,15 @@ jobs:
         run: test -f target/wasm32-unknown-unknown/release/vault_token.wasm
 
       - name: Test contracts
+        env:
+          PROPTEST_RNG_SEED: "29062026"
         run: cargo test --lib
+
+      - name: Run deterministic share-accounting properties
+        env:
+          PROPTEST_CASES: "32"
+          PROPTEST_RNG_SEED: "29062026"
+        run: cargo test -p nester-integration-tests property_tests
 
       # The vault contract's integration tests link against the pre-compiled
       # vault_token.wasm artifact built above. Run them explicitly and fail the

--- a/.github/workflows/contracts-property-nightly.yml
+++ b/.github/workflows/contracts-property-nightly.yml
@@ -1,0 +1,29 @@
+name: Nightly contract property tests
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  share-accounting:
+    name: Randomized share accounting
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: packages/contracts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Deliberately omit PROPTEST_RNG_SEED: each nightly run explores a new
+      # set of sequences, while ci.yml supplies the reproducible merge gate.
+      - name: Run randomized share-accounting properties
+        env:
+          PROPTEST_CASES: "256"
+        run: cargo test -p nester-integration-tests property_tests -- --nocapture

--- a/packages/contracts/contracts/vault/src/lib.rs
+++ b/packages/contracts/contracts/vault/src/lib.rs
@@ -2870,7 +2870,10 @@ impl VaultContract {
             // that are owed to queued withdrawal requests.
             let current_reserves = get_vault_liquid_reserves(&env);
             let reserved = get_liquid_reserved(&env);
-            let available = current_reserves.saturating_sub(reserved);
+            // Signed saturating subtraction can still produce a negative value.
+            // Clamp exhausted reserves to zero so fee collection is a no-op
+            // instead of attempting an invalid negative token transfer.
+            let available = current_reserves.saturating_sub(reserved).max(0);
             let collectable = fees.min(available);
 
             if collectable == 0 {

--- a/packages/contracts/tests/integration/proptest-regressions/integration/property_tests.txt
+++ b/packages/contracts/tests/integration/proptest-regressions/integration/property_tests.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 15626eeed61bd56199c773df92b778dfa3af73e78d750cc9d32087d47fd96df8 # shrinks to ops = [ReportYield { amount: 200000 }, Deposit { user_idx: 0, amount: 1 }, Deposit { user_idx: 0, amount: 1000000000 }, Withdraw { user_idx: 0, shares: 1000000000 }, Deposit { user_idx: 0, amount: 10000000 }]
+cc ffacbb6f42e28bf386628567abd63c8e1564c372cbfa3ab5c1cb10aa9886aea2 # shrinks to ops = [Deposit { user_idx: 1, amount: 10000000 }, ReportYield { yield_bps: 457 }, Withdraw { user_idx: 1, share_bps: 8953 }, Withdraw { user_idx: 1, share_bps: 7158 }, CollectFees]

--- a/packages/contracts/tests/integration/src/integration/property_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/property_tests.rs
@@ -1,8 +1,8 @@
 //! Property-based invariant tests for vault share-price and accounting.
 //!
-//! These tests generate randomised sequences of vault operations and assert
-//! that core accounting invariants hold throughout. The reference model
-//! provides an obviously-correct implementation to compare against.
+//! These tests generate adversarial sequences against the live contracts and
+//! assert the accounting invariants after every successful operation. CI uses
+//! a fixed seed; the nightly workflow deliberately leaves the seed random.
 //!
 //! Run with:
 //!   cargo test -p nester-integration-tests property_tests
@@ -15,8 +15,9 @@
 extern crate std;
 
 use proptest::prelude::*;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::Address;
 
+use nester_access_control::Role;
 use nester_test_utils::NesterHarness;
 
 const STROOP: i128 = 1;
@@ -26,8 +27,10 @@ const MIN_DEPOSIT: i128 = 10_000_000;
 #[derive(Debug, Clone)]
 enum VaultOp {
     Deposit { user_idx: usize, amount: i128 },
-    Withdraw { user_idx: usize, shares: i128 },
-    ReportYield { amount: i128 },
+    Withdraw { user_idx: usize, share_bps: u32 },
+    ReportYield { yield_bps: u32 },
+    ReportLoss { loss_bps: u32 },
+    CollectFees,
 }
 
 fn amount_strategy() -> impl Strategy<Value = i128> {
@@ -43,17 +46,15 @@ fn amount_strategy() -> impl Strategy<Value = i128> {
 
 fn op_strategy(num_users: usize) -> impl Strategy<Value = VaultOp> {
     prop_oneof![
-        (0..num_users, amount_strategy()).prop_map(|(user_idx, amount)| VaultOp::Deposit {
-            user_idx,
-            amount,
-        }),
-        (0..num_users, amount_strategy()).prop_map(|(user_idx, shares)| VaultOp::Withdraw {
-            user_idx,
-            shares,
-        }),
-        (0..10_000_i128).prop_map(|amount| VaultOp::ReportYield {
-            amount: amount * XLM / 100,
-        }),
+        4 => (0..num_users, amount_strategy())
+            .prop_map(|(user_idx, amount)| VaultOp::Deposit { user_idx, amount }),
+        4 => (0..num_users, 1_u32..=10_000_u32)
+            .prop_map(|(user_idx, share_bps)| VaultOp::Withdraw { user_idx, share_bps }),
+        2 => (1_u32..=2_000_u32)
+            .prop_map(|yield_bps| VaultOp::ReportYield { yield_bps }),
+        1 => (1_u32..=1_000_u32)
+            .prop_map(|loss_bps| VaultOp::ReportLoss { loss_bps }),
+        1 => Just(VaultOp::CollectFees),
     ]
 }
 
@@ -152,15 +153,14 @@ impl ReferenceModel {
         let sum_user_shares: i128 = self.user_shares.iter().sum();
         sum_user_shares == self.total_shares
     }
-
-    fn check_share_price_monotonic(&self, prev_price: i128) -> bool {
-        let current = self.share_price();
-        current >= prev_price
-    }
 }
 
 fn setup_harness_with_users(num_users: usize) -> (NesterHarness, std::vec::Vec<Address>) {
     let h = NesterHarness::setup();
+    // A generated case intentionally performs many contract calls in one Env.
+    // Remove the emulator's cumulative test budget so a valid long sequence is
+    // evaluated by the accounting invariants instead of failing on test plumbing.
+    h.env.budget().reset_unlimited();
     let mut users = std::vec![];
 
     for _ in 0..num_users {
@@ -172,189 +172,170 @@ fn setup_harness_with_users(num_users: usize) -> (NesterHarness, std::vec::Vec<A
     (h, users)
 }
 
+fn configure_invariant_harness(h: &NesterHarness) {
+    let mut breaker = h.vault().get_breaker_config_v2();
+    breaker.price_move_enabled = false;
+    breaker.yield_sanity_enabled = false;
+    breaker.withdraw_velocity_enabled = false;
+    breaker.source_failure_enabled = false;
+    h.vault().set_breaker_config(&h.admin, &breaker);
+
+    let mut fees = h.vault().get_fee_config();
+    fees.management_fee_bps = 0;
+    fees.performance_fee_bps = 1_000;
+    fees.early_withdrawal_fee_bps = 100;
+    h.vault().set_fee_config(&h.admin, &fees);
+    h.vault().grant_role(&h.admin, &h.admin, &Role::Manager);
+}
+
+fn sum_user_assets(h: &NesterHarness, users: &[Address]) -> i128 {
+    users.iter().map(|user| h.vault().get_balance(user)).sum()
+}
+
+fn sum_user_shares(h: &NesterHarness, users: &[Address]) -> i128 {
+    users.iter().map(|user| h.token().balance(user)).sum()
+}
+
 proptest! {
     #![proptest_config(ProptestConfig {
         cases: std::env::var("PROPTEST_CASES")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(100),
+            .unwrap_or(16),
         ..ProptestConfig::default()
     })]
 
     #[test]
-    fn prop_share_balance_consistency(ops in prop::collection::vec(op_strategy(3), 1..50)) {
+    fn prop_randomized_share_accounting_invariants(
+        ops in prop::collection::vec(op_strategy(3), 1..30)
+    ) {
         let (h, users) = setup_harness_with_users(3);
-        let mut model = ReferenceModel::new(3);
+        configure_invariant_harness(&h);
+        let mut previous_price = h.vault().share_price();
 
         for op in ops {
+            let mut loss_event = false;
+
             match op {
                 VaultOp::Deposit { user_idx, amount } => {
+                    // Values below the contract minimum are not valid deposits.
                     if amount < MIN_DEPOSIT {
                         continue;
                     }
-
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().deposit(&users[user_idx], &amount, &0)
-                    }));
-
-                    if let Ok(shares) = result {
-                        let model_shares = model.deposit(user_idx, amount);
-                        prop_assert!(
-                            model.check_conservation(),
-                            "share balance consistency violated after deposit"
-                        );
-                    }
+                    h.vault().deposit(&users[user_idx], &amount, &0);
                 }
-                VaultOp::Withdraw { user_idx, shares } => {
-                    if shares == 0 {
+                VaultOp::Withdraw { user_idx, share_bps } => {
+                    let owned = h.token().balance(&users[user_idx]);
+                    if owned == 0 {
                         continue;
                     }
-
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().withdraw(&users[user_idx], &shares, &0)
-                    }));
-
-                    if let Ok(_) = result {
-                        model.withdraw(user_idx, shares);
-                        prop_assert!(
-                            model.check_conservation(),
-                            "share balance consistency violated after withdraw"
-                        );
-                    }
+                    let shares = (owned * i128::from(share_bps) / 10_000)
+                        .max(1)
+                        .min(owned);
+                    h.vault().withdraw(&users[user_idx], &shares, &0);
                 }
-                VaultOp::ReportYield { amount } => {
-                    if amount > 0 {
-                        model.report_yield(amount);
+                VaultOp::ReportYield { yield_bps } => {
+                    let total_assets = h.vault().total_assets();
+                    if h.vault().total_shares() == 0 || total_assets == 0 {
+                        continue;
                     }
+                    let amount = (total_assets * i128::from(yield_bps) / 10_000).max(1);
+                    h.mint_deposit_tokens(&h.vault_id, amount);
+                    h.vault().report_yield(&h.admin, &amount);
+                }
+                VaultOp::ReportLoss { loss_bps } => {
+                    let total_assets = h.vault().total_assets();
+                    if h.vault().total_shares() == 0 || total_assets <= 1 {
+                        continue;
+                    }
+                    let loss = (total_assets * i128::from(loss_bps) / 10_000)
+                        .max(1)
+                        .min(total_assets - 1);
+                    h.vault().report_yield(&h.admin, &-loss);
+                    loss_event = true;
+                }
+                VaultOp::CollectFees => {
+                    h.vault().collect_fees(&h.admin);
                 }
             }
-        }
 
-        prop_assert!(model.check_conservation(), "final share balance consistency");
-    }
+            let total_assets = h.vault().total_assets();
+            let total_shares = h.vault().total_shares();
+            let user_assets = sum_user_assets(&h, &users);
+            let user_shares = sum_user_shares(&h, &users);
+            let current_price = h.vault().share_price();
 
-    // TODO(#1029): this property fails on a real inconsistency, not a flake.
-    // ReferenceModel::withdraw moves the 10% performance fee out of
-    // total_assets while total_shares is unchanged, so share price drops for
-    // the remaining holders (observed 10002000 -> 10000000). Whether the model,
-    // the contract, or the invariant is wrong is a vault fee-accounting
-    // question tracked in #1029, which closes by removing this ignore.
-    //
-    // The test could not run at all until the register_source arity error in
-    // adversarial_tests.rs was fixed, so this has never passed or failed in CI
-    // before. Ignoring it lets the other 263 workspace tests execute.
-    #[test]
-    #[ignore = "see #1029: performance fee dilutes remaining holders"]
-    fn prop_share_price_non_decreasing_with_positive_yield(ops in prop::collection::vec(op_strategy(2), 1..30)) {
-        let (h, users) = setup_harness_with_users(2);
-        let mut model = ReferenceModel::new(2);
-        let mut prev_price = XLM;
-
-        for op in ops {
-            match op {
-                VaultOp::Deposit { user_idx, amount } => {
-                    if amount < MIN_DEPOSIT {
-                        continue;
-                    }
-
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().deposit(&users[user_idx], &amount, &0)
-                    }));
-
-                    if let Ok(_) = result {
-                        model.deposit(user_idx, amount);
-                        let current_price = model.share_price();
-                        prop_assert!(
-                            current_price >= prev_price,
-                            "share price decreased: {} -> {}",
-                            prev_price,
-                            current_price
-                        );
-                        prev_price = current_price;
-                    }
-                }
-                VaultOp::Withdraw { user_idx, shares } => {
-                    if shares == 0 {
-                        continue;
-                    }
-
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        h.vault().withdraw(&users[user_idx], &shares, &0)
-                    }));
-
-                    if let Ok(_) = result {
-                        model.withdraw(user_idx, shares);
-                    }
-                }
-                VaultOp::ReportYield { amount } => {
-                    if amount > 0 {
-                        model.report_yield(amount);
-                        let current_price = model.share_price();
-                        prop_assert!(
-                            current_price >= prev_price,
-                            "share price decreased after yield: {} -> {}",
-                            prev_price,
-                            current_price
-                        );
-                        prev_price = current_price;
-                    }
-                }
+            prop_assert!(
+                user_assets <= total_assets,
+                "sum of user assets ({}) exceeds total assets ({}) after {:?}",
+                user_assets,
+                total_assets,
+                op
+            );
+            prop_assert_eq!(
+                user_shares,
+                total_shares,
+                "user shares do not sum to total shares after {:?}",
+                op
+            );
+            if !loss_event && total_shares > 0 {
+                prop_assert!(
+                    current_price >= previous_price,
+                    "share price decreased without a loss: {} -> {} after {:?}",
+                    previous_price,
+                    current_price,
+                    op
+                );
             }
+            previous_price = current_price;
         }
     }
 
     #[test]
     fn prop_round_trip_safety(amount in MIN_DEPOSIT..(100_000 * XLM)) {
         let (h, users) = setup_harness_with_users(1);
+        configure_invariant_harness(&h);
+        let mut fees = h.vault().get_fee_config();
+        fees.performance_fee_bps = 0;
+        fees.early_withdrawal_fee_bps = 0;
+        h.vault().set_fee_config(&h.admin, &fees);
 
-        let deposit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            h.vault().deposit(&users[0], &amount, &0)
-        }));
+        let balance_before = soroban_sdk::token::TokenClient::new(
+            &h.env,
+            &h.deposit_token_id,
+        ).balance(&users[0]);
+        let shares = h.vault().deposit(&users[0], &amount, &0);
+        h.vault().withdraw(&users[0], &shares, &0);
+        let balance_after = soroban_sdk::token::TokenClient::new(
+            &h.env,
+            &h.deposit_token_id,
+        ).balance(&users[0]);
 
-        if let Ok(shares) = deposit_result {
-            let withdraw_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                h.vault().withdraw(&users[0], &shares, &0)
-            }));
-
-            if let Ok(returned) = withdraw_result {
-                prop_assert!(
-                    returned <= amount,
-                    "round trip returned more: deposited {}, got {}",
-                    amount,
-                    returned
-                );
-            }
-        }
+        prop_assert!(
+            balance_after <= balance_before,
+            "round trip returned more: started with {}, ended with {}",
+            balance_before,
+            balance_after
+        );
     }
 
     #[test]
     fn prop_empty_vault_first_deposit(amount in MIN_DEPOSIT..(1_000_000 * XLM)) {
         let (h, users) = setup_harness_with_users(1);
-
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            h.vault().deposit(&users[0], &amount, &0)
-        }));
-
-        if let Ok(shares) = result {
-            prop_assert_eq!(shares, amount, "first deposit should be 1:1");
-        }
+        configure_invariant_harness(&h);
+        let shares = h.vault().deposit(&users[0], &amount, &0);
+        prop_assert_eq!(shares, amount, "first deposit should be 1:1");
     }
 
     #[test]
     fn prop_one_stroop_deposit_handling(num_deposits in 1..10usize) {
         let (h, users) = setup_harness_with_users(1);
+        configure_invariant_harness(&h);
+        h.vault().deposit(&users[0], &MIN_DEPOSIT, &0);
 
-        let first_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            h.vault().deposit(&users[0], &MIN_DEPOSIT, &0)
-        }));
-
-        if first_result.is_ok() {
-            for _ in 0..num_deposits {
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    h.vault().deposit(&users[0], &(MIN_DEPOSIT + STROOP), &0)
-                }));
-                let _ = result;
-            }
+        for _ in 0..num_deposits {
+            let shares = h.vault().deposit(&users[0], &(MIN_DEPOSIT + STROOP), &0);
+            prop_assert!(shares > 0, "valid deposit minted no shares");
         }
     }
 }
@@ -399,7 +380,10 @@ fn test_reference_model_yield() {
     model.report_yield(100);
     let price_after = model.share_price();
 
-    assert!(price_after > price_before, "yield should increase share price");
+    assert!(
+        price_after > price_before,
+        "yield should increase share price"
+    );
 }
 
 #[test]
@@ -420,4 +404,31 @@ fn test_reference_model_conservation() {
 
     model.withdraw(1, 1000);
     assert!(model.check_conservation());
+}
+
+// Regression for the counterexample found by the generated state machine:
+// fee collection used to derive a negative collectable amount after yield and
+// successive partial withdrawals exhausted the tracked liquid reserves.
+#[test]
+fn regression_collect_fees_with_exhausted_reserves_does_not_panic() {
+    let (h, users) = setup_harness_with_users(2);
+    configure_invariant_harness(&h);
+
+    h.vault().deposit(&users[1], &MIN_DEPOSIT, &0);
+    let yield_amount = MIN_DEPOSIT * 457 / 10_000;
+    h.mint_deposit_tokens(&h.vault_id, yield_amount);
+    h.vault().report_yield(&h.admin, &yield_amount);
+
+    let first_balance = h.token().balance(&users[1]);
+    let first_withdrawal = (first_balance * 8_953 / 10_000).max(1);
+    h.vault().withdraw(&users[1], &first_withdrawal, &0);
+
+    let second_balance = h.token().balance(&users[1]);
+    let second_withdrawal = (second_balance * 7_158 / 10_000).max(1);
+    h.vault().withdraw(&users[1], &second_withdrawal, &0);
+
+    let fees_before = h.vault().get_accrued_fees();
+    assert!(fees_before > 0);
+    h.vault().collect_fees(&h.admin);
+    assert_eq!(h.vault().get_accrued_fees(), fees_before);
 }


### PR DESCRIPTION
## Summary

  Adds a property-based invariant suite for vault share accounting across randomized deposits, withdrawals, yield accruals, losses,
  and fee events. It also fixes a discovered counterexample where exhausted liquid reserves could cause fee collection to attempt a
  negative token transfer.

  ## Related Issues

  Closes #1080

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation

  ## Changes Made

  - Added randomized share-accounting invariants covering asset and share conservation, share-price monotonicity, round-trip
    safety, and panic-free valid operations.

  - Added a fixed-seed CI run and a nightly randomized property-test workflow.
  - Persisted the discovered counterexample and added an explicit regression test.
  - Clamped unavailable liquid reserves to zero during fee collection to prevent negative transfers.

  ## Testing Done

  - Ran the fixed-seed property suite with 32 cases: 9 tests passed.
  - Ran the complete vault contract suite: 123 tests passed.
  - Ran Rust formatting and diff checks successfully.

  ## Screenshots

  Not applicable; no UI changes.

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated for changes
  - [x] Documentation updated if needed
  - [x] No secrets or credentials in the code
  - [x] Smart contract changes reviewed for security implications