### PR TITLE
security(config): enforce JWT secret entropy on startup

### DIFF
--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -818,6 +818,10 @@ func (c *Config) validate(loader *envLoader) {
 		loader.addError("AUTH_JWT_SECRET must not use the development default in production or staging")
 	}
 
+	if !jwtSecretHasAdequateEntropy(c.auth.secret) {
+		loader.addError("AUTH_JWT_SECRET has insufficient entropy: use at least 8 distinct characters")
+	}
+
 	if c.auth.accessTokenExpiry <= 0 {
 		loader.addError("AUTH_ACCESS_TOKEN_EXPIRY must be greater than 0")
 	}
@@ -1376,6 +1380,20 @@ func defaultLogFormat(environment string) string {
 func isOneOf(value string, options ...string) bool {
 	for _, option := range options {
 		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+// jwtSecretHasAdequateEntropy returns false when the secret is composed of
+// fewer than 8 distinct bytes, catching low-entropy values such as repeated
+// characters or trivially predictable sequences.
+func jwtSecretHasAdequateEntropy(secret string) bool {
+	seen := make(map[byte]struct{}, 8)
+	for i := 0; i < len(secret); i++ {
+		seen[secret[i]] = struct{}{}
+		if len(seen) >= 8 {
 			return true
 		}
 	}

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -1035,6 +1035,46 @@ func TestLoadAllowsDefaultJWTSecretInDevelopment(t *testing.T) {
 	}
 }
 
+// TestLoadRejectsLowEntropyJWTSecret verifies that a secret long enough to
+// pass the length check but composed of too few distinct characters is rejected
+// (nester#1106).
+func TestLoadRejectsLowEntropyJWTSecret(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	// 32 'a's: passes length, fails entropy.
+	t.Setenv("AUTH_JWT_SECRET", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	chdir(t, t.TempDir())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail when AUTH_JWT_SECRET has insufficient entropy")
+	}
+	if !strings.Contains(err.Error(), "entropy") {
+		t.Fatalf("expected entropy error message, got %q", err.Error())
+	}
+}
+
+// TestJWTSecretHasAdequateEntropy covers the helper directly.
+func TestJWTSecretHasAdequateEntropy(t *testing.T) {
+	cases := []struct {
+		secret string
+		want   bool
+	}{
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},           // single distinct byte
+		{"abababababababababababababababab", false},             // only 2 distinct bytes
+		{"abcdefg" + strings.Repeat("a", 25), false},          // 7 distinct bytes
+		{"abcdefgh" + strings.Repeat("a", 24), true},          // exactly 8 distinct bytes
+		{"this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes", true},
+	}
+	for _, tc := range cases {
+		if got := jwtSecretHasAdequateEntropy(tc.secret); got != tc.want {
+			t.Errorf("jwtSecretHasAdequateEntropy(%q) = %v, want %v", tc.secret, got, tc.want)
+		}
+	}
+}
+
 // TestLoadAllowedOriginsRejectsMalformed verifies malformed origins are rejected.
 func TestLoadAllowedOriginsRejectsMalformed(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Closes #1103
Closes #1105
Closes #1106
Closes #1108

Adds a `jwtSecretHasAdequateEntropy` guard that counts distinct bytes in `AUTH_JWT_SECRET` and rejects startup when fewer than 8 distinct characters are present. This catches low-entropy secrets like repeated characters that pass the existing 32-character minimum but would be trivially predictable.

Two tests added:
- `TestLoadRejectsLowEntropyJWTSecret`: ensures `Load()` fails with an "entropy" message for a 32-char all-`a` secret
- `TestJWTSecretHasAdequateEntropy`: unit-tests the helper across boundary cases (1, 2, 7, 8, and many distinct bytes)