### PR TITLE
fix(dapp): wallet network check, double-submit guard, and disconnect handling

### DIFF
--- a/apps/dapp/frontend/components/vault-action-modals.tsx
+++ b/apps/dapp/frontend/components/vault-action-modals.tsx
@@ -676,6 +676,11 @@ export function WithdrawModal({
         open && state === "input" && amount > 0
     );
 
+    // Guards double submission. A ref rather than render state: a fast second
+    // click or an Enter keypress fires before React has re-rendered with the
+    // disabled button, so state alone does not prevent a duplicate send.
+    const submittingRef = useRef(false);
+
     const canSubmit =
         !!position &&
         !!address &&
@@ -1046,6 +1051,10 @@ export function TransferModal({
     }, [watch("amount"), position]);
 
     const finalAmount = amountStroops ? Number(formatStroopsToDisplay(amountStroops, 6)) : 0;
+
+    // See the note in DepositModal: guards against a duplicate submit that
+    // render state cannot catch.
+    const submittingRef = useRef(false);
     const canSubmit =
         !isNaN(finalAmount) &&
         finalAmount > 0 &&
@@ -1304,7 +1313,7 @@ export function TransferModal({
                                             <ExternalLink className="h-3.5 w-3.5" />
                                         </Link>
                                         <span className="inline-flex items-center rounded-full border border-emerald-200 bg-white dark:bg-[#100F0F] px-3 py-2 text-xs text-emerald-700">
-                                            {receipt.walletPopupUsed ? "Wallet signature captured" : "Mock signature used"}
+                                            {"Wallet signature captured"}
                                         </span>
                                     </div>
                                 </div>

--- a/apps/dapp/frontend/components/vault-action-modals.tsx
+++ b/apps/dapp/frontend/components/vault-action-modals.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useStellarFeeEstimate } from "@/hooks/useStellarFeeEstimate";
 import { NetworkFeeDisplay } from "@/components/stellar/NetworkFeeEstimate";
 import { useTokenPrices } from "@/hooks/useTokenPrices";
@@ -34,6 +34,8 @@ import {
     UserRejectedError,
     TransactionFailedError,
     TransactionTimeoutError,
+    NetworkMismatchError,
+    WalletDisconnectedError,
 } from "@/lib/stellar/transaction";
 import { cn } from "@/lib/utils";
 import { type VaultContract as VaultDefinition, type SupportedAsset, vaultContracts as vaultDefinitions, getVaultContractById as getVaultById } from "@/lib/vault-contracts";
@@ -132,6 +134,7 @@ export function DepositModal({
     const [selectedAsset, setSelectedAsset] = useState<SupportedAsset>(
         vault?.supportedAssets?.[0] ?? "USDC"
     );
+    const submittingRef = useRef(false);
 
     // Reset selected asset when vault changes
     const assets = vault?.supportedAssets ?? ["USDC"];
@@ -203,7 +206,8 @@ export function DepositModal({
     };
 
     const processDeposit = async () => {
-        if (!vault || !address || !canSubmit) return;
+        if (!vault || !address || !canSubmit || submittingRef.current) return;
+        submittingRef.current = true;
 
         setError("");
         setState("confirming");
@@ -244,6 +248,10 @@ export function DepositModal({
         } catch (err) {
             if (err instanceof UserRejectedError) {
                 setError("You cancelled the transaction. No funds were moved.");
+            } else if (err instanceof NetworkMismatchError) {
+                setError(err.message);
+            } else if (err instanceof WalletDisconnectedError) {
+                setError(err.message);
             } else if (err instanceof TransactionFailedError) {
                 setError(`Transaction failed on-chain: ${err.reason}`);
             } else if (err instanceof TransactionTimeoutError) {
@@ -252,6 +260,8 @@ export function DepositModal({
                 setError(err instanceof Error ? err.message : "Deposit failed");
             }
             setState("error");
+        } finally {
+            submittingRef.current = false;
         }
     };
 
@@ -507,9 +517,7 @@ export function DepositModal({
                                             <ExternalLink className="h-3.5 w-3.5" />
                                         </Link>
                                         <span className="inline-flex items-center rounded-full border border-emerald-200 bg-white dark:bg-[#100F0F] px-3 py-2 text-xs text-emerald-700">
-                                            {receipt.walletPopupUsed
-                                                ? "Wallet signature captured"
-                                                : "Mock signature used"}
+                                            Wallet signature captured
                                         </span>
                                     </div>
                                 </div>
@@ -519,10 +527,7 @@ export function DepositModal({
                                         <ShieldCheck className="mt-0.5 h-4 w-4 text-emerald-600" />
                                         <div className="space-y-2 text-sm text-muted-foreground">
                                             <p>
-                                                This flow uses a mock Soroban transaction envelope until the live vault contracts are ready on testnet.
-                                            </p>
-                                            <p>
-                                                If your wallet supports signing this mock transaction, you will still get a real wallet popup before the simulated confirmation step.
+                                                Your wallet will prompt you to sign a Soroban transaction. Review the details carefully before approving.
                                             </p>
                                         </div>
                                     </div>
@@ -688,7 +693,8 @@ export function WithdrawModal({
     };
 
     const processWithdrawal = async () => {
-        if (!position || !address || !quote || !canSubmit) return;
+        if (!position || !address || !quote || !canSubmit || submittingRef.current) return;
+        submittingRef.current = true;
 
         setError("");
         setState("confirming");
@@ -733,6 +739,10 @@ export function WithdrawModal({
         } catch (err) {
             if (err instanceof UserRejectedError) {
                 setError("You cancelled the transaction. No funds were moved.");
+            } else if (err instanceof NetworkMismatchError) {
+                setError(err.message);
+            } else if (err instanceof WalletDisconnectedError) {
+                setError(err.message);
             } else if (err instanceof TransactionFailedError) {
                 setError(`Transaction failed on-chain: ${err.reason}`);
             } else if (err instanceof TransactionTimeoutError) {
@@ -741,6 +751,8 @@ export function WithdrawModal({
                 setError(err instanceof Error ? err.message : "Withdrawal failed");
             }
             setState("error");
+        } finally {
+            submittingRef.current = false;
         }
     };
 
@@ -1051,9 +1063,10 @@ export function TransferModal({
     }
 
     const handleTransfer = handleSubmit(async ({ amount: rawAmount }) => {
-        if (!position || !selectedVault) return;
+        if (!position || !selectedVault || submittingRef.current) return;
         const amt = parseFloat(rawAmount);
         if (isNaN(amt) || amt <= 0) return;
+        submittingRef.current = true;
 
         setError(null);
         setState("confirming");
@@ -1108,6 +1121,8 @@ export function TransferModal({
             } else {
                 setError(err instanceof Error ? err.message : "Transfer failed. Please try again.");
             }
+        } finally {
+            submittingRef.current = false;
         }
     });
 

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -236,14 +236,18 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
 
   const handleDeposit = async () => {
     if (!vault || !address || !canSubmit || submittingRef.current) return;
-    submittingRef.current = true;
 
     setErrorMsg("");
 
+    // Validate before claiming the submit flag. Setting it first and then
+    // returning here latches it for the lifetime of the modal, so every
+    // later deposit attempt is silently dropped by the guard above.
     if (!vault.contractAddress || !/^C[A-Z0-9]{55}$/.test(vault.contractAddress)) {
       setErrorMsg("This vault is not yet deployed on testnet. Check back soon.");
       return;
     }
+
+    submittingRef.current = true;
 
     try {
       setState("building");

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   AlertCircle,
@@ -185,6 +185,7 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
   const [selectedStrategy, setSelectedStrategy] = useState<MarketStrategy | null>(
     vault?.strategies?.[0] ?? null
   );
+  const submittingRef = useRef(false);
 
   const supportedAssets = (vault?.supportedAssets ?? ["USDC"]) as ("USDC" | "XLM")[];
   const strategies = vault?.strategies ?? [];
@@ -234,7 +235,8 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
   };
 
   const handleDeposit = async () => {
-    if (!vault || !address || !canSubmit) return;
+    if (!vault || !address || !canSubmit || submittingRef.current) return;
+    submittingRef.current = true;
 
     setErrorMsg("");
 
@@ -275,6 +277,8 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
     } catch (err) {
       setErrorMsg(humanizeError(err));
       setState("error");
+    } finally {
+      submittingRef.current = false;
     }
   };
 

--- a/apps/dapp/frontend/components/vault/withdrawModal.tsx
+++ b/apps/dapp/frontend/components/vault/withdrawModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   AlertCircle,
@@ -149,6 +149,7 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
   const [state, setState] = useState<ActionState>("input");
   const [errorMsg, setErrorMsg] = useState("");
   const [receipt, setReceipt] = useState<(TransactionReceipt & { penaltyAmount: number; netAmount: number }) | null>(null);
+  const submittingRef = useRef(false);
 
   const amount = Number(amountInput) || 0;
 
@@ -184,7 +185,8 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
   };
 
   const handleWithdraw = async () => {
-    if (!position || !address || !quote) return;
+    if (!position || !address || !quote || submittingRef.current) return;
+    submittingRef.current = true;
 
     setErrorMsg("");
 
@@ -219,6 +221,8 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
     } catch (err) {
       setErrorMsg(humanizeError(err));
       setState("error");
+    } finally {
+      submittingRef.current = false;
     }
   };
 

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -326,9 +326,9 @@ export async function signTransaction(txXdr: string): Promise<string> {
 
   const network = getCurrentNetwork();
 
-  // Network mismatch check (#1095): verify the wallet is on the same network
-  // before attempting to sign. This prevents signing a transaction intended
-  // for testnet when the wallet is on mainnet (or vice versa).
+  // Confirm the wallet is still connected (#1099). A locked, closed, or
+  // switched-account wallet surfaces as getAddress() throwing, so a failure
+  // here IS the disconnect case and must not be swallowed.
   try {
     const { address: currentAddress } = await walletModule.getAddress();
     if (!currentAddress) {
@@ -336,8 +336,36 @@ export async function signTransaction(txXdr: string): Promise<string> {
     }
   } catch (err) {
     if (err instanceof WalletDisconnectedError) throw err;
-    // If getAddress fails for other reasons, the wallet may be locked or
-    // disconnected — let signTransaction attempt and fail with a clear error.
+    throw new WalletDisconnectedError();
+  }
+
+  // Network mismatch check (#1095). Compare the wallet's actual network
+  // against the one the transaction was built for. Signing a testnet
+  // transaction while the wallet is on mainnet (or the reverse) means the
+  // user approves something other than what they were shown.
+  //
+  // getNetwork() is not implemented by every wallet module; when it is
+  // absent we cannot verify and deliberately proceed rather than blocking
+  // signing on wallets that simply do not expose it.
+  const getNetwork = (
+    walletModule as unknown as {
+      getNetwork?: () => Promise<{ networkPassphrase?: string; network?: string }>;
+    }
+  ).getNetwork;
+
+  if (typeof getNetwork === "function") {
+    let walletPassphrase: string | undefined;
+    try {
+      const net = await getNetwork.call(walletModule);
+      walletPassphrase = net?.networkPassphrase;
+    } catch {
+      // Treat an unreadable network as unverifiable rather than mismatched.
+      walletPassphrase = undefined;
+    }
+
+    if (walletPassphrase && walletPassphrase !== network.networkPassphrase) {
+      throw new NetworkMismatchError(walletPassphrase, network.networkPassphrase);
+    }
   }
 
   let result: { signedTxXdr: string };

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -111,6 +111,26 @@ export class TransactionFailedError extends Error {
 }
 
 /**
+ * Thrown when the wallet's network does not match the app's configured network.
+ */
+export class NetworkMismatchError extends Error {
+  constructor(walletNetwork: string, appNetwork: string) {
+    super(`Wallet is on ${walletNetwork} but the app is on ${appNetwork}. Please switch your wallet network.`);
+    this.name = "NetworkMismatchError";
+  }
+}
+
+/**
+ * Thrown when the wallet disconnects between building and signing a transaction.
+ */
+export class WalletDisconnectedError extends Error {
+  constructor() {
+    super("Wallet disconnected. Please reconnect your wallet and try again.");
+    this.name = "WalletDisconnectedError";
+  }
+}
+
+/**
  * Thrown when the submission times out waiting for ledger confirmation.
  */
 export class TransactionTimeoutError extends Error {
@@ -301,12 +321,24 @@ export async function signTransaction(txXdr: string): Promise<string> {
 
   const walletModule = StellarWalletsKit.selectedModule;
   if (!walletModule) {
-    throw new Error(
-      "No Stellar wallet connected. Please connect a wallet and try again."
-    );
+    throw new WalletDisconnectedError();
   }
 
   const network = getCurrentNetwork();
+
+  // Network mismatch check (#1095): verify the wallet is on the same network
+  // before attempting to sign. This prevents signing a transaction intended
+  // for testnet when the wallet is on mainnet (or vice versa).
+  try {
+    const { address: currentAddress } = await walletModule.getAddress();
+    if (!currentAddress) {
+      throw new WalletDisconnectedError();
+    }
+  } catch (err) {
+    if (err instanceof WalletDisconnectedError) throw err;
+    // If getAddress fails for other reasons, the wallet may be locked or
+    // disconnected — let signTransaction attempt and fail with a clear error.
+  }
 
   let result: { signedTxXdr: string };
   try {


### PR DESCRIPTION
## What this is

`staging/dapp-wallet-fixes` — PR #1166 (dapp wallet and double-submit fixes) merged and then repaired.

#1166 originally targeted `main`, which is 103 commits behind `dev`, so it presented as 873 files / +122,550 lines. Retargeted to this staging branch the real change is **4 files, +73/-18**. That was purely a base-branch artifact, not the contributor's diff.

## Fixes applied on top

Six defects, two of which broke the build:

- **`submittingRef` was declared only in `DepositModal`** but used in `WithdrawModal` and `TransferModal`. Both threw `ReferenceError` before their `try` block — withdraw set no error state, transfer failed as an unhandled rejection inside `handleSubmit`. So the PR's own double-submit guard was broken in two of the three modals it touched. Each component now declares its own ref.
- **`depositModal.tsx` latched the submit flag.** It set `submittingRef.current = true` before validating the contract address, so the undeployed-vault guard returned with the flag stuck on, silently killing every later deposit in that modal instance. Validation now runs first.
- **The network check did not check the network.** The block labelled "Network mismatch check (#1095)" only asserted the address was non-empty. `NetworkMismatchError` was thrown nowhere, making the class and both `instanceof` branches in the modals dead code. It now compares the wallet's passphrase against the one the transaction was built for. `getNetwork()` is not implemented by every wallet module, so an absent or unreadable value is treated as unverifiable rather than mismatched — blocking signing on wallets that simply do not expose it would be worse.
- **The disconnect path was bypassed.** The same block swallowed every non-`WalletDisconnectedError` from `getAddress()`, which is exactly how a locked or closed wallet surfaces. A real disconnect fell through to a generic signing error instead of the intended message.
- **`TransferModal` still rendered the "Mock signature used" copy** that #1166 removed from the deposit panel. `walletPopupUsed` is always `true` now, so the branch was dead.

## Issues

Closes #1093, #1095, #1096, #1099 — all four are only genuinely satisfied with the repairs above. As merged, #1095 and #1099 were labelled but unimplemented, and #1096 worked in one modal of three.

## Verification

`tsc --noEmit` is clean for all four touched files. The two `ReferenceError`s would have failed a `next build`; note that #1166's own CI ran only CodeRabbit and dependabot-auto-merge — no type-check or build job — which is why nothing caught them. Worth addressing separately: a PR targeting `main` gets almost no CI coverage.
