### PR TITLE
 feat(api): harden chain boundary with retries, circuit breaking and staleness monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,70 @@ TRACING_LATENCY_THRESHOLD=1s
 METRICS_ENABLED=true
 METRICS_ADDR=127.0.0.1:9090
 
+# Balance freshness (nester#1088). How far behind the chain the event
+# indexer's view may fall before the API reports it stale and the
+# IndexerStalenessBudgetExceeded alert pages.
+#
+# 5m is the balance-freshness SLO restated in seconds: 60 ledgers at a ~5s
+# close interval is exactly 300s. Healthy operation sits well under 20s — the
+# indexer polls every 6s and advances to the tip it just read — so the gap
+# absorbs a slow RPC round trip, a rolling restart, and the 12-ledger
+# cold-start rewind without paging.
+#
+# This single value drives the alert threshold AND the X-Indexer-Stale header
+# clients read, so they cannot drift apart. Lower it only with the runbook's
+# recovery verification steps in mind; a value near the 6s poll interval will
+# flap permanently.
+INDEXER_STALENESS_BUDGET=5m
+
+# --- Chain circuit breakers (nester#1087) ------------------------------
+# Soroban RPC and Horizon each get their own breaker. When one degrades,
+# calls to it fail immediately and locally instead of piling onto it until
+# they time out — which is what turns a partial upstream outage into a
+# total one by exhausting the connection pool.
+#
+# Independent state, shared policy: a Horizon outage never sheds Soroban
+# traffic. See docs/observability/circuit-breakers.md.
+#
+# The kill switch exists because a resilience mechanism can itself cause an
+# outage if its thresholds are wrong for an environment.
+CIRCUIT_BREAKER_ENABLED=true
+# Share of calls that must fail, within the window, to open the breaker.
+CIRCUIT_BREAKER_FAILURE_RATIO=0.5
+# Calls that must be observed before the ratio may open it. Without this,
+# one failure out of one is a 100% failure ratio and an idle upstream would
+# be shed on a single blip.
+CIRCUIT_BREAKER_MIN_REQUESTS=10
+# How far back outcomes are counted; older ones expire.
+CIRCUIT_BREAKER_WINDOW=60s
+# How long to shed before admitting a single probe (~3 ledger closes).
+CIRCUIT_BREAKER_OPEN_DURATION=15s
+
+# --- Soroban RPC retry (nester#1086) -----------------------------------
+# Bounded, jittered retry shared by every Soroban RPC call site, so a
+# transient failure is absorbed instead of surfacing as a user-facing error.
+#
+# ONLY IDEMPOTENT READS ARE RETRIED. sendTransaction never is — a
+# resubmitted envelope is a second attempt to move real money — and the
+# write path's durability comes from the submission record instead.
+#
+# The retry loop sits outside the circuit breaker: each attempt is real load
+# the breaker should see, and an open breaker stops the loop immediately.
+# See docs/observability/circuit-breakers.md.
+#
+# Set MAX_ATTEMPTS=1 to disable retrying without losing the metrics or the
+# typed error.
+RPC_RETRY_MAX_ATTEMPTS=3
+# Backoff cap for the first retry; doubles per attempt up to MAX_DELAY. The
+# delay actually waited is drawn uniformly from [0, cap) — full jitter, so a
+# wave of clients that failed together does not retry in lockstep.
+RPC_RETRY_BASE_DELAY=100ms
+RPC_RETRY_MAX_DELAY=2s
+# Total wall-clock allowance for one logical call, backoff included. Applied
+# as a context deadline, so one hung attempt cannot outlive it. Keep it below
+# SERVER_WRITE_TIMEOUT.
+RPC_RETRY_BUDGET=12s
+
 # The intelligence service serves a single port, so its exposition is
 # guarded by a bearer token rather than isolated on a second listener. An
 # empty token disables the check, which is only safe where the port is not

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -47,6 +47,31 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Horizon API endpoint.
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# How far behind the chain the event indexer's view may fall before the API
+# reports it stale (X-Indexer-Stale: true) and the staleness alert pages.
+# 5m is the balance-freshness SLO in seconds: 60 ledgers x ~5s close interval.
+# See docs/observability/slo.md#5-balance-freshness.
+INDEXER_STALENESS_BUDGET=5m
+
+# Circuit breakers guarding Soroban RPC and Horizon. When an upstream
+# degrades, calls to it fail fast locally instead of exhausting the
+# connection pool. Independent state per upstream, shared policy.
+# See docs/observability/circuit-breakers.md.
+CIRCUIT_BREAKER_ENABLED=true
+CIRCUIT_BREAKER_FAILURE_RATIO=0.5
+CIRCUIT_BREAKER_MIN_REQUESTS=10
+CIRCUIT_BREAKER_WINDOW=60s
+CIRCUIT_BREAKER_OPEN_DURATION=15s
+
+# Bounded, jittered retry for Soroban RPC. Only idempotent reads are
+# retried; sendTransaction never is (the submission record owns the write
+# path). Set MAX_ATTEMPTS=1 to disable retrying without losing the metrics.
+# Keep BUDGET below SERVER_WRITE_TIMEOUT.
+RPC_RETRY_MAX_ATTEMPTS=3
+RPC_RETRY_BASE_DELAY=100ms
+RPC_RETRY_MAX_DELAY=2s
+RPC_RETRY_BUDGET=12s
+
 # Stellar USDC issuer address used by the oracle order book query.
 # Defaults to Circle's mainnet USDC issuer when not set.
 # Override this value for testnet or other Stellar networks.

--- a/apps/api/cmd/api/breaker_health_test.go
+++ b/apps/api/cmd/api/breaker_health_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
+)
+
+func testBreakerConfig() breaker.Config {
+	return breaker.Config{
+		FailureRatio: 0.5,
+		MinRequests:  4,
+		Window:       time.Minute,
+		OpenDuration: 15 * time.Second,
+	}
+}
+
+func tripBreaker(t *testing.T, b *breaker.Breaker) {
+	t.Helper()
+
+	for i := 0; i < 200; i++ {
+		if b.State() == breaker.StateOpen {
+			return
+		}
+		permit, err := b.Allow()
+		if err != nil {
+			break
+		}
+		b.Record(permit, breaker.Failure)
+	}
+	if b.State() != breaker.StateOpen {
+		t.Fatal("breaker did not open")
+	}
+}
+
+// serveDetailedHealth runs the handler with no database and no reachable
+// upstreams. The chain probes fail, which is fine: what is under test is the
+// breaker section, and a failing probe alongside an open breaker is exactly
+// the shape an operator sees during an outage.
+func serveDetailedHealth(t *testing.T, breakers map[metrics.Upstream]*breaker.Breaker) detailedHealthResponse {
+	t.Helper()
+
+	var ready atomic.Bool
+	ready.Store(true)
+
+	handler := detailedHealthHandler(detailedHealthDeps{
+		ready:        &ready,
+		dbTimeout:    time.Millisecond,
+		httpClient:   &http.Client{Timeout: time.Millisecond},
+		horizonURL:   "http://127.0.0.1:1/horizon",
+		rpcURL:       "http://127.0.0.1:1/rpc",
+		startedAt:    time.Now(),
+		environment:  "test",
+		buildVersion: "test",
+		breakers:     breakers,
+	})
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodGet, "/health/detailed", nil))
+
+	var resp detailedHealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode health response: %v\nbody: %s", err, rec.Body.String())
+	}
+	return resp
+}
+
+// The acceptance criterion: breaker state appears in the readiness response,
+// for both chain upstreams, in each of the three states.
+func TestDetailedHealthReportsBreakerState(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	soroban := breaker.NewWithClock(string(metrics.UpstreamSorobanRPC), testBreakerConfig(), nil, clock)
+	horizon := breaker.NewWithClock(string(metrics.UpstreamHorizon), testBreakerConfig(), nil, clock)
+	breakers := map[metrics.Upstream]*breaker.Breaker{
+		metrics.UpstreamSorobanRPC: soroban,
+		metrics.UpstreamHorizon:    horizon,
+	}
+
+	// CLOSED
+	resp := serveDetailedHealth(t, breakers)
+	if got := resp.SorobanRPC.CircuitBreaker; got == nil || got.State != "closed" {
+		t.Fatalf("soroban circuit_breaker = %+v, want state closed", got)
+	}
+	if got := resp.Horizon.CircuitBreaker; got == nil || got.State != "closed" {
+		t.Fatalf("horizon circuit_breaker = %+v, want state closed", got)
+	}
+
+	// OPEN, and only for the upstream that failed.
+	tripBreaker(t, soroban)
+
+	resp = serveDetailedHealth(t, breakers)
+	if got := resp.SorobanRPC.CircuitBreaker; got.State != "open" {
+		t.Fatalf("soroban state = %q, want open", got.State)
+	}
+	if got := resp.Horizon.CircuitBreaker; got.State != "closed" {
+		t.Fatalf("horizon state = %q, want closed: a Soroban outage moved Horizon's reported state", got.State)
+	}
+	if got := resp.SorobanRPC.CircuitBreaker.RetrySeconds; got != 15 {
+		t.Fatalf("retry_in_seconds = %v, want 15", got)
+	}
+	if got := resp.SorobanRPC.CircuitBreaker.FailureRatio; got != 1 {
+		t.Fatalf("failure_ratio = %v, want 1", got)
+	}
+
+	// HALF-OPEN
+	now = now.Add(15 * time.Second)
+	resp = serveDetailedHealth(t, breakers)
+	if got := resp.SorobanRPC.CircuitBreaker.State; got != "half_open" {
+		t.Fatalf("soroban state = %q, want half_open", got)
+	}
+}
+
+// An open breaker degrades the reported status but must NOT make the endpoint
+// return 503. Chain dependencies have never gated readiness here, and evicting
+// the pod from its load balancer over an upstream outage would turn the
+// partial failure into the total one this feature exists to prevent.
+func TestOpenBreakerDegradesStatusWithoutFailingReadiness(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	soroban := breaker.NewWithClock(
+		string(metrics.UpstreamSorobanRPC), testBreakerConfig(), nil,
+		func() time.Time { return now },
+	)
+	tripBreaker(t, soroban)
+
+	var ready atomic.Bool
+	ready.Store(true)
+
+	handler := detailedHealthHandler(detailedHealthDeps{
+		ready:        &ready,
+		dbTimeout:    time.Millisecond,
+		httpClient:   &http.Client{Timeout: time.Millisecond},
+		horizonURL:   "http://127.0.0.1:1/horizon",
+		rpcURL:       "http://127.0.0.1:1/rpc",
+		startedAt:    time.Now(),
+		environment:  "test",
+		buildVersion: "test",
+		breakers: map[metrics.Upstream]*breaker.Breaker{
+			metrics.UpstreamSorobanRPC: soroban,
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodGet, "/health/detailed", nil))
+
+	var resp detailedHealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "degraded" {
+		t.Fatalf("status = %q, want degraded", resp.Status)
+	}
+}
+
+// When the breakers are disabled the field is absent rather than reporting a
+// closed breaker that does not exist. Absence means "not guarded".
+func TestDetailedHealthOmitsBreakerWhenDisabled(t *testing.T) {
+	resp := serveDetailedHealth(t, nil)
+
+	if resp.SorobanRPC.CircuitBreaker != nil {
+		t.Fatalf("soroban circuit_breaker = %+v, want absent", resp.SorobanRPC.CircuitBreaker)
+	}
+	if resp.Horizon.CircuitBreaker != nil {
+		t.Fatalf("horizon circuit_breaker = %+v, want absent", resp.Horizon.CircuitBreaker)
+	}
+}
+
+// The JSON contract, asserted on the wire rather than through the Go struct,
+// because it is what an operator's tooling reads.
+func TestBreakerStatusJSONShape(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	b := breaker.NewWithClock("soroban_rpc", testBreakerConfig(), nil, func() time.Time { return now })
+	tripBreaker(t, b)
+
+	encoded, err := json.Marshal(dependencyStatus{
+		OK:             false,
+		CircuitBreaker: newBreakerStatus(b),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cb, ok := decoded["circuit_breaker"].(map[string]any)
+	if !ok {
+		t.Fatalf("circuit_breaker missing from %s", encoded)
+	}
+	for _, field := range []string{"state", "failure_ratio", "observed_requests", "rejected_total", "retry_in_seconds"} {
+		if _, ok := cb[field]; !ok {
+			t.Errorf("circuit_breaker is missing %q: %s", field, encoded)
+		}
+	}
+	if cb["state"] != "open" {
+		t.Errorf("state = %v, want open", cb["state"])
+	}
+}
+
+func TestBreakerDegraded(t *testing.T) {
+	cases := map[string]struct {
+		status *breakerStatus
+		want   bool
+	}{
+		"absent is not degraded": {nil, false},
+		"closed is not degraded": {&breakerStatus{State: "closed"}, false},
+		"open is degraded":       {&breakerStatus{State: "open"}, true},
+		"half-open is degraded":  {&breakerStatus{State: "half_open"}, true},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := breakerDegraded(tc.status); got != tc.want {
+				t.Fatalf("breakerDegraded() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -22,6 +22,7 @@ import (
 	migratedb "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
 	"github.com/suncrestlabs/nester/apps/api/internal/cache"
 	"github.com/suncrestlabs/nester/apps/api/internal/config"
 	cryptopkg "github.com/suncrestlabs/nester/apps/api/internal/crypto"
@@ -29,6 +30,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/nudge"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/usersignal"
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
 	"github.com/suncrestlabs/nester/apps/api/internal/handler"
 	"github.com/suncrestlabs/nester/apps/api/internal/harvest"
 	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
@@ -37,6 +39,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
 	"github.com/suncrestlabs/nester/apps/api/internal/scheduler"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	performancesvc "github.com/suncrestlabs/nester/apps/api/internal/service/performance"
@@ -213,6 +216,43 @@ func run() error {
 	// Additional collectors still attach to it below.
 	appMetrics := metrics.New()
 
+	// Balance freshness (nester#1088). One tracker is the source of truth for
+	// the lag metrics, the staleness alert, and the freshness headers the API
+	// returns, so the pager and the UI can never disagree about whether
+	// balances are current. It is created here because the middleware chain
+	// below and the indexer goroutine further down both read it.
+	indexerFreshness := freshness.NewTracker(cfg.Indexer().StalenessBudget())
+	if err := appMetrics.RegisterFreshness(indexerFreshness); err != nil {
+		// Non-fatal: losing the freshness metrics must not stop the API from
+		// serving, and the API still reports staleness in its own headers.
+		baseLogger.Error("failed to register indexer freshness collector", "error", err)
+	}
+
+	// Circuit breakers for the chain upstreams (nester#1087). Built before the
+	// first chain client because every one of them is wired through
+	// chainHTTPClient below.
+	chainBreakers, err := newChainBreakers(cfg, appMetrics, baseLogger)
+	if err != nil {
+		return fmt.Errorf("init chain circuit breakers: %w", err)
+	}
+
+	// The bounded, jittered retry policy every Soroban RPC call site shares
+	// (nester#1086). One Runner and one policy for the whole process: a
+	// per-call-site policy is how behaviour drifted between call sites in the
+	// first place. Only idempotent reads are retried — the stellar package
+	// decides that per RPC method, and sendTransaction is never among them.
+	sorobanRPCOptions := stellarpkg.RPCOptions{
+		Runner:   retry.New(),
+		Policy:   cfg.RPCRetry().Policy(),
+		Observer: appMetrics.RPCRecorderFor(metrics.UpstreamSorobanRPC),
+	}
+	baseLogger.Info("soroban rpc retry policy",
+		"max_attempts", sorobanRPCOptions.Policy.MaxAttempts,
+		"base_delay", sorobanRPCOptions.Policy.BaseDelay.String(),
+		"max_delay", sorobanRPCOptions.Policy.MaxDelay.String(),
+		"budget", sorobanRPCOptions.Policy.Budget.String(),
+	)
+
 	vaultRepository := postgres.NewVaultRepository(db)
 	vaultService := service.NewVaultService(vaultRepository)
 	// Deposit and withdrawal SLIs (nester#1056).
@@ -229,6 +269,9 @@ func run() error {
 
 	transactionRepository := postgres.NewTransactionRepository(db)
 	transactionService := service.NewTransactionService(transactionRepository, cfg.Stellar().HorizonURL())
+	// Confirmation polling is the steadiest Horizon caller, so it is the
+	// traffic most worth shedding when Horizon degrades (nester#1087).
+	transactionService.SetHTTPClient(chainBreakers.client(appMetrics, 10*time.Second, metrics.UpstreamHorizon))
 	// Balance is moved only after a deposit/withdrawal is confirmed on-chain
 	// (issue #496); the vault repository applies it idempotently by tx hash.
 	transactionService.SetBalanceApplier(vaultRepository)
@@ -280,6 +323,11 @@ func run() error {
 	//   - Local: STELLAR_OPERATOR_SECRET is set here. Retained for local
 	//     development; see docs/security/signing-isolation.md for why it is not
 	//     the recommended production configuration.
+	// Durable chain-submission records (nester#1085). Created before any
+	// invoker, because every chain write is required to persist an intent
+	// through this store before it is sent.
+	submissionStore := stellarpkg.NewPostgresSubmissionStore(db)
+
 	var chainInvoker service.VaultChainInvoker
 	switch {
 	case cfg.Stellar().SigningIsolated():
@@ -304,6 +352,14 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("init isolated chain invoker: %w", err)
 		}
+		// The invoker calls Soroban RPC and Horizon through one client; the
+		// breaker routes per request URL, so the two stay independent.
+		inv.SetHTTPClient(chainBreakers.client(appMetrics, 30*time.Second, metrics.UpstreamSorobanRPC))
+		inv.SetRPCOptions(sorobanRPCOptions)
+		// Durable submission records (nester#1085): every chain write now
+		// persists an intent before it is sent, so a lost RPC response can
+		// never leave a transaction the system knows nothing about.
+		inv.SetSubmissionStore(submissionStore, baseLogger.WithGroup("chain-submission"))
 		chainInvoker = inv
 		vaultService.SetDepositInvoker(inv)
 		baseLogger.Info("signing is isolated: this process holds no operator key",
@@ -321,6 +377,12 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("init chain invoker: %w", err)
 		}
+		inv.SetHTTPClient(chainBreakers.client(appMetrics, 30*time.Second, metrics.UpstreamSorobanRPC))
+		inv.SetRPCOptions(sorobanRPCOptions)
+		// Durable submission records (nester#1085): every chain write now
+		// persists an intent before it is sent, so a lost RPC response can
+		// never leave a transaction the system knows nothing about.
+		inv.SetSubmissionStore(submissionStore, baseLogger.WithGroup("chain-submission"))
 		chainInvoker = inv
 		vaultService.SetDepositInvoker(inv)
 		baseLogger.Warn("signing key is held in the API process; " +
@@ -346,10 +408,11 @@ func run() error {
 	adminService.SetTemplateRepository(goalTemplateRepo)
 	adminHandler := handler.NewAdminHandler(adminService, userService)
 	adminHandler.SetEventSyncer(&stellarpkg.EventSyncer{
-		DB:      db,
-		SysRepo: systemStateRepository,
-		RPCURL:  cfg.Stellar().RPCURL(),
-		Logger:  baseLogger,
+		DB:         db,
+		SysRepo:    systemStateRepository,
+		RPCURL:     cfg.Stellar().RPCURL(),
+		Logger:     baseLogger,
+		RPCOptions: sorobanRPCOptions,
 	})
 	adminHandler.SetLeadership(schedulerLeadership)
 
@@ -359,10 +422,11 @@ func run() error {
 	// live-indexed events are processed identically.
 	backfillRepo := postgres.NewBackfillRepository(db)
 	backfillRunner := &stellarpkg.Runner{
-		DB:     db,
-		Repo:   backfillRepo,
-		RPCURL: cfg.Stellar().RPCURL(),
-		Logger: baseLogger.WithGroup("backfill"),
+		DB:         db,
+		Repo:       backfillRepo,
+		RPCURL:     cfg.Stellar().RPCURL(),
+		Logger:     baseLogger.WithGroup("backfill"),
+		RPCOptions: sorobanRPCOptions,
 	}
 	adminHandler.SetBackfillRunner(backfillRunner, backfillRepo)
 
@@ -425,9 +489,9 @@ func run() error {
 	// it lands in "other" and shows up as an unattributed series.
 	xlmProviders, fiatProvider := oracleService.Providers()
 	for _, provider := range xlmProviders {
-		instrumentRateProvider(appMetrics, provider)
+		instrumentRateProvider(appMetrics, chainBreakers, provider)
 	}
-	instrumentRateProvider(appMetrics, fiatProvider)
+	instrumentRateProvider(appMetrics, chainBreakers, fiatProvider)
 	rateHandler := handler.NewRateHandler(oracleService)
 
 	// maxWSConnsPerIP bounds simultaneous WebSocket connections from one
@@ -502,9 +566,10 @@ func run() error {
 		cfg.Stellar().NetworkPassphrase(),
 		"",
 	)
-	contractReader.SetHTTPClient(appMetrics.InstrumentClient(
-		&http.Client{Timeout: 30 * time.Second}, metrics.UpstreamSorobanRPC,
-	))
+	contractReader.SetHTTPClient(
+		chainBreakers.client(appMetrics, 30*time.Second, metrics.UpstreamSorobanRPC),
+	)
+	contractReader.SetRPCOptions(sorobanRPCOptions)
 
 	tracker := performancesvc.NewTracker(
 		performanceRepository,
@@ -693,6 +758,7 @@ func run() error {
 		startedAt:    startedAt,
 		environment:  cfg.Environment(),
 		buildVersion: version,
+		breakers:     chainBreakers.readers(),
 	}))
 	yieldHarvestHandler := handler.NewYieldHarvestHandler(yieldHarvestService)
 	yieldHarvestHandler.Register(mux)
@@ -1353,21 +1419,28 @@ func run() error {
 			middleware.RecoverPanic(baseLogger)(
 				appMetrics.Middleware(mux)(
 					cors(
-						globalLimiter(
-							authRouteLimiter(
-								writeLimiter(
-									authenticator(
-										walletBinding(
-											idempotencyMiddleware(
-												costQuota(
-													settlementLimiter(
-														walletLimiter(
-															middleware.LimitRequestBody(1 * 1024 * 1024)(
-																middleware.Logging(baseLogger)(
-																	middleware.Tracing(
-																		cfg.Tracing().ServiceName(),
-																		cfg.Tracing().LatencyThreshold(),
-																	)(mux),
+						// Inside cors so its Access-Control-Expose-Headers
+						// covers the freshness headers, and outside every
+						// rejection layer so a rate-limited or unauthorised
+						// response still tells the client how current the
+						// indexed data is.
+						middleware.IndexerFreshness(indexerFreshness)(
+							globalLimiter(
+								authRouteLimiter(
+									writeLimiter(
+										authenticator(
+											walletBinding(
+												idempotencyMiddleware(
+													costQuota(
+														settlementLimiter(
+															walletLimiter(
+																middleware.LimitRequestBody(1 * 1024 * 1024)(
+																	middleware.Logging(baseLogger)(
+																		middleware.Tracing(
+																			cfg.Tracing().ServiceName(),
+																			cfg.Tracing().LatencyThreshold(),
+																		)(mux),
+																	),
 																),
 															),
 														),
@@ -1400,10 +1473,44 @@ func run() error {
 		"auto_migrate", cfg.Startup().EnableAutoMigrate(),
 	)
 
-	// Balance-freshness SLI (nester#1056): the indexer publishes its own lag
-	// from the network tip it already fetches, so the sample costs no extra
-	// RPC call.
-	stellarpkg.StartEventIndexerWithMetrics(shutdownCtx, baseLogger, db, systemStateRepository, cfg.Stellar().RPCURL(), appMetrics)
+	// Submission reconciler (nester#1085). It resolves pending chain writes
+	// by asking the chain about a specific transaction hash — the only thing
+	// in the system permitted to decide that a submission ended.
+	//
+	// Its chain lookup is a read-only invoker (nil signer), deliberately
+	// independent of whether this deployment can sign: submissions left
+	// pending by a previous deployment still need resolving, and reconciling
+	// requires no key material.
+	if reconcileLookup, err := stellarpkg.NewContractInvokerWithSigner(
+		cfg.Stellar().RPCURL(),
+		cfg.Stellar().HorizonURL(),
+		cfg.Stellar().NetworkPassphrase(),
+		nil,
+	); err != nil {
+		baseLogger.Error("failed to build submission reconciler chain lookup", "error", err)
+	} else {
+		reconcileLookup.SetHTTPClient(chainBreakers.client(appMetrics, 30*time.Second, metrics.UpstreamSorobanRPC))
+		reconcileLookup.SetRPCOptions(sorobanRPCOptions)
+
+		submissionReconciler := stellarpkg.NewSubmissionReconciler(
+			submissionStore, reconcileLookup, baseLogger.WithGroup("submission-reconciler"),
+		)
+		// Same leader gate the rebalancer and protocol-health jobs use, so
+		// one instance sweeps rather than every replica.
+		submissionReconciler.SetLeaderChecker(schedulerLeadership)
+		go submissionReconciler.Run(shutdownCtx)
+	}
+
+	// Balance-freshness SLI (nester#1056, nester#1088): the indexer samples
+	// its own position against the network tip on every tick and publishes it
+	// to the freshness tracker, which the metrics collector and the API
+	// freshness headers both read.
+	stellarpkg.StartEventIndexer(shutdownCtx, baseLogger, db, systemStateRepository, stellarpkg.IndexerOptions{
+		RPCURL:     cfg.Stellar().RPCURL(),
+		HTTPClient: chainBreakers.client(appMetrics, stellarpkg.IndexerRequestTimeout, metrics.UpstreamSorobanRPC),
+		RPCOptions: sorobanRPCOptions,
+		Recorder:   indexerFreshness,
+	})
 
 	// The metrics endpoint runs on its own listener so it is never reachable
 	// through the public port. It is not registered on mux at any point, so
@@ -1530,15 +1637,126 @@ type httpClientSetter interface {
 	SetHTTPClient(*http.Client)
 }
 
-// instrumentRateProvider installs a metrics-instrumented HTTP client on an
-// exchange-rate provider.
+// chainBreakerSet holds the circuit breakers guarding Soroban RPC and Horizon,
+// plus the router that dispatches an outbound request to the right one
+// (nester#1087).
+//
+// A nil set means the breakers are disabled, and every method on it degrades
+// to "no guard" so no call site needs to branch.
+type chainBreakerSet struct {
+	router *breaker.Router
+}
+
+// newChainBreakers builds one breaker per chain upstream, wires them to the
+// metrics collector, and returns the router the HTTP clients are built on.
+//
+// Two breakers, not one: Soroban RPC and Horizon fail independently, and a
+// Horizon outage shedding Soroban traffic would take deposits offline for a
+// dependency they do not need. They share a *policy* because both degrade the
+// same way, but never state.
+func newChainBreakers(cfg *config.Config, m *metrics.Metrics, logger *slog.Logger) (*chainBreakerSet, error) {
+	if !cfg.CircuitBreaker().Enabled() {
+		logger.Warn("chain circuit breakers are disabled; a degraded Soroban RPC or Horizon will not be shed")
+		return nil, nil
+	}
+
+	policy := cfg.CircuitBreaker().Policy()
+	onTransition := chainBreakerLogger(logger.WithGroup("circuit-breaker"))
+
+	sorobanBreaker := breaker.New(string(metrics.UpstreamSorobanRPC), policy, onTransition)
+	horizonBreaker := breaker.New(string(metrics.UpstreamHorizon), policy, onTransition)
+
+	router := breaker.NewRouter()
+	if err := router.Register(cfg.Stellar().RPCURL(), sorobanBreaker); err != nil {
+		return nil, err
+	}
+	if err := router.Register(cfg.Stellar().HorizonURL(), horizonBreaker); err != nil {
+		return nil, err
+	}
+
+	if err := m.RegisterBreakers(map[metrics.Upstream]metrics.BreakerReader{
+		metrics.UpstreamSorobanRPC: sorobanBreaker,
+		metrics.UpstreamHorizon:    horizonBreaker,
+	}); err != nil {
+		// Non-fatal, for the same reason as the freshness collector: losing
+		// the metric must not stop the API serving, and the breakers still
+		// protect the upstreams and still appear in /health/detailed.
+		logger.Error("failed to register circuit breaker collector", "error", err)
+	}
+
+	logger.Info("chain circuit breakers enabled",
+		"failure_ratio", policy.FailureRatio,
+		"min_requests", policy.MinRequests,
+		"window", policy.Window.String(),
+		"open_duration", policy.OpenDuration.String(),
+	)
+
+	return &chainBreakerSet{router: router}, nil
+}
+
+// chainBreakerLogger logs state transitions only.
+//
+// Rejections are deliberately not logged: an open breaker can reject thousands
+// of calls a second, and logging each one turns an upstream outage into a
+// logging outage. The rejection counter metric carries that volume instead.
+func chainBreakerLogger(logger *slog.Logger) breaker.TransitionFunc {
+	return func(name string, from, to breaker.State, snapshot breaker.Snapshot) {
+		attrs := []any{
+			"upstream", name,
+			"from", from.String(),
+			"to", to.String(),
+			"failure_ratio", snapshot.FailureRatio,
+			"observed_requests", snapshot.Total,
+		}
+
+		// Opening is the operator-visible event: chain calls are now being
+		// shed. Recovery and probing are informational.
+		if to == breaker.StateOpen {
+			logger.Warn("circuit breaker opened; shedding calls to upstream", attrs...)
+			return
+		}
+		logger.Info("circuit breaker state changed", attrs...)
+	}
+}
+
+// readers exposes the breakers for the health response, keyed by upstream.
+func (s *chainBreakerSet) readers() map[metrics.Upstream]*breaker.Breaker {
+	if s == nil {
+		return nil
+	}
+	out := make(map[metrics.Upstream]*breaker.Breaker, len(s.router.Breakers()))
+	for _, b := range s.router.Breakers() {
+		out[metrics.Upstream(b.Name())] = b
+	}
+	return out
+}
+
+// client returns an HTTP client for one chain upstream: metrics innermost,
+// breaker outermost.
+//
+// The order matters. A rejected call never reaches the metrics transport, so
+// it is not counted as an outbound request and does not plant a near-zero
+// sample in the latency histogram or a transport error under a made-up kind.
+// nester_outbound_* therefore keeps meaning "calls we actually made", and the
+// shed load is reported by the breaker's own rejection counter instead.
+func (s *chainBreakerSet) client(m *metrics.Metrics, timeout time.Duration, upstream metrics.Upstream) *http.Client {
+	client := m.InstrumentClient(&http.Client{Timeout: timeout}, upstream)
+	if s == nil {
+		return client
+	}
+	client.Transport = s.router.Transport(client.Transport)
+	return client
+}
+
+// instrumentRateProvider installs a metrics-instrumented, circuit-broken HTTP
+// client on an exchange-rate provider.
 //
 // The upstream label is derived from the provider's own Name(), which returns
 // a fixed string per implementation, so the label set stays bounded by the
 // number of provider types rather than by anything at runtime. An unknown
 // provider is still instrumented, under "other", so a new one is never
 // silently invisible.
-func instrumentRateProvider(m *metrics.Metrics, provider oracle.Provider) {
+func instrumentRateProvider(m *metrics.Metrics, breakers *chainBreakerSet, provider oracle.Provider) {
 	setter, ok := provider.(httpClientSetter)
 	if !ok {
 		return
@@ -1554,7 +1772,10 @@ func instrumentRateProvider(m *metrics.Metrics, provider oracle.Provider) {
 		upstream = metrics.UpstreamCoinGecko
 	}
 
-	setter.SetHTTPClient(m.InstrumentClient(&http.Client{Timeout: 10 * time.Second}, upstream))
+	// Every provider gets the same client factory. Only the chain upstreams
+	// have a breaker registered, so the router passes CoinGecko and DeFiLlama
+	// straight through — this issue scopes the breaker to Soroban and Horizon.
+	setter.SetHTTPClient(breakers.client(m, 10*time.Second, upstream))
 }
 
 func livenessHandler(ready *atomic.Bool) http.HandlerFunc {
@@ -1600,6 +1821,15 @@ type detailedHealthDeps struct {
 	startedAt    time.Time
 	environment  string
 	buildVersion string
+
+	// breakers is keyed by upstream; nil entries mean that dependency is not
+	// guarded. The probes below deliberately do NOT go through these clients:
+	// a health check is a diagnostic, and an open breaker must not be able to
+	// report the upstream as unreachable when it has in fact recovered. The
+	// probe result and the breaker state are two independent facts, and seeing
+	// "reachable, but breaker still open" is exactly what tells an operator
+	// recovery is one probe away.
+	breakers map[metrics.Upstream]*breaker.Breaker
 }
 
 type dependencyStatus struct {
@@ -1608,6 +1838,46 @@ type dependencyStatus struct {
 	LatencyMillis int64  `json:"latency_ms,omitempty"`
 	Error         string `json:"error,omitempty"`
 	LatestLedger  uint64 `json:"latest_ledger,omitempty"`
+
+	// CircuitBreaker reports whether calls to this dependency are currently
+	// being shed (nester#1087): "closed", "half_open", or "open". Omitted when
+	// the breakers are disabled, so the field's absence means "not guarded"
+	// rather than "guarded and healthy".
+	CircuitBreaker *breakerStatus `json:"circuit_breaker,omitempty"`
+}
+
+// breakerStatus is one breaker's state as it appears in the health response.
+//
+// It reports the ratio and sample size alongside the state because "open" on
+// its own does not tell an operator whether the upstream is badly broken or
+// marginally over the threshold, and that is the first thing they need.
+type breakerStatus struct {
+	State        string  `json:"state"`
+	FailureRatio float64 `json:"failure_ratio"`
+	Observed     int     `json:"observed_requests"`
+	Rejected     uint64  `json:"rejected_total"`
+	RetrySeconds float64 `json:"retry_in_seconds,omitempty"`
+}
+
+// breakerDegraded reports whether a breaker is shedding or about to probe.
+// Half-open counts: calls are still being rejected while the single probe runs.
+func breakerDegraded(s *breakerStatus) bool {
+	return s != nil && s.State != breaker.StateClosed.String()
+}
+
+func newBreakerStatus(b *breaker.Breaker) *breakerStatus {
+	if b == nil {
+		return nil
+	}
+
+	snapshot := b.Snapshot()
+	return &breakerStatus{
+		State:        snapshot.State.String(),
+		FailureRatio: snapshot.FailureRatio,
+		Observed:     snapshot.Total,
+		Rejected:     snapshot.Rejected,
+		RetrySeconds: snapshot.RetryIn.Seconds(),
+	}
 }
 
 type dbStatus struct {
@@ -1641,44 +1911,61 @@ func detailedHealthHandler(deps detailedHealthDeps) http.HandlerFunc {
 			GeneratedAt: time.Now().UTC(),
 		}
 
-		dbCtx, dbCancel := context.WithTimeout(r.Context(), deps.dbTimeout)
-		dbStart := time.Now()
-		dbErr := deps.pgPool.Ping(dbCtx)
-		dbCancel()
-		stat := deps.pgPool.Pool.Stat()
-		resp.Database = dbStatus{
-			OK:            dbErr == nil,
-			LatencyMillis: time.Since(dbStart).Milliseconds(),
-			MaxConns:      stat.MaxConns(),
-			AcquiredConns: stat.AcquiredConns(),
-			IdleConns:     stat.IdleConns(),
-			TotalConns:    stat.TotalConns(),
-		}
-		if dbErr != nil {
-			resp.Database.Error = dbErr.Error()
+		// A health endpoint is what you call when things are already broken,
+		// so it must not panic on a dependency it was handed as nil.
+		if deps.pgPool != nil {
+			dbCtx, dbCancel := context.WithTimeout(r.Context(), deps.dbTimeout)
+			dbStart := time.Now()
+			dbErr := deps.pgPool.Ping(dbCtx)
+			dbCancel()
+			stat := deps.pgPool.Pool.Stat()
+			resp.Database = dbStatus{
+				OK:            dbErr == nil,
+				LatencyMillis: time.Since(dbStart).Milliseconds(),
+				MaxConns:      stat.MaxConns(),
+				AcquiredConns: stat.AcquiredConns(),
+				IdleConns:     stat.IdleConns(),
+				TotalConns:    stat.TotalConns(),
+			}
+			if dbErr != nil {
+				resp.Database.Error = dbErr.Error()
+			}
+		} else {
+			resp.Database = dbStatus{Error: "database pool is not configured"}
 		}
 
 		hStart := time.Now()
 		hRes := stellarpkg.PingHorizon(r.Context(), deps.httpClient, deps.horizonURL)
 		resp.Horizon = dependencyStatus{
-			OK:            hRes.OK,
-			Endpoint:      hRes.Endpoint,
-			Error:         hRes.Error,
-			LatencyMillis: time.Since(hStart).Milliseconds(),
-			LatestLedger:  hRes.LatestLedger,
+			OK:             hRes.OK,
+			Endpoint:       hRes.Endpoint,
+			Error:          hRes.Error,
+			LatencyMillis:  time.Since(hStart).Milliseconds(),
+			LatestLedger:   hRes.LatestLedger,
+			CircuitBreaker: newBreakerStatus(deps.breakers[metrics.UpstreamHorizon]),
 		}
 
 		rStart := time.Now()
 		rRes := stellarpkg.PingSorobanRPC(r.Context(), deps.httpClient, deps.rpcURL)
 		resp.SorobanRPC = dependencyStatus{
-			OK:            rRes.OK,
-			Endpoint:      rRes.Endpoint,
-			Error:         rRes.Error,
-			LatencyMillis: time.Since(rStart).Milliseconds(),
-			LatestLedger:  rRes.LatestLedger,
+			OK:             rRes.OK,
+			Endpoint:       rRes.Endpoint,
+			Error:          rRes.Error,
+			LatencyMillis:  time.Since(rStart).Milliseconds(),
+			LatestLedger:   rRes.LatestLedger,
+			CircuitBreaker: newBreakerStatus(deps.breakers[metrics.UpstreamSorobanRPC]),
 		}
 
-		degraded := !resp.Database.OK || !resp.Horizon.OK || !resp.SorobanRPC.OK
+		// An open breaker is a degraded dependency even when the probe above
+		// succeeded, because callers are still being shed until the next probe
+		// closes it. It does not affect the HTTP status: chain dependencies
+		// have never gated readiness here, and making an open breaker return
+		// 503 would evict the pod from its load balancer over an upstream
+		// outage — turning the partial failure into the total one this feature
+		// exists to prevent. Only the database and draining do that.
+		degraded := !resp.Database.OK || !resp.Horizon.OK || !resp.SorobanRPC.OK ||
+			breakerDegraded(resp.Horizon.CircuitBreaker) ||
+			breakerDegraded(resp.SorobanRPC.CircuitBreaker)
 		draining := !deps.ready.Load()
 		switch {
 		case draining:

--- a/apps/api/internal/breaker/breaker.go
+++ b/apps/api/internal/breaker/breaker.go
@@ -1,0 +1,522 @@
+// Package breaker implements the circuit breaker that protects Nester's chain
+// dependencies — Soroban RPC and Horizon (nester#1087).
+//
+// The problem it solves is load amplification. When a chain endpoint degrades,
+// every in-flight request sits on it until its own timeout, holding a
+// connection the whole time. Requests arrive faster than they drain, the pool
+// saturates, and a partial upstream outage becomes a total application outage
+// — including for the endpoints that never needed the chain at all.
+//
+// The breaker cuts that feedback loop: once an upstream is demonstrably
+// unhealthy, calls to it fail immediately and locally, holding no connection
+// and waiting on nothing.
+//
+// # States
+//
+//	CLOSED     calls pass through; outcomes are counted in a rolling window.
+//	           Exceeding the failure ratio (with enough samples) opens it.
+//	OPEN       calls are rejected immediately with ErrOpen. No connection is
+//	           opened and no timeout is waited on.
+//	HALF-OPEN  entered once the open period elapses. Exactly one probe call is
+//	           admitted; every other caller keeps failing fast. The probe's
+//	           outcome decides: success closes, failure re-opens.
+//
+// # What counts as a failure
+//
+// This type is transport-agnostic — the caller classifies each outcome and
+// reports it via Record. See transport.go for the HTTP classification, which
+// is where the "a 404 is not an unhealthy upstream" reasoning lives.
+//
+// # Concurrency
+//
+// One Breaker is shared by every goroutine calling its upstream. All state
+// lives under a single mutex held only for bookkeeping — never across the
+// network call itself, which happens between Allow and Record.
+package breaker
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ErrOpen is returned by Allow when the breaker is not admitting calls.
+//
+// Callers match it with errors.Is. It survives the wrapping that
+// http.Client.Do applies (*url.Error implements Unwrap), so a handler can
+// distinguish "we declined to call the chain" from "the chain call failed".
+var ErrOpen = errors.New("circuit breaker is open")
+
+// OpenError carries which upstream rejected the call and how long until the
+// next probe is admitted, so an API layer can answer with a Retry-After rather
+// than an opaque failure.
+type OpenError struct {
+	Name    string
+	RetryIn time.Duration
+}
+
+func (e *OpenError) Error() string {
+	return fmt.Sprintf("%s: %s (retry in %s)", e.Name, ErrOpen.Error(), e.RetryIn.Round(time.Second))
+}
+
+func (e *OpenError) Unwrap() error { return ErrOpen }
+
+// State is the breaker's current mode.
+//
+// The values ascend with severity — closed < half-open < open — so a metric
+// threshold or a max() across replicas reads monotonically as "how bad is it",
+// which is not true of an arbitrary ordering.
+type State int
+
+const (
+	StateClosed State = iota
+	StateHalfOpen
+	StateOpen
+)
+
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateHalfOpen:
+		return "half_open"
+	case StateOpen:
+		return "open"
+	default:
+		return "unknown"
+	}
+}
+
+// windowBuckets is how finely the rolling window is subdivided.
+//
+// Not configurable: it trades memory for the granularity at which old
+// outcomes expire, and ten is fine for every window length this is used with.
+// Exposing it would be an implementation detail masquerading as an operational
+// control.
+const windowBuckets = 10
+
+// Config is the breaker's policy. Every field has a default; the zero Config
+// is usable.
+type Config struct {
+	// FailureRatio is the share of failed calls, within Window, at or above
+	// which the breaker opens. 0.5 means "half of the calls are failing".
+	FailureRatio float64
+
+	// MinRequests is how many calls must be observed within Window before the
+	// ratio is allowed to open the breaker.
+	//
+	// A ratio alone is unusable at small samples: one failed call out of one
+	// is a 100% failure ratio, and without this floor a single timeout on an
+	// idle upstream would open the breaker. The cost of the floor is that a
+	// very quiet upstream may never accumulate enough calls to trip — which is
+	// acceptable, because with no traffic there is no pile-on to prevent.
+	MinRequests int
+
+	// Window is how far back outcomes are counted. Older outcomes expire, so
+	// a burst of failures cannot hold the breaker open indefinitely after the
+	// upstream recovers.
+	Window time.Duration
+
+	// OpenDuration is how long the breaker stays open before admitting a
+	// probe.
+	OpenDuration time.Duration
+}
+
+// Defaults for the chain upstreams. See docs/observability/circuit-breakers.md
+// for how these were chosen.
+const (
+	DefaultFailureRatio = 0.5
+	DefaultMinRequests  = 10
+	DefaultWindow       = 60 * time.Second
+	DefaultOpenDuration = 15 * time.Second
+)
+
+func (c Config) withDefaults() Config {
+	if c.FailureRatio <= 0 {
+		c.FailureRatio = DefaultFailureRatio
+	}
+	if c.MinRequests <= 0 {
+		c.MinRequests = DefaultMinRequests
+	}
+	if c.Window <= 0 {
+		c.Window = DefaultWindow
+	}
+	if c.OpenDuration <= 0 {
+		c.OpenDuration = DefaultOpenDuration
+	}
+	return c
+}
+
+// Validate reports a policy that cannot behave sensibly. Startup rejects such
+// a configuration rather than letting it become an incident.
+func (c Config) Validate() error {
+	if c.FailureRatio <= 0 || c.FailureRatio > 1 {
+		return fmt.Errorf("failure ratio must be greater than 0 and at most 1, got %v", c.FailureRatio)
+	}
+	if c.MinRequests <= 0 {
+		return fmt.Errorf("minimum requests must be greater than 0, got %d", c.MinRequests)
+	}
+	if c.Window <= 0 {
+		return fmt.Errorf("window must be greater than 0, got %v", c.Window)
+	}
+	if c.OpenDuration <= 0 {
+		return fmt.Errorf("open duration must be greater than 0, got %v", c.OpenDuration)
+	}
+	return nil
+}
+
+// Outcome is how a completed call is counted.
+type Outcome int
+
+const (
+	// Success: the upstream answered and behaved.
+	Success Outcome = iota
+
+	// Failure: the upstream is implicated — no response, or one that says it
+	// is unwell.
+	Failure
+
+	// Ignored: the call ended for a reason that says nothing about upstream
+	// health, such as the caller cancelling. It is counted neither way, but it
+	// still releases a half-open probe slot — without that, a cancelled probe
+	// would strand the breaker in half-open with no probe ever admitted again.
+	Ignored
+)
+
+// Permit authorises one call. It carries the generation it was issued in, so
+// an outcome arriving after the breaker has moved on is discarded rather than
+// applied to a state it does not describe.
+type Permit struct {
+	generation uint64
+	probe      bool
+	valid      bool
+}
+
+// TransitionFunc is called after each state change, outside the breaker's
+// lock. Transitions are rare, so this is a reasonable place to log; per-call
+// rejections are deliberately not reported here, because an open breaker
+// rejecting thousands of calls must not turn an upstream outage into a logging
+// outage. Use the rejection counter for that.
+type TransitionFunc func(name string, from, to State, snapshot Snapshot)
+
+type bucket struct {
+	total    int
+	failures int
+}
+
+// Breaker is a single upstream's circuit breaker.
+type Breaker struct {
+	name         string
+	cfg          Config
+	now          func() time.Time
+	onTransition TransitionFunc
+
+	mu            sync.Mutex
+	state         State
+	generation    uint64
+	openedAt      time.Time
+	probeInFlight bool
+
+	buckets     [windowBuckets]bucket
+	bucketIndex int
+	bucketStart time.Time
+	bucketDur   time.Duration
+
+	rejected uint64
+}
+
+// New returns a breaker for the named upstream. The name appears in errors,
+// logs, and the metric label, so it must come from a bounded set.
+func New(name string, cfg Config, onTransition TransitionFunc) *Breaker {
+	return NewWithClock(name, cfg, onTransition, time.Now)
+}
+
+// NewWithClock is New with an injectable clock, so the open period and the
+// rolling window can be driven deterministically in tests instead of slept
+// through.
+func NewWithClock(name string, cfg Config, onTransition TransitionFunc, now func() time.Time) *Breaker {
+	if now == nil {
+		now = time.Now
+	}
+	cfg = cfg.withDefaults()
+
+	return &Breaker{
+		name:         name,
+		cfg:          cfg,
+		now:          now,
+		onTransition: onTransition,
+		state:        StateClosed,
+		bucketStart:  now(),
+		bucketDur:    cfg.Window / windowBuckets,
+	}
+}
+
+// Name returns the upstream this breaker guards.
+func (b *Breaker) Name() string { return b.name }
+
+// Allow asks permission to make one call.
+//
+// It returns ErrOpen without touching the network when the breaker is open, or
+// when it is half-open and another caller already holds the probe. On success
+// the caller MUST report the outcome via Record, or the half-open probe slot
+// leaks.
+func (b *Breaker) Allow() (Permit, error) {
+	b.mu.Lock()
+	permit, err, event := b.allowLocked()
+	b.mu.Unlock()
+
+	b.emit(event)
+	return permit, err
+}
+
+func (b *Breaker) allowLocked() (Permit, error, *transition) {
+	now := b.now()
+	b.advanceLocked(now)
+
+	var event *transition
+
+	// The open period is measured, not timed: there is no goroutine or timer
+	// waiting to move the breaker to half-open, so a breaker that is never
+	// called again costs nothing and leaks nothing.
+	if b.state == StateOpen && now.Sub(b.openedAt) >= b.cfg.OpenDuration {
+		event = b.setStateLocked(StateHalfOpen, now)
+	}
+
+	switch b.state {
+	case StateOpen:
+		b.rejected++
+		return Permit{}, b.openErrorLocked(now), event
+
+	case StateHalfOpen:
+		// Single-flight probe. Every other caller keeps failing fast, so a
+		// recovering upstream is not hit by the entire backlog the moment the
+		// open period ends.
+		if b.probeInFlight {
+			b.rejected++
+			return Permit{}, b.openErrorLocked(now), event
+		}
+		b.probeInFlight = true
+		return Permit{generation: b.generation, probe: true, valid: true}, nil, event
+
+	default:
+		return Permit{generation: b.generation, valid: true}, nil, event
+	}
+}
+
+// Record reports how a permitted call ended.
+//
+// An outcome from a superseded generation is discarded: the breaker has
+// already changed state on other evidence, and applying a stale result would
+// let a call that started before an incident close a breaker opened during it.
+func (b *Breaker) Record(permit Permit, outcome Outcome) {
+	if !permit.valid {
+		return
+	}
+
+	b.mu.Lock()
+	event := b.recordLocked(permit, outcome)
+	b.mu.Unlock()
+
+	b.emit(event)
+}
+
+func (b *Breaker) recordLocked(permit Permit, outcome Outcome) *transition {
+	if permit.generation != b.generation {
+		// Superseded. setStateLocked already cleared probeInFlight, so a
+		// stale probe cannot leave the slot held.
+		return nil
+	}
+
+	if permit.probe {
+		b.probeInFlight = false
+	}
+
+	// Ignored says nothing about the upstream, so it is neither counted nor
+	// allowed to decide a half-open probe. Releasing the slot above is the
+	// whole point: the next caller gets to probe.
+	if outcome == Ignored {
+		return nil
+	}
+
+	now := b.now()
+	b.advanceLocked(now)
+
+	if b.state == StateHalfOpen {
+		if outcome == Failure {
+			return b.setStateLocked(StateOpen, now)
+		}
+		return b.setStateLocked(StateClosed, now)
+	}
+
+	b.buckets[b.bucketIndex].total++
+	if outcome == Failure {
+		b.buckets[b.bucketIndex].failures++
+	}
+
+	if b.state == StateClosed && b.trippedLocked() {
+		return b.setStateLocked(StateOpen, now)
+	}
+	return nil
+}
+
+// trippedLocked reports whether the rolling window justifies opening.
+func (b *Breaker) trippedLocked() bool {
+	total, failures := b.countsLocked()
+	if total < b.cfg.MinRequests {
+		return false
+	}
+	return float64(failures)/float64(total) >= b.cfg.FailureRatio
+}
+
+func (b *Breaker) countsLocked() (total, failures int) {
+	for _, bkt := range b.buckets {
+		total += bkt.total
+		failures += bkt.failures
+	}
+	return total, failures
+}
+
+// advanceLocked rolls the window forward to now, clearing the buckets that
+// have aged out. This is what stops failures from an incident half an hour ago
+// contributing to the current ratio.
+func (b *Breaker) advanceLocked(now time.Time) {
+	elapsed := now.Sub(b.bucketStart)
+	if elapsed < b.bucketDur {
+		return
+	}
+
+	steps := int(elapsed / b.bucketDur)
+	if steps >= windowBuckets {
+		// Nothing in the window is still current.
+		b.buckets = [windowBuckets]bucket{}
+		b.bucketIndex = 0
+	} else {
+		for i := 0; i < steps; i++ {
+			b.bucketIndex = (b.bucketIndex + 1) % windowBuckets
+			b.buckets[b.bucketIndex] = bucket{}
+		}
+	}
+	b.bucketStart = b.bucketStart.Add(time.Duration(steps) * b.bucketDur)
+}
+
+type transition struct {
+	from, to State
+	snapshot Snapshot
+}
+
+// setStateLocked moves the breaker and returns the event to emit once the lock
+// is released. It never calls out while holding the mutex: the callback logs,
+// and a blocked log write must not serialise every caller of the upstream.
+func (b *Breaker) setStateLocked(to State, now time.Time) *transition {
+	from := b.state
+	if from == to {
+		return nil
+	}
+
+	b.state = to
+
+	// Bumping the generation invalidates every permit issued before this
+	// point, so calls still in flight cannot apply their outcome to the new
+	// state.
+	b.generation++
+	b.probeInFlight = false
+
+	switch to {
+	case StateOpen:
+		b.openedAt = now
+	case StateClosed:
+		// Start the recovered upstream with a clean window. Carrying the
+		// failures that opened the breaker into the closed state would
+		// immediately re-trip it on the first new failure.
+		b.buckets = [windowBuckets]bucket{}
+		b.bucketIndex = 0
+		b.bucketStart = now
+	}
+
+	return &transition{from: from, to: to, snapshot: b.snapshotLocked(now)}
+}
+
+func (b *Breaker) emit(event *transition) {
+	if event == nil || b.onTransition == nil {
+		return
+	}
+	b.onTransition(b.name, event.from, event.to, event.snapshot)
+}
+
+func (b *Breaker) openErrorLocked(now time.Time) error {
+	retryIn := b.cfg.OpenDuration - now.Sub(b.openedAt)
+	if retryIn < 0 {
+		retryIn = 0
+	}
+	return &OpenError{Name: b.name, RetryIn: retryIn}
+}
+
+// Snapshot is a breaker's state at one instant, for metrics and the health
+// response.
+type Snapshot struct {
+	Name         string
+	State        State
+	Total        int
+	Failures     int
+	FailureRatio float64
+	Rejected     uint64
+
+	// RetryIn is how long until a probe is admitted. Zero unless open.
+	RetryIn time.Duration
+}
+
+// Snapshot reports the breaker's current state without side effects.
+//
+// An open breaker whose open period has elapsed is reported as half-open even
+// though no caller has arrived to make the transition, because that is the
+// truthful answer to "would a call be admitted right now". Reporting it as
+// open would tell an operator the upstream is still being shed when it is in
+// fact ready to probe.
+func (b *Breaker) Snapshot() Snapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Roll the window forward before reading it. Without this a breaker that
+	// stopped being called would keep reporting the failures that were current
+	// when the last call happened, so the health endpoint and the metric would
+	// show an upstream still failing long after its traffic stopped.
+	now := b.now()
+	b.advanceLocked(now)
+
+	return b.snapshotLocked(now)
+}
+
+// State is the effective state, following Snapshot's semantics.
+func (b *Breaker) State() State {
+	return b.Snapshot().State
+}
+
+func (b *Breaker) snapshotLocked(now time.Time) Snapshot {
+	total, failures := b.countsLocked()
+
+	ratio := 0.0
+	if total > 0 {
+		ratio = float64(failures) / float64(total)
+	}
+
+	state := b.state
+	retryIn := time.Duration(0)
+	if state == StateOpen {
+		if remaining := b.cfg.OpenDuration - now.Sub(b.openedAt); remaining > 0 {
+			retryIn = remaining
+		} else {
+			state = StateHalfOpen
+		}
+	}
+
+	return Snapshot{
+		Name:         b.name,
+		State:        state,
+		Total:        total,
+		Failures:     failures,
+		FailureRatio: ratio,
+		Rejected:     b.rejected,
+		RetryIn:      retryIn,
+	}
+}

--- a/apps/api/internal/breaker/breaker_test.go
+++ b/apps/api/internal/breaker/breaker_test.go
@@ -1,0 +1,678 @@
+package breaker
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock drives the open period and the rolling window without sleeping.
+// Every timing assertion below is about a boundary measured in seconds or
+// minutes; sleeping through them would make the suite slow and, worse, flaky.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func testConfig() Config {
+	return Config{
+		FailureRatio: 0.5,
+		MinRequests:  4,
+		Window:       60 * time.Second,
+		OpenDuration: 15 * time.Second,
+	}
+}
+
+func newTestBreaker(t *testing.T, cfg Config) (*Breaker, *fakeClock) {
+	t.Helper()
+	clock := newFakeClock()
+	return NewWithClock("test_upstream", cfg, nil, clock.Now), clock
+}
+
+// call runs one permitted call with the given outcome. It fails the test if
+// the breaker refused, so a test that means to exercise the closed path cannot
+// silently pass while the breaker was rejecting.
+func call(t *testing.T, b *Breaker, outcome Outcome) {
+	t.Helper()
+	permit, err := b.Allow()
+	if err != nil {
+		t.Fatalf("Allow() = %v, want permission", err)
+	}
+	b.Record(permit, outcome)
+}
+
+func mustReject(t *testing.T, b *Breaker) error {
+	t.Helper()
+	permit, err := b.Allow()
+	if err == nil {
+		b.Record(permit, Success)
+		t.Fatal("Allow() granted permission, want rejection")
+	}
+	if !errors.Is(err, ErrOpen) {
+		t.Fatalf("Allow() = %v, want an error matching ErrOpen", err)
+	}
+	return err
+}
+
+func assertState(t *testing.T, b *Breaker, want State) {
+	t.Helper()
+	if got := b.State(); got != want {
+		t.Fatalf("state = %s, want %s", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CLOSED
+// ---------------------------------------------------------------------------
+
+func TestClosedBreakerPassesCallsThrough(t *testing.T) {
+	b, _ := newTestBreaker(t, testConfig())
+
+	for i := 0; i < 50; i++ {
+		call(t, b, Success)
+	}
+
+	assertState(t, b, StateClosed)
+	if got := b.Snapshot().Rejected; got != 0 {
+		t.Fatalf("rejected = %d, want 0", got)
+	}
+}
+
+// Failures below the ratio must not open the breaker. A quarter of calls
+// failing is a bad day for the upstream, not an outage, and shedding traffic
+// there would cost more availability than it saves.
+func TestFailuresBelowTheRatioKeepTheBreakerClosed(t *testing.T) {
+	b, _ := newTestBreaker(t, testConfig())
+
+	for i := 0; i < 5; i++ {
+		call(t, b, Failure)
+		call(t, b, Success)
+		call(t, b, Success)
+		call(t, b, Success)
+	}
+
+	assertState(t, b, StateClosed)
+	if got := b.Snapshot().FailureRatio; got != 0.25 {
+		t.Fatalf("failure ratio = %v, want 0.25", got)
+	}
+}
+
+// The floor that stops a ratio from being meaningless at tiny sample sizes.
+// Three failures out of three is a 100% failure ratio, and without MinRequests
+// a single blip on an idle upstream would shed all its traffic.
+func TestRatioAloneCannotOpenTheBreakerBelowMinRequests(t *testing.T) {
+	cfg := testConfig()
+	cfg.MinRequests = 4
+	b, _ := newTestBreaker(t, cfg)
+
+	for i := 0; i < 3; i++ {
+		call(t, b, Failure)
+	}
+	assertState(t, b, StateClosed)
+
+	// The fourth failure reaches MinRequests, and the ratio is 1.0.
+	call(t, b, Failure)
+	assertState(t, b, StateOpen)
+}
+
+// The ratio is configurable, and the configured value is what decides.
+func TestFailureRatioIsConfigurable(t *testing.T) {
+	cases := []struct {
+		name      string
+		ratio     float64
+		failures  int
+		successes int
+		wantState State
+	}{
+		{"strict ratio trips on a fifth of calls", 0.2, 2, 8, StateOpen},
+		{"default ratio does not trip on a fifth of calls", 0.5, 2, 8, StateClosed},
+		{"tolerant ratio survives three quarters failing", 0.8, 6, 2, StateClosed},
+		{"tolerant ratio trips once four fifths fail", 0.8, 8, 2, StateOpen},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.FailureRatio = tc.ratio
+			b, _ := newTestBreaker(t, cfg)
+
+			// Successes first, then failures, so the running ratio only ever
+			// approaches its final value from below. Driving the failures
+			// first would trip every case on the opening burst and prove
+			// nothing about the configured ratio.
+			for i := 0; i < tc.successes; i++ {
+				call(t, b, Success)
+			}
+			for i := 0; i < tc.failures; i++ {
+				if b.State() != StateClosed {
+					break
+				}
+				call(t, b, Failure)
+			}
+
+			assertState(t, b, tc.wantState)
+		})
+	}
+}
+
+// Exactly at the ratio opens: the threshold is "at or above", and an upstream
+// failing precisely half its calls is not serving.
+func TestBreakerOpensAtExactlyTheRatio(t *testing.T) {
+	b, _ := newTestBreaker(t, testConfig())
+
+	call(t, b, Success)
+	call(t, b, Success)
+	call(t, b, Failure)
+	assertState(t, b, StateClosed)
+
+	call(t, b, Failure) // 2/4 = 0.5, and MinRequests is 4.
+	assertState(t, b, StateOpen)
+}
+
+// Old failures must not hold the breaker near its threshold forever. Once the
+// window has rolled past them they are gone.
+func TestOutcomesExpireOutOfTheRollingWindow(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+
+	call(t, b, Failure)
+	call(t, b, Failure)
+	call(t, b, Failure)
+	if got := b.Snapshot().Failures; got != 3 {
+		t.Fatalf("failures = %d, want 3", got)
+	}
+
+	clock.Advance(61 * time.Second)
+
+	snapshot := b.Snapshot()
+	if snapshot.Total != 0 || snapshot.Failures != 0 {
+		t.Fatalf("window still holds %d/%d after it elapsed, want 0/0", snapshot.Failures, snapshot.Total)
+	}
+
+	// And those expired failures cannot combine with new ones to trip it.
+	call(t, b, Failure)
+	call(t, b, Failure)
+	call(t, b, Failure)
+	assertState(t, b, StateClosed)
+}
+
+// ---------------------------------------------------------------------------
+// OPEN
+// ---------------------------------------------------------------------------
+
+// The core promise: while open, no call is attempted and the caller is told
+// immediately.
+func TestOpenBreakerRejectsWithoutCallingTheUpstream(t *testing.T) {
+	b, _ := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+
+	for i := 0; i < 100; i++ {
+		mustReject(t, b)
+	}
+
+	if got := b.Snapshot().Rejected; got != 100 {
+		t.Fatalf("rejected = %d, want 100", got)
+	}
+}
+
+// The rejection is recognisable, so an API layer can answer 503 with a
+// Retry-After rather than a generic 500.
+func TestOpenErrorIsTypedAndCarriesRetryHint(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+
+	err := mustReject(t, b)
+
+	var openErr *OpenError
+	if !errors.As(err, &openErr) {
+		t.Fatalf("error %v is not an *OpenError", err)
+	}
+	if openErr.Name != "test_upstream" {
+		t.Fatalf("name = %q, want %q", openErr.Name, "test_upstream")
+	}
+	if openErr.RetryIn != 15*time.Second {
+		t.Fatalf("retry in = %v, want 15s", openErr.RetryIn)
+	}
+
+	clock.Advance(10 * time.Second)
+	err = mustReject(t, b)
+	_ = errors.As(err, &openErr)
+	if openErr.RetryIn != 5*time.Second {
+		t.Fatalf("retry in after 10s = %v, want 5s", openErr.RetryIn)
+	}
+}
+
+// Before the open period elapses, nothing gets through — not even one probe.
+func TestBreakerStaysOpenForTheFullOpenDuration(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+
+	clock.Advance(14 * time.Second)
+	mustReject(t, b)
+	assertState(t, b, StateOpen)
+}
+
+// ---------------------------------------------------------------------------
+// HALF-OPEN
+// ---------------------------------------------------------------------------
+
+// The full recovery path the acceptance criteria name:
+// CLOSED -> OPEN -> HALF-OPEN -> CLOSED.
+func TestBreakerRecoversThroughHalfOpen(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+
+	assertState(t, b, StateClosed)
+
+	tripBreaker(t, b)
+	assertState(t, b, StateOpen)
+	mustReject(t, b)
+
+	clock.Advance(15 * time.Second)
+	assertState(t, b, StateHalfOpen)
+
+	// The probe is admitted and succeeds.
+	permit, err := b.Allow()
+	if err != nil {
+		t.Fatalf("probe was refused after the open period: %v", err)
+	}
+	b.Record(permit, Success)
+
+	assertState(t, b, StateClosed)
+
+	// And normal service resumes.
+	call(t, b, Success)
+	assertState(t, b, StateClosed)
+}
+
+// The failure path: a probe that fails puts the breaker straight back to open
+// for another full period, rather than letting the next caller through.
+func TestFailedProbeReopensTheBreaker(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+
+	clock.Advance(15 * time.Second)
+
+	permit, err := b.Allow()
+	if err != nil {
+		t.Fatalf("probe was refused: %v", err)
+	}
+	b.Record(permit, Failure)
+
+	assertState(t, b, StateOpen)
+	mustReject(t, b)
+
+	// The open period restarts from the failed probe, not from the original
+	// trip: another 15s must pass before the next probe.
+	clock.Advance(14 * time.Second)
+	assertState(t, b, StateOpen)
+	clock.Advance(1 * time.Second)
+	assertState(t, b, StateHalfOpen)
+}
+
+// A single probe, not a thundering herd. When the open period ends, the whole
+// backlog must not be released onto an upstream that has only just come back.
+func TestHalfOpenAdmitsExactlyOneProbe(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+	clock.Advance(15 * time.Second)
+
+	permit, err := b.Allow()
+	if err != nil {
+		t.Fatalf("first caller was refused the probe: %v", err)
+	}
+
+	// While that probe is in flight every other caller keeps failing fast.
+	for i := 0; i < 50; i++ {
+		mustReject(t, b)
+	}
+
+	b.Record(permit, Success)
+	assertState(t, b, StateClosed)
+}
+
+// The concurrent form of the same guarantee, run under -race: exactly one of
+// N simultaneous callers may probe.
+func TestConcurrentCallersProduceOneProbe(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+	clock.Advance(15 * time.Second)
+
+	const callers = 64
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		granted int
+	)
+
+	// Deliberately no Record: the probe stays in flight for the duration of
+	// the test. Completing it would close the breaker and the remaining
+	// callers would then be admitted legitimately, which measures nothing.
+	// What is under test is that while one probe is outstanding, no second
+	// caller gets through.
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := b.Allow(); err != nil {
+				return
+			}
+			mu.Lock()
+			granted++
+			mu.Unlock()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if granted != 1 {
+		t.Fatalf("%d callers were admitted during half-open, want exactly 1", granted)
+	}
+}
+
+// A cancelled probe must release the slot. Without this the breaker would sit
+// in half-open forever: no probe in flight, but no probe admissible either,
+// and the upstream could never be found healthy again.
+func TestCancelledProbeReleasesTheSlot(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+	clock.Advance(15 * time.Second)
+
+	permit, err := b.Allow()
+	if err != nil {
+		t.Fatalf("probe was refused: %v", err)
+	}
+	b.Record(permit, Ignored)
+
+	// Still half-open — the cancellation proved nothing either way — but the
+	// next caller can now probe.
+	assertState(t, b, StateHalfOpen)
+
+	permit, err = b.Allow()
+	if err != nil {
+		t.Fatalf("slot was not released after a cancelled probe: %v", err)
+	}
+	b.Record(permit, Success)
+	assertState(t, b, StateClosed)
+}
+
+// An outcome from before a state change must not be applied afterwards.
+// Otherwise a call that started during the outage could close a breaker that
+// re-opened while it was in flight.
+func TestStaleOutcomesAreDiscarded(t *testing.T) {
+	b, _ := newTestBreaker(t, testConfig())
+
+	// A permit taken while closed...
+	stale, err := b.Allow()
+	if err != nil {
+		t.Fatalf("Allow() = %v", err)
+	}
+
+	// ...the breaker trips on other evidence...
+	tripBreaker(t, b)
+	assertState(t, b, StateOpen)
+
+	// ...and the old call finally succeeds. It must not count.
+	b.Record(stale, Success)
+	assertState(t, b, StateOpen)
+}
+
+// ---------------------------------------------------------------------------
+// Isolation, config, and reporting
+// ---------------------------------------------------------------------------
+
+// Soroban and Horizon fail independently. One upstream's outage must never
+// shed the other's traffic — that would turn a partial failure into the total
+// one this feature exists to prevent.
+func TestBreakersDoNotShareState(t *testing.T) {
+	clock := newFakeClock()
+	soroban := NewWithClock("soroban_rpc", testConfig(), nil, clock.Now)
+	horizon := NewWithClock("horizon", testConfig(), nil, clock.Now)
+
+	tripBreaker(t, soroban)
+
+	assertState(t, soroban, StateOpen)
+	assertState(t, horizon, StateClosed)
+
+	// Horizon keeps serving while Soroban sheds.
+	for i := 0; i < 10; i++ {
+		call(t, horizon, Success)
+	}
+	assertState(t, horizon, StateClosed)
+	mustReject(t, soroban)
+
+	// And the reverse.
+	tripBreaker(t, horizon)
+	assertState(t, horizon, StateOpen)
+}
+
+// Closing resets the window. Carrying the failures that opened the breaker
+// into the recovered state would re-trip it on the very first new failure,
+// making recovery impossible while any traffic still failed occasionally.
+func TestClosingResetsTheWindow(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+	clock.Advance(15 * time.Second)
+
+	permit, _ := b.Allow()
+	b.Record(permit, Success)
+
+	snapshot := b.Snapshot()
+	if snapshot.Total != 0 || snapshot.Failures != 0 {
+		t.Fatalf("window carried %d/%d into the closed state, want 0/0", snapshot.Failures, snapshot.Total)
+	}
+
+	// One failure after recovery must not immediately re-open it.
+	call(t, b, Failure)
+	assertState(t, b, StateClosed)
+}
+
+// Snapshot reports the state a call would actually meet. An open breaker whose
+// period has elapsed is ready to probe, and reporting it as open would tell an
+// operator traffic is still being shed when it is not.
+func TestSnapshotReportsHalfOpenOnceThePeriodElapsesWithoutACall(t *testing.T) {
+	b, clock := newTestBreaker(t, testConfig())
+	tripBreaker(t, b)
+
+	if got := b.Snapshot().State; got != StateOpen {
+		t.Fatalf("state = %s, want open", got)
+	}
+
+	clock.Advance(15 * time.Second)
+
+	// No Allow() in between — the transition is derived from the clock.
+	snapshot := b.Snapshot()
+	if snapshot.State != StateHalfOpen {
+		t.Fatalf("state = %s, want half_open", snapshot.State)
+	}
+	if snapshot.RetryIn != 0 {
+		t.Fatalf("retry in = %v, want 0 once the period has elapsed", snapshot.RetryIn)
+	}
+}
+
+func TestTransitionsAreReportedOnce(t *testing.T) {
+	clock := newFakeClock()
+
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+	record := func(name string, from, to State, _ Snapshot) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, from.String()+"->"+to.String())
+	}
+
+	b := NewWithClock("test_upstream", testConfig(), record, clock.Now)
+
+	tripBreaker(t, b)
+	clock.Advance(15 * time.Second)
+	permit, _ := b.Allow()
+	b.Record(permit, Success)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	want := []string{"closed->open", "open->half_open", "half_open->closed"}
+	if len(events) != len(want) {
+		t.Fatalf("transitions = %v, want %v", events, want)
+	}
+	for i := range want {
+		if events[i] != want[i] {
+			t.Fatalf("transitions = %v, want %v", events, want)
+		}
+	}
+}
+
+// Rejections are never reported as transitions: an open breaker rejecting
+// thousands of calls must not produce thousands of log lines.
+func TestRejectionsAreNotReportedAsTransitions(t *testing.T) {
+	clock := newFakeClock()
+
+	var mu sync.Mutex
+	count := 0
+	record := func(string, State, State, Snapshot) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	}
+
+	b := NewWithClock("test_upstream", testConfig(), record, clock.Now)
+	tripBreaker(t, b)
+
+	mu.Lock()
+	afterTrip := count
+	mu.Unlock()
+
+	for i := 0; i < 500; i++ {
+		mustReject(t, b)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != afterTrip {
+		t.Fatalf("500 rejections produced %d extra transition callbacks, want 0", count-afterTrip)
+	}
+}
+
+func TestZeroConfigUsesDefaults(t *testing.T) {
+	b := New("test_upstream", Config{}, nil)
+
+	if b.cfg.FailureRatio != DefaultFailureRatio {
+		t.Errorf("failure ratio = %v, want %v", b.cfg.FailureRatio, DefaultFailureRatio)
+	}
+	if b.cfg.MinRequests != DefaultMinRequests {
+		t.Errorf("min requests = %d, want %d", b.cfg.MinRequests, DefaultMinRequests)
+	}
+	if b.cfg.Window != DefaultWindow {
+		t.Errorf("window = %v, want %v", b.cfg.Window, DefaultWindow)
+	}
+	if b.cfg.OpenDuration != DefaultOpenDuration {
+		t.Errorf("open duration = %v, want %v", b.cfg.OpenDuration, DefaultOpenDuration)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	valid := testConfig()
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+
+	cases := map[string]func(*Config){
+		"zero ratio":         func(c *Config) { c.FailureRatio = 0 },
+		"negative ratio":     func(c *Config) { c.FailureRatio = -0.1 },
+		"ratio above one":    func(c *Config) { c.FailureRatio = 1.5 },
+		"zero min requests":  func(c *Config) { c.MinRequests = 0 },
+		"zero window":        func(c *Config) { c.Window = 0 },
+		"zero open duration": func(c *Config) { c.OpenDuration = 0 },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := testConfig()
+			mutate(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("Validate() = nil, want an error")
+			}
+		})
+	}
+}
+
+// Concurrent callers hammering a breaker through its whole lifecycle. Run
+// under -race, this is what proves the state machine is safe to share.
+func TestConcurrentUseIsRaceFree(t *testing.T) {
+	b := New("test_upstream", testConfig(), func(string, State, State, Snapshot) {})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				permit, err := b.Allow()
+				if err != nil {
+					continue
+				}
+				outcome := Success
+				if (id+j)%3 == 0 {
+					outcome = Failure
+				}
+				b.Record(permit, outcome)
+			}
+		}(i)
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				_ = b.Snapshot()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// tripBreaker drives a closed breaker to open by failing calls until it trips.
+//
+// The bound is generous rather than exact because the number of failures
+// required depends on what is already in the window: a breaker that has just
+// served successful calls needs enough failures to drag the ratio over the
+// threshold, not merely MinRequests of them.
+func tripBreaker(t *testing.T, b *Breaker) {
+	t.Helper()
+
+	const maxAttempts = 200
+	for i := 0; i < maxAttempts; i++ {
+		if b.State() == StateOpen {
+			return
+		}
+		permit, err := b.Allow()
+		if err != nil {
+			break
+		}
+		b.Record(permit, Failure)
+	}
+
+	if b.State() != StateOpen {
+		t.Fatalf("breaker did not open after %d failures", maxAttempts)
+	}
+}

--- a/apps/api/internal/breaker/transport.go
+++ b/apps/api/internal/breaker/transport.go
@@ -1,0 +1,206 @@
+package breaker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Router maps an outbound request to the breaker guarding its upstream.
+//
+// Routing is by URL rather than by client because ContractInvoker talks to
+// Soroban RPC and Horizon through a single *http.Client — it builds and
+// simulates against the RPC, then reads the operator account from Horizon.
+// Keying the breaker to the client would force those two upstreams to share
+// failure state, so a Horizon outage would shed Soroban traffic. Routing per
+// request keeps them independent without splitting any client.
+//
+// Only configured upstreams are routed; anything else passes through
+// unguarded. The set of breakers therefore comes from configuration and is
+// fixed at startup, never derived from the request, so neither the breaker
+// count nor the metric label set can be moved by traffic.
+type Router struct {
+	entries []routeEntry
+}
+
+type routeEntry struct {
+	host    string
+	prefix  string
+	breaker *Breaker
+}
+
+// NewRouter returns an empty router. A router with no entries passes every
+// request through, which is what a deployment with the breaker disabled gets.
+func NewRouter() *Router { return &Router{} }
+
+// Register routes requests matching rawURL's host and path prefix to b.
+//
+// The path prefix matters for the single-host case: a local stack can serve
+// Horizon and Soroban RPC from one origin on different paths, and matching on
+// host alone would silently give them one breaker under whichever name
+// registered first.
+func (r *Router) Register(rawURL string, b *Breaker) error {
+	if b == nil {
+		return errors.New("breaker is required")
+	}
+
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return fmt.Errorf("parse %s upstream url: %w", b.Name(), err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("%s upstream url %q has no host", b.Name(), rawURL)
+	}
+
+	entry := routeEntry{
+		host:   strings.ToLower(parsed.Host),
+		prefix: strings.TrimSuffix(parsed.Path, "/"),
+	}
+
+	for _, existing := range r.entries {
+		if existing.host == entry.host && existing.prefix == entry.prefix {
+			return fmt.Errorf(
+				"upstream %s collides with %s: both resolve to %s%s",
+				b.Name(), existing.breaker.Name(), entry.host, entry.prefix,
+			)
+		}
+	}
+
+	entry.breaker = b
+	r.entries = append(r.entries, entry)
+	return nil
+}
+
+// Breakers returns every registered breaker, in registration order.
+func (r *Router) Breakers() []*Breaker {
+	out := make([]*Breaker, 0, len(r.entries))
+	for _, entry := range r.entries {
+		out = append(out, entry.breaker)
+	}
+	return out
+}
+
+// For returns the breaker guarding u, or nil when the URL is not a guarded
+// upstream. The longest matching path prefix wins.
+func (r *Router) For(u *url.URL) *Breaker {
+	if u == nil {
+		return nil
+	}
+
+	host := strings.ToLower(u.Host)
+	var best *routeEntry
+
+	for i := range r.entries {
+		entry := &r.entries[i]
+		if entry.host != host {
+			continue
+		}
+		if entry.prefix != "" && !strings.HasPrefix(u.Path, entry.prefix) {
+			continue
+		}
+		if best == nil || len(entry.prefix) > len(best.prefix) {
+			best = entry
+		}
+	}
+
+	if best == nil {
+		return nil
+	}
+	return best.breaker
+}
+
+// Transport wraps next so requests to guarded upstreams pass through their
+// breaker. A nil next uses http.DefaultTransport.
+func (r *Router) Transport(next http.RoundTripper) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return &transport{router: r, next: next}
+}
+
+type transport struct {
+	router *Router
+	next   http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper.
+//
+// The rejection path returns before calling next, so an open breaker opens no
+// connection, resolves no name, and waits on no timeout. That is the whole
+// point of the feature: the caller's failure is local and immediate.
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	b := t.router.For(req.URL)
+	if b == nil {
+		return t.next.RoundTrip(req)
+	}
+
+	permit, err := b.Allow()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, rtErr := t.next.RoundTrip(req)
+	b.Record(permit, Classify(req.Context(), resp, rtErr))
+	return resp, rtErr
+}
+
+// Classify decides whether one completed HTTP attempt implicates the upstream.
+//
+// The rule is "does this suggest the upstream cannot serve us", not "did the
+// caller get what they wanted":
+//
+//   - Transport failures — connection refused, DNS, TLS, read timeout — are
+//     failures. These are precisely the errors that hold a connection until it
+//     times out, which is the pile-on this breaker exists to stop.
+//
+//   - Caller cancellation is ignored. The client disconnected or a parent
+//     context was cancelled; the upstream was never given a chance to answer,
+//     and counting it would let a burst of abandoned requests open a breaker
+//     over a perfectly healthy endpoint. A deadline that expired is NOT
+//     ignored — waiting past the deadline is exactly the symptom of a
+//     degrading upstream.
+//
+//   - 5xx is a failure: the upstream is telling us it is unwell.
+//
+//   - 429 is a failure. It is a 4xx, but it is the upstream asking for less
+//     load, and continuing to push is the behaviour this breaker exists to
+//     prevent. Shedding until it recovers is the cooperative response.
+//
+//   - Every other 4xx is a success. A 404 for an unfunded account, or a 400
+//     for a malformed contract call, means the upstream is healthy and
+//     answering correctly. Counting these would let ordinary user input open
+//     the breaker and take the chain offline for everyone — a denial of
+//     service any client could trigger.
+//
+// JSON-RPC errors returned inside a 200 are deliberately NOT inspected. Doing
+// so would require reading and replacing the response body in a transport, and
+// Soroban's application errors ("startLedger is before the oldest ledger") are
+// mostly client mistakes rather than node ill-health. The failure mode in this
+// issue — an endpoint degrading under load — surfaces as transport errors and
+// 5xx, which are covered.
+func Classify(ctx context.Context, resp *http.Response, err error) Outcome {
+	if err != nil {
+		if errors.Is(err, context.Canceled) || (ctx != nil && errors.Is(ctx.Err(), context.Canceled)) {
+			return Ignored
+		}
+		return Failure
+	}
+
+	if resp == nil {
+		return Ignored
+	}
+
+	switch {
+	case resp.StatusCode >= 500:
+		return Failure
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return Failure
+	default:
+		return Success
+	}
+}
+
+var _ http.RoundTripper = (*transport)(nil)

--- a/apps/api/internal/breaker/transport_test.go
+++ b/apps/api/internal/breaker/transport_test.go
@@ -1,0 +1,506 @@
+package breaker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingTransport records how many requests actually reached it, which is
+// how "the breaker made no network call" is asserted throughout this file.
+type countingTransport struct {
+	calls  atomic.Int64
+	status int
+	err    error
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	if t.err != nil {
+		return nil, t.err
+	}
+	return &http.Response{
+		StatusCode: t.status,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Request:    req,
+	}, nil
+}
+
+const (
+	sorobanURL = "https://soroban-testnet.example/rpc"
+	horizonURL = "https://horizon-testnet.example"
+)
+
+func newTestRouter(t *testing.T, clock *fakeClock, cfg Config) (*Router, *Breaker, *Breaker) {
+	t.Helper()
+
+	soroban := NewWithClock("soroban_rpc", cfg, nil, clock.Now)
+	horizon := NewWithClock("horizon", cfg, nil, clock.Now)
+
+	router := NewRouter()
+	if err := router.Register(sorobanURL, soroban); err != nil {
+		t.Fatalf("register soroban: %v", err)
+	}
+	if err := router.Register(horizonURL, horizon); err != nil {
+		t.Fatalf("register horizon: %v", err)
+	}
+	return router, soroban, horizon
+}
+
+func doGet(client *http.Client, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	return resp, err
+}
+
+// The behaviour the whole feature exists for: once the breaker is open, calls
+// stop reaching the network entirely.
+func TestOpenBreakerMakesNoNetworkCall(t *testing.T) {
+	clock := newFakeClock()
+	cfg := testConfig()
+	router, soroban, _ := newTestRouter(t, clock, cfg)
+
+	upstream := &countingTransport{status: http.StatusInternalServerError}
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	// Drive it open on real 5xx responses.
+	for soroban.State() == StateClosed {
+		if _, err := doGet(client, sorobanURL); err != nil {
+			t.Fatalf("request while closed: %v", err)
+		}
+	}
+
+	callsWhenOpen := upstream.calls.Load()
+
+	for i := 0; i < 100; i++ {
+		_, err := doGet(client, sorobanURL)
+		if err == nil {
+			t.Fatal("request succeeded while the breaker was open")
+		}
+		if !errors.Is(err, ErrOpen) {
+			t.Fatalf("error = %v, want one matching ErrOpen", err)
+		}
+	}
+
+	if got := upstream.calls.Load(); got != callsWhenOpen {
+		t.Fatalf("%d requests reached the upstream while open, want 0", got-callsWhenOpen)
+	}
+}
+
+// The rejection must be immediate. A fast failure that still waited on a
+// timeout would leave the pile-on exactly as it was.
+func TestOpenBreakerFailsFast(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, _ := newTestRouter(t, clock, testConfig())
+
+	// An upstream that would block far longer than this test may run.
+	slow := &countingTransport{err: errors.New("dial tcp: i/o timeout")}
+	client := &http.Client{Transport: router.Transport(slow)}
+
+	for soroban.State() == StateClosed {
+		_, _ = doGet(client, sorobanURL)
+	}
+
+	started := time.Now()
+	for i := 0; i < 1000; i++ {
+		if _, err := doGet(client, sorobanURL); err == nil {
+			t.Fatal("request succeeded while open")
+		}
+	}
+	elapsed := time.Since(started)
+
+	// 1000 rejections are pure local bookkeeping; anything near a network
+	// timeout means the rejection path is not short-circuiting.
+	if elapsed > time.Second {
+		t.Fatalf("1000 rejections took %v, want a fraction of a second", elapsed)
+	}
+}
+
+// errors.Is must survive the *url.Error that http.Client.Do wraps a transport
+// error in, or no handler could recognise the condition.
+func TestOpenErrorSurvivesClientWrapping(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, _ := newTestRouter(t, clock, testConfig())
+
+	upstream := &countingTransport{status: http.StatusBadGateway}
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	for soroban.State() == StateClosed {
+		_, _ = doGet(client, sorobanURL)
+	}
+
+	_, err := doGet(client, sorobanURL)
+	if !errors.Is(err, ErrOpen) {
+		t.Fatalf("errors.Is(%v, ErrOpen) = false through *url.Error", err)
+	}
+
+	var openErr *OpenError
+	if !errors.As(err, &openErr) {
+		t.Fatalf("errors.As(%v, *OpenError) = false", err)
+	}
+	if openErr.Name != "soroban_rpc" {
+		t.Fatalf("name = %q, want soroban_rpc", openErr.Name)
+	}
+}
+
+// One upstream failing must not shed the other's traffic.
+func TestUpstreamsAreIsolated(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, horizon := newTestRouter(t, clock, testConfig())
+
+	// A transport that fails Soroban and serves Horizon.
+	upstream := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Host, "soroban") {
+			return nil, errors.New("connection refused")
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}")), Request: req}, nil
+	})
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	for i := 0; i < 40 && soroban.State() == StateClosed; i++ {
+		_, _ = doGet(client, sorobanURL)
+	}
+
+	if soroban.State() != StateOpen {
+		t.Fatalf("soroban state = %s, want open", soroban.State())
+	}
+	if horizon.State() != StateClosed {
+		t.Fatalf("horizon state = %s, want closed: a Soroban outage shed Horizon traffic", horizon.State())
+	}
+
+	// Horizon still serves.
+	resp, err := doGet(client, horizonURL+"/accounts/GABC")
+	if err != nil {
+		t.Fatalf("horizon request failed while soroban was open: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("horizon status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// A recovering upstream is restored without operator action.
+func TestRecoveryThroughTheTransport(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, _ := newTestRouter(t, clock, testConfig())
+
+	var healthy atomic.Bool
+	upstream := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !healthy.Load() {
+			return nil, errors.New("connection refused")
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}")), Request: req}, nil
+	})
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	for i := 0; i < 40 && soroban.State() == StateClosed; i++ {
+		_, _ = doGet(client, sorobanURL)
+	}
+	if soroban.State() != StateOpen {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	// The upstream comes back, but the breaker is still shedding.
+	healthy.Store(true)
+	if _, err := doGet(client, sorobanURL); !errors.Is(err, ErrOpen) {
+		t.Fatalf("request was admitted before the open period elapsed: %v", err)
+	}
+
+	clock.Advance(15 * time.Second)
+
+	// The probe goes through and closes the breaker.
+	resp, err := doGet(client, sorobanURL)
+	if err != nil {
+		t.Fatalf("probe failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("probe status = %d, want 200", resp.StatusCode)
+	}
+	if soroban.State() != StateClosed {
+		t.Fatalf("state after a successful probe = %s, want closed", soroban.State())
+	}
+
+	// Traffic flows again.
+	for i := 0; i < 20; i++ {
+		if _, err := doGet(client, sorobanURL); err != nil {
+			t.Fatalf("request after recovery: %v", err)
+		}
+	}
+}
+
+// Requests to hosts with no breaker registered pass straight through. The
+// breaker set comes from configuration, so an unguarded upstream must not be
+// silently blocked or silently given a breaker.
+func TestUnroutedHostsPassThrough(t *testing.T) {
+	clock := newFakeClock()
+	router, _, _ := newTestRouter(t, clock, testConfig())
+
+	upstream := &countingTransport{status: http.StatusInternalServerError}
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	for i := 0; i < 50; i++ {
+		if _, err := doGet(client, "https://api.coingecko.example/price"); err != nil {
+			t.Fatalf("unrouted request failed: %v", err)
+		}
+	}
+
+	if got := upstream.calls.Load(); got != 50 {
+		t.Fatalf("%d of 50 unrouted requests reached the upstream, want all", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Failure classification
+// ---------------------------------------------------------------------------
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		err    error
+		ctx    context.Context
+		want   Outcome
+	}{
+		{name: "200 is a success", status: http.StatusOK, want: Success},
+		{name: "301 is a success", status: http.StatusMovedPermanently, want: Success},
+
+		// The upstream answered correctly; our request was wrong. Counting
+		// these would let ordinary user input take the chain offline.
+		{name: "400 is a success", status: http.StatusBadRequest, want: Success},
+		{name: "404 is a success", status: http.StatusNotFound, want: Success},
+
+		// The upstream asking for less load.
+		{name: "429 is a failure", status: http.StatusTooManyRequests, want: Failure},
+
+		{name: "500 is a failure", status: http.StatusInternalServerError, want: Failure},
+		{name: "502 is a failure", status: http.StatusBadGateway, want: Failure},
+		{name: "503 is a failure", status: http.StatusServiceUnavailable, want: Failure},
+
+		{name: "transport error is a failure", err: errors.New("connection refused"), want: Failure},
+		{name: "dns failure is a failure", err: &net.DNSError{Err: "no such host"}, want: Failure},
+
+		// A deadline that expired IS the symptom of a degrading upstream.
+		{name: "deadline exceeded is a failure", err: context.DeadlineExceeded, want: Failure},
+
+		// The caller went away; the upstream never got its chance.
+		{name: "caller cancellation is ignored", err: context.Canceled, want: Ignored},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			var resp *http.Response
+			if tc.err == nil {
+				resp = &http.Response{StatusCode: tc.status}
+			}
+
+			if got := Classify(ctx, resp, tc.err); got != tc.want {
+				t.Fatalf("Classify() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A cancelled parent context is recognised even when the transport reports a
+// different error, which is what net/http actually does on cancellation.
+func TestClassifyDetectsCancellationViaContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := Classify(ctx, nil, errors.New("request canceled"))
+	if got != Ignored {
+		t.Fatalf("Classify() = %v, want Ignored", got)
+	}
+}
+
+// A cancelled request must not count against a healthy upstream — otherwise a
+// burst of client disconnects could open the breaker over a working endpoint.
+func TestCancelledRequestsDoNotOpenTheBreaker(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, _ := newTestRouter(t, clock, testConfig())
+
+	upstream := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, req.Context().Err()
+	})
+	client := &http.Client{Transport: router.Transport(upstream)}
+
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, sorobanURL, nil)
+		_, _ = client.Do(req)
+	}
+
+	if soroban.State() != StateClosed {
+		t.Fatalf("state = %s after 100 cancelled requests, want closed", soroban.State())
+	}
+	if got := soroban.Snapshot().Total; got != 0 {
+		t.Fatalf("%d cancelled requests were counted, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Routing
+// ---------------------------------------------------------------------------
+
+func TestRouterMatchesOnHost(t *testing.T) {
+	clock := newFakeClock()
+	router, soroban, horizon := newTestRouter(t, clock, testConfig())
+
+	cases := map[string]*Breaker{
+		sorobanURL:                         soroban,
+		sorobanURL + "?foo=bar":            soroban,
+		horizonURL + "/accounts/GABC":      horizon,
+		"https://horizon-testnet.example/": horizon,
+		"https://unrelated.example/thing":  nil,
+
+		// The soroban upstream is configured with a /rpc path, so the bare
+		// root of that host is a different endpoint and is left unguarded.
+		// Failing open on an unrecognised path is the safe direction: the
+		// alternative is blocking a call the breaker knows nothing about.
+		"https://soroban-testnet.example/": nil,
+	}
+
+	for rawURL, want := range cases {
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			t.Fatalf("build request for %s: %v", rawURL, err)
+		}
+		if got := router.For(req.URL); got != want {
+			t.Fatalf("For(%s) = %v, want %v", rawURL, got, want)
+		}
+	}
+}
+
+// A local stack can serve both upstreams from one origin on different paths.
+// Matching on host alone would silently give them a single shared breaker
+// under whichever name registered first.
+func TestRouterDistinguishesUpstreamsOnTheSameHost(t *testing.T) {
+	clock := newFakeClock()
+	soroban := NewWithClock("soroban_rpc", testConfig(), nil, clock.Now)
+	horizon := NewWithClock("horizon", testConfig(), nil, clock.Now)
+
+	router := NewRouter()
+	if err := router.Register("http://localhost:8000/soroban/rpc", soroban); err != nil {
+		t.Fatalf("register soroban: %v", err)
+	}
+	if err := router.Register("http://localhost:8000", horizon); err != nil {
+		t.Fatalf("register horizon: %v", err)
+	}
+
+	rpcReq, _ := http.NewRequest(http.MethodGet, "http://localhost:8000/soroban/rpc", nil)
+	if got := router.For(rpcReq.URL); got != soroban {
+		t.Fatalf("rpc path routed to %v, want the soroban breaker", got)
+	}
+
+	horizonReq, _ := http.NewRequest(http.MethodGet, "http://localhost:8000/accounts/GABC", nil)
+	if got := router.For(horizonReq.URL); got != horizon {
+		t.Fatalf("horizon path routed to %v, want the horizon breaker", got)
+	}
+}
+
+// A genuine collision is a configuration mistake and must be loud at startup,
+// not a silently shared breaker reporting under the wrong name.
+func TestRouterRejectsCollidingUpstreams(t *testing.T) {
+	router := NewRouter()
+	if err := router.Register(sorobanURL, New("soroban_rpc", testConfig(), nil)); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+
+	err := router.Register(sorobanURL, New("horizon", testConfig(), nil))
+	if err == nil {
+		t.Fatal("Register() accepted a colliding upstream, want an error")
+	}
+	if !strings.Contains(err.Error(), "collides") {
+		t.Fatalf("error = %v, want it to name the collision", err)
+	}
+}
+
+func TestRouterRejectsUnusableURLs(t *testing.T) {
+	router := NewRouter()
+	b := New("soroban_rpc", testConfig(), nil)
+
+	if err := router.Register("", b); err == nil {
+		t.Error("Register(\"\") = nil, want an error")
+	}
+	if err := router.Register("not-a-url", b); err == nil {
+		t.Error("Register(\"not-a-url\") = nil, want an error")
+	}
+	if err := router.Register(sorobanURL, nil); err == nil {
+		t.Error("Register(nil breaker) = nil, want an error")
+	}
+}
+
+// An empty router guards nothing, which is what a deployment with the breaker
+// disabled gets. It must not reject or panic.
+func TestEmptyRouterPassesEverythingThrough(t *testing.T) {
+	upstream := &countingTransport{status: http.StatusInternalServerError}
+	client := &http.Client{Transport: NewRouter().Transport(upstream)}
+
+	for i := 0; i < 20; i++ {
+		if _, err := doGet(client, sorobanURL); err != nil {
+			t.Fatalf("request through an empty router failed: %v", err)
+		}
+	}
+	if got := upstream.calls.Load(); got != 20 {
+		t.Fatalf("%d of 20 requests reached the upstream, want all", got)
+	}
+}
+
+// Against a real server, to prove the transport composes with net/http rather
+// than only with a stub round tripper.
+func TestTransportAgainstRealServer(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	clock := newFakeClock()
+	b := NewWithClock("soroban_rpc", testConfig(), nil, clock.Now)
+	router := NewRouter()
+	if err := router.Register(server.URL, b); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	client := &http.Client{Transport: router.Transport(nil)}
+
+	for i := 0; i < 40 && b.State() == StateClosed; i++ {
+		_, _ = doGet(client, server.URL)
+	}
+	if b.State() != StateOpen {
+		t.Fatalf("state = %s, want open", b.State())
+	}
+
+	hitsWhenOpen := hits.Load()
+	for i := 0; i < 25; i++ {
+		if _, err := doGet(client, server.URL); !errors.Is(err, ErrOpen) {
+			t.Fatalf("request %d = %v, want ErrOpen", i, err)
+		}
+	}
+	if got := hits.Load(); got != hitsWhenOpen {
+		t.Fatalf("%d requests reached the real server while open, want 0", got-hitsWhenOpen)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -11,6 +11,10 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
 )
 
 // defaultDevJWTSecret is the placeholder value shipped in .env.example. It is long
@@ -58,6 +62,48 @@ type Config struct {
 	schedulerLeadership   SchedulerLeadershipConfig
 	tracing               TracingConfig
 	metrics               MetricsConfig
+	indexer               IndexerConfig
+	circuitBreaker        CircuitBreakerConfig
+	rpcRetry              RPCRetryConfig
+}
+
+// CircuitBreakerConfig is the policy protecting the chain upstreams, Soroban
+// RPC and Horizon (nester#1087).
+//
+// One policy, two independent breakers. The thresholds are shared because both
+// upstreams degrade the same way and there is no evidence for different
+// numbers; the failure *state* is strictly separate, so a Horizon outage never
+// sheds Soroban traffic. See docs/observability/circuit-breakers.md.
+type CircuitBreakerConfig struct {
+	enabled      bool
+	failureRatio float64
+	minRequests  int
+	window       time.Duration
+	openDuration time.Duration
+}
+
+// RPCRetryConfig is the bounded, jittered retry policy shared by every Soroban
+// RPC call site (nester#1086).
+//
+// It applies only to idempotent reads. Writes are never retried here — a
+// resubmitted transaction is a second attempt to move real money — and go
+// through the submission record instead.
+type RPCRetryConfig struct {
+	maxAttempts int
+	baseDelay   time.Duration
+	maxDelay    time.Duration
+	budget      time.Duration
+}
+
+// IndexerConfig holds the event indexer's freshness contract (nester#1088).
+//
+// The staleness budget is a single number with three consumers — the
+// `nester_indexer_staleness_budget_seconds` metric the alert compares against,
+// the `X-Indexer-Stale` header the API returns, and the SLO documentation —
+// so that the pager, the UI, and the runbook can never disagree about whether
+// balances are current.
+type IndexerConfig struct {
+	stalenessBudget time.Duration
 }
 
 // TracingConfig holds the OpenTelemetry tracing settings (nester#1054).
@@ -416,6 +462,27 @@ func Load() (*Config, error) {
 			// host port.
 			addr: loader.stringDefault("METRICS_ADDR", "127.0.0.1:9090"),
 		},
+		indexer: IndexerConfig{
+			stalenessBudget: loader.durationDefault("INDEXER_STALENESS_BUDGET", freshness.DefaultBudget),
+		},
+		circuitBreaker: CircuitBreakerConfig{
+			// A kill switch, because a resilience mechanism can itself cause
+			// an outage if its thresholds are wrong for a given environment.
+			// Turning it off must not require a code change.
+			enabled:      loader.boolDefault("CIRCUIT_BREAKER_ENABLED", true),
+			failureRatio: loader.floatDefault("CIRCUIT_BREAKER_FAILURE_RATIO", breaker.DefaultFailureRatio),
+			minRequests:  loader.intDefault("CIRCUIT_BREAKER_MIN_REQUESTS", breaker.DefaultMinRequests),
+			window:       loader.durationDefault("CIRCUIT_BREAKER_WINDOW", breaker.DefaultWindow),
+			openDuration: loader.durationDefault("CIRCUIT_BREAKER_OPEN_DURATION", breaker.DefaultOpenDuration),
+		},
+		rpcRetry: RPCRetryConfig{
+			// 1 disables retrying without disabling the helper: the metrics
+			// and the typed error stay, only the second attempt goes away.
+			maxAttempts: loader.intDefault("RPC_RETRY_MAX_ATTEMPTS", retry.DefaultMaxAttempts),
+			baseDelay:   loader.durationDefault("RPC_RETRY_BASE_DELAY", retry.DefaultBaseDelay),
+			maxDelay:    loader.durationDefault("RPC_RETRY_MAX_DELAY", retry.DefaultMaxDelay),
+			budget:      loader.durationDefault("RPC_RETRY_BUDGET", retry.DefaultBudget),
+		},
 	}
 
 	if cfg.bankAccountCipherKey == "" && environment == "development" {
@@ -443,6 +510,48 @@ func (c Config) Server() ServerConfig {
 
 func (c Config) Metrics() MetricsConfig {
 	return c.metrics
+}
+
+func (c Config) Indexer() IndexerConfig {
+	return c.indexer
+}
+
+func (c Config) CircuitBreaker() CircuitBreakerConfig {
+	return c.circuitBreaker
+}
+
+// Enabled reports whether chain calls are guarded. When false the breakers are
+// not installed at all and every request goes straight to the upstream.
+func (b CircuitBreakerConfig) Enabled() bool { return b.enabled }
+
+func (c Config) RPCRetry() RPCRetryConfig {
+	return c.rpcRetry
+}
+
+// Policy returns the retry policy this configuration describes.
+func (r RPCRetryConfig) Policy() retry.Policy {
+	return retry.Policy{
+		MaxAttempts: r.maxAttempts,
+		BaseDelay:   r.baseDelay,
+		MaxDelay:    r.maxDelay,
+		Budget:      r.budget,
+	}
+}
+
+// Policy returns the breaker policy this configuration describes.
+func (b CircuitBreakerConfig) Policy() breaker.Config {
+	return breaker.Config{
+		FailureRatio: b.failureRatio,
+		MinRequests:  b.minRequests,
+		Window:       b.window,
+		OpenDuration: b.openDuration,
+	}
+}
+
+// StalenessBudget is how far behind the chain indexed data may fall before the
+// API reports it stale and the alert pages.
+func (i IndexerConfig) StalenessBudget() time.Duration {
+	return i.stalenessBudget
 }
 
 // Enabled reports whether the internal metrics listener should be started.
@@ -965,6 +1074,29 @@ func (c *Config) validate(loader *envLoader) {
 
 	if c.apyRefresh.broadcastThresholdBPS < 0 {
 		loader.addError("APY_BROADCAST_THRESHOLD must not be negative")
+	}
+
+	// A non-positive budget would mark every response stale and hold the
+	// staleness alert permanently firing, so it is refused at startup rather
+	// than discovered when the pager will not stop.
+	if c.indexer.stalenessBudget <= 0 {
+		loader.addError("INDEXER_STALENESS_BUDGET must be greater than 0")
+	}
+
+	// Only meaningful when the breakers are actually installed; a disabled
+	// breaker's thresholds are never read, so they must not block startup.
+	// The policy owns the rules, so they are stated once rather than
+	// duplicated here and left to drift.
+	if c.circuitBreaker.enabled {
+		if err := c.circuitBreaker.Policy().Validate(); err != nil {
+			loader.addError("CIRCUIT_BREAKER_* configuration is invalid: " + err.Error())
+		}
+	}
+
+	// The policy owns the rules, so they are stated once rather than
+	// duplicated here and left to drift.
+	if err := c.rpcRetry.Policy().Validate(); err != nil {
+		loader.addError("RPC_RETRY_* configuration is invalid: " + err.Error())
 	}
 
 	if c.transactionPoller.interval <= 0 {

--- a/apps/api/internal/config/config_breaker_test.go
+++ b/apps/api/internal/config/config_breaker_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+)
+
+func TestCircuitBreakerDefaults(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if !cfg.CircuitBreaker().Enabled() {
+		t.Error("expected the chain circuit breakers to be enabled by default")
+	}
+
+	policy := cfg.CircuitBreaker().Policy()
+	if policy.FailureRatio != breaker.DefaultFailureRatio {
+		t.Errorf("failure ratio = %v, want %v", policy.FailureRatio, breaker.DefaultFailureRatio)
+	}
+	if policy.MinRequests != breaker.DefaultMinRequests {
+		t.Errorf("min requests = %d, want %d", policy.MinRequests, breaker.DefaultMinRequests)
+	}
+	if policy.Window != breaker.DefaultWindow {
+		t.Errorf("window = %v, want %v", policy.Window, breaker.DefaultWindow)
+	}
+	if policy.OpenDuration != breaker.DefaultOpenDuration {
+		t.Errorf("open duration = %v, want %v", policy.OpenDuration, breaker.DefaultOpenDuration)
+	}
+}
+
+func TestCircuitBreakerOverrides(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("CIRCUIT_BREAKER_FAILURE_RATIO", "0.75")
+	t.Setenv("CIRCUIT_BREAKER_MIN_REQUESTS", "25")
+	t.Setenv("CIRCUIT_BREAKER_WINDOW", "2m")
+	t.Setenv("CIRCUIT_BREAKER_OPEN_DURATION", "45s")
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	policy := cfg.CircuitBreaker().Policy()
+	if policy.FailureRatio != 0.75 {
+		t.Errorf("failure ratio = %v, want 0.75", policy.FailureRatio)
+	}
+	if policy.MinRequests != 25 {
+		t.Errorf("min requests = %d, want 25", policy.MinRequests)
+	}
+	if policy.Window != 2*time.Minute {
+		t.Errorf("window = %v, want 2m", policy.Window)
+	}
+	if policy.OpenDuration != 45*time.Second {
+		t.Errorf("open duration = %v, want 45s", policy.OpenDuration)
+	}
+}
+
+// The kill switch. A resilience mechanism can itself cause an outage if its
+// thresholds are wrong for an environment, so turning it off must not require
+// a code change.
+func TestCircuitBreakerCanBeDisabled(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("CIRCUIT_BREAKER_ENABLED", "false")
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.CircuitBreaker().Enabled() {
+		t.Error("expected the circuit breakers to be disabled")
+	}
+}
+
+// A policy that cannot behave sensibly is refused at startup rather than
+// discovered when it sheds all traffic or none.
+func TestCircuitBreakerRejectsUnusablePolicies(t *testing.T) {
+	cases := map[string]map[string]string{
+		"ratio of zero":      {"CIRCUIT_BREAKER_FAILURE_RATIO": "0"},
+		"negative ratio":     {"CIRCUIT_BREAKER_FAILURE_RATIO": "-0.5"},
+		"ratio above one":    {"CIRCUIT_BREAKER_FAILURE_RATIO": "1.5"},
+		"zero min requests":  {"CIRCUIT_BREAKER_MIN_REQUESTS": "0"},
+		"negative min":       {"CIRCUIT_BREAKER_MIN_REQUESTS": "-1"},
+		"zero window":        {"CIRCUIT_BREAKER_WINDOW": "0s"},
+		"zero open duration": {"CIRCUIT_BREAKER_OPEN_DURATION": "0s"},
+	}
+
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			for key, value := range env {
+				t.Setenv(key, value)
+			}
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to reject %v", env)
+			}
+			if !strings.Contains(err.Error(), "CIRCUIT_BREAKER") {
+				t.Errorf("expected the error to name the setting, got %v", err)
+			}
+		})
+	}
+}
+
+// A disabled breaker's thresholds are never read, so they must not be able to
+// block startup. Otherwise the kill switch could not be used to recover from a
+// bad configuration.
+func TestDisabledCircuitBreakerSkipsPolicyValidation(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("CIRCUIT_BREAKER_ENABLED", "false")
+	t.Setenv("CIRCUIT_BREAKER_FAILURE_RATIO", "0")
+	chdir(t, t.TempDir())
+
+	if _, err := Load(); err != nil {
+		t.Fatalf("a disabled breaker's thresholds blocked startup: %v", err)
+	}
+}

--- a/apps/api/internal/config/config_indexer_test.go
+++ b/apps/api/internal/config/config_indexer_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+)
+
+// The budget must default to the documented value rather than to whatever a
+// deployment happens to set, because it is the number the API's stale flag,
+// the staleness alert, and the SLO documentation are all stated against.
+func TestIndexerStalenessBudgetDefaults(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if got := cfg.Indexer().StalenessBudget(); got != freshness.DefaultBudget {
+		t.Errorf("staleness budget = %v, want %v", got, freshness.DefaultBudget)
+	}
+	if freshness.DefaultBudget != 5*time.Minute {
+		t.Errorf("the documented budget is 5m; DefaultBudget is %v", freshness.DefaultBudget)
+	}
+}
+
+func TestIndexerStalenessBudgetOverride(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("INDEXER_STALENESS_BUDGET", "90s")
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if got := cfg.Indexer().StalenessBudget(); got != 90*time.Second {
+		t.Errorf("staleness budget = %v, want 90s", got)
+	}
+}
+
+// A non-positive budget would mark every response stale and hold the alert
+// permanently firing. Refusing it at startup is far cheaper than discovering
+// it when the pager will not stop.
+func TestIndexerStalenessBudgetMustBePositive(t *testing.T) {
+	for _, value := range []string{"0s", "-1m"} {
+		t.Run(value, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("INDEXER_STALENESS_BUDGET", value)
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to reject INDEXER_STALENESS_BUDGET=%s", value)
+			}
+			if !strings.Contains(err.Error(), "INDEXER_STALENESS_BUDGET") {
+				t.Errorf("expected the error to name INDEXER_STALENESS_BUDGET, got %v", err)
+			}
+		})
+	}
+}

--- a/apps/api/internal/config/config_rpc_retry_test.go
+++ b/apps/api/internal/config/config_rpc_retry_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
+)
+
+func TestRPCRetryDefaults(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	policy := cfg.RPCRetry().Policy()
+	if policy.MaxAttempts != retry.DefaultMaxAttempts {
+		t.Errorf("max attempts = %d, want %d", policy.MaxAttempts, retry.DefaultMaxAttempts)
+	}
+	if policy.BaseDelay != retry.DefaultBaseDelay {
+		t.Errorf("base delay = %v, want %v", policy.BaseDelay, retry.DefaultBaseDelay)
+	}
+	if policy.MaxDelay != retry.DefaultMaxDelay {
+		t.Errorf("max delay = %v, want %v", policy.MaxDelay, retry.DefaultMaxDelay)
+	}
+	if policy.Budget != retry.DefaultBudget {
+		t.Errorf("budget = %v, want %v", policy.Budget, retry.DefaultBudget)
+	}
+}
+
+// The budget must stay below the server's write timeout, or the retry loop
+// becomes the thing holding a request open longest and the client gets a
+// truncated response instead of the typed 503.
+func TestRPCRetryBudgetFitsInsideTheWriteTimeout(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	budget := cfg.RPCRetry().Policy().Budget
+	if writeTimeout := cfg.Server().WriteTimeout(); budget >= writeTimeout {
+		t.Fatalf("retry budget %v is not below the server write timeout %v", budget, writeTimeout)
+	}
+}
+
+func TestRPCRetryOverrides(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("RPC_RETRY_MAX_ATTEMPTS", "5")
+	t.Setenv("RPC_RETRY_BASE_DELAY", "250ms")
+	t.Setenv("RPC_RETRY_MAX_DELAY", "4s")
+	t.Setenv("RPC_RETRY_BUDGET", "9s")
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	policy := cfg.RPCRetry().Policy()
+	if policy.MaxAttempts != 5 {
+		t.Errorf("max attempts = %d, want 5", policy.MaxAttempts)
+	}
+	if policy.BaseDelay != 250*time.Millisecond {
+		t.Errorf("base delay = %v, want 250ms", policy.BaseDelay)
+	}
+	if policy.MaxDelay != 4*time.Second {
+		t.Errorf("max delay = %v, want 4s", policy.MaxDelay)
+	}
+	if policy.Budget != 9*time.Second {
+		t.Errorf("budget = %v, want 9s", policy.Budget)
+	}
+}
+
+// One attempt turns retrying off without turning the helper off: the metrics
+// and the typed error stay, only the second attempt goes away. It must be an
+// accepted value, not rejected as nonsensical.
+func TestRPCRetryCanBeDisabledWithASingleAttempt(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("RPC_RETRY_MAX_ATTEMPTS", "1")
+	chdir(t, t.TempDir())
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() rejected a single-attempt policy: %v", err)
+	}
+	if got := cfg.RPCRetry().Policy().MaxAttempts; got != 1 {
+		t.Fatalf("max attempts = %d, want 1", got)
+	}
+}
+
+func TestRPCRetryRejectsUnusablePolicies(t *testing.T) {
+	cases := map[string]map[string]string{
+		"zero attempts":        {"RPC_RETRY_MAX_ATTEMPTS": "0"},
+		"negative attempts":    {"RPC_RETRY_MAX_ATTEMPTS": "-2"},
+		"zero base delay":      {"RPC_RETRY_BASE_DELAY": "0s"},
+		"max delay below base": {"RPC_RETRY_BASE_DELAY": "5s", "RPC_RETRY_MAX_DELAY": "1s"},
+		"zero budget":          {"RPC_RETRY_BUDGET": "0s"},
+		"negative budget":      {"RPC_RETRY_BUDGET": "-1s"},
+	}
+
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			for key, value := range env {
+				t.Setenv(key, value)
+			}
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to reject %v", env)
+			}
+			if !strings.Contains(err.Error(), "RPC_RETRY") {
+				t.Errorf("expected the error to name the setting, got %v", err)
+			}
+		})
+	}
+}

--- a/apps/api/internal/freshness/freshness.go
+++ b/apps/api/internal/freshness/freshness.go
@@ -1,0 +1,258 @@
+// Package freshness owns the single definition of how stale Nester's indexed
+// view of the chain is (nester#1088).
+//
+// Three consumers read the same model, and that is the point: the Prometheus
+// metrics, the staleness alert, and the freshness headers the API returns to
+// clients must never disagree about whether balances are current. Before this
+// package the lag threshold lived only in a Prometheus expression, so the API
+// had no way to tell a client that the balance it was serving was stale.
+//
+// The model has two inputs, both taken from the indexer:
+//
+//	indexedLedger — the cursor the indexer has committed (system_state)
+//	networkLedger — the tip the Soroban RPC reported at that moment
+//
+// and one derived quantity, staleness in wall time:
+//
+//	lag = (now - sampledAt) + (networkLedger - indexedLedger) * LedgerCloseInterval
+//
+// The first term is how long it has been since freshness was verified at all;
+// the second is how far behind the chain the indexer was when it last looked.
+// Both terms are required. Dropping the first would let the number freeze at a
+// healthy value the moment the indexer died — the exact failure this issue
+// exists to eliminate — and dropping the second would report a busily-polling
+// but hopelessly-behind indexer as perfectly fresh.
+//
+// Because the first term grows with the clock, lag is computed on read rather
+// than pushed on a timer. A dead indexer therefore produces a climbing number
+// with no goroutine of ours still running to produce it.
+package freshness
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// LedgerCloseInterval is the nominal Stellar ledger close time. It converts
+// ledger lag into wall time so that one budget, stated in seconds, can govern
+// both units.
+//
+// Real close times vary by a few hundred milliseconds, so this is an estimate
+// and the derived seconds figure inherits that error. At the scale the budget
+// operates on — minutes — the error is immaterial, and it is the same 5s
+// figure the SLO documentation and the flow-latency buckets already assume.
+const LedgerCloseInterval = 5 * time.Second
+
+// DefaultBudget is the staleness budget: how far behind the chain indexed data
+// may fall before it is served as stale and the alert pages.
+//
+// Five minutes is the existing balance-freshness SLO restated in seconds. That
+// SLO permits 60 ledgers of lag, and 60 * 5s is exactly 300s, so this
+// introduces no second, contradictory threshold — it expresses the same budget
+// in the unit the API contract and the seconds-based alert both need.
+//
+// Healthy operation sits an order of magnitude inside it: the indexer polls
+// every 6s and advances its cursor to the tip it just read, so a healthy
+// sample is a handful of ledgers behind and no more than one poll old, i.e.
+// well under 20s of staleness. The gap between that and 300s absorbs a slow
+// RPC round trip, a restart, and the 12-ledger cold-start rewind without
+// paging.
+const DefaultBudget = 5 * time.Minute
+
+// Snapshot is the freshness of indexed data at one instant.
+//
+// It is a value, not a live view: everything needed to render a metric, an
+// alert, or an HTTP header is resolved at the moment it is taken, so no caller
+// has to hold a lock or re-derive the staleness rule.
+type Snapshot struct {
+	// Sampled reports whether the indexer has ever published a position.
+	// Until it has, IndexedLedger, NetworkLedger and LagLedgers are
+	// meaningless and must not be published as zero: "zero ledgers behind"
+	// and "we have no idea" are opposite claims.
+	Sampled bool
+
+	IndexedLedger uint64
+	NetworkLedger uint64
+
+	// LagLedgers is NetworkLedger - IndexedLedger, floored at zero. An
+	// indexed ledger ahead of the reported tip is normal for a moment after
+	// the cursor advances, and is not negative lag.
+	LagLedgers uint64
+
+	// Lag is how stale the indexed data is in wall time. It grows with the
+	// clock while the indexer is not reporting, so it is the quantity both
+	// the alert and the API contract are defined against.
+	Lag time.Duration
+
+	// SampleAge is how long ago the last successful sample was taken, or how
+	// long the tracker has existed if there has never been one.
+	SampleAge time.Duration
+
+	Budget time.Duration
+
+	// Stale is Lag > Budget. Strictly greater: data exactly at the budget is
+	// still within it.
+	Stale bool
+
+	// SampleErrors counts failed sampling attempts since process start.
+	// Reported separately rather than folded into Lag, because a sentinel lag
+	// written on error is indistinguishable from a real stall.
+	SampleErrors uint64
+}
+
+// Reader reports the current freshness of indexed data. The metrics collector
+// and the API middleware depend on this rather than on *Tracker so both can be
+// tested against a fixed snapshot.
+type Reader interface {
+	Snapshot() Snapshot
+}
+
+// Tracker is the process-wide freshness state. The indexer writes to it, the
+// metrics collector and the API read from it, concurrently and continuously.
+type Tracker struct {
+	budget time.Duration
+	now    func() time.Time
+
+	mu            sync.RWMutex
+	sampled       bool
+	sampledAt     time.Time
+	indexedLedger uint64
+	networkLedger uint64
+	sampleErrors  uint64
+}
+
+// NewTracker returns a tracker enforcing the given staleness budget. A
+// non-positive budget falls back to DefaultBudget so a misconfigured value
+// cannot make every response report itself stale.
+func NewTracker(budget time.Duration) *Tracker {
+	return NewTrackerWithClock(budget, time.Now)
+}
+
+// NewTrackerWithClock is NewTracker with an injectable clock, so staleness can
+// be tested at exact boundaries without sleeping.
+func NewTrackerWithClock(budget time.Duration, now func() time.Time) *Tracker {
+	if budget <= 0 {
+		budget = DefaultBudget
+	}
+	if now == nil {
+		now = time.Now
+	}
+
+	return &Tracker{
+		budget: budget,
+		now:    now,
+		// Age is measured from construction until the first sample lands, so
+		// an indexer that never starts goes stale after one budget rather
+		// than reporting perfect freshness forever. That also gives a fresh
+		// deployment exactly one budget of grace before it can page, which is
+		// what keeps restarts off the pager.
+		sampledAt: now(),
+	}
+}
+
+// Observe records a successful freshness sample.
+func (t *Tracker) Observe(indexedLedger, networkLedger uint64) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.sampled = true
+	t.sampledAt = t.now()
+	t.indexedLedger = indexedLedger
+	t.networkLedger = networkLedger
+}
+
+// ObserveFailure records a sampling attempt that failed.
+//
+// It deliberately does not touch sampledAt: a failed sample proves nothing
+// about freshness, so the previous reading must keep ageing. Resetting the age
+// here would let a permanently-failing sampler hold the freshness signal at
+// zero and silence the alert.
+func (t *Tracker) ObserveFailure() {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.sampleErrors++
+}
+
+// Budget returns the staleness budget this tracker enforces.
+func (t *Tracker) Budget() time.Duration {
+	if t == nil {
+		return DefaultBudget
+	}
+	return t.budget
+}
+
+// Snapshot computes freshness as of now.
+func (t *Tracker) Snapshot() Snapshot {
+	if t == nil {
+		return Snapshot{Budget: DefaultBudget}
+	}
+
+	t.mu.RLock()
+	sampled := t.sampled
+	sampledAt := t.sampledAt
+	indexed := t.indexedLedger
+	network := t.networkLedger
+	errors := t.sampleErrors
+	t.mu.RUnlock()
+
+	age := t.now().Sub(sampledAt)
+	if age < 0 {
+		// A clock stepping backwards must not report data as fresher than it
+		// is; treat the sample as current instead of negative-aged.
+		age = 0
+	}
+
+	snapshot := Snapshot{
+		Sampled:      sampled,
+		Budget:       t.budget,
+		SampleAge:    age,
+		SampleErrors: errors,
+		Lag:          age,
+	}
+
+	if sampled {
+		snapshot.IndexedLedger = indexed
+		snapshot.NetworkLedger = network
+		if network > indexed {
+			snapshot.LagLedgers = network - indexed
+		}
+		snapshot.Lag = addSaturating(age, ledgerLagDuration(snapshot.LagLedgers))
+	}
+
+	snapshot.Stale = snapshot.Lag > t.budget
+
+	return snapshot
+}
+
+// ledgerLagDuration converts a ledger count to wall time, saturating instead
+// of overflowing. Ledger sequences are 32-bit on Stellar but arrive here as
+// uint64 from the RPC and from a text column in system_state; a corrupt value
+// multiplied by 5s would wrap int64 and produce a *negative* duration, which
+// would report a completely dead indexer as fresh.
+func ledgerLagDuration(ledgers uint64) time.Duration {
+	const maxLedgers = uint64(math.MaxInt64) / uint64(LedgerCloseInterval)
+	if ledgers > maxLedgers {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(ledgers) * LedgerCloseInterval
+}
+
+// addSaturating adds two non-negative durations, clamping at the maximum
+// rather than wrapping negative. Same reasoning as ledgerLagDuration.
+func addSaturating(a, b time.Duration) time.Duration {
+	const max = time.Duration(math.MaxInt64)
+	if b > max-a {
+		return max
+	}
+	return a + b
+}

--- a/apps/api/internal/freshness/freshness_test.go
+++ b/apps/api/internal/freshness/freshness_test.go
@@ -1,0 +1,331 @@
+package freshness
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a manually advanced clock. Every staleness assertion below is
+// about a boundary measured in minutes; sleeping for them would make the suite
+// unusable and the boundaries themselves untestable.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestTracker(budget time.Duration) (*Tracker, *fakeClock) {
+	clock := newFakeClock()
+	return NewTrackerWithClock(budget, clock.Now), clock
+}
+
+func TestFreshSampleIsNotStale(t *testing.T) {
+	tracker, _ := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_000, 1_002)
+
+	got := tracker.Snapshot()
+	if !got.Sampled {
+		t.Fatal("snapshot reports no sample after Observe")
+	}
+	if got.LagLedgers != 2 {
+		t.Fatalf("lag ledgers = %d, want 2", got.LagLedgers)
+	}
+	if want := 2 * LedgerCloseInterval; got.Lag != want {
+		t.Fatalf("lag = %v, want %v", got.Lag, want)
+	}
+	if got.Stale {
+		t.Fatalf("2 ledgers behind reported stale against a %v budget", got.Budget)
+	}
+}
+
+// An indexed ledger ahead of the reported tip happens for a moment whenever
+// the cursor advances between the tip read and the next sample. It is not
+// negative lag, and it must not underflow uint64 into an enormous value.
+func TestIndexedAheadOfTipIsZeroLag(t *testing.T) {
+	tracker, _ := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_005, 1_000)
+
+	got := tracker.Snapshot()
+	if got.LagLedgers != 0 {
+		t.Fatalf("lag ledgers = %d, want 0", got.LagLedgers)
+	}
+	if got.Lag != 0 {
+		t.Fatalf("lag = %v, want 0", got.Lag)
+	}
+}
+
+// The staleness boundary, stated exactly: at the budget the data is still
+// fresh, one nanosecond past it is stale. `>` not `>=`, matching the alert
+// expression and the documented rule.
+func TestStalenessBoundary(t *testing.T) {
+	const budget = 5 * time.Minute
+
+	cases := []struct {
+		name      string
+		elapsed   time.Duration
+		wantStale bool
+	}{
+		{"below budget", budget - time.Second, false},
+		{"exactly at budget", budget, false},
+		{"one nanosecond past budget", budget + time.Nanosecond, true},
+		{"far past budget", 2 * budget, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker, clock := newTestTracker(budget)
+			// Zero ledger lag, so the whole of Lag is elapsed time and the
+			// boundary is exercised precisely.
+			tracker.Observe(1_000, 1_000)
+
+			clock.Advance(tc.elapsed)
+
+			got := tracker.Snapshot()
+			if got.Lag != tc.elapsed {
+				t.Fatalf("lag = %v, want %v", got.Lag, tc.elapsed)
+			}
+			if got.Stale != tc.wantStale {
+				t.Fatalf("stale = %v, want %v (lag %v, budget %v)", got.Stale, tc.wantStale, got.Lag, budget)
+			}
+		})
+	}
+}
+
+// The failure this whole issue exists to make visible: the indexer stops and
+// nothing updates the freshness signal again. Lag must keep climbing on the
+// clock alone, and must eventually cross the budget.
+func TestLagClimbsWhileTheIndexerIsSilent(t *testing.T) {
+	tracker, clock := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_000, 1_001)
+	first := tracker.Snapshot()
+
+	clock.Advance(time.Minute)
+	second := tracker.Snapshot()
+	if second.Lag <= first.Lag {
+		t.Fatalf("lag did not grow while the indexer was silent: %v then %v", first.Lag, second.Lag)
+	}
+	if second.Stale {
+		t.Fatal("one minute of silence exceeded a five minute budget")
+	}
+
+	clock.Advance(10 * time.Minute)
+	third := tracker.Snapshot()
+	if !third.Stale {
+		t.Fatalf("eleven minutes of silence reported fresh (lag %v, budget %v)", third.Lag, third.Budget)
+	}
+	// The ledger figures are still the last observed ones — the indexer never
+	// said otherwise — which is exactly why the seconds view is the one that
+	// pages.
+	if third.LagLedgers != 1 {
+		t.Fatalf("lag ledgers = %d, want the last observed 1", third.LagLedgers)
+	}
+}
+
+// Before the first sample there is no position to report, and reporting zero
+// ledgers of lag would claim the indexer is exactly at the tip. The seconds
+// view still ages from process start, so an indexer that never runs at all
+// goes stale rather than looking perfect forever.
+func TestUnsampledTrackerAgesFromConstruction(t *testing.T) {
+	tracker, clock := newTestTracker(DefaultBudget)
+
+	initial := tracker.Snapshot()
+	if initial.Sampled {
+		t.Fatal("a tracker with no samples reports Sampled")
+	}
+	if initial.Stale {
+		t.Fatal("a freshly constructed tracker is stale, which would page on every deploy")
+	}
+
+	clock.Advance(DefaultBudget + time.Second)
+
+	got := tracker.Snapshot()
+	if got.Sampled {
+		t.Fatal("still reports Sampled with no observation")
+	}
+	if !got.Stale {
+		t.Fatalf("an indexer that never reported is not stale after %v", got.Lag)
+	}
+	if got.LagLedgers != 0 || got.IndexedLedger != 0 || got.NetworkLedger != 0 {
+		t.Fatalf("ledger fields populated without a sample: %+v", got)
+	}
+}
+
+// A failed sample must not reset the age. If it did, a permanently failing
+// sampler would hold the freshness signal at zero and silence the alert
+// forever — the same frozen-value failure, arrived at from the error path.
+func TestSampleFailureDoesNotRefreshTheSignal(t *testing.T) {
+	tracker, clock := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_000, 1_000)
+	clock.Advance(4 * time.Minute)
+
+	tracker.ObserveFailure()
+	tracker.ObserveFailure()
+
+	got := tracker.Snapshot()
+	if got.SampleAge != 4*time.Minute {
+		t.Fatalf("sample age = %v, want 4m: a failure reset the age", got.SampleAge)
+	}
+	if got.SampleErrors != 2 {
+		t.Fatalf("sample errors = %d, want 2", got.SampleErrors)
+	}
+
+	clock.Advance(2 * time.Minute)
+	if !tracker.Snapshot().Stale {
+		t.Fatal("six minutes of failed samples reported fresh")
+	}
+}
+
+func TestObserveRefreshesTheSignal(t *testing.T) {
+	tracker, clock := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_000, 1_000)
+	clock.Advance(10 * time.Minute)
+	if !tracker.Snapshot().Stale {
+		t.Fatal("precondition: tracker should be stale before recovery")
+	}
+
+	tracker.Observe(1_100, 1_100)
+
+	got := tracker.Snapshot()
+	if got.Stale {
+		t.Fatalf("a fresh sample did not clear staleness (lag %v)", got.Lag)
+	}
+	if got.SampleAge != 0 {
+		t.Fatalf("sample age = %v, want 0 immediately after Observe", got.SampleAge)
+	}
+	if got.IndexedLedger != 1_100 {
+		t.Fatalf("indexed ledger = %d, want 1100", got.IndexedLedger)
+	}
+}
+
+// Ledger lag contributes to the seconds figure at the nominal close interval,
+// so the two units the issue asks for describe the same budget.
+func TestLedgerLagContributesToSeconds(t *testing.T) {
+	tracker, _ := newTestTracker(DefaultBudget)
+
+	// 60 ledgers is the documented ledger-lag SLO; at a 5s close interval it
+	// is exactly the 5 minute budget, so it must sit on the boundary rather
+	// than over it.
+	tracker.Observe(1_000, 1_060)
+
+	got := tracker.Snapshot()
+	if want := 5 * time.Minute; got.Lag != want {
+		t.Fatalf("lag = %v, want %v", got.Lag, want)
+	}
+	if got.Stale {
+		t.Fatal("60 ledgers of lag is exactly the budget and must not be stale")
+	}
+}
+
+// A corrupt cursor must not wrap the duration arithmetic negative, which would
+// report a completely dead indexer as fresh.
+func TestAbsurdLedgerLagSaturatesRatherThanWrapping(t *testing.T) {
+	tracker, _ := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1, math.MaxUint64)
+
+	got := tracker.Snapshot()
+	if got.Lag < 0 {
+		t.Fatalf("lag wrapped negative: %v", got.Lag)
+	}
+	if !got.Stale {
+		t.Fatalf("an absurd lag of %v was reported fresh", got.Lag)
+	}
+}
+
+// A clock that steps backwards (NTP correction, VM restore) must not make the
+// data look fresher than it is.
+func TestBackwardsClockDoesNotReportNegativeAge(t *testing.T) {
+	tracker, clock := newTestTracker(DefaultBudget)
+
+	tracker.Observe(1_000, 1_000)
+	clock.Advance(-time.Hour)
+
+	got := tracker.Snapshot()
+	if got.SampleAge != 0 {
+		t.Fatalf("sample age = %v, want 0 after the clock stepped backwards", got.SampleAge)
+	}
+	if got.Lag < 0 {
+		t.Fatalf("lag = %v, want a non-negative duration", got.Lag)
+	}
+}
+
+func TestNonPositiveBudgetFallsBackToDefault(t *testing.T) {
+	for _, budget := range []time.Duration{0, -time.Second} {
+		tracker := NewTracker(budget)
+		if got := tracker.Budget(); got != DefaultBudget {
+			t.Fatalf("budget for %v = %v, want %v", budget, got, DefaultBudget)
+		}
+	}
+}
+
+// A nil tracker is safe on every path, so a deployment wired without an
+// indexer degrades to "no freshness information" rather than panicking in the
+// request path.
+func TestNilTrackerIsSafe(t *testing.T) {
+	var tracker *Tracker
+
+	tracker.Observe(1, 2)
+	tracker.ObserveFailure()
+
+	got := tracker.Snapshot()
+	if got.Budget != DefaultBudget {
+		t.Fatalf("nil tracker budget = %v, want %v", got.Budget, DefaultBudget)
+	}
+	if got.Sampled {
+		t.Fatal("nil tracker reports a sample")
+	}
+}
+
+// The indexer writes while the metrics scrape and every API request read. Run
+// under -race, this is what proves that is safe.
+func TestConcurrentObserveAndSnapshot(t *testing.T) {
+	tracker := NewTracker(DefaultBudget)
+
+	var wg sync.WaitGroup
+	for writer := 0; writer < 4; writer++ {
+		wg.Add(1)
+		go func(base uint64) {
+			defer wg.Done()
+			for i := uint64(0); i < 500; i++ {
+				tracker.Observe(base+i, base+i+3)
+				tracker.ObserveFailure()
+			}
+		}(uint64(writer) * 1000)
+	}
+	for reader := 0; reader < 4; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				_ = tracker.Snapshot()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := tracker.Snapshot().SampleErrors; got != 2000 {
+		t.Fatalf("sample errors = %d, want 2000", got)
+	}
+}

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,7 +13,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	"github.com/suncrestlabs/nester/apps/api/internal/ws"
 	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
@@ -775,10 +778,47 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "DUPLICATE_TRANSACTION", err.Error()))
 	case errors.Is(err, vault.ErrInsufficientBalance), errors.Is(err, vault.ErrVaultClosed), errors.Is(err, vault.ErrVaultNotActive):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+
+	// The chain never gave us an answer: either the circuit breaker declined
+	// to call it (nester#1087) or the call was retried to exhaustion
+	// (nester#1086). Both are 503 rather than the default 500, because both
+	// are known, temporary upstream conditions rather than a fault in this
+	// service — and because 500 would tell a client to treat it as a bug
+	// rather than to back off.
+	//
+	// One response code for both: a client's correct action is identical, and
+	// the distinction that matters to us is in the metrics, not on the wire.
+	//
+	// Deliberately not logged here. An open breaker can reject every request
+	// for its whole open period, and a log line each would turn an upstream
+	// outage into a logging outage; the breaker's rejection counter and the
+	// RPC exhaustion counter carry that volume instead.
+	case errors.Is(err, breaker.ErrOpen), errors.Is(err, retry.ErrExhausted):
+		w.Header().Set("Retry-After", retryAfterSeconds(err))
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(
+			http.StatusServiceUnavailable,
+			"UPSTREAM_UNAVAILABLE",
+			"the Stellar network is temporarily unreachable; please retry shortly",
+		))
+
 	default:
 		logpkg.FromContext(r.Context()).Error("vault handler failed", "error", err.Error())
 		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error"))
 	}
+}
+
+// retryAfterSeconds renders the breaker's remaining open period as a
+// Retry-After value, so a client backs off for as long as the shedding will
+// actually last instead of guessing. Falls back to "1" when the breaker did
+// not carry a duration, which is still better than no hint at all.
+func retryAfterSeconds(err error) string {
+	var openErr *breaker.OpenError
+	if errors.As(err, &openErr) {
+		if seconds := int(math.Ceil(openErr.RetryIn.Seconds())); seconds > 0 {
+			return strconv.Itoa(seconds)
+		}
+	}
+	return "1"
 }
 
 func decodeJSON(r *http.Request, destination any) error {

--- a/apps/api/internal/handler/vault_handler_breaker_test.go
+++ b/apps/api/internal/handler/vault_handler_breaker_test.go
@@ -1,0 +1,155 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
+	"github.com/suncrestlabs/nester/apps/api/pkg/response"
+)
+
+// A chain call the breaker declined is a known, temporary upstream condition
+// with a known retry time — not a fault in this service. Reporting it as 500
+// tells a client to treat it as a bug rather than to back off, and buries a
+// deliberate load-shed among genuine internal errors.
+func TestOpenBreakerBecomesServiceUnavailable(t *testing.T) {
+	h := &VaultHandler{}
+
+	// Wrapped the way http.Client.Do wraps a transport error, because that is
+	// the shape the error actually arrives in.
+	err := fmt.Errorf("simulate contract: %w", &breaker.OpenError{
+		Name:    "soroban_rpc",
+		RetryIn: 12 * time.Second,
+	})
+
+	rec := httptest.NewRecorder()
+	h.writeDomainError(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults/x", nil), err)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "12" {
+		t.Fatalf("Retry-After = %q, want \"12\"", got)
+	}
+
+	var body response.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Success {
+		t.Fatal("success = true on a rejected chain call")
+	}
+	if body.Error == nil || body.Error.Code != "UPSTREAM_UNAVAILABLE" {
+		t.Fatalf("error = %+v, want code UPSTREAM_UNAVAILABLE", body.Error)
+	}
+
+	// The upstream's identity is an internal detail; the client is told what
+	// to do, not which dependency broke.
+	if got := rec.Body.String(); contains(got, "soroban_rpc") {
+		t.Fatalf("response leaks the upstream name: %s", got)
+	}
+}
+
+// A read retried to exhaustion is the same class of failure as a breaker
+// rejection — the chain never answered — and must produce the same typed 503
+// rather than a generic 500 (nester#1086).
+func TestRetryExhaustionBecomesServiceUnavailable(t *testing.T) {
+	h := &VaultHandler{}
+
+	// Wrapped the way the RPC client wraps it, so the test exercises the
+	// error as it actually arrives at the handler.
+	err := fmt.Errorf("rpc simulateTransaction: %w", &retry.Error{
+		Attempts: 3,
+		Elapsed:  4 * time.Second,
+		Err:      errors.New("connection reset by peer"),
+	})
+
+	rec := httptest.NewRecorder()
+	h.writeDomainError(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults/x", nil), err)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+
+	var body response.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error == nil || body.Error.Code != "UPSTREAM_UNAVAILABLE" {
+		t.Fatalf("error = %+v, want code UPSTREAM_UNAVAILABLE", body.Error)
+	}
+
+	// The retry loop carries no cooldown of its own, so the client is still
+	// given a floor rather than an absent header.
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want \"1\"", got)
+	}
+}
+
+// A bare ErrOpen with no duration still yields a usable hint rather than an
+// absent or zero header, which some clients treat as "retry immediately".
+func TestRetryAfterFallsBackWhenNoDurationIsCarried(t *testing.T) {
+	h := &VaultHandler{}
+
+	rec := httptest.NewRecorder()
+	h.writeDomainError(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults/x", nil), breaker.ErrOpen)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want \"1\"", got)
+	}
+}
+
+func TestRetryAfterSeconds(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want string
+	}{
+		"whole seconds":      {&breaker.OpenError{RetryIn: 15 * time.Second}, "15"},
+		"rounds up":          {&breaker.OpenError{RetryIn: 1500 * time.Millisecond}, "2"},
+		"elapsed":            {&breaker.OpenError{RetryIn: 0}, "1"},
+		"unrelated error":    {errors.New("boom"), "1"},
+		"wrapped open error": {fmt.Errorf("call: %w", &breaker.OpenError{RetryIn: 8 * time.Second}), "8"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := retryAfterSeconds(tc.err); got != tc.want {
+				t.Fatalf("retryAfterSeconds() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Errors that are not breaker rejections keep their existing mapping. The new
+// case must not have widened into a catch-all.
+func TestUnrelatedErrorsStillMapToInternalError(t *testing.T) {
+	h := &VaultHandler{}
+
+	rec := httptest.NewRecorder()
+	h.writeDomainError(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults/x", nil), errors.New("boom"))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("Retry-After = %q on an unrelated error, want none", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/internal/metrics/breaker.go
+++ b/apps/api/internal/metrics/breaker.go
@@ -1,0 +1,103 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+)
+
+// BreakerReader reports one circuit breaker's current state. Implemented by
+// *breaker.Breaker.
+type BreakerReader interface {
+	Snapshot() breaker.Snapshot
+}
+
+// BreakerCollector exposes circuit breaker state for the chain upstreams
+// (nester#1087).
+//
+// A pull collector, like PoolCollector and FreshnessCollector, and for a
+// reason specific to this state machine: an open breaker becomes half-open
+// when its open period elapses, which is a function of the clock rather than
+// of anything happening. A pushed gauge would keep reporting "open" until the
+// next call arrived to move it, so the metric would disagree with what the
+// breaker would actually do. Reading at scrape time cannot drift.
+//
+// The upstream label is the bounded Upstream constant set, never a URL or a
+// host: a redirect or a per-environment endpoint would otherwise mint series,
+// and a URL can carry credentials in its userinfo.
+type BreakerCollector struct {
+	readers map[Upstream]BreakerReader
+
+	state        *prometheus.Desc
+	failureRatio *prometheus.Desc
+	rejected     *prometheus.Desc
+}
+
+// NewBreakerCollector builds a collector over the given breakers.
+func NewBreakerCollector(readers map[Upstream]BreakerReader) *BreakerCollector {
+	const subsystem = "circuit_breaker"
+
+	name := func(n string) string {
+		return prometheus.BuildFQName(Namespace, subsystem, n)
+	}
+	labels := []string{"upstream"}
+
+	return &BreakerCollector{
+		readers: readers,
+
+		// 0 = closed, 1 = half_open, 2 = open. Ascending with severity, so
+		// `> 0` reads as "not fully healthy" and max() across replicas is the
+		// worst state rather than an arbitrary one.
+		state: prometheus.NewDesc(name("state"),
+			"Circuit breaker state for a chain upstream: 0 closed, 1 half-open, 2 open.",
+			labels, nil),
+
+		// The number the state is derived from. During an incident the useful
+		// question is not only "has it tripped" but "how close is it", and
+		// after recovery this is what shows the window draining.
+		failureRatio: prometheus.NewDesc(name("failure_ratio"),
+			"Observed failure ratio within the breaker's rolling window.",
+			labels, nil),
+
+		// Calls the breaker refused without touching the network. This is the
+		// load actually shed, and it is why rejections are not logged
+		// individually.
+		rejected: prometheus.NewDesc(name("rejected_total"),
+			"Requests rejected without contacting the upstream because the breaker was not admitting calls.",
+			labels, nil),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *BreakerCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.state
+	ch <- c.failureRatio
+	ch <- c.rejected
+}
+
+// Collect implements prometheus.Collector.
+func (c *BreakerCollector) Collect(ch chan<- prometheus.Metric) {
+	for upstream, reader := range c.readers {
+		if reader == nil {
+			continue
+		}
+
+		snapshot := reader.Snapshot()
+		label := string(upstream)
+
+		ch <- prometheus.MustNewConstMetric(c.state, prometheus.GaugeValue, float64(snapshot.State), label)
+		ch <- prometheus.MustNewConstMetric(c.failureRatio, prometheus.GaugeValue, snapshot.FailureRatio, label)
+		ch <- prometheus.MustNewConstMetric(c.rejected, prometheus.CounterValue, float64(snapshot.Rejected), label)
+	}
+}
+
+// RegisterBreakers attaches a breaker collector to the registry.
+//
+// An empty or nil map is a no-op so callers need not branch when the breaker
+// is disabled.
+func (m *Metrics) RegisterBreakers(readers map[Upstream]BreakerReader) error {
+	if m == nil || len(readers) == 0 {
+		return nil
+	}
+	return m.registry.Register(NewBreakerCollector(readers))
+}

--- a/apps/api/internal/metrics/breaker_test.go
+++ b/apps/api/internal/metrics/breaker_test.go
@@ -1,0 +1,229 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+)
+
+func breakerLabels(upstream Upstream) map[string]string {
+	return map[string]string{"upstream": string(upstream)}
+}
+
+// gaugeValueFor is gaugeValue with a label selector, which the shared helper
+// does not offer and which every assertion here needs.
+func gaugeValueFor(t *testing.T, m *Metrics, name string, labels map[string]string) float64 {
+	t.Helper()
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsMatch(metric, labels) {
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("%s%v not found in registry", name, labels)
+	return 0
+}
+
+func newBreakerMetrics(t *testing.T, clock func() time.Time, cfg breaker.Config) (*Metrics, *breaker.Breaker, *breaker.Breaker) {
+	t.Helper()
+
+	soroban := breaker.NewWithClock(string(UpstreamSorobanRPC), cfg, nil, clock)
+	horizon := breaker.NewWithClock(string(UpstreamHorizon), cfg, nil, clock)
+
+	m := New()
+	if err := m.RegisterBreakers(map[Upstream]BreakerReader{
+		UpstreamSorobanRPC: soroban,
+		UpstreamHorizon:    horizon,
+	}); err != nil {
+		t.Fatalf("RegisterBreakers: %v", err)
+	}
+	return m, soroban, horizon
+}
+
+func tripBreaker(t *testing.T, b *breaker.Breaker) {
+	t.Helper()
+
+	for i := 0; i < 200; i++ {
+		if b.State() == breaker.StateOpen {
+			return
+		}
+		permit, err := b.Allow()
+		if err != nil {
+			break
+		}
+		b.Record(permit, breaker.Failure)
+	}
+	if b.State() != breaker.StateOpen {
+		t.Fatal("breaker did not open")
+	}
+}
+
+// The acceptance criterion: breaker state is a metric, for both upstreams, and
+// it tracks the state machine through every transition.
+func TestBreakerStateMetricFollowsEveryTransition(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	cfg := breaker.Config{FailureRatio: 0.5, MinRequests: 4, Window: time.Minute, OpenDuration: 15 * time.Second}
+	m, soroban, _ := newBreakerMetrics(t, clock, cfg)
+
+	// CLOSED
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamSorobanRPC)); got != 0 {
+		t.Fatalf("state = %v, want 0 (closed)", got)
+	}
+
+	// OPEN
+	tripBreaker(t, soroban)
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamSorobanRPC)); got != 2 {
+		t.Fatalf("state = %v, want 2 (open)", got)
+	}
+
+	// HALF-OPEN, derived from the clock with no call in between. A pushed
+	// gauge would still read "open" here and disagree with what the breaker
+	// would actually do — which is why this is a pull collector.
+	now = now.Add(15 * time.Second)
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamSorobanRPC)); got != 1 {
+		t.Fatalf("state = %v, want 1 (half-open)", got)
+	}
+
+	// CLOSED again, after a successful probe.
+	permit, err := soroban.Allow()
+	if err != nil {
+		t.Fatalf("probe refused: %v", err)
+	}
+	soroban.Record(permit, breaker.Success)
+
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamSorobanRPC)); got != 0 {
+		t.Fatalf("state = %v, want 0 (closed)", got)
+	}
+}
+
+// Both upstreams are reported, independently.
+func TestBreakerMetricsAreReportedPerUpstream(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	cfg := breaker.Config{FailureRatio: 0.5, MinRequests: 4, Window: time.Minute, OpenDuration: 15 * time.Second}
+	m, soroban, _ := newBreakerMetrics(t, func() time.Time { return now }, cfg)
+
+	tripBreaker(t, soroban)
+
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamSorobanRPC)); got != 2 {
+		t.Fatalf("soroban state = %v, want 2 (open)", got)
+	}
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_state", breakerLabels(UpstreamHorizon)); got != 0 {
+		t.Fatalf("horizon state = %v, want 0 (closed): one upstream's outage moved the other's metric", got)
+	}
+}
+
+func TestBreakerRejectionAndRatioMetrics(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	cfg := breaker.Config{FailureRatio: 0.5, MinRequests: 4, Window: time.Minute, OpenDuration: 15 * time.Second}
+	m, soroban, _ := newBreakerMetrics(t, func() time.Time { return now }, cfg)
+
+	tripBreaker(t, soroban)
+
+	if got := gaugeValueFor(t, m, "nester_circuit_breaker_failure_ratio", breakerLabels(UpstreamSorobanRPC)); got != 1 {
+		t.Fatalf("failure ratio = %v, want 1", got)
+	}
+
+	for i := 0; i < 7; i++ {
+		if _, err := soroban.Allow(); err == nil {
+			t.Fatal("Allow() granted permission while open")
+		}
+	}
+
+	if got := counterValue(t, m.Registry(), "nester_circuit_breaker_rejected_total", breakerLabels(UpstreamSorobanRPC)); got != 7 {
+		t.Fatalf("rejected = %v, want 7", got)
+	}
+}
+
+// Only the bounded Upstream constants may appear as labels, and there is
+// exactly one series per upstream per metric. Nothing about a request can move
+// the series count.
+func TestBreakerMetricCardinalityIsFixed(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	m, soroban, _ := newBreakerMetrics(t, func() time.Time { return now }, breaker.Config{})
+
+	tripBreaker(t, soroban)
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	found := 0
+	for _, family := range families {
+		name := family.GetName()
+		if len(name) < len("nester_circuit_breaker_") || name[:len("nester_circuit_breaker_")] != "nester_circuit_breaker_" {
+			continue
+		}
+		found++
+
+		if got := len(family.GetMetric()); got != 2 {
+			t.Fatalf("%s has %d series, want 2 (one per upstream)", name, got)
+		}
+		for _, metric := range family.GetMetric() {
+			labels := metric.GetLabel()
+			if len(labels) != 1 || labels[0].GetName() != "upstream" {
+				t.Fatalf("%s carries labels %v, want exactly one named upstream", name, labels)
+			}
+			switch value := labels[0].GetValue(); value {
+			case string(UpstreamSorobanRPC), string(UpstreamHorizon):
+			default:
+				t.Fatalf("%s has upstream=%q, which is not a bounded constant", name, value)
+			}
+		}
+	}
+
+	if found != 3 {
+		t.Fatalf("found %d nester_circuit_breaker_* families, want 3", found)
+	}
+}
+
+// A deployment with the breakers disabled registers no collector and no
+// series, rather than reporting a permanently-closed breaker that does not
+// exist.
+func TestRegisterBreakersWithNoReadersIsANoOp(t *testing.T) {
+	m := New()
+
+	if err := m.RegisterBreakers(nil); err != nil {
+		t.Fatalf("RegisterBreakers(nil) = %v, want nil", err)
+	}
+	if err := m.RegisterBreakers(map[Upstream]BreakerReader{}); err != nil {
+		t.Fatalf("RegisterBreakers(empty) = %v, want nil", err)
+	}
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, family := range families {
+		if name := family.GetName(); len(name) >= len("nester_circuit_breaker_") &&
+			name[:len("nester_circuit_breaker_")] == "nester_circuit_breaker_" {
+			t.Fatalf("%s was registered with no breakers", name)
+		}
+	}
+}
+
+func TestRegisterBreakersRejectsDuplicates(t *testing.T) {
+	m := New()
+	readers := map[Upstream]BreakerReader{
+		UpstreamSorobanRPC: breaker.New("soroban_rpc", breaker.Config{}, nil),
+	}
+
+	if err := m.RegisterBreakers(readers); err != nil {
+		t.Fatalf("first RegisterBreakers: %v", err)
+	}
+	if err := m.RegisterBreakers(readers); err == nil {
+		t.Fatal("duplicate registration succeeded; the series would be reported twice")
+	}
+}

--- a/apps/api/internal/metrics/freshness.go
+++ b/apps/api/internal/metrics/freshness.go
@@ -1,0 +1,114 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+)
+
+// FreshnessCollector exposes the balance-freshness SLI: how far behind the
+// chain the event indexer is, in ledgers and in seconds (nester#1088).
+//
+// It is a pull collector, following PoolCollector, and that is the substance
+// of this file rather than a stylistic preference. These series were
+// previously gauges the indexer pushed on each successful poll, which meant a
+// dead indexer left every one of them frozen at its last healthy value: lag 0,
+// sample age 0, alerts silent, dashboards green. Deriving them at scrape time
+// from freshness.Tracker instead means the numbers keep moving on the clock,
+// so an indexer that stops — wedged, panicked, or never started — is visible
+// without anything of ours still having to run.
+//
+// No metric here carries a label. The freshness of the indexed view is a
+// single process-wide fact, so there is nothing to break it down by and no way
+// for traffic to move the series count.
+type FreshnessCollector struct {
+	reader freshness.Reader
+
+	lagLedgers   *prometheus.Desc
+	lagSeconds   *prometheus.Desc
+	sampleAge    *prometheus.Desc
+	budget       *prometheus.Desc
+	sampleErrors *prometheus.Desc
+}
+
+// NewFreshnessCollector builds a collector over the given freshness source.
+func NewFreshnessCollector(reader freshness.Reader) *FreshnessCollector {
+	const subsystem = "indexer"
+
+	name := func(n string) string {
+		return prometheus.BuildFQName(Namespace, subsystem, n)
+	}
+
+	return &FreshnessCollector{
+		reader: reader,
+
+		lagLedgers: prometheus.NewDesc(name("lag_ledgers"),
+			"Network ledger tip minus last successfully indexed ledger.", nil, nil),
+
+		// The seconds view of the same lag, and the one the staleness budget
+		// and the API contract are stated in. It includes the age of the last
+		// sample, so it climbs while the indexer is not reporting rather than
+		// holding at the last observed value.
+		lagSeconds: prometheus.NewDesc(name("lag_seconds"),
+			"Age of the indexed view of the chain in seconds: time since the last freshness sample plus that sample's ledger lag.", nil, nil),
+
+		sampleAge: prometheus.NewDesc(name("lag_last_sample_age_seconds"),
+			"Seconds since the indexer last published a freshness sample.", nil, nil),
+
+		// Published so alert rules can compare lag against the budget the
+		// application is actually enforcing, instead of restating the number
+		// in PromQL where it can drift from the API's answer.
+		budget: prometheus.NewDesc(name("staleness_budget_seconds"),
+			"Configured staleness budget: indexed data older than this is served and alerted on as stale.", nil, nil),
+
+		sampleErrors: prometheus.NewDesc(name("lag_sample_errors_total"),
+			"Failed attempts to sample indexer lag.", nil, nil),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *FreshnessCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.lagLedgers
+	ch <- c.lagSeconds
+	ch <- c.sampleAge
+	ch <- c.budget
+	ch <- c.sampleErrors
+}
+
+// Collect implements prometheus.Collector.
+func (c *FreshnessCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.reader == nil {
+		return
+	}
+
+	snapshot := c.reader.Snapshot()
+
+	gauge := func(d *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v)
+	}
+
+	gauge(c.lagSeconds, snapshot.Lag.Seconds())
+	gauge(c.sampleAge, snapshot.SampleAge.Seconds())
+	gauge(c.budget, snapshot.Budget.Seconds())
+	ch <- prometheus.MustNewConstMetric(c.sampleErrors, prometheus.CounterValue, float64(snapshot.SampleErrors))
+
+	// Ledger lag is omitted until the indexer has published a position.
+	// Emitting zero before the first sample would claim the indexer is exactly
+	// at the tip on every cold start — the most dangerous value this gauge can
+	// hold, because it is the one that looks perfect. The absence is safe:
+	// lag_seconds above is always present, keeps climbing, and is what pages.
+	if snapshot.Sampled {
+		gauge(c.lagLedgers, float64(snapshot.LagLedgers))
+	}
+}
+
+// RegisterFreshness attaches a freshness collector to the registry.
+//
+// A nil reader is a no-op so callers do not need to branch; the API can boot
+// without an indexer in some tooling paths.
+func (m *Metrics) RegisterFreshness(reader freshness.Reader) error {
+	if m == nil || reader == nil {
+		return nil
+	}
+	return m.registry.Register(NewFreshnessCollector(reader))
+}

--- a/apps/api/internal/metrics/freshness_test.go
+++ b/apps/api/internal/metrics/freshness_test.go
@@ -1,0 +1,224 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+)
+
+// stubReader returns a fixed snapshot, so the collector is asserted against a
+// known freshness state rather than against a live clock.
+type stubReader struct {
+	snapshot freshness.Snapshot
+}
+
+func (s stubReader) Snapshot() freshness.Snapshot { return s.snapshot }
+
+func registryWithFreshness(t *testing.T, reader freshness.Reader) *Metrics {
+	t.Helper()
+
+	m := New()
+	if err := m.RegisterFreshness(reader); err != nil {
+		t.Fatalf("RegisterFreshness: %v", err)
+	}
+	return m
+}
+
+// hasSeries reports whether a metric family exists at all, which gaugeValue
+// cannot: it returns 0 both for "the gauge reads zero" and for "the series is
+// not there", and the difference is the whole point of the cold-start case.
+func hasSeries(t *testing.T, m *Metrics, name string) bool {
+	t.Helper()
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() == name {
+			return len(family.GetMetric()) > 0
+		}
+	}
+	return false
+}
+
+func TestFreshnessCollectorExportsLagInLedgersAndSeconds(t *testing.T) {
+	m := registryWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled:       true,
+		IndexedLedger: 1_000,
+		NetworkLedger: 1_007,
+		LagLedgers:    7,
+		Lag:           41 * time.Second,
+		SampleAge:     6 * time.Second,
+		Budget:        5 * time.Minute,
+		SampleErrors:  3,
+	}})
+
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_ledgers"); got != 7 {
+		t.Fatalf("lag ledgers = %v, want 7", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 41 {
+		t.Fatalf("lag seconds = %v, want 41", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_last_sample_age_seconds"); got != 6 {
+		t.Fatalf("sample age = %v, want 6", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_staleness_budget_seconds"); got != 300 {
+		t.Fatalf("budget = %v, want 300", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_indexer_lag_sample_errors_total", nil); got != 3 {
+		t.Fatalf("sample errors = %v, want 3", got)
+	}
+}
+
+// A caught-up indexer reports zero lag in both units. The series must exist
+// and read zero, not vanish: an absent series cannot be alerted on, and the
+// dashboard would show a gap rather than a healthy line.
+func TestFreshnessCollectorReportsZeroLagWhenCaughtUp(t *testing.T) {
+	m := registryWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled: true,
+		Budget:  5 * time.Minute,
+	}})
+
+	if !hasSeries(t, m, "nester_indexer_lag_ledgers") {
+		t.Fatal("lag_ledgers series missing for a caught-up indexer")
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_ledgers"); got != 0 {
+		t.Fatalf("lag ledgers = %v, want 0", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 0 {
+		t.Fatalf("lag seconds = %v, want 0", got)
+	}
+}
+
+// Before the first sample the ledger lag is unknown. Publishing zero would be
+// the single most dangerous value the gauge can hold, because it is the one
+// that looks perfect — so the series is withheld while the seconds view, which
+// is always present, carries the truth.
+func TestLedgerLagIsWithheldUntilTheIndexerReports(t *testing.T) {
+	m := registryWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled: false,
+		Lag:     9 * time.Minute,
+		Budget:  5 * time.Minute,
+	}})
+
+	if hasSeries(t, m, "nester_indexer_lag_ledgers") {
+		t.Fatal("lag_ledgers published before the indexer reported a position")
+	}
+	if !hasSeries(t, m, "nester_indexer_lag_seconds") {
+		t.Fatal("lag_seconds missing: nothing would page for an indexer that never started")
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 540 {
+		t.Fatalf("lag seconds = %v, want 540", got)
+	}
+}
+
+// The reason this is a pull collector rather than gauges the indexer pushes.
+// Nothing observes anything here after registration; the numbers must still
+// grow between scrapes, because they are derived from the clock at scrape
+// time. A pushed gauge would freeze at its last healthy value the moment the
+// indexer died, and the alert would never fire.
+func TestLagSecondsGrowsBetweenScrapesWithoutTheIndexer(t *testing.T) {
+	clock := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	tracker := freshness.NewTrackerWithClock(5*time.Minute, func() time.Time { return clock })
+
+	m := registryWithFreshness(t, tracker)
+	tracker.Observe(1_000, 1_000)
+
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 0 {
+		t.Fatalf("lag seconds immediately after a sample = %v, want 0", got)
+	}
+
+	// The indexer is now dead: no further Observe calls, only time passing.
+	clock = clock.Add(10 * time.Minute)
+
+	lag := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds")
+	if lag != 600 {
+		t.Fatalf("lag seconds after 10m of silence = %v, want 600", lag)
+	}
+	if budget := gaugeValue(t, m.Registry(), "nester_indexer_staleness_budget_seconds"); lag <= budget {
+		t.Fatalf("lag %v did not exceed budget %v, so the alert would not fire", lag, budget)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_last_sample_age_seconds"); got != 600 {
+		t.Fatalf("sample age = %v, want 600", got)
+	}
+}
+
+// Recovery has to be visible too, or an operator cannot tell a fixed indexer
+// from a still-broken one.
+func TestLagSecondsFallsAfterTheIndexerCatchesUp(t *testing.T) {
+	clock := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	tracker := freshness.NewTrackerWithClock(5*time.Minute, func() time.Time { return clock })
+
+	m := registryWithFreshness(t, tracker)
+	tracker.Observe(1_000, 1_000)
+	clock = clock.Add(10 * time.Minute)
+
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 600 {
+		t.Fatalf("precondition: lag seconds = %v, want 600", got)
+	}
+
+	tracker.Observe(1_120, 1_122)
+
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_seconds"); got != 10 {
+		t.Fatalf("lag seconds after catching up = %v, want 10 (2 ledgers)", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_ledgers"); got != 2 {
+		t.Fatalf("lag ledgers after catching up = %v, want 2", got)
+	}
+}
+
+// Registering twice must fail rather than panic or silently double-count, and
+// a nil reader must be a no-op so the API can boot without an indexer.
+func TestRegisterFreshnessGuards(t *testing.T) {
+	m := New()
+
+	if err := m.RegisterFreshness(nil); err != nil {
+		t.Fatalf("RegisterFreshness(nil) = %v, want nil", err)
+	}
+	if hasSeries(t, m, "nester_indexer_lag_seconds") {
+		t.Fatal("a nil reader registered a collector")
+	}
+
+	tracker := freshness.NewTracker(time.Minute)
+	if err := m.RegisterFreshness(tracker); err != nil {
+		t.Fatalf("first RegisterFreshness: %v", err)
+	}
+	if err := m.RegisterFreshness(tracker); err == nil {
+		t.Fatal("duplicate registration succeeded; a second collector would double the series")
+	}
+}
+
+// Freshness is one process-wide fact, so none of its series may carry a label.
+// A label here could only come from something request-scoped, which is exactly
+// the cardinality leak the package policy forbids.
+func TestFreshnessSeriesCarryNoLabels(t *testing.T) {
+	m := registryWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled: true,
+		Budget:  5 * time.Minute,
+	}})
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	found := 0
+	for _, family := range families {
+		if len(family.GetName()) < len("nester_indexer_") || family.GetName()[:len("nester_indexer_")] != "nester_indexer_" {
+			continue
+		}
+		found++
+		if got := len(family.GetMetric()); got != 1 {
+			t.Fatalf("%s has %d series, want exactly 1", family.GetName(), got)
+		}
+		if got := len(family.GetMetric()[0].GetLabel()); got != 0 {
+			t.Fatalf("%s carries %d labels, want none", family.GetName(), got)
+		}
+	}
+
+	if found != 5 {
+		t.Fatalf("found %d nester_indexer_* families, want 5", found)
+	}
+}

--- a/apps/api/internal/metrics/metrics.go
+++ b/apps/api/internal/metrics/metrics.go
@@ -65,6 +65,11 @@ type Metrics struct {
 	// Service level indicators (nester#1056). Defined in slo.go; held here
 	// so one scrape carries both the infrastructure and the product view.
 	slo *sloCollectors
+
+	// Retry instrumentation for the chain RPC helper (nester#1086). Defined
+	// in rpc.go. These count logical calls, where the outbound collectors
+	// above count HTTP attempts.
+	rpc *rpcCollectors
 }
 
 // New builds the registry and registers every collector on it.
@@ -155,6 +160,7 @@ func New() *Metrics {
 		}, []string{"upstream", "kind"}),
 
 		slo: newSLOCollectors(),
+		rpc: newRPCCollectors(),
 	}
 
 	registry.MustRegister(
@@ -170,6 +176,7 @@ func New() *Metrics {
 	)
 
 	registry.MustRegister(m.slo.collectors()...)
+	registry.MustRegister(m.rpc.collectors()...)
 
 	// Process and Go runtime collectors: goroutine count, heap, GC pauses,
 	// open file descriptors, CPU. Free to collect and the first thing anyone

--- a/apps/api/internal/metrics/rpc.go
+++ b/apps/api/internal/metrics/rpc.go
@@ -1,0 +1,118 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// rpcCallDurationBuckets cover a whole logical RPC call — every attempt plus
+// the backoff between them — not a single round trip.
+//
+// That is why they reach further than dependencyDurationBuckets: a healthy
+// Soroban read lands well under 500ms, but a call that retried twice
+// legitimately spends seconds, and the whole point of this histogram is to
+// show the difference between "fast" and "succeeded, eventually". The tail at
+// 15s brackets the default 12s retry budget, so a call cut off by the budget
+// is visibly distinct from one that merely took a while.
+var rpcCallDurationBuckets = []float64{
+	0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 8, 12, 15,
+}
+
+// rpcCollectors instrument the shared retry helper (nester#1086).
+//
+// These describe *logical* calls, where the outbound metrics describe HTTP
+// attempts. The pair is deliberate and the difference is the useful signal:
+// when attempts_total climbs faster than outbound requests would suggest, the
+// upstream is flaky but recovering; when exhaustions_total starts moving, the
+// retries have stopped being enough and users are seeing errors.
+type rpcCollectors struct {
+	attempts    *prometheus.CounterVec
+	exhaustions *prometheus.CounterVec
+	duration    *prometheus.HistogramVec
+}
+
+func newRPCCollectors() *rpcCollectors {
+	labels := []string{"upstream"}
+
+	return &rpcCollectors{
+		// Counts every attempt, including the first. Rated against the count
+		// of logical calls (duration_seconds_count), this is the average
+		// attempts per call — the cleanest early warning that an upstream is
+		// degrading, because it moves long before anything fails outright.
+		attempts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "rpc",
+			Name:      "attempts_total",
+			Help:      "Individual RPC attempts made, including retries, by upstream.",
+		}, labels),
+
+		// Logical calls that used up their attempts or their budget without
+		// an answer. These are the ones that reach the user as an error, so
+		// this is the counter an alert would watch.
+		exhaustions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "rpc",
+			Name:      "exhaustions_total",
+			Help:      "Logical RPC calls that exhausted the retry policy without succeeding, by upstream.",
+		}, labels),
+
+		// Wall time for the whole logical call, retries and backoff included.
+		// This is what a user waited, which the per-attempt outbound histogram
+		// cannot show.
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: "rpc",
+			Name:      "call_duration_seconds",
+			Help:      "End-to-end latency of a logical RPC call including retries and backoff, by upstream.",
+			Buckets:   rpcCallDurationBuckets,
+		}, labels),
+	}
+}
+
+func (c *rpcCollectors) collectors() []prometheus.Collector {
+	return []prometheus.Collector{c.attempts, c.exhaustions, c.duration}
+}
+
+// RPCRecorder reports completed logical RPC calls for one upstream.
+//
+// It is bound to an upstream at construction rather than taking one per call,
+// so a call site physically cannot report against the wrong label — and the
+// label set stays the bounded Upstream constants rather than anything a
+// caller passes in.
+type RPCRecorder struct {
+	metrics  *Metrics
+	upstream Upstream
+}
+
+// RPCRecorderFor returns a recorder bound to the given upstream. A nil
+// *Metrics yields a recorder whose methods are no-ops, so a service
+// constructed without metrics behaves exactly as before.
+func (m *Metrics) RPCRecorderFor(upstream Upstream) *RPCRecorder {
+	return &RPCRecorder{metrics: m, upstream: upstream}
+}
+
+// RecordRPCCall records one completed logical call.
+//
+// attempts counts every try including the first; elapsed is the wall time
+// across all of them; exhausted reports whether the retry policy ran out
+// rather than the call reaching a decision.
+func (r *RPCRecorder) RecordRPCCall(attempts int, elapsed time.Duration, exhausted bool) {
+	if r == nil || r.metrics == nil {
+		return
+	}
+
+	upstream := string(r.upstream)
+
+	// A call always makes at least one attempt; guarding here keeps a caller
+	// that reports zero from silently under-counting the denominator.
+	if attempts > 0 {
+		r.metrics.rpc.attempts.WithLabelValues(upstream).Add(float64(attempts))
+	}
+	if exhausted {
+		r.metrics.rpc.exhaustions.WithLabelValues(upstream).Inc()
+	}
+	if elapsed >= 0 {
+		r.metrics.rpc.duration.WithLabelValues(upstream).Observe(elapsed.Seconds())
+	}
+}

--- a/apps/api/internal/metrics/rpc_test.go
+++ b/apps/api/internal/metrics/rpc_test.go
@@ -1,0 +1,153 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func rpcLabels(upstream Upstream) map[string]string {
+	return map[string]string{"upstream": string(upstream)}
+}
+
+// The acceptance criterion: attempts, exhaustions, and latency, per upstream.
+func TestRPCRecorderRecordsAttemptsExhaustionsAndLatency(t *testing.T) {
+	m := New()
+	recorder := m.RPCRecorderFor(UpstreamSorobanRPC)
+
+	// A first-try success.
+	recorder.RecordRPCCall(1, 120*time.Millisecond, false)
+	// One that needed two retries but got there.
+	recorder.RecordRPCCall(3, 900*time.Millisecond, false)
+	// One that never did.
+	recorder.RecordRPCCall(3, 2*time.Second, true)
+
+	labels := rpcLabels(UpstreamSorobanRPC)
+
+	if got := counterValue(t, m.Registry(), "nester_rpc_attempts_total", labels); got != 7 {
+		t.Errorf("attempts = %v, want 7 (1 + 3 + 3)", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_rpc_exhaustions_total", labels); got != 1 {
+		t.Errorf("exhaustions = %v, want 1", got)
+	}
+	if got := histogramCount(t, m.Registry(), "nester_rpc_call_duration_seconds", labels); got != 3 {
+		t.Errorf("duration observations = %d, want 3", got)
+	}
+}
+
+// Attempts and call count are read together as "average attempts per call",
+// which is the earliest signal that an upstream is degrading. That reading
+// only works if every call is observed exactly once.
+func TestAttemptsAndCallCountSupportTheRatio(t *testing.T) {
+	m := New()
+	recorder := m.RPCRecorderFor(UpstreamSorobanRPC)
+
+	for i := 0; i < 4; i++ {
+		recorder.RecordRPCCall(2, time.Second, false)
+	}
+
+	labels := rpcLabels(UpstreamSorobanRPC)
+	attempts := counterValue(t, m.Registry(), "nester_rpc_attempts_total", labels)
+	calls := float64(histogramCount(t, m.Registry(), "nester_rpc_call_duration_seconds", labels))
+
+	if calls == 0 {
+		t.Fatal("no calls observed")
+	}
+	if ratio := attempts / calls; ratio != 2 {
+		t.Fatalf("attempts per call = %v, want 2", ratio)
+	}
+}
+
+// Each upstream is counted separately, so a flaky Soroban endpoint does not
+// show up as Horizon retrying.
+func TestRPCMetricsAreSeparatedByUpstream(t *testing.T) {
+	m := New()
+
+	m.RPCRecorderFor(UpstreamSorobanRPC).RecordRPCCall(3, time.Second, true)
+	m.RPCRecorderFor(UpstreamHorizon).RecordRPCCall(1, time.Millisecond, false)
+
+	if got := counterValue(t, m.Registry(), "nester_rpc_attempts_total", rpcLabels(UpstreamSorobanRPC)); got != 3 {
+		t.Errorf("soroban attempts = %v, want 3", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_rpc_attempts_total", rpcLabels(UpstreamHorizon)); got != 1 {
+		t.Errorf("horizon attempts = %v, want 1", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_rpc_exhaustions_total", rpcLabels(UpstreamHorizon)); got != 0 {
+		t.Errorf("horizon exhaustions = %v, want 0: one upstream's failure moved the other's counter", got)
+	}
+}
+
+// A recorder bound to a nil *Metrics must be safe on every path, so a service
+// constructed without metrics behaves exactly as before rather than panicking
+// mid-call.
+func TestNilMetricsRPCRecorderIsSafe(t *testing.T) {
+	var m *Metrics
+
+	recorder := m.RPCRecorderFor(UpstreamSorobanRPC)
+	recorder.RecordRPCCall(3, time.Second, true)
+
+	var nilRecorder *RPCRecorder
+	nilRecorder.RecordRPCCall(1, time.Second, false)
+}
+
+// A caller reporting zero attempts must not decrement or pollute the counter;
+// the histogram still records the call so the denominator stays honest.
+func TestZeroAttemptsDoesNotCorruptTheCounter(t *testing.T) {
+	m := New()
+	recorder := m.RPCRecorderFor(UpstreamSorobanRPC)
+
+	recorder.RecordRPCCall(0, time.Second, false)
+
+	labels := rpcLabels(UpstreamSorobanRPC)
+	if got := counterValue(t, m.Registry(), "nester_rpc_attempts_total", labels); got != 0 {
+		t.Fatalf("attempts = %v, want 0", got)
+	}
+	if got := histogramCount(t, m.Registry(), "nester_rpc_call_duration_seconds", labels); got != 1 {
+		t.Fatalf("duration observations = %d, want 1", got)
+	}
+}
+
+// The label set is the bounded Upstream constants and nothing else. A label
+// that a caller could move is the cardinality leak the package policy exists
+// to prevent.
+func TestRPCMetricCardinalityIsBounded(t *testing.T) {
+	m := New()
+
+	// One exhausted call per upstream as well as one successful one, so all
+	// three families have a series for both and the count below is comparing
+	// like with like. A CounterVec with no observed label value reports no
+	// family at all.
+	for _, upstream := range []Upstream{UpstreamSorobanRPC, UpstreamHorizon} {
+		recorder := m.RPCRecorderFor(upstream)
+		recorder.RecordRPCCall(1, time.Second, false)
+		recorder.RecordRPCCall(3, 2*time.Second, true)
+	}
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	found := 0
+	const prefix = "nester_rpc_"
+	for _, family := range families {
+		name := family.GetName()
+		if len(name) < len(prefix) || name[:len(prefix)] != prefix {
+			continue
+		}
+		found++
+
+		if got := len(family.GetMetric()); got != 2 {
+			t.Fatalf("%s has %d series, want 2 (one per upstream used)", name, got)
+		}
+		for _, metric := range family.GetMetric() {
+			labels := metric.GetLabel()
+			if len(labels) != 1 || labels[0].GetName() != "upstream" {
+				t.Fatalf("%s carries labels %v, want exactly one named upstream", name, labels)
+			}
+		}
+	}
+
+	if found != 3 {
+		t.Fatalf("found %d nester_rpc_* families, want 3", found)
+	}
+}

--- a/apps/api/internal/metrics/slo.go
+++ b/apps/api/internal/metrics/slo.go
@@ -100,10 +100,6 @@ type sloCollectors struct {
 	flowAttemptsTotal *prometheus.CounterVec
 	flowDuration      *prometheus.HistogramVec
 
-	indexerLagLedgers      prometheus.Gauge
-	indexerLagStaleness    prometheus.Gauge
-	indexerLagScrapeErrors prometheus.Counter
-
 	reconcileRunsTotal      *prometheus.CounterVec
 	reconcileDivergences    *prometheus.CounterVec
 	reconcileLastRunAge     prometheus.Gauge
@@ -181,38 +177,6 @@ func newSLOCollectors() *sloCollectors {
 			Buckets:   flowDurationBuckets,
 		}, []string{"flow", "outcome"}),
 
-		// Balance freshness. Ledgers rather than seconds because the
-		// indexer's own unit is the ledger sequence, and converting to time
-		// would bake in an assumed close interval that varies.
-		indexerLagLedgers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: "indexer",
-			Name:      "lag_ledgers",
-			Help:      "Network ledger tip minus last successfully indexed ledger.",
-		}),
-
-		// A lag gauge alone cannot distinguish "lag is 0" from "the sampler
-		// died and the value is frozen at its last write". This gauge is the
-		// age of the lag reading, so an alert can require freshness of the
-		// freshness signal. Without it the balance SLI fails silently in the
-		// most dangerous direction: reporting perfect health.
-		indexerLagStaleness: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: "indexer",
-			Name:      "lag_last_sample_age_seconds",
-			Help:      "Seconds since the indexer lag gauge was last successfully updated.",
-		}),
-
-		// Sampling errors are counted rather than folded into the lag value,
-		// because writing a sentinel lag on error would be indistinguishable
-		// from a real stall and would page for the wrong reason.
-		indexerLagScrapeErrors: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: Namespace,
-			Subsystem: "indexer",
-			Name:      "lag_sample_errors_total",
-			Help:      "Failed attempts to sample indexer lag.",
-		}),
-
 		// Reconciliation (nester#1108). The reconciler compares our record of
 		// the money path against the chain. Until now it reported only to the
 		// log, which means a divergence — the single most serious signal this
@@ -279,9 +243,6 @@ func (c *sloCollectors) collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		c.flowAttemptsTotal,
 		c.flowDuration,
-		c.indexerLagLedgers,
-		c.indexerLagStaleness,
-		c.indexerLagScrapeErrors,
 		c.reconcileRunsTotal,
 		c.reconcileDivergences,
 		c.reconcileLastRunAge,
@@ -311,35 +272,6 @@ func (m *Metrics) RecordFlowAttempt(flow Flow, outcome FlowOutcome, duration tim
 	if duration > 0 && outcome != OutcomeRejected {
 		m.slo.flowDuration.WithLabelValues(string(flow), string(outcome)).Observe(duration.Seconds())
 	}
-}
-
-// SetIndexerLag publishes the current indexer lag and resets the staleness
-// gauge, which the sampler's own ticker ages between calls.
-func (m *Metrics) SetIndexerLag(lagLedgers uint64) {
-	if m == nil {
-		return
-	}
-
-	m.slo.indexerLagLedgers.Set(float64(lagLedgers))
-	m.slo.indexerLagStaleness.Set(0)
-}
-
-// SetIndexerLagSampleAge publishes how old the lag reading is.
-func (m *Metrics) SetIndexerLagSampleAge(age time.Duration) {
-	if m == nil {
-		return
-	}
-
-	m.slo.indexerLagStaleness.Set(age.Seconds())
-}
-
-// RecordIndexerLagSampleError counts a failed lag sample.
-func (m *Metrics) RecordIndexerLagSampleError() {
-	if m == nil {
-		return
-	}
-
-	m.slo.indexerLagScrapeErrors.Inc()
 }
 
 // RecordReconcileRun records one completed reconciliation pass and resets the

--- a/apps/api/internal/metrics/slo_test.go
+++ b/apps/api/internal/metrics/slo_test.go
@@ -17,9 +17,6 @@ func TestNilMetricsIsSafeOnEveryPath(t *testing.T) {
 
 	m.RecordFlowAttempt(FlowDeposit, OutcomeSucceeded, time.Second)
 	m.RecordFlowAttempt(FlowWithdrawal, OutcomeFailedChain, 0)
-	m.SetIndexerLag(42)
-	m.SetIndexerLagSampleAge(time.Minute)
-	m.RecordIndexerLagSampleError()
 	m.RecordReconcileRun(ReconcileCompleted)
 	m.RecordReconcileRun(ReconcileFailed)
 	m.RecordReconcileDivergence(DivergenceMismatch)
@@ -134,55 +131,6 @@ func TestFlowLabelCardinalityIsBounded(t *testing.T) {
 	}
 
 	t.Fatal("nester_flow_attempts_total not found in registry")
-}
-
-func TestIndexerLagGauges(t *testing.T) {
-	m := New()
-
-	m.SetIndexerLag(37)
-	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_ledgers"); got != 37 {
-		t.Fatalf("lag gauge = %v, want 37", got)
-	}
-
-	// A successful sample resets the staleness gauge: the reading is current.
-	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_last_sample_age_seconds"); got != 0 {
-		t.Fatalf("sample age after a successful sample = %v, want 0", got)
-	}
-
-	m.SetIndexerLagSampleAge(90 * time.Second)
-	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_last_sample_age_seconds"); got != 90 {
-		t.Fatalf("sample age = %v, want 90", got)
-	}
-}
-
-// The staleness gauge is what distinguishes "lag is genuinely low" from "the
-// sampler died and the value is frozen at a healthy number". Without it the
-// balance-freshness SLI fails in its most dangerous direction: reporting
-// perfect health. This asserts the lag value and its age are independent, so
-// an ageing sample cannot be masked by a stale-but-low lag reading.
-func TestStalenessIsIndependentOfLagValue(t *testing.T) {
-	m := New()
-
-	m.SetIndexerLag(3)
-	m.SetIndexerLagSampleAge(600 * time.Second)
-
-	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_ledgers"); got != 3 {
-		t.Fatalf("lag gauge = %v, want 3 (a healthy-looking value)", got)
-	}
-	if got := gaugeValue(t, m.Registry(), "nester_indexer_lag_last_sample_age_seconds"); got != 600 {
-		t.Fatalf("sample age = %v, want 600 (stale despite the healthy lag)", got)
-	}
-}
-
-func TestIndexerLagSampleErrorsAreCounted(t *testing.T) {
-	m := New()
-
-	m.RecordIndexerLagSampleError()
-	m.RecordIndexerLagSampleError()
-
-	if got := counterValue(t, m.Registry(), "nester_indexer_lag_sample_errors_total", nil); got != 2 {
-		t.Fatalf("sample errors = %v, want 2", got)
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/internal/middleware/cors.go
+++ b/apps/api/internal/middleware/cors.go
@@ -1,6 +1,14 @@
 package middleware
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
+
+// exposedHeaders lists the response headers a browser may read cross-origin.
+// Without this a cross-origin client can see the freshness headers on the
+// wire but not from JavaScript, so the UI could not degrade on stale data.
+var exposedHeaders = strings.Join(freshnessHeaders, ", ")
 
 // CORS returns a middleware that echoes the request's Origin header back in
 // Access-Control-Allow-Origin only when the origin is in allowedOrigins.
@@ -26,6 +34,7 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 				if _, ok := allowed[origin]; ok {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
+					w.Header().Set("Access-Control-Expose-Headers", exposedHeaders)
 
 					if r.Method == http.MethodOptions {
 						w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")

--- a/apps/api/internal/middleware/freshness.go
+++ b/apps/api/internal/middleware/freshness.go
@@ -1,0 +1,106 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+)
+
+// Freshness headers describing how current the indexed data behind a response
+// is (nester#1088, consumed by the UI degradation work in nester#35).
+//
+// Balances served from the event indexer are only as current as the indexer
+// is. When it falls behind, the API keeps answering — a stale balance is far
+// more useful than an error, and a 5xx would take down screens that do not
+// depend on indexed data at all — but the client is told, so it can say
+// "as of a few minutes ago" instead of implying the number is live.
+//
+// Headers rather than a body field, deliberately: the freshness of the indexed
+// view is a property of the whole response, not of one payload, and every
+// route that serves indexed data gets it automatically. A per-handler envelope
+// field would be opt-in, and the handler added next year that forgot to opt in
+// would silently serve stale balances as fresh — which is the failure this
+// issue exists to remove.
+const (
+	// HeaderIndexerStale is the authoritative fresh/stale answer, "true" or
+	// "false". A client that reads nothing else can read this.
+	HeaderIndexerStale = "X-Indexer-Stale"
+
+	// HeaderIndexerLagSeconds is how far behind the chain the indexed view is,
+	// in whole seconds, rounded up so it never understates staleness. This is
+	// the figure a UI renders.
+	HeaderIndexerLagSeconds = "X-Indexer-Lag-Seconds"
+
+	// HeaderIndexerLagLedgers is the same lag in ledgers. Omitted entirely
+	// when the indexer has not yet reported a position: no header means "not
+	// known", which a zero would misreport as "exactly at the tip".
+	HeaderIndexerLagLedgers = "X-Indexer-Lag-Ledgers"
+
+	// HeaderIndexerStalenessBudgetSeconds is the budget the stale flag was
+	// decided against, so a client can present the threshold without
+	// hardcoding it.
+	HeaderIndexerStalenessBudgetSeconds = "X-Indexer-Staleness-Budget-Seconds"
+)
+
+// freshnessHeaders is the list browsers must be allowed to read cross-origin.
+// See CORS, which sets Access-Control-Expose-Headers from it.
+var freshnessHeaders = []string{
+	HeaderIndexerStale,
+	HeaderIndexerLagSeconds,
+	HeaderIndexerLagLedgers,
+	HeaderIndexerStalenessBudgetSeconds,
+}
+
+// apiPathPrefix scopes the freshness headers to the versioned API. Liveness
+// probes and any non-API route are left untouched: freshness describes the
+// data an API response carries, and /health answers a different question.
+const apiPathPrefix = "/api/"
+
+// IndexerFreshness returns a middleware that annotates every API response with
+// the freshness of the indexed data behind it.
+//
+// A nil reader disables annotation and passes requests straight through, so a
+// deployment without an indexer behaves exactly as it did before.
+func IndexerFreshness(reader freshness.Reader) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if reader == nil {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasPrefix(r.URL.Path, apiPathPrefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Written before the handler runs, because headers are only
+			// mutable until the first WriteHeader and a handler may write
+			// immediately.
+			snapshot := reader.Snapshot()
+			header := w.Header()
+			header.Set(HeaderIndexerStale, strconv.FormatBool(snapshot.Stale))
+			header.Set(HeaderIndexerLagSeconds, strconv.FormatInt(wholeSecondsUp(snapshot.Lag), 10))
+			header.Set(HeaderIndexerStalenessBudgetSeconds, strconv.FormatInt(wholeSecondsUp(snapshot.Budget), 10))
+			if snapshot.Sampled {
+				header.Set(HeaderIndexerLagLedgers, strconv.FormatUint(snapshot.LagLedgers, 10))
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// wholeSecondsUp rounds a duration up to whole seconds.
+//
+// Up rather than down so the reported lag is never smaller than the real one:
+// a client comparing the number against the budget must not conclude the data
+// is inside it when the stale flag says otherwise.
+func wholeSecondsUp(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	return int64((d + time.Second - 1) / time.Second)
+}

--- a/apps/api/internal/middleware/freshness_test.go
+++ b/apps/api/internal/middleware/freshness_test.go
@@ -1,0 +1,211 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/freshness"
+)
+
+type stubReader struct {
+	snapshot freshness.Snapshot
+}
+
+func (s stubReader) Snapshot() freshness.Snapshot { return s.snapshot }
+
+// serveWithFreshness runs one request through the middleware and returns the
+// recorded response.
+func serveWithFreshness(t *testing.T, reader freshness.Reader, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := IndexerFreshness(reader)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestFreshDataIsLabelledFresh(t *testing.T) {
+	rec := serveWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled:    true,
+		LagLedgers: 2,
+		Lag:        10 * time.Second,
+		Budget:     5 * time.Minute,
+		Stale:      false,
+	}}, "/api/v1/vaults")
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want 200", got)
+	}
+	if got := rec.Header().Get(HeaderIndexerStale); got != "false" {
+		t.Fatalf("%s = %q, want \"false\"", HeaderIndexerStale, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerLagSeconds); got != "10" {
+		t.Fatalf("%s = %q, want \"10\"", HeaderIndexerLagSeconds, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerLagLedgers); got != "2" {
+		t.Fatalf("%s = %q, want \"2\"", HeaderIndexerLagLedgers, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerStalenessBudgetSeconds); got != "300" {
+		t.Fatalf("%s = %q, want \"300\"", HeaderIndexerStalenessBudgetSeconds, got)
+	}
+}
+
+// The case the issue is about: the indexer is behind, the balance in the body
+// is out of date, and the response still succeeds — but says so. A 5xx here
+// would take down screens that do not depend on indexed data at all, and would
+// tell the user nothing useful about their money.
+func TestStaleDataIsServedAndLabelledStale(t *testing.T) {
+	rec := serveWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled:    true,
+		LagLedgers: 140,
+		Lag:        12 * time.Minute,
+		Budget:     5 * time.Minute,
+		Stale:      true,
+	}}, "/api/v1/vaults")
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want 200: stale data must still be served", got)
+	}
+	if got := rec.Body.String(); got == "" {
+		t.Fatal("stale response carried no body")
+	}
+	if got := rec.Header().Get(HeaderIndexerStale); got != "true" {
+		t.Fatalf("%s = %q, want \"true\"", HeaderIndexerStale, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerLagSeconds); got != "720" {
+		t.Fatalf("%s = %q, want \"720\"", HeaderIndexerLagSeconds, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerLagLedgers); got != "140" {
+		t.Fatalf("%s = %q, want \"140\"", HeaderIndexerLagLedgers, got)
+	}
+}
+
+// Ledger lag is unknown until the indexer reports a position. The header is
+// omitted rather than sent as 0, so a client can tell "we don't know" from
+// "exactly at the tip" — and the seconds figure still marks the data stale.
+func TestLedgerLagHeaderIsOmittedWhenUnknown(t *testing.T) {
+	rec := serveWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled: false,
+		Lag:     8 * time.Minute,
+		Budget:  5 * time.Minute,
+		Stale:   true,
+	}}, "/api/v1/vaults")
+
+	if _, ok := rec.Header()[http.CanonicalHeaderKey(HeaderIndexerLagLedgers)]; ok {
+		t.Fatalf("%s was sent before the indexer reported a position", HeaderIndexerLagLedgers)
+	}
+	if got := rec.Header().Get(HeaderIndexerStale); got != "true" {
+		t.Fatalf("%s = %q, want \"true\"", HeaderIndexerStale, got)
+	}
+	if got := rec.Header().Get(HeaderIndexerLagSeconds); got != "480" {
+		t.Fatalf("%s = %q, want \"480\"", HeaderIndexerLagSeconds, got)
+	}
+}
+
+// Sub-second lag rounds up rather than down, so the reported number is never
+// smaller than the real one and can never contradict the stale flag.
+func TestLagSecondsRoundsUp(t *testing.T) {
+	rec := serveWithFreshness(t, stubReader{snapshot: freshness.Snapshot{
+		Sampled: true,
+		Lag:     1500 * time.Millisecond,
+		Budget:  5 * time.Minute,
+	}}, "/api/v1/vaults")
+
+	if got := rec.Header().Get(HeaderIndexerLagSeconds); got != "2" {
+		t.Fatalf("%s = %q, want \"2\"", HeaderIndexerLagSeconds, got)
+	}
+}
+
+// Freshness describes the data an API response carries. Liveness probes answer
+// a different question and are left exactly as they were.
+func TestNonAPIPathsAreNotAnnotated(t *testing.T) {
+	reader := stubReader{snapshot: freshness.Snapshot{Sampled: true, Stale: true, Budget: time.Minute}}
+
+	for _, path := range []string{"/health", "/healthz", "/"} {
+		rec := serveWithFreshness(t, reader, path)
+		if got := rec.Header().Get(HeaderIndexerStale); got != "" {
+			t.Fatalf("%s annotated with %s = %q", path, HeaderIndexerStale, got)
+		}
+	}
+}
+
+// A deployment wired without an indexer must behave exactly as it did before:
+// no headers, no panic, request served.
+func TestNilReaderPassesThrough(t *testing.T) {
+	rec := serveWithFreshness(t, nil, "/api/v1/vaults")
+
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("status = %d, want 200", got)
+	}
+	if got := rec.Header().Get(HeaderIndexerStale); got != "" {
+		t.Fatalf("%s = %q with a nil reader, want no header", HeaderIndexerStale, got)
+	}
+}
+
+// Headers must be set before the wrapped handler writes, or a handler that
+// responds immediately would flush the status line first and silently drop
+// them.
+func TestHeadersSurviveAHandlerThatWritesImmediately(t *testing.T) {
+	handler := IndexerFreshness(stubReader{snapshot: freshness.Snapshot{
+		Sampled: true,
+		Lag:     11 * time.Minute,
+		Budget:  5 * time.Minute,
+		Stale:   true,
+	}})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("immediate"))
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil))
+
+	if got := rec.Header().Get(HeaderIndexerStale); got != "true" {
+		t.Fatalf("%s = %q, want \"true\"", HeaderIndexerStale, got)
+	}
+}
+
+// An error response is still an API response, and a client handling a 500
+// benefits from knowing whether the indexed view is also stale.
+func TestErrorResponsesAreAnnotated(t *testing.T) {
+	handler := IndexerFreshness(stubReader{snapshot: freshness.Snapshot{
+		Sampled: true,
+		Lag:     7 * time.Minute,
+		Budget:  5 * time.Minute,
+		Stale:   true,
+	}})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil))
+
+	if got := rec.Header().Get(HeaderIndexerStale); got != "true" {
+		t.Fatalf("%s = %q on a 500, want \"true\"", HeaderIndexerStale, got)
+	}
+}
+
+// The headers are useless to a browser client on another origin unless CORS
+// exposes them, so the two must not drift apart.
+func TestCORSExposesEveryFreshnessHeader(t *testing.T) {
+	handler := CORS([]string{"https://app.nester.test"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil)
+	req.Header.Set("Origin", "https://app.nester.test")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	exposed := rec.Header().Get("Access-Control-Expose-Headers")
+	for _, name := range freshnessHeaders {
+		if !strings.Contains(exposed, name) {
+			t.Fatalf("Access-Control-Expose-Headers %q does not expose %s", exposed, name)
+		}
+	}
+}

--- a/apps/api/internal/retry/retry.go
+++ b/apps/api/internal/retry/retry.go
@@ -1,0 +1,314 @@
+// Package retry provides the bounded, jittered retry loop that every Soroban
+// RPC call site shares (nester#1086).
+//
+// Before this, transient RPC failures surfaced directly as user-facing errors
+// and each call site decided for itself whether to try again — which in
+// practice meant none of them did. A single connection reset during a balance
+// read became an error on the user's screen.
+//
+// The loop is deliberately bounded in three independent ways, because any one
+// of them alone fails somewhere:
+//
+//	MaxAttempts  caps the work done for one logical call.
+//	Budget       caps the wall time, so three attempts against an endpoint
+//	             that hangs cannot outlive the caller's own deadline.
+//	ctx          still wins over both; a cancelled caller stops immediately.
+//
+// # Jitter
+//
+// Backoff is exponential with **full jitter**: the delay is drawn uniformly
+// from [0, cap) rather than being cap exactly. Retrying on a fixed schedule
+// synchronises every client that failed at the same moment — the retry storm
+// arrives together and knocks the recovering endpoint back over. Spreading the
+// attempts is the entire reason jitter exists here, and drawing from the whole
+// interval spreads them better than jittering around a fixed point.
+//
+// # What this package does NOT decide
+//
+// Whether a given error is worth retrying, and whether a given operation is
+// safe to retry at all. Both are the caller's business: this package retries
+// exactly what it is told to. See internal/stellar for the Soroban rules —
+// notably that writes are never retried here, because a resubmitted
+// transaction is a double spend, and they go through the submission record
+// instead.
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Defaults sized for Soroban RPC on a user request path.
+//
+// Three attempts, not more: these calls sit inside HTTP handlers with their
+// own write timeout, and a fourth attempt buys little once two have failed
+// while costing every waiting user another backoff. The 12s budget is
+// comfortably above any healthy chain read and below the API's 15s write
+// timeout, so the retry loop can never be the thing that holds a request open
+// longest.
+const (
+	DefaultMaxAttempts = 3
+	DefaultBaseDelay   = 100 * time.Millisecond
+	DefaultMaxDelay    = 2 * time.Second
+	DefaultBudget      = 12 * time.Second
+)
+
+// Policy bounds one retry loop. The zero value is usable and takes the
+// defaults above.
+type Policy struct {
+	// MaxAttempts is the total number of calls, including the first. 1
+	// disables retrying without disabling the helper.
+	MaxAttempts int
+
+	// BaseDelay is the backoff cap for the first retry; it doubles per
+	// attempt up to MaxDelay.
+	BaseDelay time.Duration
+
+	// MaxDelay caps the exponential growth.
+	MaxDelay time.Duration
+
+	// Budget is the total wall-clock allowance for the whole loop, including
+	// backoff. It is applied as a context deadline, so a single hung attempt
+	// cannot outlive it.
+	Budget time.Duration
+}
+
+func (p Policy) withDefaults() Policy {
+	if p.MaxAttempts <= 0 {
+		p.MaxAttempts = DefaultMaxAttempts
+	}
+	if p.BaseDelay <= 0 {
+		p.BaseDelay = DefaultBaseDelay
+	}
+	if p.MaxDelay <= 0 {
+		p.MaxDelay = DefaultMaxDelay
+	}
+	if p.Budget <= 0 {
+		p.Budget = DefaultBudget
+	}
+	return p
+}
+
+// Validate reports a policy that cannot behave sensibly, so startup can refuse
+// it rather than letting it become an incident.
+func (p Policy) Validate() error {
+	if p.MaxAttempts < 1 {
+		return fmt.Errorf("max attempts must be at least 1, got %d", p.MaxAttempts)
+	}
+	if p.BaseDelay <= 0 {
+		return fmt.Errorf("base delay must be greater than 0, got %v", p.BaseDelay)
+	}
+	if p.MaxDelay < p.BaseDelay {
+		return fmt.Errorf("max delay %v must be at least the base delay %v", p.MaxDelay, p.BaseDelay)
+	}
+	if p.Budget <= 0 {
+		return fmt.Errorf("budget must be greater than 0, got %v", p.Budget)
+	}
+	return nil
+}
+
+// ErrExhausted marks a call that used up its attempts or its budget. Callers
+// match it with errors.Is to answer "the upstream never gave us an answer",
+// which is a different condition from "the upstream said no".
+var ErrExhausted = errors.New("retry attempts exhausted")
+
+// Error is the typed failure returned when a retried call never succeeded.
+//
+// It carries the last error so the underlying cause is not lost, and the shape
+// of the attempt so an operator reading a log line knows whether the loop ran
+// out of attempts or ran out of time — which point at different problems.
+type Error struct {
+	Attempts int
+	Elapsed  time.Duration
+	Err      error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s after %d attempt(s) in %s: %v",
+		ErrExhausted.Error(), e.Attempts, e.Elapsed.Round(time.Millisecond), e.Err)
+}
+
+// Unwrap returns both sentinels so errors.Is matches ErrExhausted *and*
+// anything the underlying error wraps. Callers that care about the cause
+// (a status code, a transport failure) keep working unchanged.
+func (e *Error) Unwrap() []error { return []error{ErrExhausted, e.Err} }
+
+// Result describes how a completed loop ran, for metrics. It is returned on
+// success and on failure, because "succeeded, but only on the third attempt"
+// is exactly the signal that an upstream is degrading before it breaks.
+type Result struct {
+	Attempts int
+	Elapsed  time.Duration
+}
+
+// Runner executes retry loops. One is shared by every call site; it holds no
+// per-call state.
+type Runner struct {
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+	// jitter maps a backoff cap to the delay actually waited.
+	jitter func(time.Duration) time.Duration
+}
+
+// New returns a Runner using the real clock and a concurrency-safe PRNG.
+func New() *Runner {
+	return &Runner{now: time.Now, sleep: sleepCtx, jitter: fullJitter}
+}
+
+// NewWithClock is New with the clock, sleep, and jitter injected, so tests can
+// assert the exact backoff schedule without waiting for it.
+//
+// A nil jitter means "wait the full cap", which makes the schedule
+// deterministic; that is the right default for a test and the wrong one for
+// production, which is why it is only reachable through this constructor.
+func NewWithClock(
+	now func() time.Time,
+	sleep func(context.Context, time.Duration) error,
+	jitter func(time.Duration) time.Duration,
+) *Runner {
+	if now == nil {
+		now = time.Now
+	}
+	if sleep == nil {
+		sleep = sleepCtx
+	}
+	if jitter == nil {
+		jitter = func(d time.Duration) time.Duration { return d }
+	}
+	return &Runner{now: now, sleep: sleep, jitter: jitter}
+}
+
+// Do runs fn until it succeeds, returns an error the caller does not want
+// retried, or the loop runs out of attempts, budget, or context.
+//
+// retryable decides which errors are worth another attempt. A nil retryable
+// means nothing is retried, so a caller that forgets to supply one gets the
+// old single-attempt behaviour rather than silently retrying a write.
+//
+// The returned error is a *Error (matching ErrExhausted) only when attempts or
+// budget ran out. An error the caller declined to retry is returned unchanged,
+// because wrapping it would make every non-transient failure look like an
+// upstream outage.
+func (r *Runner) Do(
+	ctx context.Context,
+	policy Policy,
+	retryable func(error) bool,
+	fn func(context.Context) error,
+) (Result, error) {
+	policy = policy.withDefaults()
+
+	// The budget is a context deadline rather than a check between attempts,
+	// so a single attempt that hangs is cut off by it too. Without this, one
+	// slow call against an unresponsive endpoint would ignore the budget
+	// entirely and hold the caller for its client timeout instead.
+	ctx, cancel := context.WithTimeout(ctx, policy.Budget)
+	defer cancel()
+
+	startedAt := r.now()
+	var lastErr error
+
+	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+		// Checked before each attempt so a cancelled caller stops immediately
+		// rather than paying for one more round trip.
+		if err := ctx.Err(); err != nil {
+			return r.exhausted(attempt-1, startedAt, lastErr, err)
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			return Result{Attempts: attempt, Elapsed: r.since(startedAt)}, nil
+		}
+		lastErr = err
+
+		if retryable == nil || !retryable(err) {
+			return Result{Attempts: attempt, Elapsed: r.since(startedAt)}, err
+		}
+		if attempt == policy.MaxAttempts {
+			break
+		}
+
+		delay := r.jitter(backoffCap(policy, attempt))
+		if sleepErr := r.sleep(ctx, delay); sleepErr != nil {
+			// The budget or the caller expired while backing off. The last
+			// real error is the useful one to report, not the timeout.
+			return r.exhausted(attempt, startedAt, lastErr, sleepErr)
+		}
+	}
+
+	return r.exhausted(policy.MaxAttempts, startedAt, lastErr, nil)
+}
+
+func (r *Runner) exhausted(attempts int, startedAt time.Time, lastErr, ctxErr error) (Result, error) {
+	if lastErr == nil {
+		lastErr = ctxErr
+	}
+	result := Result{Attempts: attempts, Elapsed: r.since(startedAt)}
+	return result, &Error{Attempts: attempts, Elapsed: result.Elapsed, Err: lastErr}
+}
+
+func (r *Runner) since(startedAt time.Time) time.Duration {
+	elapsed := r.now().Sub(startedAt)
+	if elapsed < 0 {
+		// A clock stepping backwards must not report a negative latency into
+		// a histogram.
+		return 0
+	}
+	return elapsed
+}
+
+// backoffCap is the upper bound on the delay before the given attempt's retry:
+// BaseDelay doubled once per elapsed attempt, clamped to MaxDelay.
+func backoffCap(policy Policy, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	// Shifting is bounded before it is applied: 2^62 nanoseconds already
+	// exceeds any sane MaxDelay, and shifting past 63 would wrap to zero and
+	// silently turn the backoff off.
+	const maxShift = 62
+	shift := attempt - 1
+	if shift > maxShift {
+		return policy.MaxDelay
+	}
+
+	scaled := float64(policy.BaseDelay) * math.Pow(2, float64(shift))
+	if scaled >= float64(policy.MaxDelay) {
+		return policy.MaxDelay
+	}
+	return time.Duration(scaled)
+}
+
+// fullJitter draws uniformly from [0, cap). See the package comment for why
+// the whole interval is used rather than a band around cap.
+func fullJitter(cap time.Duration) time.Duration {
+	if cap <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(cap)))
+}
+
+// sleepCtx waits for d, or returns early with the context's error.
+//
+// It uses a timer rather than time.Sleep so a cancelled caller is released
+// immediately instead of after the full backoff, and the timer is always
+// stopped so a cancelled wait leaks nothing.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/apps/api/internal/retry/retry_test.go
+++ b/apps/api/internal/retry/retry_test.go
@@ -1,0 +1,561 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock records the delays the loop asked for instead of waiting them out.
+// Every backoff assertion below is about a schedule measured in seconds;
+// sleeping through it would make the suite slow and flaky, and would not let a
+// test see the delays at all.
+type fakeClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	delays []time.Duration
+	// cancelAfter, when positive, makes the Nth sleep report the context as
+	// expired, standing in for the budget running out mid-backoff.
+	cancelAfter int
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Sleep(_ context.Context, d time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.delays = append(c.delays, d)
+	c.now = c.now.Add(d)
+
+	if c.cancelAfter > 0 && len(c.delays) >= c.cancelAfter {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func (c *fakeClock) Delays() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Duration(nil), c.delays...)
+}
+
+func testPolicy() Policy {
+	return Policy{
+		MaxAttempts: 3,
+		BaseDelay:   100 * time.Millisecond,
+		MaxDelay:    2 * time.Second,
+		Budget:      12 * time.Second,
+	}
+}
+
+// newTestRunner returns a runner with no jitter, so the backoff schedule is
+// exactly the cap and can be asserted.
+func newTestRunner(clock *fakeClock) *Runner {
+	return NewWithClock(clock.Now, clock.Sleep, nil)
+}
+
+var errTransient = errors.New("connection reset")
+
+func alwaysRetryable(error) bool { return true }
+
+// ---------------------------------------------------------------------------
+// The happy paths
+// ---------------------------------------------------------------------------
+
+func TestSuccessOnFirstAttemptDoesNotSleep(t *testing.T) {
+	clock := newFakeClock()
+
+	calls := 0
+	result, err := newTestRunner(clock).Do(context.Background(), testPolicy(), alwaysRetryable,
+		func(context.Context) error {
+			calls++
+			return nil
+		})
+
+	if err != nil {
+		t.Fatalf("Do() = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("fn called %d times, want 1", calls)
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", result.Attempts)
+	}
+	if got := clock.Delays(); len(got) != 0 {
+		t.Fatalf("slept %v on a first-attempt success, want no sleeps", got)
+	}
+}
+
+// The reason the feature exists: a transient failure is absorbed instead of
+// reaching the user.
+func TestTransientFailureIsAbsorbed(t *testing.T) {
+	clock := newFakeClock()
+
+	calls := 0
+	result, err := newTestRunner(clock).Do(context.Background(), testPolicy(), alwaysRetryable,
+		func(context.Context) error {
+			calls++
+			if calls < 3 {
+				return errTransient
+			}
+			return nil
+		})
+
+	if err != nil {
+		t.Fatalf("Do() = %v, want nil after recovery", err)
+	}
+	if calls != 3 {
+		t.Fatalf("fn called %d times, want 3", calls)
+	}
+	if result.Attempts != 3 {
+		t.Fatalf("attempts = %d, want 3: the metric must show it took three tries", result.Attempts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backoff schedule
+// ---------------------------------------------------------------------------
+
+func TestBackoffIsExponentialAndCapped(t *testing.T) {
+	clock := newFakeClock()
+	policy := Policy{MaxAttempts: 6, BaseDelay: 100 * time.Millisecond, MaxDelay: 500 * time.Millisecond, Budget: time.Minute}
+
+	_, err := newTestRunner(clock).Do(context.Background(), policy, alwaysRetryable,
+		func(context.Context) error { return errTransient })
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Do() = %v, want an exhaustion error", err)
+	}
+
+	// Five retries after six attempts: 100, 200, 400, then clamped at 500.
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		500 * time.Millisecond,
+		500 * time.Millisecond,
+	}
+
+	got := clock.Delays()
+	if len(got) != len(want) {
+		t.Fatalf("delays = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("delays = %v, want %v", got, want)
+		}
+	}
+}
+
+// Full jitter must draw from the whole interval below the cap, never above it.
+// Retrying on a fixed schedule synchronises every client that failed together,
+// and the resulting storm is what knocks a recovering endpoint back over.
+func TestFullJitterStaysWithinTheCap(t *testing.T) {
+	for _, cap := range []time.Duration{time.Millisecond, 100 * time.Millisecond, 2 * time.Second} {
+		belowCap := false
+		for i := 0; i < 200; i++ {
+			got := fullJitter(cap)
+			if got < 0 || got >= cap {
+				t.Fatalf("fullJitter(%v) = %v, want within [0, %v)", cap, got, cap)
+			}
+			if got < cap/2 {
+				belowCap = true
+			}
+		}
+		// Not a distribution test — just proof it is not returning the cap
+		// every time, which would be no jitter at all.
+		if !belowCap {
+			t.Errorf("fullJitter(%v) never returned a value below half the cap", cap)
+		}
+	}
+}
+
+func TestFullJitterHandlesZeroCap(t *testing.T) {
+	if got := fullJitter(0); got != 0 {
+		t.Fatalf("fullJitter(0) = %v, want 0", got)
+	}
+	if got := fullJitter(-time.Second); got != 0 {
+		t.Fatalf("fullJitter(negative) = %v, want 0", got)
+	}
+}
+
+// A pathological attempt count must not shift the backoff into a wrap.
+func TestBackoffCapDoesNotOverflow(t *testing.T) {
+	policy := Policy{BaseDelay: time.Second, MaxDelay: 30 * time.Second}.withDefaults()
+
+	for _, attempt := range []int{0, 1, 64, 1000, 1 << 30} {
+		got := backoffCap(policy, attempt)
+		if got <= 0 {
+			t.Fatalf("backoffCap(attempt=%d) = %v, want a positive delay", attempt, got)
+		}
+		if got > policy.MaxDelay {
+			t.Fatalf("backoffCap(attempt=%d) = %v, want at most %v", attempt, got, policy.MaxDelay)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+func TestMaxAttemptsIsRespected(t *testing.T) {
+	for _, maxAttempts := range []int{1, 2, 5} {
+		t.Run("", func(t *testing.T) {
+			clock := newFakeClock()
+			policy := testPolicy()
+			policy.MaxAttempts = maxAttempts
+
+			calls := 0
+			result, err := newTestRunner(clock).Do(context.Background(), policy, alwaysRetryable,
+				func(context.Context) error {
+					calls++
+					return errTransient
+				})
+
+			if calls != maxAttempts {
+				t.Fatalf("fn called %d times, want %d", calls, maxAttempts)
+			}
+			if result.Attempts != maxAttempts {
+				t.Fatalf("attempts = %d, want %d", result.Attempts, maxAttempts)
+			}
+			if !errors.Is(err, ErrExhausted) {
+				t.Fatalf("Do() = %v, want an exhaustion error", err)
+			}
+			if got := len(clock.Delays()); got != maxAttempts-1 {
+				t.Fatalf("slept %d times for %d attempts, want %d", got, maxAttempts, maxAttempts-1)
+			}
+		})
+	}
+}
+
+// MaxAttempts of 1 turns retrying off without turning the helper off, so a
+// deployment can disable retries without losing the metrics or the typed
+// error.
+func TestSingleAttemptPolicyNeverRetries(t *testing.T) {
+	clock := newFakeClock()
+	policy := testPolicy()
+	policy.MaxAttempts = 1
+
+	calls := 0
+	_, err := newTestRunner(clock).Do(context.Background(), policy, alwaysRetryable,
+		func(context.Context) error {
+			calls++
+			return errTransient
+		})
+
+	if calls != 1 {
+		t.Fatalf("fn called %d times, want 1", calls)
+	}
+	if len(clock.Delays()) != 0 {
+		t.Fatalf("slept %v with retries disabled", clock.Delays())
+	}
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Do() = %v, want an exhaustion error", err)
+	}
+}
+
+// The budget running out mid-backoff stops the loop, and the reported error is
+// the last real failure rather than the timeout that ended the wait.
+func TestBudgetExhaustionStopsTheLoop(t *testing.T) {
+	clock := newFakeClock()
+	clock.cancelAfter = 1
+
+	calls := 0
+	result, err := newTestRunner(clock).Do(context.Background(), testPolicy(), alwaysRetryable,
+		func(context.Context) error {
+			calls++
+			return errTransient
+		})
+
+	if calls != 1 {
+		t.Fatalf("fn called %d times, want 1: the budget expired during the first backoff", calls)
+	}
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Do() = %v, want an exhaustion error", err)
+	}
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("Do() = %v, want it to carry the underlying failure", err)
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", result.Attempts)
+	}
+}
+
+// A slow attempt must be cut off by the budget rather than running to its own
+// client timeout. Without this the budget would bound only the backoff, which
+// is the cheap part.
+func TestBudgetBoundsASlowAttempt(t *testing.T) {
+	policy := testPolicy()
+	policy.Budget = 50 * time.Millisecond
+
+	started := time.Now()
+	_, err := New().Do(context.Background(), policy, alwaysRetryable,
+		func(ctx context.Context) error {
+			// Stands in for a hung upstream with a far longer client timeout.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+				return nil
+			}
+		})
+	elapsed := time.Since(started)
+
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Do() = %v, want an exhaustion error", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("a hung attempt ran for %v against a 50ms budget", elapsed)
+	}
+}
+
+// A cancelled caller stops the loop immediately; it does not pay for another
+// round trip or another backoff.
+func TestContextCancellationStopsImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	clock := newFakeClock()
+	calls := 0
+	_, err := newTestRunner(clock).Do(ctx, testPolicy(), alwaysRetryable,
+		func(context.Context) error {
+			calls++
+			return errTransient
+		})
+
+	if calls != 0 {
+		t.Fatalf("fn called %d times with an already-cancelled context, want 0", calls)
+	}
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Do() = %v, want an exhaustion error", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Do() = %v, want it to carry the cancellation", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// What is and is not retried
+// ---------------------------------------------------------------------------
+
+// An error the caller declines to retry is returned unchanged. Wrapping it
+// would make every deterministic failure look like an upstream outage, and the
+// handler layer maps those to different HTTP statuses.
+func TestNonRetryableErrorIsReturnedUnwrapped(t *testing.T) {
+	clock := newFakeClock()
+	sentinel := errors.New("contract rejected the call")
+
+	calls := 0
+	result, err := newTestRunner(clock).Do(context.Background(), testPolicy(),
+		func(error) bool { return false },
+		func(context.Context) error {
+			calls++
+			return sentinel
+		})
+
+	if calls != 1 {
+		t.Fatalf("fn called %d times, want 1", calls)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Do() = %v, want the original error", err)
+	}
+	if errors.Is(err, ErrExhausted) {
+		t.Fatal("a declined error was reported as retry exhaustion")
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", result.Attempts)
+	}
+}
+
+// The safety default. A caller that supplies no predicate gets one attempt,
+// not unlimited retries — because the operation this package is most likely to
+// be pointed at without thought is a write.
+func TestNilRetryablePredicateRetriesNothing(t *testing.T) {
+	clock := newFakeClock()
+
+	calls := 0
+	_, err := newTestRunner(clock).Do(context.Background(), testPolicy(), nil,
+		func(context.Context) error {
+			calls++
+			return errTransient
+		})
+
+	if calls != 1 {
+		t.Fatalf("fn called %d times with a nil predicate, want 1", calls)
+	}
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("Do() = %v, want the original error", err)
+	}
+}
+
+// Only the errors the predicate accepts are retried, and the loop stops the
+// moment it sees one it does not.
+func TestLoopStopsOnTheFirstNonRetryableError(t *testing.T) {
+	clock := newFakeClock()
+	permanent := errors.New("bad request")
+
+	calls := 0
+	_, err := newTestRunner(clock).Do(context.Background(), testPolicy(),
+		func(err error) bool { return errors.Is(err, errTransient) },
+		func(context.Context) error {
+			calls++
+			if calls == 1 {
+				return errTransient
+			}
+			return permanent
+		})
+
+	if calls != 2 {
+		t.Fatalf("fn called %d times, want 2", calls)
+	}
+	if !errors.Is(err, permanent) {
+		t.Fatalf("Do() = %v, want the permanent error", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The typed error
+// ---------------------------------------------------------------------------
+
+// Exhaustion must be recognisable as exhaustion *and* keep its cause, so the
+// handler layer can answer 503 while the log line still names what broke.
+func TestExhaustionErrorIsTypedAndKeepsItsCause(t *testing.T) {
+	clock := newFakeClock()
+
+	_, err := newTestRunner(clock).Do(context.Background(), testPolicy(), alwaysRetryable,
+		func(context.Context) error { return errTransient })
+
+	if !errors.Is(err, ErrExhausted) {
+		t.Fatalf("errors.Is(%v, ErrExhausted) = false", err)
+	}
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("errors.Is(%v, errTransient) = false: the cause was lost", err)
+	}
+
+	var retryErr *Error
+	if !errors.As(err, &retryErr) {
+		t.Fatalf("errors.As(%v, *Error) = false", err)
+	}
+	if retryErr.Attempts != 3 {
+		t.Fatalf("Attempts = %d, want 3", retryErr.Attempts)
+	}
+	if retryErr.Err == nil {
+		t.Fatal("Err is nil; the underlying failure was dropped")
+	}
+	if got := retryErr.Error(); got == "" {
+		t.Fatal("Error() is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+func TestZeroPolicyUsesDefaults(t *testing.T) {
+	got := Policy{}.withDefaults()
+
+	if got.MaxAttempts != DefaultMaxAttempts {
+		t.Errorf("max attempts = %d, want %d", got.MaxAttempts, DefaultMaxAttempts)
+	}
+	if got.BaseDelay != DefaultBaseDelay {
+		t.Errorf("base delay = %v, want %v", got.BaseDelay, DefaultBaseDelay)
+	}
+	if got.MaxDelay != DefaultMaxDelay {
+		t.Errorf("max delay = %v, want %v", got.MaxDelay, DefaultMaxDelay)
+	}
+	if got.Budget != DefaultBudget {
+		t.Errorf("budget = %v, want %v", got.Budget, DefaultBudget)
+	}
+}
+
+func TestPolicyValidate(t *testing.T) {
+	if err := testPolicy().Validate(); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	cases := map[string]func(*Policy){
+		"zero attempts":     func(p *Policy) { p.MaxAttempts = 0 },
+		"negative attempts": func(p *Policy) { p.MaxAttempts = -1 },
+		"zero base delay":   func(p *Policy) { p.BaseDelay = 0 },
+		"max below base":    func(p *Policy) { p.MaxDelay = p.BaseDelay - time.Millisecond },
+		"zero budget":       func(p *Policy) { p.Budget = 0 },
+		"negative budget":   func(p *Policy) { p.Budget = -time.Second },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			policy := testPolicy()
+			mutate(&policy)
+			if err := policy.Validate(); err == nil {
+				t.Fatal("Validate() = nil, want an error")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// One Runner is shared by every call site. Run under -race, this is what
+// proves that is safe — including the PRNG behind the jitter.
+func TestRunnerIsSafeForConcurrentUse(t *testing.T) {
+	runner := New()
+	policy := Policy{MaxAttempts: 3, BaseDelay: time.Microsecond, MaxDelay: time.Microsecond, Budget: time.Minute}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = runner.Do(context.Background(), policy, alwaysRetryable,
+					func(context.Context) error {
+						if (id+j)%2 == 0 {
+							return errTransient
+						}
+						return nil
+					})
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// sleepCtx must release a cancelled caller immediately rather than after the
+// full backoff, and must not leak its timer either way.
+func TestSleepCtxReleasesOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	err := sleepCtx(ctx, 5*time.Second)
+	elapsed := time.Since(started)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sleepCtx() = %v, want context.Canceled", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("sleepCtx waited %v after cancellation", elapsed)
+	}
+}
+
+func TestSleepCtxWaits(t *testing.T) {
+	started := time.Now()
+	if err := sleepCtx(context.Background(), 20*time.Millisecond); err != nil {
+		t.Fatalf("sleepCtx() = %v, want nil", err)
+	}
+	if elapsed := time.Since(started); elapsed < 15*time.Millisecond {
+		t.Fatalf("sleepCtx returned after %v, want at least ~20ms", elapsed)
+	}
+}

--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/signing"
 	"github.com/suncrestlabs/nester/apps/api/internal/stellar"
@@ -56,6 +58,36 @@ func NewSorobanVaultChainInvoker(
 		invoker:            inv,
 		defaultSlippageBps: defaultSlippageBps,
 	}, nil
+}
+
+// SetHTTPClient replaces the HTTP client used for outbound chain calls. It
+// exists so startup can install the metrics-instrumented, circuit-broken
+// transport; a nil client is ignored so callers need not branch.
+//
+// The underlying invoker uses one client for both Soroban RPC and Horizon, so
+// this single client carries both upstreams. The breaker routes per request
+// URL rather than per client, which is what keeps their failure state
+// independent — see internal/breaker.Router.
+func (s *SorobanVaultChainInvoker) SetHTTPClient(client *http.Client) {
+	if client != nil {
+		s.invoker.SetHTTPClient(client)
+	}
+}
+
+// SetSubmissionStore installs the durable submission record (nester#1085), so
+// every chain write this invoker performs persists an intent before it is
+// sent and a lost RPC response can be reconciled rather than resubmitted.
+func (s *SorobanVaultChainInvoker) SetSubmissionStore(store stellar.SubmissionStore, logger *slog.Logger) {
+	s.invoker.SetSubmissionStore(store, logger)
+}
+
+// SetRPCOptions installs the shared Soroban retry policy (nester#1086).
+//
+// Only the invoker's reads are affected: simulateTransaction and the
+// getTransaction polls are retried, sendTransaction is not. The write path's
+// durability comes from the submission record, not from repeating the call.
+func (s *SorobanVaultChainInvoker) SetRPCOptions(opts stellar.RPCOptions) {
+	s.invoker.SetRPCOptions(opts)
 }
 
 func (s *SorobanVaultChainInvoker) PauseVault(ctx context.Context, contractAddress string) error {

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -54,6 +54,16 @@ func NewTransactionService(repository transaction.Repository, horizonURL string)
 	}
 }
 
+// SetHTTPClient replaces the HTTP client used to confirm transactions against
+// Horizon. It exists so startup can install the metrics-instrumented,
+// circuit-broken transport; a nil client is ignored so callers need not
+// branch.
+func (s *TransactionService) SetHTTPClient(client *http.Client) {
+	if client != nil {
+		s.client = client
+	}
+}
+
 // SetBalanceApplier wires the vault balance applier used to credit/debit a
 // vault once a deposit/withdrawal is confirmed on-chain. Optional: when unset,
 // status is still reconciled but no balance is moved (used by tests that only

--- a/apps/api/internal/stellar/backfill.go
+++ b/apps/api/internal/stellar/backfill.go
@@ -1,12 +1,9 @@
 package stellar
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -80,10 +77,15 @@ type resettableEventType struct {
 // Exported for the admin handler to surface a clear pre-flight error rather
 // than let Run fail mid-way.
 func NonResettableEventTypesInRange(ctx context.Context, client *http.Client, rpcURL string, contractIDs []string, from, to uint64) ([]string, error) {
+	// A pre-flight read on the admin path, so it takes the package's default
+	// retry policy rather than threading the configured one through the admin
+	// handler's signature for a call that runs once per operator action.
+	rpc := newRPCClient(rpcURL, client, RPCOptions{}, false)
+
 	found := map[string]bool{}
 	cursor := from
 	for cursor <= to {
-		page, err := fetchSorobanEventsRange(ctx, client, rpcURL, contractIDs, cursor, to)
+		page, err := fetchSorobanEventsRange(ctx, rpc, contractIDs, cursor, to)
 		if err != nil {
 			return nil, err
 		}
@@ -115,6 +117,10 @@ type Runner struct {
 	Client *http.Client
 	RPCURL string
 	Logger *slog.Logger
+
+	// RPCOptions carries the shared retry policy (nester#1086). Every call a
+	// backfill makes is getEvents, so all of it is retryable.
+	RPCOptions RPCOptions
 
 	// throttle is the pause between batches, giving live indexing priority
 	// for database/RPC capacity (#840's non-interference requirement).
@@ -217,7 +223,7 @@ func (r *Runner) Resume(ctx context.Context, runID uuid.UUID) (*backfill.Run, er
 // execute drives one run (fresh or resumed) from run.ResumeFrom() through
 // run.ToLedger, checkpointing after every batch.
 func (r *Runner) execute(ctx context.Context, run *backfill.Run) error {
-	client := r.httpClient()
+	rpc := r.rpcClient()
 
 	if run.Mode == backfill.ModeRebuild && run.ResumeFrom() == run.FromLedger {
 		// Reset scope is applied once, at the very start of a fresh run —
@@ -235,7 +241,7 @@ func (r *Runner) execute(ctx context.Context, run *backfill.Run) error {
 	skipped := run.EventsSkippedDuplicate
 
 	for cursor <= run.ToLedger {
-		headroomLedger, err := r.headLedgerMinusMargin(ctx, client, run.ContractIDs)
+		headroomLedger, err := r.headLedgerMinusMargin(ctx, rpc, run.ContractIDs)
 		if err != nil {
 			return fmt.Errorf("check chain head: %w", err)
 		}
@@ -244,7 +250,7 @@ func (r *Runner) execute(ctx context.Context, run *backfill.Run) error {
 			return fmt.Errorf("%w (requested up to ledger %d, safety margin currently allows up to %d)", ErrTooCloseToHead, run.ToLedger, headroomLedger)
 		}
 
-		page, err := fetchSorobanEventsRange(ctx, client, r.RPCURL, run.ContractIDs, cursor, batchEnd)
+		page, err := fetchSorobanEventsRange(ctx, rpc, run.ContractIDs, cursor, batchEnd)
 		if err != nil {
 			return fmt.Errorf("fetch events [%d,%d]: %w", cursor, batchEnd, err)
 		}
@@ -330,11 +336,11 @@ func (r *Runner) resetScope(ctx context.Context, run *backfill.Run) error {
 	return tx.Commit()
 }
 
-func (r *Runner) headLedgerMinusMargin(ctx context.Context, client *http.Client, contractIDs []string) (uint64, error) {
+func (r *Runner) headLedgerMinusMargin(ctx context.Context, rpc *rpcClient, contractIDs []string) (uint64, error) {
 	// A cheap, zero-event probe: getEvents at the current chain tip always
 	// returns latestLedger, which is used purely as a head proxy — no event
 	// data from this call is applied.
-	page, err := fetchSorobanEventsRange(ctx, client, r.RPCURL, contractIDs, 0, 0)
+	page, err := fetchSorobanEventsRange(ctx, rpc, contractIDs, 0, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -359,7 +365,15 @@ func (r *Runner) httpClient() *http.Client {
 	if r.Client != nil {
 		return r.Client
 	}
-	return &http.Client{Timeout: 30 * time.Second}
+	return &http.Client{Timeout: defaultRPCTimeout}
+}
+
+// rpcClient builds the shared Soroban caller for this run. Untraced: a
+// backfill issues thousands of identical getEvents calls, and a span per page
+// would swamp the trace store without telling an operator anything the run's
+// own progress record does not.
+func (r *Runner) rpcClient() *rpcClient {
+	return newRPCClient(r.RPCURL, r.httpClient(), r.RPCOptions, false)
 }
 
 func (r *Runner) logger() *slog.Logger {
@@ -389,8 +403,7 @@ type eventsPage struct {
 // support an endLedger filter — only startLedger + pagination.
 func fetchSorobanEventsRange(
 	ctx context.Context,
-	client *http.Client,
-	rpcURL string,
+	rpc *rpcClient,
 	contractIDs []string,
 	fromLedger, toLedger uint64,
 ) (eventsPage, error) {
@@ -400,37 +413,12 @@ func fetchSorobanEventsRange(
 		return eventsPage{}, nil
 	}
 
-	body, err := json.Marshal(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "nester-backfill",
-		"method":  "getEvents",
-		"params": map[string]any{
-			"startLedger": fromLedger,
-			"filters": []map[string]any{
-				{"type": "contract", "contractIds": contractIDs},
-			},
-			"pagination": map[string]any{"limit": 200},
+	params := map[string]any{
+		"startLedger": fromLedger,
+		"filters": []map[string]any{
+			{"type": "contract", "contractIds": contractIDs},
 		},
-	})
-	if err != nil {
-		return eventsPage{}, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rpcURL, bytes.NewReader(body))
-	if err != nil {
-		return eventsPage{}, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return eventsPage{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return eventsPage{}, fmt.Errorf("rpc returned %d: %s", resp.StatusCode, string(payload))
+		"pagination": map[string]any{"limit": 200},
 	}
 
 	var rpcResp struct {
@@ -449,9 +437,7 @@ func fetchSorobanEventsRange(
 		} `json:"error"`
 	}
 
-	decoder := json.NewDecoder(resp.Body)
-	decoder.UseNumber()
-	if err := decoder.Decode(&rpcResp); err != nil {
+	if err := rpc.call(ctx, "getEvents", params, &rpcResp); err != nil {
 		return eventsPage{}, err
 	}
 	if rpcResp.Error != nil {

--- a/apps/api/internal/stellar/fetcher.go
+++ b/apps/api/internal/stellar/fetcher.go
@@ -1,28 +1,35 @@
 package stellar
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
 // rpcEventFetcher is the production EventFetcher: a thin adapter over the
 // Soroban JSON-RPC endpoint the indexer has always polled.
 //
-// It holds no state beyond its client and URL so a single instance is safe to
-// reuse across polls.
+// It holds no state beyond its caller so a single instance is safe to reuse
+// across polls. Both of its methods are reads, so both are retried under the
+// shared policy (nester#1086) — which matters most here, because a transient
+// failure in the indexer's poll loop previously stalled indexing until the
+// next tick.
 type rpcEventFetcher struct {
-	client *http.Client
-	url    string
+	rpc *rpcClient
 }
 
 // NewRPCEventFetcher returns an EventFetcher backed by a Soroban JSON-RPC
 // endpoint.
 func NewRPCEventFetcher(client *http.Client, rpcURL string) EventFetcher {
-	return &rpcEventFetcher{client: client, url: rpcURL}
+	return NewRPCEventFetcherWithOptions(client, rpcURL, RPCOptions{})
+}
+
+// NewRPCEventFetcherWithOptions is NewRPCEventFetcher with the shared retry
+// policy and metrics observer supplied by startup.
+func NewRPCEventFetcherWithOptions(client *http.Client, rpcURL string, opts RPCOptions) EventFetcher {
+	// Untraced: the indexer polls every few seconds forever, and a span per
+	// poll would bury the request-scoped traces an operator actually reads.
+	return &rpcEventFetcher{rpc: newRPCClient(rpcURL, client, opts, false)}
 }
 
 // FetchEvents implements EventFetcher using the getEvents RPC method.
@@ -31,7 +38,7 @@ func (f *rpcEventFetcher) FetchEvents(
 	contractIDs []string,
 	startLedger uint64,
 ) ([]indexedEvent, uint64, error) {
-	return fetchSorobanEvents(ctx, f.client, f.url, contractIDs, startLedger)
+	return fetchSorobanEvents(ctx, f.rpc, contractIDs, startLedger)
 }
 
 // LatestLedger implements EventFetcher using the getLatestLedger RPC method.
@@ -40,32 +47,6 @@ func (f *rpcEventFetcher) FetchEvents(
 // indexer had no way to derive a valid startLedger on a fresh database and
 // fell back to 0, which the RPC rejects (B-02).
 func (f *rpcEventFetcher) LatestLedger(ctx context.Context) (uint64, error) {
-	body, err := json.Marshal(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "nester-indexer",
-		"method":  "getLatestLedger",
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.url, bytes.NewReader(body))
-	if err != nil {
-		return 0, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := f.client.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 0, fmt.Errorf("getLatestLedger returned %d: %s", resp.StatusCode, string(payload))
-	}
-
 	var rpcResp struct {
 		Result struct {
 			Sequence uint64 `json:"sequence"`
@@ -75,9 +56,7 @@ func (f *rpcEventFetcher) LatestLedger(ctx context.Context) (uint64, error) {
 		} `json:"error"`
 	}
 
-	decoder := json.NewDecoder(resp.Body)
-	decoder.UseNumber()
-	if err := decoder.Decode(&rpcResp); err != nil {
+	if err := f.rpc.call(ctx, "getLatestLedger", nil, &rpcResp); err != nil {
 		return 0, err
 	}
 	if rpcResp.Error != nil {

--- a/apps/api/internal/stellar/health.go
+++ b/apps/api/internal/stellar/health.go
@@ -62,6 +62,13 @@ func PingHorizon(ctx context.Context, client *http.Client, horizonURL string) He
 
 // PingSorobanRPC issues a getHealth JSON-RPC call to a Soroban RPC node and
 // reports reachability.
+//
+// This is the one Soroban call that deliberately does NOT go through the
+// shared retry client (nester#1086), for the same reason it bypasses the
+// circuit breaker: a health probe must report the upstream's real state right
+// now. Retrying would make an unreachable endpoint look merely slow, and would
+// hold /health/detailed open for the retry budget while doing it. The caller
+// supplies its own timeout via ctx.
 func PingSorobanRPC(ctx context.Context, client *http.Client, rpcURL string) HealthResult {
 	body, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",

--- a/apps/api/internal/stellar/indexer.go
+++ b/apps/api/internal/stellar/indexer.go
@@ -1,13 +1,11 @@
 package stellar
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -20,33 +18,71 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/systemstate"
 )
 
-// LagRecorder receives balance-freshness samples from the event indexer
-// (nester#1056). Implemented by *metrics.Metrics; declared as an interface
-// here so the stellar package does not depend on the metrics package and a
-// nil recorder disables sampling without a branch at every call site.
-type LagRecorder interface {
-	SetIndexerLag(lagLedgers uint64)
-	SetIndexerLagSampleAge(age time.Duration)
-	RecordIndexerLagSampleError()
+// IndexerPollInterval is how often the indexer polls for new events.
+//
+// Ledgers close roughly every 5s, so polling slightly slower than that keeps
+// the indexer within a ledger or two of the tip without spending an RPC round
+// trip on ledgers that have not closed yet. The staleness budget in
+// internal/freshness is set an order of magnitude above it.
+const IndexerPollInterval = 6 * time.Second
+
+// IndexerRequestTimeout bounds a single RPC call made by the indexer loop. It
+// sits above the poll interval so a slow-but-working RPC still completes, and
+// well below the point where polls would queue indefinitely. Exported so
+// startup can build the indexer's client with the same bound rather than
+// restating it.
+const IndexerRequestTimeout = 8 * time.Second
+
+// FreshnessRecorder receives balance-freshness samples from the event indexer
+// (nester#1056, nester#1088). Implemented by *freshness.Tracker; declared as
+// an interface here so the stellar package does not depend on it, and a nil
+// recorder disables sampling without a branch at every call site.
+type FreshnessRecorder interface {
+	// Observe reports a successful sample of the indexer's position.
+	Observe(indexedLedger, networkLedger uint64)
+	// ObserveFailure reports a sample that could not be taken.
+	ObserveFailure()
 }
 
-// StartEventIndexerWithMetrics is StartEventIndexer with balance-freshness
-// instrumentation. recorder may be nil, in which case no samples are taken
-// and the indexer behaves exactly as before: telemetry must never be able to
-// stop the indexer from indexing.
-func StartEventIndexerWithMetrics(ctx context.Context, logger *slog.Logger, db *sql.DB, sysRepo systemstate.Repository, rpcURL string, recorder LagRecorder) {
-	startEventIndexer(ctx, logger, db, sysRepo, rpcURL, recorder)
+// IndexerOptions configures the long-running event indexer.
+//
+// A struct rather than more parameters: the indexer has accumulated a client,
+// a retry policy, and a freshness recorder alongside its URL, and a
+// seven-argument call at the wiring site is unreadable and easy to transpose.
+// Every field is optional except RPCURL.
+type IndexerOptions struct {
+	// RPCURL is the Soroban endpoint. Empty disables the indexer.
+	RPCURL string
+
+	// HTTPClient carries the metrics and circuit-breaker transports. Nil
+	// falls back to a plain client with IndexerRequestTimeout. Startup passes
+	// an instrumented, circuit-broken one: the indexer is by far the heaviest
+	// Soroban caller — a request every IndexerPollInterval, forever — so it is
+	// the traffic most worth shedding when the RPC degrades (nester#1087).
+	HTTPClient *http.Client
+
+	// RPCOptions carries the shared retry policy (nester#1086). Both of the
+	// indexer's calls are reads, so both are retried.
+	RPCOptions RPCOptions
+
+	// Recorder receives balance-freshness samples. Nil disables sampling and
+	// the indexer behaves exactly as before: telemetry must never be able to
+	// stop the indexer from indexing.
+	Recorder FreshnessRecorder
 }
 
-func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, sysRepo systemstate.Repository, rpcURL string) {
-	startEventIndexer(ctx, logger, db, sysRepo, rpcURL, nil)
-}
-
-func startEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, sysRepo systemstate.Repository, rpcURL string, recorder LagRecorder) {
-	if strings.TrimSpace(rpcURL) == "" {
+// StartEventIndexer launches the long-running event indexer.
+func StartEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, sysRepo systemstate.Repository, opts IndexerOptions) {
+	if strings.TrimSpace(opts.RPCURL) == "" {
 		logger.Warn("event indexer disabled: STELLAR_RPC_URL is empty")
 		return
 	}
+
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: IndexerRequestTimeout}
+	}
+	recorder := opts.Recorder
 
 	// The long-running loop owns scheduling and telemetry only. All indexing
 	// behaviour — cursor resolution, cold start, ordering, idempotency, and
@@ -55,77 +91,82 @@ func startEventIndexer(ctx context.Context, logger *slog.Logger, db *sql.DB, sys
 	poller := &EventPoller{
 		DB:      db,
 		SysRepo: sysRepo,
-		Fetcher: NewRPCEventFetcher(&http.Client{Timeout: 8 * time.Second}, rpcURL),
+		Fetcher: NewRPCEventFetcherWithOptions(httpClient, opts.RPCURL, opts.RPCOptions),
 		Logger:  logger,
 	}
 
 	go func() {
-		ticker := time.NewTicker(6 * time.Second)
+		ticker := time.NewTicker(IndexerPollInterval)
 		defer ticker.Stop()
-
-		// Age of the last successful lag sample. Published on every tick so
-		// that a stalled or erroring indexer makes the freshness signal
-		// visibly stale instead of leaving the lag gauge frozen at a healthy
-		// value, which is the one failure mode a balance-freshness SLI must
-		// not have.
-		lastLagSampleAt := time.Now()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				// Sampled before polling so a slow or failing pass shows up as
-				// staleness rather than being hidden behind a frozen gauge.
-				lag, lagErr := indexerLagLedgers(ctx, sysRepo, poller.Fetcher)
+				// Sampled before polling, and independently of whether the
+				// poll succeeds. A failing poll does not invalidate a
+				// successful position read — the cursor genuinely is where it
+				// says, and it is genuinely not advancing — so publishing the
+				// sample is what makes the lag visibly climb during a stall
+				// instead of going quiet.
+				sampleFreshness(ctx, sysRepo, poller.Fetcher, recorder)
 
 				if _, err := poller.PollEvents(ctx); err != nil {
 					logger.Error("event indexer poll failed", "error", err)
-					recordLagSampleError(recorder, lastLagSampleAt)
-					continue
-				}
-
-				// A zero cursor means the indexer has never persisted a
-				// ledger, so there is no meaningful lag to report yet;
-				// publishing tip-minus-zero would report the entire ledger
-				// history as lag and page instantly on a fresh deploy.
-				if recorder != nil {
-					if lagErr != nil {
-						recordLagSampleError(recorder, lastLagSampleAt)
-						continue
-					}
-					recorder.SetIndexerLag(lag)
-					recorder.SetIndexerLagSampleAge(0)
-					lastLagSampleAt = time.Now()
 				}
 			}
 		}
 	}()
 }
 
-// indexerLagLedgers reports how many ledgers behind the network tip the
-// persisted cursor currently is.
-//
-// It returns an error when the cursor has never been set, because "lag" is
-// undefined before the first successful index and reporting zero there would
-// masquerade as a healthy indexer.
-func indexerLagLedgers(ctx context.Context, sysRepo systemstate.Repository, fetcher EventFetcher) (uint64, error) {
-	cursor, err := getLastIndexedLedger(ctx, sysRepo)
-	if err != nil {
-		return 0, err
-	}
-	if cursor == 0 {
-		return 0, fmt.Errorf("indexer cursor not yet initialised")
+// sampleFreshness publishes one balance-freshness sample, or records that it
+// could not be taken. A nil recorder makes it a no-op.
+func sampleFreshness(ctx context.Context, sysRepo systemstate.Repository, fetcher EventFetcher, recorder FreshnessRecorder) {
+	if recorder == nil {
+		return
 	}
 
-	tip, err := fetcher.LatestLedger(ctx)
+	indexed, tip, err := readIndexerPosition(ctx, sysRepo, fetcher)
 	if err != nil {
-		return 0, err
+		recorder.ObserveFailure()
+		return
 	}
-	if tip <= cursor {
-		return 0, nil
+
+	recorder.Observe(indexed, tip)
+}
+
+// readIndexerPosition returns the persisted cursor and the current network
+// tip.
+//
+// It returns an error when the cursor has never been set, because position is
+// undefined before the first successful index and reporting ledger 0 would
+// make the lag the entire ledger history. The caller records the failure
+// instead, which ages the freshness signal — the honest signal for "this
+// indexer has never run".
+func readIndexerPosition(ctx context.Context, sysRepo systemstate.Repository, fetcher EventFetcher) (indexed uint64, tip uint64, err error) {
+	indexed, err = getLastIndexedLedger(ctx, sysRepo)
+	if err != nil {
+		return 0, 0, err
 	}
-	return tip - cursor, nil
+	if indexed == 0 {
+		return 0, 0, fmt.Errorf("indexer cursor not yet initialised")
+	}
+
+	tip, err = fetcher.LatestLedger(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	// A tip of 0 is a broken RPC, not a real position. Publishing it would
+	// compute zero lag against any cursor and reset the sample age, reporting
+	// the indexer as perfectly fresh while the network position is in fact
+	// unknown — a false negative on exactly the signal this exists to raise.
+	// resolveStartLedger refuses a zero tip for the same reason.
+	if tip == 0 {
+		return 0, 0, fmt.Errorf("rpc reported latest ledger 0")
+	}
+
+	return indexed, tip, nil
 }
 
 func loadVaultContractIDs(ctx context.Context, db *sql.DB) ([]string, error) {
@@ -635,45 +676,19 @@ const sorobanEventPageLimit = 200
 
 func fetchSorobanEvents(
 	ctx context.Context,
-	client *http.Client,
-	rpcURL string,
+	rpc *rpcClient,
 	contractIDs []string,
 	startLedger uint64,
 ) ([]indexedEvent, uint64, error) {
-	body, err := json.Marshal(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "nester-indexer",
-		"method":  "getEvents",
-		"params": map[string]any{
-			"startLedger": startLedger,
-			"filters": []map[string]any{
-				{
-					"type":        "contract",
-					"contractIds": contractIDs,
-				},
+	params := map[string]any{
+		"startLedger": startLedger,
+		"filters": []map[string]any{
+			{
+				"type":        "contract",
+				"contractIds": contractIDs,
 			},
-			"pagination": map[string]any{"limit": sorobanEventPageLimit},
 		},
-	})
-	if err != nil {
-		return nil, 0, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rpcURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, 0, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, 0, fmt.Errorf("rpc returned %d: %s", resp.StatusCode, string(payload))
+		"pagination": map[string]any{"limit": sorobanEventPageLimit},
 	}
 
 	var rpcResp struct {
@@ -692,9 +707,7 @@ func fetchSorobanEvents(
 		} `json:"error"`
 	}
 
-	decoder := json.NewDecoder(resp.Body)
-	decoder.UseNumber()
-	if err := decoder.Decode(&rpcResp); err != nil {
+	if err := rpc.call(ctx, "getEvents", params, &rpcResp); err != nil {
 		return nil, 0, err
 	}
 	if rpcResp.Error != nil {
@@ -780,6 +793,10 @@ type EventSyncer struct {
 	SysRepo systemstate.Repository
 	RPCURL  string
 	Logger  *slog.Logger
+
+	// RPCOptions carries the shared retry policy. Zero means package
+	// defaults, which is what an EventSyncer built outside startup gets.
+	RPCOptions RPCOptions
 }
 
 func (s *EventSyncer) SyncEvents(ctx context.Context) (int, error) {
@@ -796,8 +813,8 @@ func (s *EventSyncer) SyncEvents(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	events, latestLedger, err := fetchSorobanEvents(ctx, client, s.RPCURL, contractIDs, startLedger)
+	rpc := newRPCClient(s.RPCURL, &http.Client{Timeout: defaultRPCTimeout}, s.RPCOptions, false)
+	events, latestLedger, err := fetchSorobanEvents(ctx, rpc, contractIDs, startLedger)
 	if err != nil {
 		return 0, fmt.Errorf("fetch events: %w", err)
 	}
@@ -819,16 +836,4 @@ func (s *EventSyncer) SyncEvents(ctx context.Context) (int, error) {
 	}
 
 	return processed, nil
-}
-
-// recordLagSampleError counts a failed freshness sample and publishes how
-// stale the last good reading now is. Split out so every error path in the
-// indexer loop reports staleness identically.
-func recordLagSampleError(recorder LagRecorder, lastSampleAt time.Time) {
-	if recorder == nil {
-		return
-	}
-
-	recorder.RecordIndexerLagSampleError()
-	recorder.SetIndexerLagSampleAge(time.Since(lastSampleAt))
 }

--- a/apps/api/internal/stellar/indexer_freshness_test.go
+++ b/apps/api/internal/stellar/indexer_freshness_test.go
@@ -1,0 +1,152 @@
+package stellar
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/systemstate"
+)
+
+// recordingRecorder captures what the indexer publishes, so the sampling
+// contract can be asserted without a database or a Prometheus registry.
+type recordingRecorder struct {
+	samples  [][2]uint64
+	failures int
+}
+
+func (r *recordingRecorder) Observe(indexedLedger, networkLedger uint64) {
+	r.samples = append(r.samples, [2]uint64{indexedLedger, networkLedger})
+}
+
+func (r *recordingRecorder) ObserveFailure() {
+	r.failures++
+}
+
+func TestSampleFreshnessPublishesCursorAndTip(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.values[systemstate.KeyLastLedger] = "1000"
+	recorder := &recordingRecorder{}
+
+	sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 1_007}, recorder)
+
+	if len(recorder.samples) != 1 {
+		t.Fatalf("samples = %d, want 1", len(recorder.samples))
+	}
+	if got := recorder.samples[0]; got != [2]uint64{1_000, 1_007} {
+		t.Fatalf("sample = %v, want [1000 1007]", got)
+	}
+	if recorder.failures != 0 {
+		t.Fatalf("failures = %d, want 0", recorder.failures)
+	}
+}
+
+// A cursor that has never been set is not "zero ledgers behind": it is no
+// information at all. Publishing tip-minus-zero would report the entire ledger
+// history as lag and page on every fresh deploy, so it is recorded as a
+// failed sample and the freshness signal simply keeps ageing.
+func TestSampleFreshnessTreatsAnUninitialisedCursorAsUnknown(t *testing.T) {
+	cases := map[string]*stubSysRepo{
+		"absent cursor": newStubSysRepo(),
+		"cursor seeded at zero by migration 025": func() *stubSysRepo {
+			repo := newStubSysRepo()
+			repo.values[systemstate.KeyLastLedger] = "0"
+			return repo
+		}(),
+	}
+
+	for name, sysRepo := range cases {
+		t.Run(name, func(t *testing.T) {
+			recorder := &recordingRecorder{}
+
+			sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 493_812}, recorder)
+
+			if len(recorder.samples) != 0 {
+				t.Fatalf("published a position with no cursor: %v", recorder.samples)
+			}
+			if recorder.failures != 1 {
+				t.Fatalf("failures = %d, want 1", recorder.failures)
+			}
+		})
+	}
+}
+
+// An unreachable RPC means the tip is unknown, which is not the same as the
+// indexer being caught up. Recording a failure leaves the last good reading in
+// place to keep ageing, rather than writing a sentinel that would be
+// indistinguishable from a real stall.
+func TestSampleFreshnessRecordsFailureWhenTheTipIsUnavailable(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.values[systemstate.KeyLastLedger] = "1000"
+	recorder := &recordingRecorder{}
+
+	fetcher := &scriptedFetcher{tipErr: errors.New("rpc unreachable")}
+	sampleFreshness(context.Background(), sysRepo, fetcher, recorder)
+
+	if len(recorder.samples) != 0 {
+		t.Fatalf("published a position without a tip: %v", recorder.samples)
+	}
+	if recorder.failures != 1 {
+		t.Fatalf("failures = %d, want 1", recorder.failures)
+	}
+}
+
+// An RPC reporting ledger 0 is broken, not a real position. Publishing it
+// would compute zero lag against any cursor and reset the sample age, so the
+// indexer would report as perfectly fresh while its position relative to the
+// network is unknown.
+func TestSampleFreshnessRejectsAZeroTip(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.values[systemstate.KeyLastLedger] = "1000"
+	recorder := &recordingRecorder{}
+
+	sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 0}, recorder)
+
+	if len(recorder.samples) != 0 {
+		t.Fatalf("published a position against a zero tip: %v", recorder.samples)
+	}
+	if recorder.failures != 1 {
+		t.Fatalf("failures = %d, want 1", recorder.failures)
+	}
+}
+
+// A database that cannot serve the cursor is the same kind of unknown.
+func TestSampleFreshnessRecordsFailureWhenTheCursorCannotBeRead(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.getErr = errors.New("connection refused")
+	recorder := &recordingRecorder{}
+
+	sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 1_007}, recorder)
+
+	if recorder.failures != 1 {
+		t.Fatalf("failures = %d, want 1", recorder.failures)
+	}
+}
+
+// Telemetry must never be able to stop the indexer from indexing, so a
+// deployment wired without a recorder samples nothing and does not panic.
+func TestSampleFreshnessWithNilRecorderIsANoOp(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.values[systemstate.KeyLastLedger] = "1000"
+
+	sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 1_007}, nil)
+}
+
+// An indexer momentarily ahead of the reported tip is normal — the cursor
+// advances between the tip read and the next sample. The position is published
+// as-is; clamping to zero lag is the freshness model's job, not the sampler's,
+// so both consumers see the same raw numbers.
+func TestSampleFreshnessPublishesAPositionAheadOfTheTip(t *testing.T) {
+	sysRepo := newStubSysRepo()
+	sysRepo.values[systemstate.KeyLastLedger] = "1010"
+	recorder := &recordingRecorder{}
+
+	sampleFreshness(context.Background(), sysRepo, &scriptedFetcher{tip: 1_007}, recorder)
+
+	if len(recorder.samples) != 1 {
+		t.Fatalf("samples = %d, want 1", len(recorder.samples))
+	}
+	if got := recorder.samples[0]; got != [2]uint64{1_010, 1_007} {
+		t.Fatalf("sample = %v, want [1010 1007]", got)
+	}
+}

--- a/apps/api/internal/stellar/invoker.go
+++ b/apps/api/internal/stellar/invoker.go
@@ -1,16 +1,16 @@
 package stellar
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/stellar/go/strkey"
@@ -21,6 +21,12 @@ import (
 )
 
 var (
+	// ErrSubmissionUnresolved means the chain's answer is not yet known
+	// (nester#1085). It is NOT a failure: the transaction may have landed.
+	// A caller must never treat it as permission to submit again — the
+	// durable record is pending and the reconciler owns the outcome.
+	ErrSubmissionUnresolved = errors.New("chain submission outcome is not yet known")
+
 	ErrSimulateFailed  = errors.New("soroban simulate failed")
 	ErrSubmitFailed    = errors.New("soroban send failed")
 	ErrTxFailed        = errors.New("soroban transaction failed")
@@ -38,6 +44,14 @@ type ContractInvoker struct {
 	signer          TransactionSigner
 	operatorAddress string
 	httpClient      *http.Client
+	rpcOpts         RPCOptions
+	rpc             *rpcClient
+
+	// submissions is the durable submission record (nester#1085). When nil,
+	// send falls back to submitting without one — reachable only in tests and
+	// tooling, never in a wired application.
+	submissions SubmissionStore
+	logger      *slog.Logger
 }
 
 // NewContractInvoker builds an invoker whose operator key lives in this
@@ -64,8 +78,9 @@ func NewContractInvokerWithSigner(rpcURL, horizonURL, networkPassphrase string, 
 		horizonURL:        horizonURL,
 		networkPassphrase: networkPassphrase,
 		signer:            signer,
-		httpClient:        &http.Client{Timeout: 30 * time.Second},
+		httpClient:        &http.Client{Timeout: defaultRPCTimeout},
 	}
+	inv.rebuildRPC()
 	if signer != nil {
 		inv.operatorAddress = signer.OperatorAddress()
 	}
@@ -98,7 +113,36 @@ func (c *ContractInvoker) signEnvelope(ctx context.Context, req SignRequest) (st
 func (c *ContractInvoker) SetHTTPClient(client *http.Client) {
 	if client != nil {
 		c.httpClient = client
+		c.rebuildRPC()
 	}
+}
+
+// SetSubmissionStore installs the durable submission record (nester#1085).
+//
+// Startup always calls this. Without it, send submits without persisting an
+// intent first, which is only acceptable in tests and tooling that never
+// touch a real network.
+func (c *ContractInvoker) SetSubmissionStore(store SubmissionStore, logger *slog.Logger) {
+	c.submissions = store
+	c.logger = logger
+}
+
+// SetRPCOptions installs the shared retry policy and its metrics observer
+// (nester#1086). Startup calls it; without it the invoker retries on the
+// package defaults.
+func (c *ContractInvoker) SetRPCOptions(opts RPCOptions) {
+	c.rpcOpts = opts
+	c.rebuildRPC()
+}
+
+// rebuildRPC recreates the shared caller after any of its inputs change.
+//
+// Traced, unlike the reader's: these calls carry a transaction through
+// simulate, submit, and polling, and separating those in a waterfall is how an
+// operator sees where a deposit stalled. The reader's high-frequency view
+// calls would only add noise.
+func (c *ContractInvoker) rebuildRPC() {
+	c.rpc = newRPCClient(c.rpcURL, c.httpClient, c.rpcOpts, true)
 }
 
 // InvokeVoidFunction calls a contract function with signature (caller: Address).
@@ -302,8 +346,59 @@ type getTxParams struct {
 	Hash string `json:"hash"`
 }
 
+// getTxResult carries the transaction's status and the chain's own clock and
+// memory.
+//
+// The ledger times are not decoration: they are what turns a NOT_FOUND into
+// either proof that a transaction can never land or an admission that we can
+// no longer tell. See DetermineOutcome in submission.go. Reading expiry from
+// the chain's clock rather than ours is what stops a skewed local clock from
+// manufacturing permission to resubmit.
 type getTxResult struct {
 	Status string `json:"status"`
+
+	// Unix seconds, as strings — the RPC encodes them that way.
+	LatestLedgerCloseTime string `json:"latestLedgerCloseTime"`
+	OldestLedgerCloseTime string `json:"oldestLedgerCloseTime"`
+}
+
+// chainView converts the RPC's string-encoded ledger times into a ChainView.
+// A time that is missing or unparseable yields a zero value, which
+// DetermineOutcome treats as "no usable view" rather than guessing.
+func (r getTxResult) chainView() ChainView {
+	return ChainView{
+		LatestLedgerCloseTime: parseLedgerCloseTime(r.LatestLedgerCloseTime),
+		OldestLedgerCloseTime: parseLedgerCloseTime(r.OldestLedgerCloseTime),
+	}
+}
+
+func parseLedgerCloseTime(raw string) time.Time {
+	seconds, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || seconds <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(seconds, 0).UTC()
+}
+
+// LookupTransaction asks the chain what became of one specific transaction.
+//
+// This is the reconciler's only question, and it is asked by hash — the exact
+// transaction, never a heuristic match on account, amount, or timing.
+//
+// getTransaction is an idempotent read, so it goes through the shared retry
+// policy (nester#1086) like any other; an RPC that is merely flaky must not
+// leave a submission unresolved. An RPC that is genuinely down returns an
+// error here, and the caller keeps the submission pending.
+func (c *ContractInvoker) LookupTransaction(ctx context.Context, hash string) (TransactionStatus, ChainView, error) {
+	var resp rpcResponse[getTxResult]
+	if err := c.rpcCall(ctx, "getTransaction", getTxParams{Hash: hash}, &resp); err != nil {
+		return "", ChainView{}, err
+	}
+	if resp.Error != nil {
+		return "", ChainView{}, fmt.Errorf("getTransaction: %s", resp.Error.Message)
+	}
+
+	return TransactionStatus(resp.Result.Status), resp.Result.chainView(), nil
 }
 
 type rpcResponse[T any] struct {
@@ -314,40 +409,16 @@ type rpcResponse[T any] struct {
 	} `json:"error,omitempty"`
 }
 
+// rpcCall delegates to the shared client, which opens one span per JSON-RPC
+// round trip so the trace waterfall separates simulate, submit, and each poll
+// of getTransaction. Neither params nor the response body is recorded: both
+// carry transaction XDR.
+//
+// Retrying is decided per method by the shared client. simulateTransaction and
+// getTransaction are reads and are retried; sendTransaction is not, and never
+// can be here — see idempotentRPCMethods.
 func (c *ContractInvoker) rpcCall(ctx context.Context, method string, params, result any) error {
-	// One span per JSON-RPC round trip so the trace waterfall separates
-	// simulate, submit, and each poll of getTransaction. Neither params nor
-	// the response body is recorded: both carry transaction XDR.
-	ctx, span := startRPCSpan(ctx, method)
-	defer span.End()
-
-	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
-	if err != nil {
-		telemetry.RecordError(span, err)
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.rpcURL, bytes.NewReader(body))
-	if err != nil {
-		telemetry.RecordError(span, err)
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		wrapped := fmt.Errorf("rpc %s: %w", method, err)
-		telemetry.RecordError(span, wrapped)
-		return wrapped
-	}
-	defer resp.Body.Close()
-
-	span.SetAttributes(semconv.HTTPResponseStatusCode(resp.StatusCode))
-
-	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		telemetry.RecordError(span, err)
-		return err
-	}
-	return nil
+	return c.rpc.call(ctx, method, params, result)
 }
 
 func (c *ContractInvoker) simulate(ctx context.Context, txB64 string) (simulateResult, error) {
@@ -364,7 +435,110 @@ func (c *ContractInvoker) simulate(ctx context.Context, txB64 string) (simulateR
 	return resp.Result, nil
 }
 
+// send is the single chokepoint through which every chain submission in this
+// package passes, and therefore where the durable submission record is
+// written (nester#1085).
+//
+// The ordering is the correctness boundary and it is not negotiable:
+//
+//	persist the intent  →  submit  →  record the outcome
+//
+// Never the reverse. A crash between persisting and submitting loses an
+// unsent intent, which costs nothing. A crash between submitting and
+// persisting would leave a transaction on-chain that nothing in the system
+// knows about, which no amount of later reconciliation can recover.
+//
+// Enforcing it here rather than at each caller is deliberate: a submission
+// path added later cannot forget to opt in, because there is no other way to
+// reach sendTransaction.
 func (c *ContractInvoker) send(ctx context.Context, txB64 string) (string, error) {
+	// Without a store this is the pre-#1085 behaviour: submit and hope. That
+	// is only reachable in tests and tooling — startup always wires one — and
+	// it fails loudly in the one place it would be dangerous, below.
+	if c.submissions == nil {
+		return c.submitEnvelope(ctx, txB64)
+	}
+
+	// The chain's identity for this exact transaction, known BEFORE it is
+	// sent. This is what lets the reconciler ask a precise question later
+	// instead of guessing from account and amount.
+	identity, err := IdentifyTransaction(txB64, c.networkPassphrase)
+	if err != nil {
+		return "", fmt.Errorf("identify transaction: %w", err)
+	}
+	if identity.ValidUntil.IsZero() {
+		// A transaction with no maxTime can never be proven un-landable, so a
+		// lost response for it could never be resolved. Every path here builds
+		// with time bounds; refusing loudly stops a future change from
+		// silently creating submissions that can never be reconciled.
+		return "", fmt.Errorf("%w: %s", ErrNoTimeBound, identity.Hash)
+	}
+
+	now := time.Now().UTC()
+	reference := idempotencyReferenceFrom(ctx)
+	if reference == "" {
+		// No caller-supplied reference. The transaction hash is itself a
+		// stable identity for this exact envelope, so it serves as the
+		// reference: a genuine duplicate submission of the same signed
+		// envelope collapses onto the same record, and the durability
+		// guarantee does not depend on callers remembering to supply one.
+		reference = "tx:" + identity.Hash
+	}
+
+	stored, claimed, err := c.submissions.Claim(ctx, SubmissionIntent{
+		IdempotencyReference: reference,
+		TransactionHash:      identity.Hash,
+		ValidUntil:           identity.ValidUntil,
+		SourceAccount:        c.operatorAddress,
+		State:                SubmissionPending,
+		CreatedAt:            now,
+	})
+	if err != nil {
+		// The intent could not be made durable, so nothing is submitted. This
+		// is the safe direction: no chain write happens that we could lose
+		// track of.
+		return "", fmt.Errorf("record submission intent: %w", err)
+	}
+
+	if !claimed {
+		// Another request already owns this logical submission. Return its
+		// transaction identity rather than submitting a second time — this is
+		// what makes N concurrent duplicates one chain submission.
+		return stored.TransactionHash, existingSubmissionResult(stored)
+	}
+
+	hash, submitErr := c.submitEnvelope(ctx, txB64)
+
+	// Recorded whatever happened, because "we handed it over" is true even if
+	// the response never came back. It is what the reconciler measures the
+	// RPC's memory window against.
+	if err := c.submissions.MarkSubmitted(ctx, stored.ID, time.Now().UTC()); err != nil {
+		c.logSubmission("failed to record submission attempt", stored, "error", err.Error())
+	}
+
+	if submitErr != nil {
+		// The critical branch. An error here is NOT an outcome: the
+		// transaction may have been accepted and the response lost. The
+		// record stays pending and the reconciler will ask the chain.
+		//
+		// There is deliberately no resubmit on this path, and no state
+		// transition to failed. Both would be guesses.
+		c.logSubmission("submission response lost; awaiting chain reconciliation", stored,
+			"error", submitErr.Error())
+		return stored.TransactionHash, fmt.Errorf("%w (submission %s pending reconciliation): %w",
+			ErrSubmissionUnresolved, stored.ID, submitErr)
+	}
+
+	return hash, nil
+}
+
+// submitEnvelope performs the sendTransaction call itself.
+//
+// Note what is absent: any retry. sendTransaction is excluded from the shared
+// retry policy by idempotentRPCMethods (nester#1086), because a write timeout
+// is not a read timeout — repeating it is how the same transaction gets
+// submitted twice. Recovery for writes is reconciliation, not repetition.
+func (c *ContractInvoker) submitEnvelope(ctx context.Context, txB64 string) (string, error) {
 	var resp rpcResponse[sendResult]
 	if err := c.rpcCall(ctx, "sendTransaction", sendParams{Transaction: txB64}, &resp); err != nil {
 		return "", err
@@ -376,6 +550,35 @@ func (c *ContractInvoker) send(ctx context.Context, txB64 string) (string, error
 		return "", fmt.Errorf("%w: %s", ErrSubmitFailed, resp.Result.ErrorResultXDR)
 	}
 	return resp.Result.Hash, nil
+}
+
+// existingSubmissionResult reports what a duplicate request should see, based
+// on where the original got to.
+func existingSubmissionResult(stored SubmissionIntent) error {
+	switch stored.State {
+	case SubmissionLanded:
+		return nil
+	case SubmissionRejected, SubmissionExpired:
+		return fmt.Errorf("%w: submission %s ended %s", ErrSubmitFailed, stored.ID, stored.State)
+	case SubmissionUnresolvable:
+		return fmt.Errorf("%w: submission %s could not be resolved against the chain", ErrSubmissionUnresolved, stored.ID)
+	default:
+		return fmt.Errorf("%w: submission %s is already in flight", ErrSubmissionUnresolved, stored.ID)
+	}
+}
+
+// logSubmission emits a structured submission event. It never records the
+// signed envelope or any key material — only the record's own identifiers.
+func (c *ContractInvoker) logSubmission(msg string, intent SubmissionIntent, extra ...any) {
+	if c.logger == nil {
+		return
+	}
+	attrs := append([]any{
+		"submission_id", intent.ID,
+		"transaction_hash", intent.TransactionHash,
+		"state", string(intent.State),
+	}, extra...)
+	c.logger.Warn(msg, attrs...)
 }
 
 func (c *ContractInvoker) waitForTx(ctx context.Context, hash string) error {

--- a/apps/api/internal/stellar/poller_test.go
+++ b/apps/api/internal/stellar/poller_test.go
@@ -25,6 +25,7 @@ import (
 // the default unit-test job rather than only where PostgreSQL is available.
 type stubSysRepo struct {
 	values map[string]string
+	getErr error
 	setErr error
 }
 
@@ -33,6 +34,9 @@ func newStubSysRepo() *stubSysRepo {
 }
 
 func (s *stubSysRepo) Get(_ context.Context, key string) (string, error) {
+	if s.getErr != nil {
+		return "", s.getErr
+	}
 	v, ok := s.values[key]
 	if !ok {
 		return "", systemstate.ErrKeyNotFound

--- a/apps/api/internal/stellar/reader.go
+++ b/apps/api/internal/stellar/reader.go
@@ -1,13 +1,10 @@
 package stellar
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
-	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stellar/go/keypair"
@@ -16,11 +13,16 @@ import (
 )
 
 // ContractReader performs read-only Soroban contract simulations via RPC.
+//
+// Every call it makes is a simulation — it never submits — so all of its
+// traffic is idempotent and eligible for the shared retry policy.
 type ContractReader struct {
 	rpcURL            string
 	networkPassphrase string
 	sourceAddress     string
 	httpClient        *http.Client
+	rpcOpts           RPCOptions
+	rpc               *rpcClient
 }
 
 // NewContractReader builds a reader that simulates view calls without submitting
@@ -29,21 +31,39 @@ func NewContractReader(rpcURL, networkPassphrase, sourceAddress string) *Contrac
 	if sourceAddress == "" {
 		sourceAddress = keypair.MustRandom().Address()
 	}
-	return &ContractReader{
+	r := &ContractReader{
 		rpcURL:            rpcURL,
 		networkPassphrase: networkPassphrase,
 		sourceAddress:     sourceAddress,
-		httpClient:        &http.Client{Timeout: 30 * time.Second},
+		httpClient:        &http.Client{Timeout: defaultRPCTimeout},
 	}
+	r.rebuildRPC()
+	return r
 }
 
 // SetHTTPClient replaces the HTTP client used for outbound calls. It exists so
-// startup can install a metrics-instrumented transport; a nil client is
-// ignored so callers need not branch.
+// startup can install a metrics-instrumented, circuit-broken transport; a nil
+// client is ignored so callers need not branch.
 func (r *ContractReader) SetHTTPClient(client *http.Client) {
 	if client != nil {
 		r.httpClient = client
+		r.rebuildRPC()
 	}
+}
+
+// SetRPCOptions installs the shared retry policy and its metrics observer.
+// Startup calls it; without it the reader retries on the package defaults,
+// which keeps tests and tooling working unchanged.
+func (r *ContractReader) SetRPCOptions(opts RPCOptions) {
+	r.rpcOpts = opts
+	r.rebuildRPC()
+}
+
+// rebuildRPC recreates the shared caller after any of its inputs change. The
+// caller is immutable once built, so replacing it is simpler than mutating it
+// under a lock — and these setters only ever run during startup wiring.
+func (r *ContractReader) rebuildRPC() {
+	r.rpc = newRPCClient(r.rpcURL, r.httpClient, r.rpcOpts, false)
 }
 
 // TotalAssets calls the vault_token total_assets() view and converts the i128
@@ -187,22 +207,8 @@ type simulateResultExtended struct {
 	ReturnValue     string `json:"returnValue,omitempty"`
 }
 
+// rpcCall delegates to the shared client so reads here get the same bounded,
+// jittered retry every other Soroban call site does (nester#1086).
 func (r *ContractReader) rpcCall(ctx context.Context, method string, params, result any) error {
-	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.rpcURL, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("rpc %s: %w", method, err)
-	}
-	defer resp.Body.Close()
-
-	return json.NewDecoder(resp.Body).Decode(result)
+	return r.rpc.call(ctx, method, params, result)
 }

--- a/apps/api/internal/stellar/reconciler.go
+++ b/apps/api/internal/stellar/reconciler.go
@@ -1,0 +1,220 @@
+package stellar
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+// SubmissionReconciler resolves pending chain submissions against the chain
+// (nester#1085).
+//
+// It is the only thing in the system permitted to decide that a submission
+// ended, and it decides by asking the chain about a specific transaction
+// hash. It never resubmits, never infers an outcome from elapsed time, and
+// never treats an unreachable RPC as an answer.
+//
+// It follows the repository's existing background-worker shape: a Run loop on
+// a ticker, gated by the same LeaderChecker the rebalancer and protocol-health
+// jobs use, so exactly one instance reconciles at a time.
+type SubmissionReconciler struct {
+	store  SubmissionStore
+	chain  ChainLookup
+	logger *slog.Logger
+
+	interval time.Duration
+	batch    int
+
+	// leader gates the sweep. Nil means "always leader", matching the
+	// convention in internal/scheduler so single-instance deployments and
+	// tests are unaffected.
+	leader LeaderChecker
+
+	now func() time.Time
+}
+
+// LeaderChecker reports whether this instance currently holds leadership.
+// Structurally identical to scheduler.LeaderChecker; declared here so the
+// stellar package does not depend on the scheduler package.
+type LeaderChecker interface {
+	IsLeader() bool
+}
+
+// Defaults for the reconciliation sweep.
+//
+// The interval is short relative to the five-minute transaction time bounds,
+// so a submission that will resolve does so promptly; the batch bounds how
+// much work one sweep does, so a backlog drains steadily rather than in one
+// burst against a recovering RPC.
+const (
+	DefaultReconcileInterval = 15 * time.Second
+	DefaultReconcileBatch    = 50
+)
+
+// NewSubmissionReconciler builds a reconciler. A nil logger, zero interval, or
+// zero batch take sensible defaults.
+func NewSubmissionReconciler(store SubmissionStore, chain ChainLookup, logger *slog.Logger) *SubmissionReconciler {
+	return &SubmissionReconciler{
+		store:    store,
+		chain:    chain,
+		logger:   logger,
+		interval: DefaultReconcileInterval,
+		batch:    DefaultReconcileBatch,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetLeaderChecker wires leader election so only one instance sweeps.
+func (r *SubmissionReconciler) SetLeaderChecker(l LeaderChecker) { r.leader = l }
+
+// SetInterval overrides the sweep cadence.
+func (r *SubmissionReconciler) SetInterval(d time.Duration) {
+	if d > 0 {
+		r.interval = d
+	}
+}
+
+// SetClock injects a clock, so tests drive the sweep without sleeping.
+func (r *SubmissionReconciler) SetClock(now func() time.Time) {
+	if now != nil {
+		r.now = now
+	}
+}
+
+func (r *SubmissionReconciler) isLeader() bool {
+	return r.leader == nil || r.leader.IsLeader()
+}
+
+// Run sweeps until ctx is cancelled.
+//
+// Recovery after a restart needs no special path: the intents are in the
+// database, so the first sweep of a freshly started process picks up
+// everything the previous one left pending. No submission state lives in
+// memory.
+func (r *SubmissionReconciler) Run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.Tick(ctx)
+		}
+	}
+}
+
+// Tick performs one sweep. Exported so tests drive it directly rather than
+// waiting on a ticker.
+func (r *SubmissionReconciler) Tick(ctx context.Context) {
+	if !r.isLeader() {
+		return
+	}
+
+	// SKIP LOCKED in the store means a concurrent reconciler takes a
+	// different set, so two instances never work the same submission — and
+	// since neither ever resubmits, the worst case of an overlap is a
+	// duplicate read of the chain.
+	intents, err := r.store.ClaimPendingForReconcile(ctx, r.batch, r.now())
+	if err != nil {
+		r.log().Error("submission reconciler: failed to claim pending submissions", "error", err.Error())
+		return
+	}
+
+	for _, intent := range intents {
+		if ctx.Err() != nil {
+			return
+		}
+		r.reconcile(ctx, intent)
+	}
+}
+
+// reconcile resolves one submission, or leaves it pending.
+//
+// Every branch that does not produce a chain-derived outcome leaves the record
+// exactly as it found it. That is the whole job.
+func (r *SubmissionReconciler) reconcile(ctx context.Context, intent SubmissionIntent) {
+	status, view, err := r.chain.LookupTransaction(ctx, intent.TransactionHash)
+	if err != nil {
+		// The RPC is unreachable, timing out, or the circuit breaker is open.
+		// None of those is information about the transaction. Debug, not
+		// error: during an outage this runs every sweep for every pending
+		// submission, and logging it loudly would bury the incident in its
+		// own noise.
+		r.log().Debug("submission reconciler: chain unreachable, leaving submission pending",
+			"submission_id", intent.ID,
+			"transaction_hash", intent.TransactionHash,
+			"error", err.Error(),
+		)
+		return
+	}
+
+	outcome := DetermineOutcome(status, view, intent)
+	if outcome == OutcomeUnknown {
+		// The chain answered, but not conclusively — typically the
+		// transaction is still inside its validity window and may yet be
+		// included. Waiting is the correct action.
+		r.log().Debug("submission reconciler: outcome not yet determined",
+			"submission_id", intent.ID,
+			"transaction_hash", intent.TransactionHash,
+			"chain_status", string(status),
+		)
+		return
+	}
+
+	state := outcome.State()
+	detail := "chain reported " + string(status) + "; outcome " + outcome.String()
+
+	if err := r.store.Resolve(ctx, intent.ID, state, detail, r.now()); err != nil {
+		if errors.Is(err, ErrIntentNotFound) {
+			// Already resolved by another sweep, or purged. Nothing to do.
+			return
+		}
+		r.log().Error("submission reconciler: failed to persist outcome",
+			"submission_id", intent.ID,
+			"state", string(state),
+			"error", err.Error(),
+		)
+		return
+	}
+
+	r.logResolved(intent, status, outcome, state)
+}
+
+func (r *SubmissionReconciler) logResolved(
+	intent SubmissionIntent,
+	status TransactionStatus,
+	outcome ChainOutcome,
+	state SubmissionState,
+) {
+	attrs := []any{
+		"submission_id", intent.ID,
+		"transaction_hash", intent.TransactionHash,
+		"chain_status", string(status),
+		"outcome", outcome.String(),
+		"state", string(state),
+		// Surfaced explicitly because it is the safety-critical fact: whether
+		// this submission is now eligible for a fresh attempt, and why.
+		"permits_new_attempt", outcome.PermitsNewAttempt(),
+	}
+
+	switch state {
+	case SubmissionLanded:
+		r.log().Info("submission reconciler: transaction landed", attrs...)
+	case SubmissionUnresolvable:
+		// The one case a human must look at: the chain can no longer tell us
+		// what happened, so neither can we.
+		r.log().Error("submission reconciler: submission can no longer be resolved against the chain", attrs...)
+	default:
+		r.log().Warn("submission reconciler: transaction did not take effect", attrs...)
+	}
+}
+
+func (r *SubmissionReconciler) log() *slog.Logger {
+	if r.logger == nil {
+		return slog.Default()
+	}
+	return r.logger
+}

--- a/apps/api/internal/stellar/reconciler_test.go
+++ b/apps/api/internal/stellar/reconciler_test.go
@@ -1,0 +1,562 @@
+package stellar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memStore is an in-memory SubmissionStore with the same atomicity contract
+// the Postgres implementation provides, so the submit and reconcile flows can
+// be driven end to end without a database. The uniqueness guarantee is under
+// a mutex here and a unique index there; both make Claim atomic, which is
+// what the flow depends on.
+type memStore struct {
+	mu       sync.Mutex
+	byID     map[string]SubmissionIntent
+	byRef    map[string]string
+	nextID   int
+	claimErr error
+}
+
+func newMemStore() *memStore {
+	return &memStore{byID: map[string]SubmissionIntent{}, byRef: map[string]string{}}
+}
+
+func (s *memStore) Claim(_ context.Context, intent SubmissionIntent) (SubmissionIntent, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.claimErr != nil {
+		return SubmissionIntent{}, false, s.claimErr
+	}
+
+	if id, exists := s.byRef[intent.IdempotencyReference]; exists {
+		stored := s.byID[id]
+		if stored.TransactionHash != intent.TransactionHash {
+			return SubmissionIntent{}, false, ErrReferenceReused
+		}
+		return stored, false, nil
+	}
+
+	s.nextID++
+	intent.ID = fmt.Sprintf("sub-%d", s.nextID)
+	if intent.State == "" {
+		intent.State = SubmissionPending
+	}
+	s.byID[intent.ID] = intent
+	s.byRef[intent.IdempotencyReference] = intent.ID
+	return intent, true, nil
+}
+
+func (s *memStore) MarkSubmitted(_ context.Context, id string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	intent, ok := s.byID[id]
+	if !ok {
+		return ErrIntentNotFound
+	}
+	intent.SubmittedAt = &at
+	s.byID[id] = intent
+	return nil
+}
+
+func (s *memStore) Resolve(_ context.Context, id string, state SubmissionState, detail string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	intent, ok := s.byID[id]
+	if !ok {
+		return ErrIntentNotFound
+	}
+	if intent.State.Terminal() {
+		// Mirrors the Postgres guard: a settled submission is never reopened.
+		return ErrIntentNotFound
+	}
+	intent.State = state
+	intent.OutcomeDetail = detail
+	intent.ResolvedAt = &at
+	s.byID[id] = intent
+	return nil
+}
+
+func (s *memStore) Get(_ context.Context, id string) (SubmissionIntent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	intent, ok := s.byID[id]
+	if !ok {
+		return SubmissionIntent{}, ErrIntentNotFound
+	}
+	return intent, nil
+}
+
+func (s *memStore) ClaimPendingForReconcile(_ context.Context, limit int, _ time.Time) ([]SubmissionIntent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.claimErr != nil {
+		return nil, s.claimErr
+	}
+
+	var out []SubmissionIntent
+	for _, intent := range s.byID {
+		if intent.State.Terminal() || len(out) >= limit {
+			continue
+		}
+		out = append(out, intent)
+	}
+	return out, nil
+}
+
+func (s *memStore) state(t *testing.T, id string) SubmissionState {
+	t.Helper()
+	intent, err := s.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", id, err)
+	}
+	return intent.State
+}
+
+// scriptedChain answers LookupTransaction from a script and counts how many
+// times it was asked, so a test can prove the reconciler reads rather than
+// writes.
+type scriptedChain struct {
+	mu      sync.Mutex
+	status  TransactionStatus
+	view    ChainView
+	err     error
+	lookups int
+}
+
+func (c *scriptedChain) LookupTransaction(_ context.Context, _ string) (TransactionStatus, ChainView, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lookups++
+	return c.status, c.view, c.err
+}
+
+func (c *scriptedChain) set(status TransactionStatus, view ChainView, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.status, c.view, c.err = status, view, err
+}
+
+func (c *scriptedChain) lookupCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lookups
+}
+
+// submitOnce records a durable intent and simulates a submission whose
+// response was lost, which is the state every scenario below starts from.
+func submitOnce(t *testing.T, store *memStore) SubmissionIntent {
+	t.Helper()
+
+	intent, claimed, err := store.Claim(context.Background(), SubmissionIntent{
+		IdempotencyReference: "vault-deposit-abc",
+		TransactionHash:      "a1b2c3",
+		ValidUntil:           validUntil,
+		SourceAccount:        "GABC",
+		DomainAction:         "deposit",
+		State:                SubmissionPending,
+		CreatedAt:            submittedAt,
+	})
+	if err != nil || !claimed {
+		t.Fatalf("Claim() = (claimed %v, err %v), want a fresh claim", claimed, err)
+	}
+	if err := store.MarkSubmitted(context.Background(), intent.ID, submittedAt); err != nil {
+		t.Fatalf("MarkSubmitted: %v", err)
+	}
+
+	intent, _ = store.Get(context.Background(), intent.ID)
+	return intent
+}
+
+func newTestReconciler(store *memStore, chain ChainLookup, now time.Time) *SubmissionReconciler {
+	r := NewSubmissionReconciler(store, chain, nil)
+	r.SetClock(func() time.Time { return now })
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — response lost after success
+// ---------------------------------------------------------------------------
+
+// The whole point of the feature: one logical submission produces exactly one
+// chain submission, even though the response was lost and the caller has no
+// idea what happened.
+func TestReconcilerResolvesASuccessWhoseResponseWasLost(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("state after a lost response = %s, want pending", got)
+	}
+
+	// The chain says it landed.
+	chain := &scriptedChain{status: TxStatusSuccess, view: chainAt(insideWindow)}
+	newTestReconciler(store, chain, insideWindow).Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("state = %s, want landed", got)
+	}
+
+	// The reconciler only ever reads. Nothing about resolving a submission
+	// causes another one.
+	if chain.lookupCount() != 1 {
+		t.Fatalf("chain was consulted %d times, want 1", chain.lookupCount())
+	}
+
+	// Once landed, further sweeps leave it alone — it is terminal, so it is
+	// not even claimed for reconciliation again.
+	newTestReconciler(store, chain, insideWindow).Tick(context.Background())
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("a settled submission was reopened: state = %s", got)
+	}
+	if chain.lookupCount() != 1 {
+		t.Fatalf("a settled submission was re-checked; lookups = %d, want 1", chain.lookupCount())
+	}
+}
+
+// A duplicate request for the same logical operation must not submit again,
+// whatever state the original is in.
+func TestDuplicateReferenceNeverCreatesASecondSubmission(t *testing.T) {
+	store := newMemStore()
+	original := submitOnce(t, store)
+
+	for i := 0; i < 5; i++ {
+		stored, claimed, err := store.Claim(context.Background(), SubmissionIntent{
+			IdempotencyReference: "vault-deposit-abc",
+			TransactionHash:      "a1b2c3",
+			ValidUntil:           validUntil,
+			CreatedAt:            submittedAt,
+		})
+		if err != nil {
+			t.Fatalf("Claim: %v", err)
+		}
+		if claimed {
+			t.Fatalf("repeat %d claimed a second submission for the same reference", i)
+		}
+		if stored.ID != original.ID {
+			t.Fatalf("repeat %d returned submission %s, want the original %s", i, stored.ID, original.ID)
+		}
+	}
+
+	if len(store.byID) != 1 {
+		t.Fatalf("%d submissions exist for one logical operation, want 1", len(store.byID))
+	}
+}
+
+// A reference reused for a materially different transaction is refused rather
+// than silently attributed to the original.
+func TestReferenceReusedForADifferentTransactionIsRefused(t *testing.T) {
+	store := newMemStore()
+	submitOnce(t, store)
+
+	_, _, err := store.Claim(context.Background(), SubmissionIntent{
+		IdempotencyReference: "vault-deposit-abc",
+		TransactionHash:      "totally-different",
+		ValidUntil:           validUntil,
+		CreatedAt:            submittedAt,
+	})
+	if !errors.Is(err, ErrReferenceReused) {
+		t.Fatalf("Claim() = %v, want ErrReferenceReused", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — response lost after failure
+// ---------------------------------------------------------------------------
+
+// The ordering is what matters: no retry is permitted until the chain has
+// actually reported the failure.
+func TestReconcilerResolvesAFailureWhoseResponseWasLost(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	// While the chain has not answered, the record is pending and no retry
+	// is permitted.
+	chain := &scriptedChain{status: TxStatusNotFound, view: chainAt(insideWindow)}
+	reconciler := newTestReconciler(store, chain, insideWindow)
+	reconciler.Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("state before the chain answered = %s, want pending", got)
+	}
+
+	// The chain now reports the transaction landed and failed.
+	chain.set(TxStatusFailed, chainAt(insideWindow), nil)
+	reconciler.Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionRejected {
+		t.Fatalf("state = %s, want rejected", got)
+	}
+
+	// Only now does a fresh attempt become permissible, and only because the
+	// chain said so.
+	resolved, _ := store.Get(context.Background(), intent.ID)
+	outcome := DetermineOutcome(TxStatusFailed, chainAt(insideWindow), resolved)
+	if !outcome.PermitsNewAttempt() {
+		t.Fatal("a chain-confirmed failure did not permit a fresh attempt")
+	}
+}
+
+// The same shape for a transaction that expired without ever landing.
+func TestReconcilerResolvesAnExpiredSubmission(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	chain := &scriptedChain{status: TxStatusNotFound, view: chainAt(insideWindow)}
+	reconciler := newTestReconciler(store, chain, insideWindow)
+
+	// Inside the window: still pending, however many times we look.
+	for i := 0; i < 10; i++ {
+		reconciler.Tick(context.Background())
+	}
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("state inside the validity window = %s, want pending", got)
+	}
+
+	// The chain's clock passes the transaction's signed maxTime.
+	chain.set(TxStatusNotFound, chainAt(pastTheWindow), nil)
+	newTestReconciler(store, chain, pastTheWindow).Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionExpired {
+		t.Fatalf("state = %s, want expired", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — RPC unavailable throughout
+// ---------------------------------------------------------------------------
+
+// Neither submission nor reconciliation can reach the chain. The record must
+// stay pending: not landed, not failed, and above all not resubmitted.
+func TestReconcilerLeavesSubmissionPendingWhileRPCIsUnavailable(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	chain := &scriptedChain{err: errors.New("connection refused")}
+	reconciler := newTestReconciler(store, chain, pastTheWindow)
+
+	// Sweep repeatedly, well past the transaction's validity window. An
+	// unreachable RPC never becomes evidence, however long the outage lasts.
+	for i := 0; i < 50; i++ {
+		reconciler.Tick(context.Background())
+		if got := store.state(t, intent.ID); got != SubmissionPending {
+			t.Fatalf("sweep %d moved the submission to %s while the RPC was down", i, got)
+		}
+	}
+
+	if chain.lookupCount() != 50 {
+		t.Fatalf("chain lookups = %d, want one per sweep", chain.lookupCount())
+	}
+
+	// When the RPC comes back, the outcome is determined normally — the
+	// record survived the whole outage.
+	chain.set(TxStatusSuccess, chainAt(pastTheWindow), nil)
+	reconciler.Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("state after recovery = %s, want landed", got)
+	}
+}
+
+// An open circuit breaker is an RPC that cannot be contacted, not a statement
+// about the transaction. It must be indistinguishable from any other outage
+// as far as the submission record is concerned (nester#1087).
+func TestOpenCircuitBreakerIsNotEvidenceAboutTheTransaction(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	chain := &scriptedChain{err: fmt.Errorf("rpc getTransaction: %w", errors.New("circuit breaker is open"))}
+	reconciler := newTestReconciler(store, chain, pastTheWindow)
+
+	for i := 0; i < 20; i++ {
+		reconciler.Tick(context.Background())
+	}
+
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("an open breaker resolved the submission to %s, want pending", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Restart recovery
+// ---------------------------------------------------------------------------
+
+// No submission state lives in memory. A brand-new reconciler — standing in
+// for a restarted process — picks up what the previous one left pending.
+func TestPendingSubmissionsSurviveAProcessRestart(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	// The process that submitted dies here, having learned nothing.
+	chain := &scriptedChain{err: errors.New("connection refused")}
+	newTestReconciler(store, chain, insideWindow).Tick(context.Background())
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("state = %s, want pending", got)
+	}
+
+	// A fresh reconciler, with no knowledge of the original request, resolves
+	// it purely from what is in the store.
+	chain.set(TxStatusSuccess, chainAt(insideWindow), nil)
+	restarted := NewSubmissionReconciler(store, chain, nil)
+	restarted.SetClock(func() time.Time { return insideWindow })
+	restarted.Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("state after restart = %s, want landed", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// Concurrent duplicate requests collapse to a single submission. The
+// uniqueness guarantee is the store's, not the caller's — there is no
+// read-then-write in application code that a race could slip between.
+func TestConcurrentDuplicateRequestsProduceOneSubmission(t *testing.T) {
+	store := newMemStore()
+
+	const callers = 32
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		claims int
+		ids    = map[string]struct{}{}
+	)
+
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			stored, claimed, err := store.Claim(context.Background(), SubmissionIntent{
+				IdempotencyReference: "vault-deposit-abc",
+				TransactionHash:      "a1b2c3",
+				ValidUntil:           validUntil,
+				CreatedAt:            submittedAt,
+			})
+			if err != nil {
+				t.Errorf("Claim: %v", err)
+				return
+			}
+
+			mu.Lock()
+			if claimed {
+				claims++
+			}
+			ids[stored.ID] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if claims != 1 {
+		t.Fatalf("%d of %d concurrent requests claimed a submission, want exactly 1", claims, callers)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("concurrent requests saw %d distinct submissions, want 1", len(ids))
+	}
+	if len(store.byID) != 1 {
+		t.Fatalf("%d submissions were created, want 1", len(store.byID))
+	}
+}
+
+// Concurrent reconcilers must not both resolve the same submission, and the
+// second must not overwrite the first's outcome.
+func TestConcurrentReconcilersResolveASubmissionOnce(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	chain := &scriptedChain{status: TxStatusSuccess, view: chainAt(insideWindow)}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			newTestReconciler(store, chain, insideWindow).Tick(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("state = %s, want landed", got)
+	}
+}
+
+// A late reconciliation must never reopen a settled submission.
+func TestResolvedSubmissionsAreNotReopened(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	if err := store.Resolve(context.Background(), intent.ID, SubmissionLanded, "landed", insideWindow); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// A stale sweep tries to record a different outcome.
+	err := store.Resolve(context.Background(), intent.ID, SubmissionExpired, "stale", pastTheWindow)
+	if err == nil {
+		t.Fatal("a settled submission accepted a second outcome")
+	}
+	if got := store.state(t, intent.ID); got != SubmissionLanded {
+		t.Fatalf("state = %s, want it to remain landed", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Leadership
+// ---------------------------------------------------------------------------
+
+type notLeader struct{}
+
+func (notLeader) IsLeader() bool { return false }
+
+// A non-leader instance does no work, so a multi-instance deployment does not
+// multiply chain reads by its replica count.
+func TestNonLeaderDoesNotSweep(t *testing.T) {
+	store := newMemStore()
+	submitOnce(t, store)
+
+	chain := &scriptedChain{status: TxStatusSuccess, view: chainAt(insideWindow)}
+	reconciler := newTestReconciler(store, chain, insideWindow)
+	reconciler.SetLeaderChecker(notLeader{})
+
+	reconciler.Tick(context.Background())
+
+	if chain.lookupCount() != 0 {
+		t.Fatalf("a non-leader made %d chain lookups, want 0", chain.lookupCount())
+	}
+}
+
+// A store that cannot be read leaves everything pending rather than failing
+// into a guess.
+func TestReconcilerToleratesAStoreFailure(t *testing.T) {
+	store := newMemStore()
+	intent := submitOnce(t, store)
+
+	chain := &scriptedChain{status: TxStatusSuccess, view: chainAt(insideWindow)}
+	reconciler := newTestReconciler(store, chain, insideWindow)
+
+	store.mu.Lock()
+	store.claimErr = errors.New("database unavailable")
+	store.mu.Unlock()
+
+	reconciler.Tick(context.Background())
+
+	if got := store.state(t, intent.ID); got != SubmissionPending {
+		t.Fatalf("state = %s, want pending", got)
+	}
+}

--- a/apps/api/internal/stellar/rpcclient.go
+++ b/apps/api/internal/stellar/rpcclient.go
@@ -1,0 +1,326 @@
+package stellar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
+	"github.com/suncrestlabs/nester/apps/api/internal/telemetry"
+)
+
+// rpcClient is the single entry point for every Soroban JSON-RPC call in this
+// package (nester#1086).
+//
+// It existed in duplicate before — ContractReader and ContractInvoker each had
+// their own rpcCall, and the indexer, the fetcher, and the backfill runner each
+// hand-rolled a third variation. None of them retried, none of them checked the
+// HTTP status, and a transient connection reset during a balance read surfaced
+// as an error on the user's screen. Consolidating them is what makes "one
+// retry policy" true rather than aspirational: there is now nowhere else to
+// make a Soroban call from.
+//
+// Layering, outermost first:
+//
+//	rpcClient.call        retry loop
+//	  http.Client         circuit breaker transport (nester#1087)
+//	    …                 metrics transport
+//	      …               net/http
+//
+// The retry loop sits OUTSIDE the breaker, deliberately. Each attempt is a
+// real connection against the upstream, so each is evidence the breaker should
+// weigh; and once the breaker opens, the loop's next attempt fails fast
+// locally instead of burning its remaining backoff on an endpoint that is
+// already known to be down. Putting retry inside the breaker would hide the
+// attempts from it and let a retry storm run to completion against a dead
+// endpoint.
+type rpcClient struct {
+	url    string
+	client *http.Client
+
+	runner *retry.Runner
+	policy retry.Policy
+
+	// observer records attempts, exhaustions, and call latency. Nil is safe
+	// and means "no metrics", so tests and tooling need no wiring.
+	observer RPCObserver
+
+	// traced controls whether each call opens a span. The invoker's calls
+	// carry transaction context worth separating in a waterfall; the
+	// indexer's poll every few seconds does not, and tracing it would swamp
+	// the trace store with identical background spans.
+	traced bool
+}
+
+// RPCOptions is the shared retry wiring that startup installs on every Soroban
+// caller in this package. The zero value is usable: it means the package
+// defaults and no metrics, which is what a test or the backfill CLI gets.
+type RPCOptions struct {
+	Runner   *retry.Runner
+	Policy   retry.Policy
+	Observer RPCObserver
+}
+
+// RPCObserver receives one report per logical RPC call, after any retries.
+// Implemented by *metrics.Metrics; declared here so this package does not
+// depend on the metrics package.
+type RPCObserver interface {
+	// RecordRPCCall reports a completed call: how many attempts it took, how
+	// long the whole thing took including backoff, and whether it ended by
+	// exhausting the retry policy.
+	RecordRPCCall(attempts int, elapsed time.Duration, exhausted bool)
+}
+
+// newRPCClient builds a caller for one Soroban RPC endpoint.
+//
+// A nil http.Client falls back to a plain one; a nil runner to a real-clock
+// one. Both defaults exist so a caller constructed outside startup — a test,
+// the backfill CLI — behaves sensibly rather than panicking.
+func newRPCClient(rpcURL string, client *http.Client, opts RPCOptions, traced bool) *rpcClient {
+	if client == nil {
+		client = &http.Client{Timeout: defaultRPCTimeout}
+	}
+	if opts.Runner == nil {
+		opts.Runner = retry.New()
+	}
+	return &rpcClient{
+		url:      rpcURL,
+		client:   client,
+		runner:   opts.Runner,
+		policy:   opts.Policy,
+		observer: opts.Observer,
+		traced:   traced,
+	}
+}
+
+// defaultRPCTimeout bounds one HTTP attempt when no client is supplied. The
+// retry budget bounds the loop as a whole; this bounds a single hung attempt
+// within it.
+const defaultRPCTimeout = 30 * time.Second
+
+// rpcStatusError is a non-2xx HTTP response from the RPC endpoint.
+//
+// It exists so retryability can be decided on the status rather than on
+// whether a JSON decode happened to fail: before this, a 502 carrying an HTML
+// error page surfaced as an opaque JSON syntax error, which is both useless to
+// read and impossible to classify.
+type rpcStatusError struct {
+	Method     string
+	StatusCode int
+	Body       string
+}
+
+func (e *rpcStatusError) Error() string {
+	return fmt.Sprintf("rpc %s returned %d: %s", e.Method, e.StatusCode, e.Body)
+}
+
+// idempotentRPCMethods is the closed set of Soroban RPC methods that may be
+// retried automatically.
+//
+// The distinction is the whole safety argument of this feature. A read can be
+// repeated freely: worst case the caller pays for a round trip it did not
+// need. sendTransaction cannot — a resubmitted envelope is a second attempt to
+// move real money, and while Stellar's sequence numbers make a true double
+// spend unlikely, "unlikely" is not a property to build a savings product on.
+// Writes are durably tracked and resubmitted by the submission record instead
+// (see submission_pipeline.go), which owns sequence allocation and
+// double-submit prevention precisely because that logic cannot live in a
+// stateless retry loop.
+//
+// An unrecognised method is NOT retried. Failing closed means a Soroban method
+// added later is safe by default, and someone must think about it to opt in.
+var idempotentRPCMethods = map[string]bool{
+	"getEvents":           true,
+	"getHealth":           true,
+	"getLatestLedger":     true,
+	"getLedgerEntries":    true,
+	"getNetwork":          true,
+	"getTransaction":      true,
+	"simulateTransaction": true,
+
+	// Explicitly listed as false rather than merely omitted, so that reading
+	// this map answers "why isn't the submit retried" without needing to know
+	// the default.
+	"sendTransaction": false,
+}
+
+// isIdempotentRPCMethod reports whether method may be retried automatically.
+func isIdempotentRPCMethod(method string) bool {
+	return idempotentRPCMethods[method]
+}
+
+// retryableRPCError decides whether a failed attempt is worth repeating.
+//
+// Retried: transport failures (connection refused, reset, DNS, TLS), read
+// timeouts, and the status codes that mean "not now" — 5xx and 429. These are
+// the failures that clear on their own, and they are the ones this issue
+// exists to stop surfacing to users.
+//
+// Not retried:
+//
+//   - breaker.ErrOpen. The breaker has already decided the upstream is unwell;
+//     retrying against it is pure latency, and the loop must fail out
+//     immediately so the caller gets its fast failure.
+//   - Caller cancellation. Nobody is waiting for the answer any more.
+//   - Any other 4xx. The upstream is healthy and rejecting our request;
+//     repeating it produces the same rejection three times slower.
+//   - JSON-RPC application errors. Those arrive inside a 200 and are decoded
+//     by the call site, not here — see the note in call().
+func retryableRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Checked first: an open breaker is the one failure that must never be
+	// retried, and it can be wrapped inside a *url.Error by http.Client.
+	if errors.Is(err, breaker.ErrOpen) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	var statusErr *rpcStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode >= 500 || statusErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	// A response that ended mid-body is a transport fault wearing a decoder's
+	// clothes; the next attempt usually gets a whole one.
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+
+	// A deadline that expired is the classic symptom of a degrading endpoint.
+	// Note this is the *attempt's* deadline; the loop's own budget expiring is
+	// handled by retry.Do, which stops rather than asking this.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// What remains at this point is a transport error, since every decode and
+	// status path above is accounted for.
+	var jsonErr *json.SyntaxError
+	if errors.As(err, &jsonErr) {
+		// A syntactically invalid body from a 2xx response is deterministic
+		// garbage, not a blip.
+		return false
+	}
+
+	return true
+}
+
+// call performs one logical JSON-RPC call, retrying it when the method is
+// idempotent and the failure looks transient.
+//
+// result is decoded from the response body. JSON-RPC *application* errors —
+// the `error` member of a 200 response — are deliberately not inspected here:
+// they are decoded into the caller's own result type, and they are
+// deterministic (a bad contract argument fails identically every time), so
+// retrying them would triple the latency of every genuine rejection.
+func (c *rpcClient) call(ctx context.Context, method string, params, result any) error {
+	var span trace.Span
+	if c.traced {
+		ctx, span = startRPCSpan(ctx, method)
+		defer span.End()
+	}
+
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
+	if err != nil {
+		recordRPCError(span, err)
+		return err
+	}
+
+	// The idempotency gate. A write reaches retry.Do with a nil predicate, so
+	// it runs exactly once and still produces the same metrics and the same
+	// typed error shape as a read — the policy is uniform, only the retrying
+	// is not.
+	var retryable func(error) bool
+	if isIdempotentRPCMethod(method) {
+		retryable = retryableRPCError
+	}
+
+	res, err := c.runner.Do(ctx, c.policy, retryable, func(ctx context.Context) error {
+		return c.attempt(ctx, method, body, result)
+	})
+
+	c.observe(res, err)
+
+	if err != nil {
+		wrapped := fmt.Errorf("rpc %s: %w", method, err)
+		recordRPCError(span, wrapped)
+		return wrapped
+	}
+	return nil
+}
+
+// attempt performs one HTTP round trip. It is called once per retry, and must
+// therefore not consume anything it cannot rebuild — hence body is passed in
+// as bytes and wrapped in a fresh reader each time.
+func (c *rpcClient) attempt(ctx context.Context, method string, body []byte, result any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if c.traced {
+		recordRPCStatus(ctx, resp.StatusCode)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// Bounded read: an error page can be arbitrarily large, and this text
+		// ends up in an error string.
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return &rpcStatusError{Method: method, StatusCode: resp.StatusCode, Body: string(payload)}
+	}
+
+	// UseNumber throughout: event payloads decode into map[string]any, and
+	// Soroban amounts are stroops that routinely exceed float64's exact
+	// integer range. Decoding them as float64 would silently round a balance.
+	decoder := json.NewDecoder(resp.Body)
+	decoder.UseNumber()
+	return decoder.Decode(result)
+}
+
+func (c *rpcClient) observe(res retry.Result, err error) {
+	if c.observer == nil {
+		return
+	}
+	c.observer.RecordRPCCall(res.Attempts, res.Elapsed, errors.Is(err, retry.ErrExhausted))
+}
+
+// recordRPCStatus attaches the HTTP status of an attempt to the active span.
+// With retries, a span can carry several of these; the last one is the status
+// the call ended on.
+func recordRPCStatus(ctx context.Context, statusCode int) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(semconv.HTTPResponseStatusCode(statusCode))
+}
+
+// recordRPCError marks the span failed, tolerating the untraced case where
+// there is no span at all.
+func recordRPCError(span trace.Span, err error) {
+	if span == nil {
+		return
+	}
+	telemetry.RecordError(span, err)
+}

--- a/apps/api/internal/stellar/rpcclient_test.go
+++ b/apps/api/internal/stellar/rpcclient_test.go
@@ -1,0 +1,538 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/breaker"
+	"github.com/suncrestlabs/nester/apps/api/internal/retry"
+)
+
+// recordingObserver captures what the retry helper reports, so the metrics
+// contract can be asserted without a Prometheus registry.
+type recordingObserver struct {
+	calls     int
+	attempts  int
+	exhausted int
+	elapsed   time.Duration
+}
+
+func (o *recordingObserver) RecordRPCCall(attempts int, elapsed time.Duration, exhausted bool) {
+	o.calls++
+	o.attempts += attempts
+	o.elapsed += elapsed
+	if exhausted {
+		o.exhausted++
+	}
+}
+
+// noSleepOptions returns retry options that never actually wait, so tests
+// exercise the full attempt schedule in microseconds rather than seconds.
+func noSleepOptions(observer RPCObserver) RPCOptions {
+	return RPCOptions{
+		Runner: retry.NewWithClock(
+			time.Now,
+			func(context.Context, time.Duration) error { return nil },
+			func(time.Duration) time.Duration { return 0 },
+		),
+		Policy: retry.Policy{
+			MaxAttempts: 3,
+			BaseDelay:   time.Millisecond,
+			MaxDelay:    time.Millisecond,
+			Budget:      10 * time.Second,
+		},
+		Observer: observer,
+	}
+}
+
+// rpcServer counts requests per JSON-RPC method and replies with whatever the
+// handler decides, so a test can assert exactly how many times a method was
+// actually sent over the wire.
+type rpcServer struct {
+	server   *httptest.Server
+	requests atomic.Int64
+	// byMethod counts calls per method name read from the request body,
+	// which is how the write-is-not-retried assertion is made.
+	byMethod sync.Map
+}
+
+func newRPCServer(t *testing.T, handler func(method string, count int, w http.ResponseWriter)) *rpcServer {
+	t.Helper()
+
+	s := &rpcServer{}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		s.requests.Add(1)
+		count := s.increment(req.Method)
+		handler(req.Method, count, w)
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *rpcServer) increment(method string) int {
+	actual, _ := s.byMethod.LoadOrStore(method, new(atomic.Int64))
+	return int(actual.(*atomic.Int64).Add(1))
+}
+
+func (s *rpcServer) count(method string) int {
+	value, ok := s.byMethod.Load(method)
+	if !ok {
+		return 0
+	}
+	return int(value.(*atomic.Int64).Load())
+}
+
+// roundTripFunc stands in for a transport whose failures are scripted, so
+// tests can produce errors net/http would otherwise have to be provoked into.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func writeRPCResult(w http.ResponseWriter, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": result})
+}
+
+// ---------------------------------------------------------------------------
+// The idempotency gate — the safety property of this feature
+// ---------------------------------------------------------------------------
+
+// A write must never be repeated automatically. A resubmitted envelope is a
+// second attempt to move real money; durability for the write path comes from
+// the submission record, not from trying again here.
+func TestWritesAreNeverRetried(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	observer := &recordingObserver{}
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(observer), false)
+
+	var result map[string]any
+	err := client.call(context.Background(), "sendTransaction", map[string]any{"transaction": "AAAA"}, &result)
+
+	if err == nil {
+		t.Fatal("call() = nil, want the 500 to surface")
+	}
+	if got := server.count("sendTransaction"); got != 1 {
+		t.Fatalf("sendTransaction was sent %d times, want exactly 1: a write must never be retried", got)
+	}
+	if observer.attempts != 1 {
+		t.Fatalf("observed attempts = %d, want 1", observer.attempts)
+	}
+}
+
+// The gate is a property of the method, not of the error: even a textbook
+// transient failure does not earn a write a second attempt.
+func TestWriteIsNotRetriedOnATransportFailure(t *testing.T) {
+	calls := 0
+	client := newRPCClient("http://127.0.0.1:1/rpc", &http.Client{Timeout: time.Second}, noSleepOptions(nil), false)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, errors.New("connection refused")
+	})}
+
+	var result map[string]any
+	_ = client.call(context.Background(), "sendTransaction", nil, &result)
+
+	if calls != 1 {
+		t.Fatalf("sendTransaction attempted %d times on a transport failure, want 1", calls)
+	}
+}
+
+// A method nobody has classified fails closed. That way a Soroban method added
+// to the RPC later is safe by default and someone has to think about it to opt
+// in.
+func TestUnknownMethodsAreNotRetried(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var result map[string]any
+	_ = client.call(context.Background(), "someMethodInventedNextYear", nil, &result)
+
+	if got := server.count("someMethodInventedNextYear"); got != 1 {
+		t.Fatalf("unknown method was sent %d times, want 1", got)
+	}
+}
+
+func TestIdempotencyClassification(t *testing.T) {
+	retried := []string{
+		"getEvents", "getHealth", "getLatestLedger",
+		"getLedgerEntries", "getNetwork", "getTransaction", "simulateTransaction",
+	}
+	for _, method := range retried {
+		if !isIdempotentRPCMethod(method) {
+			t.Errorf("%s should be retryable", method)
+		}
+	}
+
+	for _, method := range []string{"sendTransaction", "", "unknown"} {
+		if isIdempotentRPCMethod(method) {
+			t.Errorf("%s must not be retryable", method)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reads are retried
+// ---------------------------------------------------------------------------
+
+// The reason the feature exists: a transient failure during a read is absorbed
+// instead of reaching the user.
+func TestReadRecoversFromATransientFailure(t *testing.T) {
+	server := newRPCServer(t, func(_ string, count int, w http.ResponseWriter) {
+		if count < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		writeRPCResult(w, map[string]any{"sequence": 493812})
+	})
+
+	observer := &recordingObserver{}
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(observer), false)
+
+	var resp struct {
+		Result struct {
+			Sequence uint64 `json:"sequence"`
+		} `json:"result"`
+	}
+	if err := client.call(context.Background(), "getLatestLedger", nil, &resp); err != nil {
+		t.Fatalf("call() = %v, want nil after recovery", err)
+	}
+
+	if resp.Result.Sequence != 493812 {
+		t.Fatalf("sequence = %d, want 493812", resp.Result.Sequence)
+	}
+	if got := server.count("getLatestLedger"); got != 3 {
+		t.Fatalf("sent %d times, want 3", got)
+	}
+	if observer.attempts != 3 {
+		t.Fatalf("observed attempts = %d, want 3", observer.attempts)
+	}
+	if observer.exhausted != 0 {
+		t.Fatalf("observed %d exhaustions on a call that succeeded", observer.exhausted)
+	}
+}
+
+// The request body must be replayable: a retry that sent an empty body would
+// fail against a real endpoint in a way no unit test of the loop alone would
+// catch.
+func TestRequestBodyIsResentOnEveryAttempt(t *testing.T) {
+	var bodies []string
+	server := newRPCServer(t, func(_ string, count int, w http.ResponseWriter) {
+		if count < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeRPCResult(w, map[string]any{"ok": true})
+	})
+
+	// Re-wrap the handler so the raw body of each attempt is captured.
+	server.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		encoded, _ := json.Marshal(raw)
+		bodies = append(bodies, string(encoded))
+
+		if len(bodies) < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeRPCResult(w, map[string]any{"ok": true})
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var result map[string]any
+	if err := client.call(context.Background(), "getEvents", map[string]any{"startLedger": 42}, &result); err != nil {
+		t.Fatalf("call() = %v, want nil", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("captured %d bodies, want 2", len(bodies))
+	}
+	if bodies[0] != bodies[1] {
+		t.Fatalf("retry sent a different body:\n first: %s\nsecond: %s", bodies[0], bodies[1])
+	}
+	if bodies[1] == "" || bodies[1] == "null" {
+		t.Fatalf("retry sent an empty body: %q", bodies[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Failure classification
+// ---------------------------------------------------------------------------
+
+func TestRetryableRPCError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+
+		// The breaker has already decided the upstream is down; retrying past
+		// it is pure latency and defeats the fast-fail it exists to provide.
+		{"breaker open", &breaker.OpenError{Name: "soroban_rpc"}, false},
+		{"wrapped breaker open", fmt.Errorf("do: %w", &breaker.OpenError{}), false},
+
+		{"caller cancelled", context.Canceled, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+
+		{"500", &rpcStatusError{StatusCode: 500}, true},
+		{"502", &rpcStatusError{StatusCode: 502}, true},
+		{"503", &rpcStatusError{StatusCode: 503}, true},
+		{"429", &rpcStatusError{StatusCode: 429}, true},
+
+		// The upstream is healthy and rejecting our request; repeating it
+		// produces the same rejection three times slower.
+		{"400", &rpcStatusError{StatusCode: 400}, false},
+		{"404", &rpcStatusError{StatusCode: 404}, false},
+		{"wrapped 500", fmt.Errorf("rpc: %w", &rpcStatusError{StatusCode: 500}), true},
+
+		{"transport failure", errors.New("connection reset by peer"), true},
+		{"malformed json", &json.SyntaxError{}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := retryableRPCError(tc.err); got != tc.want {
+				t.Fatalf("retryableRPCError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// A 4xx is the upstream working correctly. Retrying it would let ordinary bad
+// input cost three round trips and three times the latency.
+func TestClientErrorsAreNotRetried(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var result map[string]any
+	err := client.call(context.Background(), "getEvents", nil, &result)
+	if err == nil {
+		t.Fatal("call() = nil, want the 400 to surface")
+	}
+	if got := server.count("getEvents"); got != 1 {
+		t.Fatalf("a 400 was retried %d times, want 1 attempt", got)
+	}
+	if errors.Is(err, retry.ErrExhausted) {
+		t.Fatal("a declined 4xx was reported as retry exhaustion")
+	}
+}
+
+// An open circuit breaker must stop the retry loop dead, not have it burn its
+// whole schedule against an endpoint already known to be down.
+func TestOpenBreakerStopsTheRetryLoop(t *testing.T) {
+	calls := 0
+	client := newRPCClient("https://soroban.example/rpc", &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return nil, &breaker.OpenError{Name: "soroban_rpc", RetryIn: 15 * time.Second}
+		}),
+	}, noSleepOptions(nil), false)
+
+	var result map[string]any
+	err := client.call(context.Background(), "getEvents", nil, &result)
+
+	if calls != 1 {
+		t.Fatalf("attempted %d times against an open breaker, want 1", calls)
+	}
+	if !errors.Is(err, breaker.ErrOpen) {
+		t.Fatalf("call() = %v, want it to carry breaker.ErrOpen", err)
+	}
+	if errors.Is(err, retry.ErrExhausted) {
+		t.Fatal("a breaker rejection was reported as retry exhaustion")
+	}
+}
+
+// A non-2xx must surface as a typed status error rather than as whatever the
+// JSON decoder made of an HTML error page — which is both unreadable and
+// impossible to classify.
+func TestNonSuccessStatusBecomesATypedError(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("<html>go away</html>"))
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var result map[string]any
+	err := client.call(context.Background(), "getEvents", nil, &result)
+
+	var statusErr *rpcStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("call() = %v, want an *rpcStatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", statusErr.StatusCode)
+	}
+	if statusErr.Method != "getEvents" {
+		t.Fatalf("method = %q, want getEvents", statusErr.Method)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustion
+// ---------------------------------------------------------------------------
+
+// Exhaustion must be recognisable as exhaustion so the API answers 503 rather
+// than a generic 500, and must keep its cause so the log still names what
+// broke.
+func TestExhaustionProducesATypedError(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	observer := &recordingObserver{}
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(observer), false)
+
+	var result map[string]any
+	err := client.call(context.Background(), "getEvents", nil, &result)
+
+	if !errors.Is(err, retry.ErrExhausted) {
+		t.Fatalf("call() = %v, want it to match retry.ErrExhausted", err)
+	}
+
+	var statusErr *rpcStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("call() = %v, want the underlying status error preserved", err)
+	}
+	if statusErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("underlying status = %d, want 503", statusErr.StatusCode)
+	}
+
+	if got := server.count("getEvents"); got != 3 {
+		t.Fatalf("sent %d times, want 3 (the attempt cap)", got)
+	}
+	if observer.exhausted != 1 {
+		t.Fatalf("observed %d exhaustions, want 1", observer.exhausted)
+	}
+	if observer.attempts != 3 {
+		t.Fatalf("observed attempts = %d, want 3", observer.attempts)
+	}
+}
+
+// Every completed call is reported exactly once, whatever the outcome, or the
+// attempts-per-call ratio the metrics are read as would be wrong.
+func TestObserverSeesEveryCallExactlyOnce(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		writeRPCResult(w, map[string]any{"ok": true})
+	})
+
+	observer := &recordingObserver{}
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(observer), false)
+
+	for i := 0; i < 5; i++ {
+		var result map[string]any
+		if err := client.call(context.Background(), "getEvents", nil, &result); err != nil {
+			t.Fatalf("call() = %v", err)
+		}
+	}
+
+	if observer.calls != 5 {
+		t.Fatalf("observer saw %d calls, want 5", observer.calls)
+	}
+	if observer.attempts != 5 {
+		t.Fatalf("observed attempts = %d, want 5 for five first-try successes", observer.attempts)
+	}
+}
+
+// A nil observer must be safe, so a client built outside startup needs no
+// wiring.
+func TestNilObserverIsSafe(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		writeRPCResult(w, map[string]any{"ok": true})
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), RPCOptions{}, false)
+
+	var result map[string]any
+	if err := client.call(context.Background(), "getEvents", nil, &result); err != nil {
+		t.Fatalf("call() = %v, want nil", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+// Soroban amounts are stroops and routinely exceed float64's exact integer
+// range. Decoding them as float64 would silently round a balance, so every
+// call decodes with UseNumber.
+func TestLargeIntegersDecodeWithoutLosingPrecision(t *testing.T) {
+	const exact = "9007199254740993" // 2^53 + 1: the first integer float64 cannot represent
+
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"amount":` + exact + `}}`))
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var resp struct {
+		Result map[string]any `json:"result"`
+	}
+	if err := client.call(context.Background(), "getEvents", nil, &resp); err != nil {
+		t.Fatalf("call() = %v", err)
+	}
+
+	number, ok := resp.Result["amount"].(json.Number)
+	if !ok {
+		t.Fatalf("amount decoded as %T, want json.Number", resp.Result["amount"])
+	}
+	if number.String() != exact {
+		t.Fatalf("amount = %s, want %s", number.String(), exact)
+	}
+}
+
+// A JSON-RPC application error arrives inside a 200 and is decoded by the call
+// site, not retried: a bad contract argument fails identically every time, so
+// repeating it would triple the latency of every genuine rejection.
+func TestApplicationErrorsInsideA200AreNotRetried(t *testing.T) {
+	server := newRPCServer(t, func(_ string, _ int, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"error":   map[string]any{"code": -32602, "message": "startLedger must be within the retention window"},
+		})
+	})
+
+	client := newRPCClient(server.server.URL, server.server.Client(), noSleepOptions(nil), false)
+
+	var resp struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := client.call(context.Background(), "getEvents", nil, &resp); err != nil {
+		t.Fatalf("call() = %v, want nil: a 200 is a successful round trip", err)
+	}
+	if got := server.count("getEvents"); got != 1 {
+		t.Fatalf("an application error was retried %d times, want 1", got)
+	}
+	if resp.Error == nil {
+		t.Fatal("the application error was not decoded for the call site")
+	}
+}

--- a/apps/api/internal/stellar/submission.go
+++ b/apps/api/internal/stellar/submission.go
@@ -1,0 +1,355 @@
+package stellar
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stellar/go/txnbuild"
+)
+
+// Durable submission records (nester#1085).
+//
+// The problem: if Soroban RPC times out after accepting a transaction, we do
+// not know whether it landed. Resubmitting risks doing the operation twice —
+// moving a user's money twice. Refusing to resubmit leaves it unresolved.
+//
+// The resolution is that a timeout is not an outcome. It is the absence of
+// one. The durable record carries the submission across the timeout, and the
+// chain — not a timer, not an error value, not the circuit breaker — is what
+// eventually supplies the outcome.
+//
+// The invariant this file exists to make unmissable:
+//
+//	A submission is retried ONLY when the chain proves the previous
+//	transaction can never take effect.
+//
+// It is expressed as a type (ChainOutcome) rather than a boolean, so that
+// "we don't know" is a value a future engineer has to handle explicitly
+// instead of a false that reads like "no problem".
+
+// SubmissionState is the durable lifecycle of one logical chain submission.
+//
+// PENDING IS NOT FAILURE. It means the outcome is not yet known, and it is
+// the state a submission sits in across an RPC timeout, an RPC outage, and a
+// process restart.
+type SubmissionState string
+
+const (
+	// SubmissionPending — the intent is durable and the outcome is unknown.
+	// Every submission starts here, before anything is sent.
+	SubmissionPending SubmissionState = "pending"
+
+	// SubmissionLanded — the chain included the transaction and it succeeded.
+	SubmissionLanded SubmissionState = "landed"
+
+	// SubmissionRejected — the chain included the transaction and it failed.
+	// The operation did not take effect, but the sequence number was
+	// consumed, so this exact envelope can never land again.
+	SubmissionRejected SubmissionState = "rejected"
+
+	// SubmissionExpired — the chain proves the transaction was never
+	// included and never can be: its own signed time bounds have passed
+	// according to the chain's clock.
+	SubmissionExpired SubmissionState = "expired"
+
+	// SubmissionUnresolvable — the outcome cannot be determined any more,
+	// because the RPC's history no longer covers the window in which the
+	// transaction could have been included. This is a terminal state
+	// requiring a human, and it deliberately does NOT permit a retry:
+	// "we can no longer tell" is not "it did not land".
+	SubmissionUnresolvable SubmissionState = "unresolvable"
+)
+
+// Terminal reports whether the state is final — the reconciler has no further
+// work to do on it.
+func (s SubmissionState) Terminal() bool {
+	switch s {
+	case SubmissionLanded, SubmissionRejected, SubmissionExpired, SubmissionUnresolvable:
+		return true
+	default:
+		return false
+	}
+}
+
+// ChainOutcome is what the chain has told us about one specific transaction.
+//
+// A deliberately closed set, and deliberately not a bool: the whole failure
+// mode this issue exists to prevent is code that treats "no answer" as "no,
+// it didn't land". There is no value here that means that.
+type ChainOutcome int
+
+const (
+	// OutcomeUnknown — the chain has given us no usable answer. A timeout, an
+	// RPC outage, an open circuit breaker, and a transaction that is simply
+	// still in flight all produce this. It NEVER permits a retry.
+	OutcomeUnknown ChainOutcome = iota
+
+	// OutcomeLanded — included in a ledger and successful.
+	OutcomeLanded
+
+	// OutcomeRejected — included in a ledger and failed. The operation did
+	// not take effect, and the envelope's sequence number is spent, so this
+	// transaction can never land.
+	OutcomeRejected
+
+	// OutcomeProvenNotLanded — never included, and never can be: the chain's
+	// own clock has passed the time bounds the transaction was signed with,
+	// so every validator will now refuse it.
+	OutcomeProvenNotLanded
+
+	// OutcomeUndeterminable — the RPC can no longer see far enough back to
+	// answer. Distinct from OutcomeUnknown because it is permanent: waiting
+	// longer will not help, and it must never be mistaken for proof.
+	OutcomeUndeterminable
+)
+
+func (o ChainOutcome) String() string {
+	switch o {
+	case OutcomeLanded:
+		return "landed"
+	case OutcomeRejected:
+		return "rejected"
+	case OutcomeProvenNotLanded:
+		return "proven_not_landed"
+	case OutcomeUndeterminable:
+		return "undeterminable"
+	default:
+		return "unknown"
+	}
+}
+
+// PermitsNewAttempt reports whether the chain has proven that the submitted
+// transaction can never take effect, and that a fresh attempt is therefore
+// safe.
+//
+// This is the single gate on retrying a chain write. Read the cases:
+//
+//   - Rejected: it landed and failed. The operation did not happen, and the
+//     sequence number is spent, so the old envelope is permanently dead.
+//   - ProvenNotLanded: it never landed and its signed validity window has
+//     closed, so it is permanently dead.
+//
+// Everything else — including both flavours of "we don't know" — returns
+// false. A caller cannot reach a retry without holding one of two outcomes
+// that mean "the chain has spoken and the answer is no".
+func (o ChainOutcome) PermitsNewAttempt() bool {
+	return o == OutcomeRejected || o == OutcomeProvenNotLanded
+}
+
+// State maps a chain outcome onto the durable state to persist.
+func (o ChainOutcome) State() SubmissionState {
+	switch o {
+	case OutcomeLanded:
+		return SubmissionLanded
+	case OutcomeRejected:
+		return SubmissionRejected
+	case OutcomeProvenNotLanded:
+		return SubmissionExpired
+	case OutcomeUndeterminable:
+		return SubmissionUnresolvable
+	default:
+		// Unknown leaves the record exactly where it was: pending.
+		return SubmissionPending
+	}
+}
+
+// TransactionStatus is the Soroban RPC getTransaction status field.
+type TransactionStatus string
+
+const (
+	TxStatusSuccess  TransactionStatus = "SUCCESS"
+	TxStatusFailed   TransactionStatus = "FAILED"
+	TxStatusNotFound TransactionStatus = "NOT_FOUND"
+)
+
+// ChainView is what a getTransaction response tells us about the chain
+// itself, independent of the transaction asked about.
+//
+// The ledger close times matter as much as the status. They are the chain's
+// clock and the chain's memory, and both are needed to interpret NOT_FOUND —
+// which on its own means nothing at all.
+type ChainView struct {
+	// LatestLedgerCloseTime is the chain's current clock, as the chain
+	// reports it. Deliberately not our own wall clock: whether a transaction
+	// has expired is decided by consensus time, and a skewed local clock must
+	// not be able to manufacture proof.
+	LatestLedgerCloseTime time.Time
+
+	// OldestLedgerCloseTime is how far back the RPC's transaction history
+	// reaches. Older than this, NOT_FOUND means "forgotten", not "absent".
+	OldestLedgerCloseTime time.Time
+}
+
+// Valid reports whether the view carries usable ledger times. An RPC that
+// omitted them cannot support any NOT_FOUND reasoning.
+func (v ChainView) Valid() bool {
+	return !v.LatestLedgerCloseTime.IsZero() && !v.OldestLedgerCloseTime.IsZero()
+}
+
+// SubmissionIntent is the durable record written BEFORE anything is sent.
+//
+// The ordering is the whole point: persist, then submit. A crash between the
+// two directions loses at most an unsent intent, which is harmless. The
+// reverse ordering can leave a transaction on-chain that nothing in the
+// system knows about, which is unrecoverable.
+type SubmissionIntent struct {
+	ID string
+
+	// IdempotencyReference is the caller-supplied identity of the logical
+	// operation. Unique in the database, which is what makes concurrent
+	// duplicate requests collapse to one submission rather than racing.
+	IdempotencyReference string
+
+	// TransactionHash is the real Stellar transaction hash, computed from
+	// the signed envelope BEFORE submitting. This is the identity the
+	// reconciler asks the chain about; it is not a digest of our own making.
+	TransactionHash string
+
+	// ValidUntil is the transaction's own signed maxTime. Once the chain's
+	// clock passes it, the network will refuse the transaction, which is what
+	// turns a NOT_FOUND into proof.
+	//
+	// Zero means the transaction carries no upper time bound, and therefore
+	// can never be proven un-landable. Such a submission is never retried.
+	ValidUntil time.Time
+
+	SourceAccount string
+	DomainAction  string
+	State         SubmissionState
+	Attempt       int
+
+	CreatedAt   time.Time
+	SubmittedAt *time.Time
+	ResolvedAt  *time.Time
+
+	// OutcomeDetail records how the state was reached, for audit. It never
+	// carries the signed envelope or any key material.
+	OutcomeDetail string
+}
+
+// ErrNoTimeBound is returned when a transaction carries no maxTime.
+//
+// Such a transaction can never be proven un-landable — there is no moment
+// after which the network is guaranteed to refuse it — so it can never be
+// safely retried. Submissions are built with time bounds precisely so this
+// does not happen; the error exists so a future change that drops them fails
+// loudly rather than silently creating unresolvable submissions.
+var ErrNoTimeBound = errors.New("transaction has no maxTime and can never be proven un-landable")
+
+// TransactionIdentity is the chain's identity for a signed envelope: the hash
+// the network will know it by, and the validity window it enforces.
+type TransactionIdentity struct {
+	Hash       string
+	ValidUntil time.Time
+}
+
+// IdentifyTransaction derives a signed envelope's chain identity without
+// submitting it.
+//
+// This is what makes the whole design possible: because the hash is a
+// deterministic function of the signed envelope and the network passphrase,
+// we know what to ask the chain about before we take any risk. The reconciler
+// never has to guess which transaction a record refers to, and never has to
+// match on weak signals like amount, account, or timestamp.
+func IdentifyTransaction(signedEnvelopeB64, networkPassphrase string) (TransactionIdentity, error) {
+	generic, err := txnbuild.TransactionFromXDR(signedEnvelopeB64)
+	if err != nil {
+		return TransactionIdentity{}, fmt.Errorf("parse signed envelope: %w", err)
+	}
+
+	inner, ok := generic.Transaction()
+	if !ok {
+		// Fee-bump envelopes hash differently and are not produced by any
+		// path here; refusing is safer than hashing the wrong thing.
+		return TransactionIdentity{}, errors.New("expected a transaction, got fee-bump")
+	}
+
+	hash, err := inner.HashHex(networkPassphrase)
+	if err != nil {
+		return TransactionIdentity{}, fmt.Errorf("hash transaction: %w", err)
+	}
+
+	identity := TransactionIdentity{Hash: hash}
+
+	if bounds := inner.ToXDR().V1.Tx.Cond.TimeBounds; bounds != nil && bounds.MaxTime > 0 {
+		identity.ValidUntil = time.Unix(int64(bounds.MaxTime), 0).UTC()
+	}
+
+	return identity, nil
+}
+
+// DetermineOutcome converts one getTransaction response into a chain outcome.
+//
+// Pure, so the reasoning that governs whether money can move twice is
+// testable without a database, an RPC, or a clock.
+//
+// The NOT_FOUND branch is the delicate one, and it is where a naive
+// implementation goes wrong. NOT_FOUND alone means nothing: it is returned
+// for a transaction that was never submitted, for one still propagating, and
+// for one the RPC has simply forgotten. Turning it into proof needs two
+// further facts, both taken from the chain rather than from us:
+//
+//  1. The chain's clock has passed the transaction's own signed maxTime, so
+//     the network is now guaranteed to refuse it.
+//  2. The RPC's history still reaches back far enough to have seen the
+//     transaction if it had landed. Otherwise NOT_FOUND means "outside my
+//     memory", and the honest answer is that we can no longer tell.
+func DetermineOutcome(status TransactionStatus, view ChainView, intent SubmissionIntent) ChainOutcome {
+	switch status {
+	case TxStatusSuccess:
+		return OutcomeLanded
+	case TxStatusFailed:
+		// It landed. The operation did not take effect, but the sequence
+		// number is spent, so this envelope is permanently dead and a fresh
+		// attempt is safe.
+		return OutcomeRejected
+	case TxStatusNotFound:
+		// Fall through to the reasoning below.
+	default:
+		// An unrecognised status is not an answer.
+		return OutcomeUnknown
+	}
+
+	// Without the chain's clock and memory there is nothing to reason from.
+	if !view.Valid() {
+		return OutcomeUnknown
+	}
+
+	// A transaction with no upper time bound can never be proven dead: there
+	// is no point after which the network must refuse it, so it might still
+	// land at any time.
+	if intent.ValidUntil.IsZero() {
+		return OutcomeUnknown
+	}
+
+	// Still inside its validity window: it can yet be included. This is the
+	// ordinary case immediately after a timeout, and the correct answer is
+	// to keep waiting.
+	if !view.LatestLedgerCloseTime.After(intent.ValidUntil) {
+		return OutcomeUnknown
+	}
+
+	// The window has closed. Before treating NOT_FOUND as proof, check that
+	// the RPC could still have seen the transaction had it landed. If its
+	// history now starts after the transaction's window opened, a landed
+	// transaction would also read NOT_FOUND, and the two are indistinguishable.
+	//
+	// This is the case a long outage produces, and it must not be allowed to
+	// look like proof — that is exactly how a double-submit would happen.
+	if view.OldestLedgerCloseTime.After(intent.EarliestInclusion()) {
+		return OutcomeUndeterminable
+	}
+
+	return OutcomeProvenNotLanded
+}
+
+// EarliestInclusion is the earliest moment the transaction could have been
+// included in a ledger. Nothing can have happened to it before it existed, so
+// the RPC's history only needs to reach back this far to be conclusive.
+func (i SubmissionIntent) EarliestInclusion() time.Time {
+	if i.SubmittedAt != nil {
+		return *i.SubmittedAt
+	}
+	return i.CreatedAt
+}

--- a/apps/api/internal/stellar/submission_identity_test.go
+++ b/apps/api/internal/stellar/submission_identity_test.go
@@ -1,0 +1,193 @@
+package stellar
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+)
+
+// The whole design rests on knowing the chain's identity for a transaction
+// before submitting it: the reconciler asks getTransaction about this exact
+// hash. If IdentifyTransaction returned a digest of our own making — as the
+// pre-existing chain_submissions scaffold did, hashing the base64 string with
+// SHA-256 — the reconciler would ask about a transaction the chain has never
+// heard of and every submission would reconcile to NOT_FOUND forever.
+//
+// These build a real signed envelope through the same txnbuild path the
+// invoker uses, so they also guard the production precondition that every
+// submitted transaction carries a maxTime.
+
+func buildSignedEnvelope(t *testing.T, timeout int64) (envelope string, kp *keypair.Full) {
+	t.Helper()
+
+	kp = keypair.MustRandom()
+	source := txnbuild.NewSimpleAccount(kp.Address(), 1)
+
+	params := txnbuild.TransactionParams{
+		SourceAccount:        &source,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.BumpSequence{BumpTo: 2},
+		},
+		BaseFee: txnbuild.MinBaseFee,
+	}
+	if timeout > 0 {
+		params.Preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(timeout)}
+	} else {
+		params.Preconditions = txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()}
+	}
+
+	tx, err := txnbuild.NewTransaction(params)
+	if err != nil {
+		t.Fatalf("build transaction: %v", err)
+	}
+
+	signed, err := tx.Sign(network.TestNetworkPassphrase, kp)
+	if err != nil {
+		t.Fatalf("sign transaction: %v", err)
+	}
+
+	envelope, err = signed.Base64()
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	return envelope, kp
+}
+
+// The hash must be the network's canonical transaction hash — the value a
+// block explorer and getTransaction both use — not a digest of the encoded
+// string.
+func TestIdentifyTransactionProducesTheCanonicalChainHash(t *testing.T) {
+	envelope, _ := buildSignedEnvelope(t, 300)
+
+	identity, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction: %v", err)
+	}
+
+	// Independently recompute via the SDK from the same envelope.
+	generic, err := txnbuild.TransactionFromXDR(envelope)
+	if err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	inner, _ := generic.Transaction()
+	want, err := inner.HashHex(network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("HashHex: %v", err)
+	}
+
+	if identity.Hash != want {
+		t.Fatalf("hash = %s, want the canonical %s", identity.Hash, want)
+	}
+	if len(identity.Hash) != 64 {
+		t.Fatalf("hash %q is not a 32-byte hex digest", identity.Hash)
+	}
+	// Not a hash of the string we happened to encode.
+	if strings.EqualFold(identity.Hash, sha256Hex(envelope)) {
+		t.Fatal("hash is a digest of the envelope string, not the chain's transaction hash")
+	}
+}
+
+// The hash is network-scoped: the same envelope on a different network is a
+// different transaction, and asking the wrong network's hash would never
+// resolve.
+func TestTransactionHashIsNetworkScoped(t *testing.T) {
+	envelope, _ := buildSignedEnvelope(t, 300)
+
+	testnet, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction(testnet): %v", err)
+	}
+	pubnet, err := IdentifyTransaction(envelope, network.PublicNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction(pubnet): %v", err)
+	}
+
+	if testnet.Hash == pubnet.Hash {
+		t.Fatal("the same envelope hashed identically on two networks")
+	}
+}
+
+// The same envelope always yields the same identity, which is what lets the
+// transaction hash serve as a stable idempotency reference when no
+// caller-supplied one exists.
+func TestTransactionIdentityIsDeterministic(t *testing.T) {
+	envelope, _ := buildSignedEnvelope(t, 300)
+
+	first, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		again, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+		if err != nil {
+			t.Fatalf("IdentifyTransaction: %v", err)
+		}
+		if again.Hash != first.Hash || !again.ValidUntil.Equal(first.ValidUntil) {
+			t.Fatal("identity is not deterministic for the same envelope")
+		}
+	}
+}
+
+// The maxTime must survive the encode/sign round trip, because it is what
+// turns a NOT_FOUND into proof that the transaction can never land. Every
+// invoker build path sets a five-minute timeout; this is the guard that the
+// value actually reaches the submission record.
+func TestIdentifyTransactionExtractsTheSignedMaxTime(t *testing.T) {
+	before := time.Now().UTC()
+	envelope, _ := buildSignedEnvelope(t, 300)
+	after := time.Now().UTC()
+
+	identity, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction: %v", err)
+	}
+
+	if identity.ValidUntil.IsZero() {
+		t.Fatal("maxTime was lost; the submission could never be proven un-landable")
+	}
+
+	// Within the window the SDK would have produced for a 300s timeout,
+	// allowing a second of slack for the clock ticking during the test.
+	earliest := before.Add(300 * time.Second).Add(-2 * time.Second)
+	latest := after.Add(300 * time.Second).Add(2 * time.Second)
+	if identity.ValidUntil.Before(earliest) || identity.ValidUntil.After(latest) {
+		t.Fatalf("maxTime = %s, want within [%s, %s]", identity.ValidUntil, earliest, latest)
+	}
+}
+
+// A transaction built with no upper time bound reports a zero ValidUntil, so
+// send refuses it rather than creating a submission that could never be
+// reconciled.
+func TestIdentifyTransactionReportsAMissingTimeBound(t *testing.T) {
+	envelope, _ := buildSignedEnvelope(t, 0)
+
+	identity, err := IdentifyTransaction(envelope, network.TestNetworkPassphrase)
+	if err != nil {
+		t.Fatalf("IdentifyTransaction: %v", err)
+	}
+	if !identity.ValidUntil.IsZero() {
+		t.Fatalf("ValidUntil = %s, want zero for an unbounded transaction", identity.ValidUntil)
+	}
+
+	// And such an intent is never provable, however long we wait.
+	intent := SubmissionIntent{ValidUntil: identity.ValidUntil, CreatedAt: submittedAt}
+	outcome := DetermineOutcome(TxStatusNotFound, chainAt(submittedAt.Add(365*24*time.Hour)), intent)
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("an unbounded transaction was treated as expired")
+	}
+}
+
+// sha256Hex reproduces the pre-existing scaffold's (incorrect) hashing — a
+// SHA-256 of the encoded envelope string — so the test above can assert we
+// are not doing that.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/apps/api/internal/stellar/submission_store.go
+++ b/apps/api/internal/stellar/submission_store.go
@@ -1,0 +1,94 @@
+package stellar
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrIntentNotFound is returned when no submission intent exists for a
+// reference or ID.
+var ErrIntentNotFound = errors.New("submission intent not found")
+
+// ErrReferenceReused is returned when an idempotency reference is presented
+// for a materially different transaction than the one it was created with.
+//
+// Silently reusing the original would attribute a new operation to an old
+// record; silently creating a second would defeat the idempotency. Refusing
+// is the only honest option, and it mirrors the 409 the HTTP idempotency
+// middleware returns for a fingerprint mismatch (nester#835).
+var ErrReferenceReused = errors.New("idempotency reference already used for a different transaction")
+
+// SubmissionStore is the durable home of submission intents.
+//
+// It is an interface so the submit and reconcile flows can be driven
+// deterministically in tests, and so the Postgres implementation's atomicity
+// requirements are stated in one place rather than assumed at each call site.
+type SubmissionStore interface {
+	// Claim durably records the intent to submit, atomically.
+	//
+	// It MUST be atomic across processes — a database uniqueness constraint,
+	// not a read-then-write in application code, because concurrent requests
+	// with the same reference race. When the reference already exists, Claim
+	// returns the existing intent with claimed=false and MUST NOT create a
+	// second one; that is what collapses N concurrent duplicate requests into
+	// one chain submission.
+	//
+	// A reference presented with a different transaction hash than the
+	// stored one returns ErrReferenceReused.
+	Claim(ctx context.Context, intent SubmissionIntent) (stored SubmissionIntent, claimed bool, err error)
+
+	// MarkSubmitted records that the envelope was handed to the RPC. It is
+	// called after the write is in flight and says nothing about the outcome.
+	MarkSubmitted(ctx context.Context, id string, at time.Time) error
+
+	// Resolve moves an intent to a terminal state. It MUST refuse to move an
+	// already-terminal intent, so a late reconciliation cannot reopen a
+	// settled submission or overwrite one outcome with another.
+	Resolve(ctx context.Context, id string, state SubmissionState, detail string, at time.Time) error
+
+	// Get returns one intent by ID.
+	Get(ctx context.Context, id string) (SubmissionIntent, error)
+
+	// ClaimPendingForReconcile returns pending intents that are due to be
+	// checked against the chain, and marks them as being worked on.
+	//
+	// It MUST be safe for concurrent reconcilers on separate instances: two
+	// workers must never take the same intent. The Postgres implementation
+	// uses SELECT ... FOR UPDATE SKIP LOCKED for this.
+	ClaimPendingForReconcile(ctx context.Context, limit int, now time.Time) ([]SubmissionIntent, error)
+}
+
+// ChainLookup asks the chain about one transaction by hash. Implemented by
+// *ContractInvoker; declared here so the reconciler can be tested against a
+// scripted chain.
+type ChainLookup interface {
+	LookupTransaction(ctx context.Context, hash string) (TransactionStatus, ChainView, error)
+}
+
+// referenceKey is the context key carrying a caller-supplied idempotency
+// reference down to the submission chokepoint.
+type referenceKey struct{}
+
+// WithIdempotencyReference attaches a caller-supplied idempotency reference to
+// ctx, to be picked up by the submission chokepoint.
+//
+// Context rather than a parameter threaded through eight call sites, and that
+// is a deliberate trade. The enforcement lives at the chokepoint: every
+// submission gets an intent record whether or not a reference was attached,
+// because a caller that forgets must not thereby escape the durability
+// guarantee. The reference only improves what the record is keyed by — an
+// HTTP client's Idempotency-Key when there is one — rather than being the
+// thing that makes the record exist.
+func WithIdempotencyReference(ctx context.Context, reference string) context.Context {
+	if reference == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, referenceKey{}, reference)
+}
+
+// idempotencyReferenceFrom reads a caller-supplied reference, if any.
+func idempotencyReferenceFrom(ctx context.Context) string {
+	reference, _ := ctx.Value(referenceKey{}).(string)
+	return reference
+}

--- a/apps/api/internal/stellar/submission_store_postgres.go
+++ b/apps/api/internal/stellar/submission_store_postgres.go
@@ -1,0 +1,285 @@
+package stellar
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PostgresSubmissionStore is the durable SubmissionStore (nester#1085).
+//
+// Two database guarantees carry the whole design, and neither is reproducible
+// in application code:
+//
+//   - The UNIQUE constraint on idempotency_reference makes Claim atomic across
+//     processes, so concurrent duplicate requests collapse to one submission
+//     instead of racing a read-then-write.
+//   - SELECT ... FOR UPDATE SKIP LOCKED lets several reconcilers sweep at once
+//     without ever taking the same submission.
+type PostgresSubmissionStore struct {
+	db *sql.DB
+
+	// reconcileBackoff spaces out repeated checks of a submission the chain
+	// has not decided yet, so an RPC outage does not become a tight loop
+	// against a recovering endpoint.
+	reconcileBackoff time.Duration
+}
+
+// DefaultReconcileBackoff is how long a still-undecided submission waits
+// before the reconciler looks at it again. Short relative to the five-minute
+// transaction validity window, so a submission that will resolve does so
+// promptly.
+const DefaultReconcileBackoff = 20 * time.Second
+
+// NewPostgresSubmissionStore builds the durable store.
+func NewPostgresSubmissionStore(db *sql.DB) *PostgresSubmissionStore {
+	return &PostgresSubmissionStore{db: db, reconcileBackoff: DefaultReconcileBackoff}
+}
+
+const submissionColumns = `
+	id, idempotency_reference, transaction_hash, valid_until, source_account,
+	domain_action, state, attempt, outcome_detail, created_at, submitted_at,
+	resolved_at`
+
+// Claim durably records the intent, or returns the existing one.
+//
+// INSERT ... ON CONFLICT DO NOTHING is the atomic gate — the same mechanism
+// the HTTP idempotency middleware uses (nester#835), and for the same reason:
+// it is correct across instances, where a check-then-insert is not.
+func (s *PostgresSubmissionStore) Claim(ctx context.Context, intent SubmissionIntent) (SubmissionIntent, bool, error) {
+	if intent.IdempotencyReference == "" {
+		return SubmissionIntent{}, false, errors.New("submission intent requires an idempotency reference")
+	}
+
+	created, err := s.insertIntent(ctx, intent)
+	if err != nil {
+		return SubmissionIntent{}, false, err
+	}
+	if created != nil {
+		return *created, true, nil
+	}
+
+	// The reference already exists. Return the original rather than
+	// submitting a second time — this is what makes a duplicate request a
+	// no-op rather than a double-spend.
+	existing, err := s.getByReference(ctx, intent.IdempotencyReference)
+	if err != nil {
+		return SubmissionIntent{}, false, err
+	}
+
+	// The reference was created for a different transaction. Neither reusing
+	// the original nor creating a second is honest, so refuse — mirroring the
+	// 409 the HTTP idempotency middleware returns on a fingerprint mismatch.
+	if existing.TransactionHash != intent.TransactionHash {
+		return SubmissionIntent{}, false, fmt.Errorf("%w: reference %q",
+			ErrReferenceReused, intent.IdempotencyReference)
+	}
+
+	return existing, false, nil
+}
+
+// insertIntent returns the created intent, or nil when the reference already
+// existed.
+func (s *PostgresSubmissionStore) insertIntent(ctx context.Context, intent SubmissionIntent) (*SubmissionIntent, error) {
+	if intent.CreatedAt.IsZero() {
+		intent.CreatedAt = time.Now().UTC()
+	}
+
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO submission_intents
+    (idempotency_reference, transaction_hash, valid_until, source_account,
+     domain_action, state, created_at, next_reconcile_at)
+VALUES ($1, $2, $3, $4, $5, 'pending', $6, $6)
+ON CONFLICT (idempotency_reference) DO NOTHING
+RETURNING `+submissionColumns,
+		intent.IdempotencyReference,
+		intent.TransactionHash,
+		intent.ValidUntil,
+		intent.SourceAccount,
+		intent.DomainAction,
+		intent.CreatedAt,
+	)
+
+	created, err := scanIntent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		// ON CONFLICT DO NOTHING returned no row: someone else holds it.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("insert submission intent: %w", err)
+	}
+	return &created, nil
+}
+
+func (s *PostgresSubmissionStore) getByReference(ctx context.Context, reference string) (SubmissionIntent, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+submissionColumns+` FROM submission_intents WHERE idempotency_reference = $1`,
+		reference,
+	)
+
+	intent, err := scanIntent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SubmissionIntent{}, ErrIntentNotFound
+	}
+	if err != nil {
+		return SubmissionIntent{}, fmt.Errorf("load submission intent: %w", err)
+	}
+	return intent, nil
+}
+
+// MarkSubmitted records that the envelope was handed to the RPC. It says
+// nothing about the outcome, and deliberately does not change state: the
+// submission stays pending until the chain decides.
+func (s *PostgresSubmissionStore) MarkSubmitted(ctx context.Context, id string, at time.Time) error {
+	result, err := s.db.ExecContext(ctx, `
+UPDATE submission_intents
+SET submitted_at = COALESCE(submitted_at, $2),
+    attempt      = attempt + 1
+WHERE id = $1`, id, at)
+	if err != nil {
+		return fmt.Errorf("mark submitted: %w", err)
+	}
+	return requireAffected(result, ErrIntentNotFound)
+}
+
+// Resolve moves a submission to a terminal state.
+//
+// The `state = 'pending'` predicate is the guard that makes a late or
+// concurrent reconciliation harmless: a submission that has already settled
+// cannot be reopened, and one outcome can never overwrite another. The caller
+// sees ErrIntentNotFound, which the reconciler treats as "already handled".
+func (s *PostgresSubmissionStore) Resolve(ctx context.Context, id string, state SubmissionState, detail string, at time.Time) error {
+	if state == SubmissionPending {
+		return errors.New("resolve requires a terminal state")
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+UPDATE submission_intents
+SET state              = $2,
+    outcome_detail     = $3,
+    resolved_at        = $4,
+    last_reconciled_at = $4,
+    reconcile_attempts = reconcile_attempts + 1
+WHERE id = $1 AND state = 'pending'`, id, string(state), detail, at)
+	if err != nil {
+		return fmt.Errorf("resolve submission: %w", err)
+	}
+	return requireAffected(result, ErrIntentNotFound)
+}
+
+// Get returns one intent by ID.
+func (s *PostgresSubmissionStore) Get(ctx context.Context, id string) (SubmissionIntent, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+submissionColumns+` FROM submission_intents WHERE id = $1`, id)
+
+	intent, err := scanIntent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SubmissionIntent{}, ErrIntentNotFound
+	}
+	if err != nil {
+		return SubmissionIntent{}, fmt.Errorf("load submission intent: %w", err)
+	}
+	return intent, nil
+}
+
+// ClaimPendingForReconcile takes a batch of due submissions for this worker.
+//
+// SKIP LOCKED means a second reconciler running concurrently takes a
+// different batch rather than blocking or duplicating work. Pushing
+// next_reconcile_at forward in the same transaction means a submission the
+// chain has not yet decided is not re-checked immediately.
+func (s *PostgresSubmissionStore) ClaimPendingForReconcile(ctx context.Context, limit int, now time.Time) ([]SubmissionIntent, error) {
+	if limit <= 0 {
+		limit = DefaultReconcileBatch
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+WITH due AS (
+    SELECT id
+    FROM submission_intents
+    WHERE state = 'pending' AND next_reconcile_at <= $1
+    ORDER BY next_reconcile_at
+    LIMIT $2
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE submission_intents s
+SET next_reconcile_at = $3
+FROM due
+WHERE s.id = due.id
+RETURNING `+prefixColumns("s")+`
+`, now, limit, now.Add(s.reconcileBackoff))
+	if err != nil {
+		return nil, fmt.Errorf("claim pending submissions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var intents []SubmissionIntent
+	for rows.Next() {
+		intent, err := scanIntent(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan submission intent: %w", err)
+		}
+		intents = append(intents, intent)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return intents, nil
+}
+
+// prefixColumns qualifies the shared column list for a joined UPDATE.
+func prefixColumns(alias string) string {
+	return alias + `.id, ` + alias + `.idempotency_reference, ` + alias + `.transaction_hash, ` +
+		alias + `.valid_until, ` + alias + `.source_account, ` + alias + `.domain_action, ` +
+		alias + `.state, ` + alias + `.attempt, ` + alias + `.outcome_detail, ` +
+		alias + `.created_at, ` + alias + `.submitted_at, ` + alias + `.resolved_at`
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanIntent(row rowScanner) (SubmissionIntent, error) {
+	var intent SubmissionIntent
+	err := row.Scan(
+		&intent.ID,
+		&intent.IdempotencyReference,
+		&intent.TransactionHash,
+		&intent.ValidUntil,
+		&intent.SourceAccount,
+		&intent.DomainAction,
+		&intent.State,
+		&intent.Attempt,
+		&intent.OutcomeDetail,
+		&intent.CreatedAt,
+		&intent.SubmittedAt,
+		&intent.ResolvedAt,
+	)
+	return intent, err
+}
+
+func requireAffected(result sql.Result, notFound error) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return notFound
+	}
+	return nil
+}
+
+var _ SubmissionStore = (*PostgresSubmissionStore)(nil)

--- a/apps/api/internal/stellar/submission_store_postgres_test.go
+++ b/apps/api/internal/stellar/submission_store_postgres_test.go
@@ -1,0 +1,361 @@
+package stellar
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
+)
+
+// These exercise the two guarantees that only the database can provide and
+// that the in-memory store in reconciler_test.go can only imitate: the UNIQUE
+// constraint that makes Claim atomic across processes, and SKIP LOCKED, which
+// stops two reconcilers taking the same submission.
+//
+// They skip without TEST_DATABASE_DSN, matching the replay harness, and run in
+// CI's database job.
+
+func submissionDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if strings.TrimSpace(dsn) == "" {
+		t.Skip("TEST_DATABASE_DSN is not set; skipping submission store integration tests")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping test db: %v", err)
+	}
+
+	testutil.ApplyAllMigrations(t, db, "../../migrations")
+
+	if _, err := db.Exec(`TRUNCATE submission_intents`); err != nil {
+		t.Fatalf("truncate submission_intents: %v", err)
+	}
+	return db
+}
+
+func newIntent(reference, hash string, createdAt time.Time) SubmissionIntent {
+	return SubmissionIntent{
+		IdempotencyReference: reference,
+		TransactionHash:      hash,
+		ValidUntil:           createdAt.Add(5 * time.Minute),
+		SourceAccount:        "GABC",
+		DomainAction:         "deposit",
+		CreatedAt:            createdAt,
+	}
+}
+
+func TestPostgresStoreClaimIsIdempotent(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	first, claimed, err := store.Claim(ctx, newIntent("ref-1", "hash-1", now))
+	if err != nil || !claimed {
+		t.Fatalf("first Claim = (claimed %v, err %v), want a fresh claim", claimed, err)
+	}
+	if first.State != SubmissionPending {
+		t.Fatalf("state = %s, want pending", first.State)
+	}
+
+	second, claimed, err := store.Claim(ctx, newIntent("ref-1", "hash-1", now))
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if claimed {
+		t.Fatal("a repeated reference claimed a second submission")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("repeat returned %s, want the original %s", second.ID, first.ID)
+	}
+}
+
+// The core concurrency guarantee: the unique index, not application code, is
+// what collapses simultaneous duplicates into one submission.
+func TestPostgresStoreConcurrentClaimsProduceOneSubmission(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	now := time.Now().UTC()
+
+	const callers = 24
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		claims int
+		ids    = map[string]struct{}{}
+	)
+
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			stored, claimed, err := store.Claim(context.Background(), newIntent("ref-concurrent", "hash-c", now))
+			if err != nil {
+				t.Errorf("Claim: %v", err)
+				return
+			}
+
+			mu.Lock()
+			if claimed {
+				claims++
+			}
+			ids[stored.ID] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if claims != 1 {
+		t.Fatalf("%d of %d concurrent claims won, want exactly 1", claims, callers)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("callers saw %d distinct submissions, want 1", len(ids))
+	}
+
+	var rows int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM submission_intents WHERE idempotency_reference = 'ref-concurrent'`,
+	).Scan(&rows); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("%d rows exist for one logical submission, want 1", rows)
+	}
+}
+
+func TestPostgresStoreRejectsReferenceReuse(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, _, err := store.Claim(ctx, newIntent("ref-2", "hash-original", now)); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	_, _, err := store.Claim(ctx, newIntent("ref-2", "hash-different", now))
+	if !errors.Is(err, ErrReferenceReused) {
+		t.Fatalf("Claim with a reused reference = %v, want ErrReferenceReused", err)
+	}
+}
+
+// A settled submission is never reopened, so a late or concurrent
+// reconciliation cannot overwrite one outcome with another.
+func TestPostgresStoreResolveIsTerminal(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	intent, _, err := store.Claim(ctx, newIntent("ref-3", "hash-3", now))
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	if err := store.Resolve(ctx, intent.ID, SubmissionLanded, "chain reported SUCCESS", now); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// A stale sweep tries to record a different outcome.
+	err = store.Resolve(ctx, intent.ID, SubmissionExpired, "stale", now.Add(time.Minute))
+	if !errors.Is(err, ErrIntentNotFound) {
+		t.Fatalf("second Resolve = %v, want ErrIntentNotFound (the guard)", err)
+	}
+
+	stored, err := store.Get(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.State != SubmissionLanded {
+		t.Fatalf("state = %s, want it to remain landed", stored.State)
+	}
+
+	// Resolve must also refuse to move a submission back to pending.
+	if err := store.Resolve(ctx, intent.ID, SubmissionPending, "", now); err == nil {
+		t.Fatal("Resolve accepted a non-terminal state")
+	}
+}
+
+// SKIP LOCKED: two reconcilers sweeping at once take disjoint batches, so
+// neither works a submission the other already holds.
+func TestPostgresStoreConcurrentReconcilersTakeDisjointBatches(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	const total = 20
+	for i := 0; i < total; i++ {
+		ref := fmt.Sprintf("ref-batch-%d", i)
+		if _, _, err := store.Claim(ctx, newIntent(ref, fmt.Sprintf("hash-%d", i), now)); err != nil {
+			t.Fatalf("Claim %s: %v", ref, err)
+		}
+	}
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		seen = map[string]int{}
+	)
+
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			claimed, err := store.ClaimPendingForReconcile(context.Background(), total, now)
+			if err != nil {
+				t.Errorf("ClaimPendingForReconcile: %v", err)
+				return
+			}
+			mu.Lock()
+			for _, intent := range claimed {
+				seen[intent.ID]++
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("submission %s was taken by %d reconcilers, want 1", id, count)
+		}
+	}
+}
+
+// A claimed submission is pushed past its next check, so an RPC outage does
+// not turn the sweep into a tight polling loop.
+func TestPostgresStoreClaimBacksOffTheNextCheck(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, _, err := store.Claim(ctx, newIntent("ref-backoff", "hash-b", now)); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	first, err := store.ClaimPendingForReconcile(ctx, 10, now)
+	if err != nil {
+		t.Fatalf("first sweep: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("first sweep claimed %d, want 1", len(first))
+	}
+
+	// Immediately again: nothing is due.
+	second, err := store.ClaimPendingForReconcile(ctx, 10, now)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("second sweep claimed %d, want 0 until the backoff elapses", len(second))
+	}
+
+	// Once the backoff has passed it is due again.
+	third, err := store.ClaimPendingForReconcile(ctx, 10, now.Add(DefaultReconcileBackoff+time.Second))
+	if err != nil {
+		t.Fatalf("third sweep: %v", err)
+	}
+	if len(third) != 1 {
+		t.Fatalf("third sweep claimed %d, want 1", len(third))
+	}
+}
+
+// Resolved submissions drop out of the sweep entirely, so a settled record is
+// never re-examined and the reconciler's work shrinks as submissions settle.
+func TestPostgresStoreResolvedSubmissionsAreNotSwept(t *testing.T) {
+	db := submissionDB(t)
+	store := NewPostgresSubmissionStore(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	intent, _, err := store.Claim(ctx, newIntent("ref-settled", "hash-s", now))
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := store.Resolve(ctx, intent.ID, SubmissionLanded, "landed", now); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	swept, err := store.ClaimPendingForReconcile(ctx, 10, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	for _, s := range swept {
+		if s.ID == intent.ID {
+			t.Fatal("a settled submission was claimed for reconciliation")
+		}
+	}
+}
+
+// The durability guarantee, end to end: an intent written by one store handle
+// is visible to a completely separate one, which is what makes recovery after
+// a process restart work.
+func TestPostgresStoreIntentSurvivesANewProcess(t *testing.T) {
+	db := submissionDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	original := NewPostgresSubmissionStore(db)
+	intent, _, err := original.Claim(ctx, newIntent("ref-restart", "hash-r", now))
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := original.MarkSubmitted(ctx, intent.ID, now); err != nil {
+		t.Fatalf("MarkSubmitted: %v", err)
+	}
+
+	// A fresh store, standing in for a restarted process with no memory of
+	// the request.
+	restarted := NewPostgresSubmissionStore(db)
+	recovered, err := restarted.Get(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("Get after restart: %v", err)
+	}
+	if recovered.State != SubmissionPending {
+		t.Fatalf("state = %s, want pending", recovered.State)
+	}
+	if recovered.SubmittedAt == nil {
+		t.Fatal("submitted_at was not persisted; the RPC-memory check depends on it")
+	}
+	if recovered.TransactionHash != "hash-r" {
+		t.Fatalf("transaction hash = %q, want it preserved", recovered.TransactionHash)
+	}
+
+	// And it is still due for reconciliation.
+	swept, err := restarted.ClaimPendingForReconcile(ctx, 10, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sweep after restart: %v", err)
+	}
+	found := false
+	for _, s := range swept {
+		if s.ID == intent.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("a pending submission was not picked up after restart")
+	}
+}

--- a/apps/api/internal/stellar/submission_test.go
+++ b/apps/api/internal/stellar/submission_test.go
@@ -1,0 +1,397 @@
+package stellar
+
+import (
+	"testing"
+	"time"
+)
+
+// The scenarios in this file are the three the issue requires, expressed
+// against the rules that actually decide whether money can move twice. They
+// need no database, no RPC, and no clock, so they are deterministic and they
+// exercise the real decision function rather than a re-implementation of it.
+
+var (
+	// A submission created at 12:00, valid for five minutes, submitted
+	// immediately. Every scenario below varies only what the chain says.
+	submittedAt   = time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	validUntil    = submittedAt.Add(5 * time.Minute)
+	insideWindow  = submittedAt.Add(2 * time.Minute)
+	pastTheWindow = validUntil.Add(1 * time.Minute)
+)
+
+func testIntent() SubmissionIntent {
+	at := submittedAt
+	return SubmissionIntent{
+		ID:                   "11111111-1111-1111-1111-111111111111",
+		IdempotencyReference: "vault-deposit-abc",
+		TransactionHash:      "a1b2c3",
+		ValidUntil:           validUntil,
+		SourceAccount:        "GABC",
+		DomainAction:         "deposit",
+		State:                SubmissionPending,
+		CreatedAt:            submittedAt,
+		SubmittedAt:          &at,
+	}
+}
+
+// chainAt builds a view of a chain whose clock reads now and whose history
+// reaches back far enough to be conclusive.
+func chainAt(now time.Time) ChainView {
+	return ChainView{
+		LatestLedgerCloseTime: now,
+		OldestLedgerCloseTime: submittedAt.Add(-1 * time.Hour),
+	}
+}
+
+func assertOutcome(t *testing.T, got, want ChainOutcome) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("outcome = %s, want %s", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — response lost after the transaction succeeded
+// ---------------------------------------------------------------------------
+
+// The dangerous one. The chain accepted and executed the transaction, but the
+// response never reached us. A system that treats the timeout as failure and
+// resubmits moves the user's money twice.
+func TestScenarioResponseLostAfterSuccess(t *testing.T) {
+	intent := testIntent()
+
+	// Immediately after the lost response the chain has not been asked yet,
+	// so there is no outcome and the record must stay pending.
+	assertOutcome(t, DetermineOutcome(TxStatusNotFound, chainAt(insideWindow), intent), OutcomeUnknown)
+	if got := OutcomeUnknown.State(); got != SubmissionPending {
+		t.Fatalf("state after a lost response = %s, want pending", got)
+	}
+	if OutcomeUnknown.PermitsNewAttempt() {
+		t.Fatal("a lost response permitted a retry; this is the double-submit")
+	}
+
+	// The reconciler asks the chain, which reports the transaction landed.
+	outcome := DetermineOutcome(TxStatusSuccess, chainAt(insideWindow), intent)
+	assertOutcome(t, outcome, OutcomeLanded)
+
+	if got := outcome.State(); got != SubmissionLanded {
+		t.Fatalf("state = %s, want landed", got)
+	}
+	// The invariant: a landed transaction is never sent again, whatever else
+	// happens.
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("a landed transaction permitted a retry")
+	}
+}
+
+// A success discovered long after the fact is still a success. Expiry
+// reasoning must never override an actual answer from the chain.
+func TestLandedTransactionIsNeverReopenedByExpiry(t *testing.T) {
+	intent := testIntent()
+
+	outcome := DetermineOutcome(TxStatusSuccess, chainAt(pastTheWindow), intent)
+	assertOutcome(t, outcome, OutcomeLanded)
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("an expired-but-landed transaction permitted a retry")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — response lost after the transaction failed
+// ---------------------------------------------------------------------------
+
+// The chain included the transaction and it failed. The operation did not
+// take effect, so a fresh attempt is legitimate — but only once the chain has
+// actually said so. The ordering is what is under test.
+func TestScenarioResponseLostAfterFailure(t *testing.T) {
+	intent := testIntent()
+
+	// Before the chain answers: no retry.
+	before := DetermineOutcome(TxStatusNotFound, chainAt(insideWindow), intent)
+	assertOutcome(t, before, OutcomeUnknown)
+	if before.PermitsNewAttempt() {
+		t.Fatal("a retry was permitted before the chain was consulted")
+	}
+
+	// The chain reports the transaction landed and failed.
+	outcome := DetermineOutcome(TxStatusFailed, chainAt(insideWindow), intent)
+	assertOutcome(t, outcome, OutcomeRejected)
+
+	if got := outcome.State(); got != SubmissionRejected {
+		t.Fatalf("state = %s, want rejected", got)
+	}
+
+	// Only now is a fresh attempt safe: the envelope's sequence number is
+	// spent, so the original can never land after the fact.
+	if !outcome.PermitsNewAttempt() {
+		t.Fatal("a chain-confirmed failure did not permit a fresh attempt")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — RPC unavailable throughout
+// ---------------------------------------------------------------------------
+
+// Submission could not be confirmed and reconciliation cannot confirm either.
+// Unknown must remain unknown: the record stays pending, and nothing is
+// marked landed or rejected merely because the upstream is down.
+func TestScenarioRPCUnavailableThroughout(t *testing.T) {
+	intent := testIntent()
+
+	// An unreachable RPC yields no status and no view of the chain at all.
+	noView := ChainView{}
+
+	for _, status := range []TransactionStatus{TxStatusNotFound, ""} {
+		outcome := DetermineOutcome(status, noView, intent)
+		assertOutcome(t, outcome, OutcomeUnknown)
+
+		if got := outcome.State(); got != SubmissionPending {
+			t.Fatalf("status %q with no chain view produced state %s, want pending", status, got)
+		}
+		if outcome.PermitsNewAttempt() {
+			t.Fatalf("status %q with no chain view permitted a retry", status)
+		}
+	}
+
+	// Repeated failed reconciliation attempts must not accumulate into
+	// permission. There is no number of unknowns that becomes a proof.
+	for i := 0; i < 100; i++ {
+		if DetermineOutcome(TxStatusNotFound, noView, intent).PermitsNewAttempt() {
+			t.Fatalf("attempt %d turned repeated unknowns into permission to retry", i)
+		}
+	}
+}
+
+// A partial view — the RPC answered but omitted the ledger times — is not
+// enough to reason from either.
+func TestPartialChainViewIsNotProof(t *testing.T) {
+	intent := testIntent()
+
+	views := map[string]ChainView{
+		"no times at all": {},
+		"only latest":     {LatestLedgerCloseTime: pastTheWindow},
+		"only oldest":     {OldestLedgerCloseTime: submittedAt.Add(-time.Hour)},
+	}
+
+	for name, view := range views {
+		t.Run(name, func(t *testing.T) {
+			outcome := DetermineOutcome(TxStatusNotFound, view, intent)
+			assertOutcome(t, outcome, OutcomeUnknown)
+			if outcome.PermitsNewAttempt() {
+				t.Fatal("an incomplete chain view was treated as proof")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NOT_FOUND — the branch where a naive implementation goes wrong
+// ---------------------------------------------------------------------------
+
+// Inside its validity window a missing transaction may still be included.
+// This is the ordinary state immediately after a timeout, and treating it as
+// proof of non-landing is precisely the double-submit bug.
+func TestNotFoundInsideTheValidityWindowIsNotProof(t *testing.T) {
+	intent := testIntent()
+
+	for _, now := range []time.Time{
+		submittedAt,
+		insideWindow,
+		validUntil, // exactly at maxTime: still includable
+	} {
+		outcome := DetermineOutcome(TxStatusNotFound, chainAt(now), intent)
+		if outcome != OutcomeUnknown {
+			t.Fatalf("at %s outcome = %s, want unknown", now, outcome)
+		}
+		if outcome.PermitsNewAttempt() {
+			t.Fatalf("at %s a still-includable transaction permitted a retry", now)
+		}
+	}
+}
+
+// Once the chain's own clock has passed the transaction's signed maxTime, the
+// network is guaranteed to refuse it. That — not elapsed time on our side —
+// is what makes NOT_FOUND conclusive.
+func TestNotFoundPastTheValidityWindowIsProof(t *testing.T) {
+	intent := testIntent()
+
+	outcome := DetermineOutcome(TxStatusNotFound, chainAt(pastTheWindow), intent)
+	assertOutcome(t, outcome, OutcomeProvenNotLanded)
+
+	if got := outcome.State(); got != SubmissionExpired {
+		t.Fatalf("state = %s, want expired", got)
+	}
+	if !outcome.PermitsNewAttempt() {
+		t.Fatal("a provably un-landable transaction did not permit a fresh attempt")
+	}
+}
+
+// Expiry is judged by the chain's clock, not ours. A local clock running fast
+// must not be able to manufacture proof — that would be a timing assumption
+// wearing the costume of chain evidence.
+func TestExpiryUsesTheChainsClockNotOurs(t *testing.T) {
+	intent := testIntent()
+
+	// The chain is still inside the window, however late it is locally.
+	view := ChainView{
+		LatestLedgerCloseTime: insideWindow,
+		OldestLedgerCloseTime: submittedAt.Add(-time.Hour),
+	}
+
+	outcome := DetermineOutcome(TxStatusNotFound, view, intent)
+	assertOutcome(t, outcome, OutcomeUnknown)
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("the chain was still inside the window but a retry was permitted")
+	}
+}
+
+// The long-outage case, and the subtlest one. If the RPC's history no longer
+// reaches back to when the transaction could have landed, a landed
+// transaction and a never-submitted one both read NOT_FOUND. That is not
+// proof, it is amnesia, and it must be terminal-but-not-retryable rather than
+// permission to submit again.
+func TestNotFoundBeyondTheRPCsMemoryIsNotProof(t *testing.T) {
+	intent := testIntent()
+
+	view := ChainView{
+		LatestLedgerCloseTime: pastTheWindow,
+		// History begins after the transaction was submitted, so the RPC
+		// could no longer see it even if it had landed.
+		OldestLedgerCloseTime: submittedAt.Add(1 * time.Minute),
+	}
+
+	outcome := DetermineOutcome(TxStatusNotFound, view, intent)
+	assertOutcome(t, outcome, OutcomeUndeterminable)
+
+	if got := outcome.State(); got != SubmissionUnresolvable {
+		t.Fatalf("state = %s, want unresolvable", got)
+	}
+	// The point of the whole test: forgetting is not proving.
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("an unresolvable submission permitted a retry; this can double-submit")
+	}
+}
+
+// The boundary of the memory check: history reaching back to exactly the
+// moment of submission is still conclusive.
+func TestRPCMemoryBoundaryIsInclusive(t *testing.T) {
+	intent := testIntent()
+
+	view := ChainView{
+		LatestLedgerCloseTime: pastTheWindow,
+		OldestLedgerCloseTime: submittedAt,
+	}
+
+	assertOutcome(t, DetermineOutcome(TxStatusNotFound, view, intent), OutcomeProvenNotLanded)
+}
+
+// A transaction with no upper time bound can never be proven dead, because
+// there is no moment after which the network must refuse it. It must never
+// be retried, however long it has been missing.
+func TestTransactionWithoutTimeBoundsIsNeverProvenDead(t *testing.T) {
+	intent := testIntent()
+	intent.ValidUntil = time.Time{}
+
+	farFuture := chainAt(submittedAt.Add(30 * 24 * time.Hour))
+
+	outcome := DetermineOutcome(TxStatusNotFound, farFuture, intent)
+	assertOutcome(t, outcome, OutcomeUnknown)
+	if outcome.PermitsNewAttempt() {
+		t.Fatal("a transaction with no maxTime was treated as expired")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The invariant, stated directly
+// ---------------------------------------------------------------------------
+
+// Exhaustive over the outcome set: exactly two values permit another attempt,
+// and both mean the chain has said no. If someone adds an outcome and wires
+// it into PermitsNewAttempt without thinking, this fails.
+func TestOnlyChainProofPermitsANewAttempt(t *testing.T) {
+	permitted := map[ChainOutcome]bool{
+		OutcomeUnknown:         false,
+		OutcomeLanded:          false,
+		OutcomeUndeterminable:  false,
+		OutcomeRejected:        true,
+		OutcomeProvenNotLanded: true,
+	}
+
+	for outcome, want := range permitted {
+		if got := outcome.PermitsNewAttempt(); got != want {
+			t.Errorf("%s.PermitsNewAttempt() = %v, want %v", outcome, got, want)
+		}
+	}
+
+	// And nothing outside the known set may permit one either.
+	for value := -5; value < 50; value++ {
+		outcome := ChainOutcome(value)
+		if _, known := permitted[outcome]; known {
+			continue
+		}
+		if outcome.PermitsNewAttempt() {
+			t.Errorf("unrecognised outcome %d permitted a retry", value)
+		}
+	}
+}
+
+// Only an actual answer from the chain moves a record out of pending.
+func TestOnlyChainAnswersLeavePending(t *testing.T) {
+	staysPending := []ChainOutcome{OutcomeUnknown, ChainOutcome(99)}
+	for _, outcome := range staysPending {
+		if got := outcome.State(); got != SubmissionPending {
+			t.Errorf("%s.State() = %s, want pending", outcome, got)
+		}
+	}
+
+	resolves := map[ChainOutcome]SubmissionState{
+		OutcomeLanded:          SubmissionLanded,
+		OutcomeRejected:        SubmissionRejected,
+		OutcomeProvenNotLanded: SubmissionExpired,
+		OutcomeUndeterminable:  SubmissionUnresolvable,
+	}
+	for outcome, want := range resolves {
+		if got := outcome.State(); got != want {
+			t.Errorf("%s.State() = %s, want %s", outcome, got, want)
+		}
+		if !want.Terminal() {
+			t.Errorf("%s is a resolved state but reports non-terminal", want)
+		}
+	}
+
+	if SubmissionPending.Terminal() {
+		t.Error("pending must not be terminal; the reconciler would stop looking at it")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transaction identity
+// ---------------------------------------------------------------------------
+
+// The hash must be the chain's, derived from the signed envelope, so the
+// reconciler can ask about the exact transaction rather than matching on
+// account, amount, or timing.
+func TestIdentifyTransactionRejectsGarbage(t *testing.T) {
+	for _, envelope := range []string{"", "not-base64-xdr", "AAAA"} {
+		if _, err := IdentifyTransaction(envelope, "Test SDF Network ; September 2015"); err == nil {
+			t.Errorf("IdentifyTransaction(%q) = nil error, want a parse failure", envelope)
+		}
+	}
+}
+
+// EarliestInclusion is what the RPC-memory check is measured against. It must
+// prefer the submission time, and fall back to creation for an intent that
+// was never sent.
+func TestEarliestInclusion(t *testing.T) {
+	intent := testIntent()
+	if got := intent.EarliestInclusion(); !got.Equal(submittedAt) {
+		t.Fatalf("EarliestInclusion() = %s, want the submission time %s", got, submittedAt)
+	}
+
+	never := testIntent()
+	never.SubmittedAt = nil
+	never.CreatedAt = submittedAt.Add(-time.Minute)
+	if got := never.EarliestInclusion(); !got.Equal(never.CreatedAt) {
+		t.Fatalf("EarliestInclusion() = %s, want the creation time %s", got, never.CreatedAt)
+	}
+}

--- a/apps/api/migrations/104_create_submission_intents.down.sql
+++ b/apps/api/migrations/104_create_submission_intents.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_submission_intents_hash;
+DROP INDEX IF EXISTS idx_submission_intents_due;
+DROP TABLE IF EXISTS submission_intents;

--- a/apps/api/migrations/104_create_submission_intents.up.sql
+++ b/apps/api/migrations/104_create_submission_intents.up.sql
@@ -1,0 +1,69 @@
+-- Durable chain-submission records (nester#1085).
+--
+-- Written BEFORE a transaction is handed to Soroban RPC, so a lost response
+-- can never leave an on-chain transaction that nothing in the system knows
+-- about. The reconciler resolves the outcome from the chain; nothing here is
+-- ever resubmitted automatically.
+--
+-- A new table rather than an extension of chain_submissions (migration 099).
+-- That table is an unwired scaffold whose shape does not fit this record: it
+-- requires sequence_number and signed_envelope NOT NULL and is unique per
+-- (account, sequence). This record deliberately stores neither — the signed
+-- envelope carries signatures and operation arguments, and is never persisted
+-- or logged (see internal/stellar/tracing.go), and nothing here resubmits an
+-- old envelope, so there is nothing to keep it for. Reshaping 099 in place
+-- would also break the tests written against it.
+CREATE TABLE IF NOT EXISTS submission_intents (
+    id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- The caller-supplied identity of the logical operation. UNIQUE is the
+    -- concurrency guarantee: N simultaneous duplicate requests contend on
+    -- this index and exactly one wins, so an application-level
+    -- "check then insert" race cannot produce two chain submissions.
+    idempotency_reference TEXT        NOT NULL UNIQUE
+                                       CHECK (char_length(idempotency_reference) > 0),
+
+    -- The real Stellar transaction hash, computed from the signed envelope
+    -- before submitting. This is the exact identity the reconciler asks the
+    -- chain about — never a heuristic match on account, amount, or time.
+    transaction_hash      TEXT        NOT NULL,
+
+    -- The transaction's own signed maxTime. Once the chain's clock passes it
+    -- the network must refuse the transaction, which is what turns a
+    -- NOT_FOUND into proof that it can never land.
+    valid_until           TIMESTAMPTZ NOT NULL,
+
+    source_account        TEXT        NOT NULL,
+    domain_action         TEXT        NOT NULL DEFAULT '',
+
+    -- pending is not failure: it means the outcome is not yet known. The four
+    -- terminal states are all chain-derived, except unresolvable, which
+    -- records that the chain can no longer tell us and a human must decide.
+    state                 TEXT        NOT NULL DEFAULT 'pending'
+                                       CHECK (state IN ('pending', 'landed', 'rejected', 'expired', 'unresolvable')),
+
+    attempt               INTEGER     NOT NULL DEFAULT 0,
+    outcome_detail        TEXT        NOT NULL DEFAULT '',
+
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    submitted_at          TIMESTAMPTZ,
+    resolved_at           TIMESTAMPTZ,
+
+    -- Reconciliation bookkeeping. next_reconcile_at spaces out repeated
+    -- checks of a submission the chain has not yet decided, so an RPC outage
+    -- does not turn into a tight polling loop.
+    reconcile_attempts    INTEGER     NOT NULL DEFAULT 0,
+    last_reconciled_at    TIMESTAMPTZ,
+    next_reconcile_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The reconciler's only query: unresolved submissions that are due. Partial,
+-- because resolved rows are the overwhelming majority over time and never
+-- need to be found this way.
+CREATE INDEX IF NOT EXISTS idx_submission_intents_due
+    ON submission_intents (next_reconcile_at)
+    WHERE state = 'pending';
+
+-- Operator lookup: "what happened to this transaction on chain".
+CREATE INDEX IF NOT EXISTS idx_submission_intents_hash
+    ON submission_intents (transaction_hash);

--- a/docker/grafana/dashboards/slo-balance-freshness.json
+++ b/docker/grafana/dashboards/slo-balance-freshness.json
@@ -4,7 +4,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Indexer lag and the staleness guard over it (nester#1056).",
+  "description": "Indexer lag in ledgers and seconds against the staleness budget (nester#1056, nester#1088).",
   "editable": false,
   "graphTooltip": 1,
   "links": [],
@@ -18,10 +18,10 @@
       },
       "id": 1,
       "options": {
-        "content": "**SLI** network ledger tip minus last indexed ledger.\n\nThis is a gauge, not a ratio of events, so it has no burn rate and no error budget \u2014 forcing one would produce a number that means nothing during an incident.\n\nThe staleness panel is the important one: a lag gauge that reads healthy because nothing is updating it is the failure mode this SLI exists to prevent.\n\n**Runbook** `docs/observability/runbooks/balance-freshness.md`",
+        "content": "**SLI** how far behind the chain the indexed view is, in ledgers and in seconds.\n\nThis is a gauge, not a ratio of events, so it has no burn rate and no error budget \u2014 forcing one would produce a number that means nothing during an incident.\n\n**Read data staleness first.** It is the number the staleness budget, the page, and the `X-Indexer-Stale` header the API returns to clients are all stated against, and it is the only one that keeps climbing when the indexer has stopped completely.\n\n**Runbook** `docs/observability/runbooks/balance-freshness.md`",
         "mode": "markdown"
       },
-      "title": "Balance freshness \u2014 indexer lag under 60 ledgers",
+      "title": "Balance freshness \u2014 staleness budget 5 minutes",
       "type": "text"
     },
     {
@@ -29,7 +29,75 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Ledgers behind the tip. Pages above 60 (~5 minutes).",
+      "description": "Age of the indexed view: time since the last freshness sample plus that sample's ledger lag. Pages above the budget (300s), and above it the API reports every response as stale.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 120
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "indexer:freshness:lag_seconds",
+          "instant": true,
+          "legendFormat": "Data staleness",
+          "range": false,
+          "refId": "Data sta"
+        }
+      ],
+      "title": "Data staleness",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Ledgers behind the tip. Pages above 60 (~5 minutes). No data here means the indexer has not reported a position at all \u2014 read data staleness instead.",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -57,11 +125,11 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 5
       },
-      "id": 2,
+      "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -97,7 +165,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Seconds since the lag gauge was last updated. Pages above 300. If this is climbing, do not trust the lag value beside it.",
+      "description": "Seconds since the indexer last reported a position. Near zero means running but behind; climbing means stopped. This is the panel that tells the two apart.",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -125,11 +193,11 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 5
       },
-      "id": 3,
+      "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -189,11 +257,11 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 5
       },
-      "id": 4,
+      "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -223,6 +291,91 @@
       ],
       "title": "Sample errors",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Staleness plotted against the budget the API is actually enforcing, so the crossing point is exactly where clients start being told their balances are stale. Recovery shows as a sharp drop back under the budget line.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "indexer:freshness:lag_seconds",
+          "instant": false,
+          "legendFormat": "staleness",
+          "range": true,
+          "refId": "stalenes"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "indexer:freshness:budget_seconds",
+          "instant": false,
+          "legendFormat": "budget",
+          "range": true,
+          "refId": "budget"
+        }
+      ],
+      "title": "Data staleness against the budget",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -262,10 +415,10 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 0,
+        "x": 12,
         "y": 10
       },
-      "id": 5,
+      "id": 7,
       "options": {
         "legend": {
           "calcs": [
@@ -302,7 +455,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Should sit near zero and reset every poll. A steady climb means the sampler stopped, and the lag gauge is frozen at whatever it last read.",
+      "description": "Should sit near zero and reset every poll. A steady climb means the indexer stopped reporting, and the ledger lag beside it is frozen at whatever it last read.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -334,11 +487,11 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 10
+        "w": 24,
+        "x": 0,
+        "y": 19
       },
-      "id": 6,
+      "id": 8,
       "options": {
         "legend": {
           "calcs": [

--- a/docker/prometheus/rules/slo_alerts.yml
+++ b/docker/prometheus/rules/slo_alerts.yml
@@ -443,22 +443,73 @@ groups:
   # continuous quantity, not a ratio of events, and forcing it into burn-rate
   # shape would produce a number with no meaning.
   #
-  # Three distinct alerts, because three distinct things go wrong and they need
-  # different responses:
+  # Four alerts, because four distinct things go wrong and they need different
+  # responses:
   #
-  #   IndexerLagHigh    — the indexer is running but falling behind.
-  #   IndexerLagStale   — the indexer stopped updating the gauge at all. This
-  #                       is the dangerous one: without it a crashed sampler
-  #                       leaves a frozen healthy value and the SLI reports
-  #                       perfect freshness forever.
+  #   IndexerStalenessBudgetExceeded — the staleness budget is blown. This is
+  #                       the authoritative one and the only one stated in the
+  #                       same terms as the API's stale flag, so a page here
+  #                       means clients are being told their balances are
+  #                       stale. It catches an indexer that is behind AND one
+  #                       that is dead, because its metric climbs on the clock.
+  #   IndexerLagHigh    — the indexer is running but falling behind, in
+  #                       ledgers. Kept as the diagnostic split: it fires only
+  #                       when the indexer is alive enough to report a
+  #                       position, which is what distinguishes "behind" from
+  #                       "stopped".
+  #   IndexerLagStale   — the indexer stopped reporting at all. Says "do not
+  #                       trust the ledger figure beside this".
   #   IndexerMetricsAbsent — the series vanished entirely (process gone, scrape
   #                       failing). Without this, deleting the metric would
   #                       silence every alert above it.
+  #
+  # All four carry slo: balance_freshness, so Alertmanager groups them into one
+  # notification during an incident rather than four pages.
   #
   # Together these ensure missing telemetry fails visibly rather than silently,
   # which is the requirement that matters most for a freshness signal.
   - name: slo_alerts_balance_freshness
     rules:
+      # The staleness budget alert (nester#1088).
+      #
+      # Note that neither side of this comparison is a literal. The right-hand
+      # side is the budget the API is actually enforcing, exported by the
+      # process itself, so this alert fires on exactly the condition that makes
+      # the API start returning X-Indexer-Stale: true. Writing 300 here instead
+      # would let the pager and the UI disagree the first time anyone retuned
+      # INDEXER_STALENESS_BUDGET.
+      #
+      # `for: 2m` rather than the 5m the ledger alert uses. The budget has
+      # already elapsed by the time this expression is true — five minutes of
+      # staleness have accumulated — so a long `for:` would add that delay
+      # again on top. Two minutes is enough to ride out a scrape gap or a
+      # rolling restart without letting a genuine stall sit unpaged.
+      - alert: IndexerStalenessBudgetExceeded
+        expr: |
+          indexer:freshness:lag_seconds > indexer:freshness:budget_seconds
+        for: 2m
+        labels:
+          severity: page
+          slo: balance_freshness
+          service: api
+        annotations:
+          summary: >-
+            Indexed balances are {{ $value | humanizeDuration }} out of date,
+            past the staleness budget
+          description: >-
+            The indexed view of the chain is {{ $value | humanizeDuration }}
+            old against a staleness budget of
+            {{ with query "indexer:freshness:budget_seconds" }}{{ . | first | value | humanizeDuration }}{{ end }}.
+            The API is now returning X-Indexer-Stale: true on every /api/
+            response, so clients are being told their balances are out of date.
+            This fires whether the indexer is merely behind or has stopped
+            completely: nester_indexer_lag_seconds is derived from the clock at
+            scrape time, so it keeps climbing with nothing running to push it.
+            Check nester_indexer_lag_last_sample_age_seconds first — near zero
+            means running but behind, climbing means stopped.
+          dashboard: /d/nester-slo-balance/balance-freshness
+          runbook: docs/observability/runbooks/balance-freshness.md
+
       - alert: IndexerLagHigh
         expr: indexer:freshness:lag_ledgers > 60
         for: 5m

--- a/docker/prometheus/rules/slo_alerts_test.yml
+++ b/docker/prometheus/rules/slo_alerts_test.yml
@@ -515,9 +515,16 @@ tests:
     input_series:
       - series: 'nester_indexer_lag_ledgers'
         values: '2x30'
+      - series: 'nester_indexer_lag_seconds'
+        values: '16x30'
+      - series: 'nester_indexer_staleness_budget_seconds'
+        values: '300x30'
       - series: 'nester_indexer_lag_last_sample_age_seconds'
         values: '0x30'
     alert_rule_test:
+      - eval_time: 20m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts: []
       - eval_time: 20m
         alertname: IndexerLagHigh
         exp_alerts: []
@@ -600,6 +607,106 @@ tests:
             exp_annotations:
               summary: "Event indexer has not reported lag for 20m 0s"
               description: "The lag gauge has not been updated in over 5 minutes, so the freshness signal itself is stale. The indexer polls every 6s, so this means it is wedged, erroring, or dead. Critically, the lag gauge may still read healthy — do not trust it. Check nester_indexer_lag_sample_errors_total and the indexer logs."
+              dashboard: /d/nester-slo-balance/balance-freshness
+              runbook: docs/observability/runbooks/balance-freshness.md
+
+  # ---------------------------------------------------------------------------
+  # The staleness budget (nester#1088)
+  # ---------------------------------------------------------------------------
+  #
+  # The budget is not a literal in the rule — it is a series the application
+  # exports — so these cases also prove the comparison reads it rather than a
+  # hardcoded 300.
+  #
+  # Boundary: the expression uses `>`, so lag exactly at the budget is inside
+  # it and must not fire. This is the same rule the API's stale flag applies.
+  - interval: 1m
+    name: staleness exactly at the budget does not page
+    input_series:
+      - series: 'nester_indexer_lag_seconds'
+        values: '300x30'
+      - series: 'nester_indexer_staleness_budget_seconds'
+        values: '300x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts: []
+
+  - interval: 1m
+    name: staleness past the budget pages after the confirmation window
+    input_series:
+      # Flat rather than a ramp, so the asserted annotation does not depend on
+      # which sample promtool considers current at eval time.
+      - series: 'nester_indexer_lag_seconds'
+        values: '900x30'
+      - series: 'nester_indexer_staleness_budget_seconds'
+        values: '300x30'
+    alert_rule_test:
+      # Over the budget from t=0, held pending by `for: 2m`.
+      - eval_time: 1m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: balance_freshness
+              service: api
+            exp_annotations:
+              summary: "Indexed balances are 15m 0s out of date, past the staleness budget"
+              description: "The indexed view of the chain is 15m 0s old against a staleness budget of 5m 0s. The API is now returning X-Indexer-Stale: true on every /api/ response, so clients are being told their balances are out of date. This fires whether the indexer is merely behind or has stopped completely: nester_indexer_lag_seconds is derived from the clock at scrape time, so it keeps climbing with nothing running to push it. Check nester_indexer_lag_last_sample_age_seconds first — near zero means running but behind, climbing means stopped."
+              dashboard: /d/nester-slo-balance/balance-freshness
+              runbook: docs/observability/runbooks/balance-freshness.md
+
+  # A retuned budget moves the alert with it. Same lag as the case above, but a
+  # 30 minute budget: nothing may fire. This is what proves the threshold comes
+  # from the application rather than from a number in this repository.
+  - interval: 1m
+    name: a widened budget silences the same staleness
+    input_series:
+      - series: 'nester_indexer_lag_seconds'
+        values: '900x30'
+      - series: 'nester_indexer_staleness_budget_seconds'
+        values: '1800x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # A completely dead indexer. The case this issue exists for.
+  # ---------------------------------------------------------------------------
+  #
+  # The indexer stopped, so it never published another position and
+  # nester_indexer_lag_ledgers is absent entirely — IndexerLagHigh has nothing
+  # to fire on and correctly does not. The seconds view is still present and
+  # still climbing, because the process derives it from the clock at scrape
+  # time, and it is what pages.
+  - interval: 1m
+    name: a dead indexer pages on staleness even with no ledger lag series
+    input_series:
+      # Deliberately no nester_indexer_lag_ledgers series at all.
+      - series: 'nester_indexer_lag_seconds'
+        values: '1200x30'
+      - series: 'nester_indexer_staleness_budget_seconds'
+        values: '300x30'
+      - series: 'nester_indexer_lag_last_sample_age_seconds'
+        values: '1200x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: IndexerLagHigh
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: IndexerStalenessBudgetExceeded
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: balance_freshness
+              service: api
+            exp_annotations:
+              summary: "Indexed balances are 20m 0s out of date, past the staleness budget"
+              description: "The indexed view of the chain is 20m 0s old against a staleness budget of 5m 0s. The API is now returning X-Indexer-Stale: true on every /api/ response, so clients are being told their balances are out of date. This fires whether the indexer is merely behind or has stopped completely: nester_indexer_lag_seconds is derived from the clock at scrape time, so it keeps climbing with nothing running to push it. Check nester_indexer_lag_last_sample_age_seconds first — near zero means running but behind, climbing means stopped."
               dashboard: /d/nester-slo-balance/balance-freshness
               runbook: docs/observability/runbooks/balance-freshness.md
 

--- a/docker/prometheus/rules/slo_recording.yml
+++ b/docker/prometheus/rules/slo_recording.yml
@@ -592,11 +592,35 @@ groups:
   # so healthy lag is a handful of ledgers. 60 is far enough above that to
   # tolerate a slow poll or a brief RPC stall without firing, and close enough
   # that a user seeing a stale balance is caught within minutes.
+  #
+  # The same budget stated in seconds is 60 * 5s = 300s, and that is the form
+  # the API and the staleness alert use (nester#1088). It is deliberately NOT
+  # written as a literal anywhere in this file: the application exports the
+  # budget it is actually enforcing as
+  # nester_indexer_staleness_budget_seconds, and the alert compares lag against
+  # that series. An operator who retunes INDEXER_STALENESS_BUDGET therefore
+  # moves the alert and the API's stale flag together, and the two cannot drift
+  # into disagreeing about whether balances are current.
+  #
+  # `max` across replicas rather than `avg`: freshness is a property of the
+  # data being served, and if any replica is serving stale balances, users are
+  # seeing stale balances. Averaging would let a healthy majority hide it.
   - name: slo_balance_freshness
     interval: 30s
     rules:
       - record: indexer:freshness:lag_ledgers
         expr: max(nester_indexer_lag_ledgers)
+
+      # Staleness in wall time: time since the last freshness sample plus that
+      # sample's ledger lag. Unlike lag_ledgers this series is always present
+      # and always moving, because the API derives it from the clock at scrape
+      # time rather than the indexer pushing it on a successful poll. That is
+      # what makes it able to catch an indexer that has stopped entirely.
+      - record: indexer:freshness:lag_seconds
+        expr: max(nester_indexer_lag_seconds)
+
+      - record: indexer:freshness:budget_seconds
+        expr: max(nester_indexer_staleness_budget_seconds)
 
       - record: indexer:freshness:sample_age_seconds
         expr: max(nester_indexer_lag_last_sample_age_seconds)

--- a/docs/observability/circuit-breakers.md
+++ b/docs/observability/circuit-breakers.md
@@ -1,0 +1,432 @@
+# Chain resilience — retries and circuit breakers
+
+**Packages:** `apps/api/internal/retry`, `apps/api/internal/breaker`
+**Metrics:** `nester_circuit_breaker_state`, `_failure_ratio`, `_rejected_total`, `nester_rpc_attempts_total`, `_exhaustions_total`, `_call_duration_seconds`
+**Health:** `GET /health/detailed` → `soroban_rpc.circuit_breaker`, `horizon.circuit_breaker`
+
+Two mechanisms, layered, doing different jobs:
+
+| | Absorbs | Bounded by |
+|---|---|---|
+| **Retry** (nester#1086) | A *single* transient failure, so it never reaches the user | Attempts, backoff, and a total budget |
+| **Breaker** (nester#1087) | A *sustained* outage, by shedding load entirely | A failure ratio over a rolling window |
+
+Retry handles the blip; the breaker handles the outage. See
+[Where the breaker sits](#where-the-breaker-sits) for why retry wraps the
+breaker and not the other way round.
+
+## Retry policy
+
+Exponential backoff with **full jitter** — the delay is drawn uniformly from
+`[0, cap)` rather than being the cap exactly, so a wave of clients that failed
+at the same moment does not retry in lockstep and knock the recovering
+endpoint back over.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `RPC_RETRY_MAX_ATTEMPTS` | `3` | Total calls including the first. `1` disables retrying without disabling the helper. |
+| `RPC_RETRY_BASE_DELAY` | `100ms` | Backoff cap for the first retry; doubles per attempt. |
+| `RPC_RETRY_MAX_DELAY` | `2s` | Ceiling on the exponential growth. |
+| `RPC_RETRY_BUDGET` | `12s` | Total wall time for one logical call. Applied as a context deadline, so one hung attempt cannot outlive it. Must stay below `SERVER_WRITE_TIMEOUT`. |
+
+**Only idempotent reads are retried.** The classification is a closed map in
+`internal/stellar` keyed by JSON-RPC method — `getEvents`, `getLatestLedger`,
+`simulateTransaction`, `getTransaction` and friends are retried;
+`sendTransaction` is not, and an unrecognised method fails closed so a Soroban
+method added later is safe by default. A resubmitted envelope is a second
+attempt to move real money, and the write path's durability comes from the
+submission record, which owns sequence allocation and double-submit prevention
+because that cannot live in a stateless retry loop.
+
+Retried: transport failures, read timeouts, 5xx, and 429. Not retried: any
+other 4xx (the upstream is healthy and rejecting us), JSON-RPC application
+errors inside a 200 (deterministic), caller cancellation, and `ErrOpen`.
+
+Exhaustion produces a typed `*retry.Error` matching `retry.ErrExhausted`,
+which the API maps to **503 `UPSTREAM_UNAVAILABLE`** with a `Retry-After` —
+never a generic 500.
+
+---
+
+## What this protects against
+
+When a chain endpoint degrades, every in-flight request sits on it until its
+own timeout, holding a connection the whole time. Requests arrive faster than
+they drain, the connection pool saturates, and a partial upstream outage
+becomes a **total** application outage — including for the endpoints that never
+needed the chain at all.
+
+The breaker cuts that feedback loop. Once an upstream is demonstrably
+unhealthy, calls to it fail immediately and locally: no connection is opened,
+no name is resolved, no timeout is waited on.
+
+There are **two independent breakers**, one per upstream:
+
+| Upstream | Guards |
+|---|---|
+| `soroban_rpc` | Contract simulation and reads, transaction submission, the event indexer's polling |
+| `horizon` | Operator account lookups, transaction confirmation polling, the XLM/USD rate provider |
+
+They share a *policy* but never *state*. A Horizon outage must not shed Soroban
+traffic — that would take deposits offline for a dependency they do not need,
+which is the failure this feature exists to prevent.
+
+---
+
+## States
+
+```
+                    failure ratio exceeded
+     ┌──────────────────────────────────────────┐
+     │                                          ▼
+  CLOSED                                      OPEN
+     ▲                                          │
+     │ probe succeeds                           │ open duration elapses
+     │                                          ▼
+     └────────────────────────────────────  HALF-OPEN
+                                                │
+                                                │ probe fails
+                                                ▼
+                                              OPEN
+```
+
+**CLOSED** — calls pass through. Outcomes are counted in a rolling window.
+
+**OPEN** — calls are rejected immediately with a typed error. The caller sees
+`errors.Is(err, breaker.ErrOpen)`, and the error carries how long until the
+next probe.
+
+**HALF-OPEN** — entered once the open duration elapses. **Exactly one** probe
+call is admitted; every other caller keeps failing fast. This is deliberate: a
+recovering upstream must not be hit by the entire accumulated backlog the
+instant the open period ends. The probe's outcome decides — success closes the
+breaker, failure re-opens it for another full period.
+
+The `OPEN → HALF-OPEN` transition is *measured, not timed*. There is no
+goroutine or timer waiting to move it, so a breaker that is never called again
+costs nothing and leaks nothing.
+
+---
+
+## What counts as a failure
+
+The rule is "does this suggest the upstream cannot serve us", not "did the
+caller get what they wanted".
+
+| Outcome | Counted as | Why |
+|---|---|---|
+| Connection refused, DNS failure, TLS error, read timeout | **failure** | Exactly the errors that hold a connection until it times out |
+| `context.DeadlineExceeded` | **failure** | Waiting past the deadline is the symptom of a degrading upstream |
+| HTTP 5xx | **failure** | The upstream is telling us it is unwell |
+| HTTP 429 | **failure** | The upstream is asking for less load; pushing harder is the harm |
+| HTTP 4xx (other) | success | The upstream is healthy and answering correctly |
+| HTTP 2xx / 3xx | success | — |
+| Caller cancellation (`context.Canceled`) | **ignored** | The client disconnected; the upstream never got its chance |
+
+**Why other 4xx are successes.** A 404 for an unfunded account or a 400 for a
+malformed contract call means the upstream is working. Counting them would let
+ordinary user input open the breaker and take the chain offline for everyone —
+a denial of service any client could trigger by looping an invalid request.
+
+**Why cancellation is ignored, not counted.** A burst of abandoned requests
+would otherwise open a breaker over a perfectly healthy endpoint. Ignored
+outcomes still release a half-open probe slot; without that, a cancelled probe
+would strand the breaker in half-open with no probe ever admissible again.
+
+**Not inspected:** JSON-RPC errors returned inside a 200. Doing so would mean
+reading and replacing the response body inside a transport, and Soroban's
+application errors (`startLedger is before the oldest ledger`) are mostly
+client mistakes rather than node ill-health. The failure mode this issue
+addresses — an endpoint degrading under load — surfaces as transport errors and
+5xx, which are covered.
+
+---
+
+## The failure window
+
+The ratio is computed over a **rolling window**, subdivided into ten buckets
+that expire as it advances. Failures from before the window do not contribute:
+an incident half an hour ago cannot hold the breaker near its threshold now.
+
+Closing the breaker **resets the window**. Carrying the failures that opened it
+into the recovered state would re-trip it on the very first new failure, making
+recovery impossible while any traffic still failed occasionally.
+
+### Why there is a minimum request count
+
+A ratio alone is unusable at small samples:
+
+```
+1 request, 1 failure → 100% failure ratio → breaker opens
+```
+
+`CIRCUIT_BREAKER_MIN_REQUESTS` is the floor that prevents a single timeout on
+an idle upstream from shedding all its traffic. The cost is that a very quiet
+upstream may never accumulate enough calls to trip — which is acceptable,
+because with no traffic there is no pile-on to prevent.
+
+---
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `CIRCUIT_BREAKER_ENABLED` | `true` | Kill switch. When false, no breaker is installed and every call goes straight to the upstream. |
+| `CIRCUIT_BREAKER_FAILURE_RATIO` | `0.5` | Share of failed calls, within the window, at or above which the breaker opens. |
+| `CIRCUIT_BREAKER_MIN_REQUESTS` | `10` | Calls that must be observed within the window before the ratio may open it. |
+| `CIRCUIT_BREAKER_WINDOW` | `60s` | How far back outcomes are counted. |
+| `CIRCUIT_BREAKER_OPEN_DURATION` | `15s` | How long the breaker sheds before admitting a probe. |
+
+One policy governs both upstreams. Separate per-upstream thresholds would
+double the configuration surface with no evidence that Soroban and Horizon need
+different numbers; the failure *state* is what must stay separate, and it does.
+
+**Why these defaults.** 0.5 is unambiguous degradation rather than noise. 10
+calls in 60s is low enough that a real outage under normal traffic trips within
+a window, high enough that one or two stray failures cannot. 15s is roughly
+three ledger closes — long enough to actually shed load, short enough that a
+transient blip costs one short outage rather than a long one.
+
+An invalid policy is **refused at startup**. A disabled breaker's thresholds
+are not validated, so the kill switch can always be used to recover from a bad
+configuration.
+
+---
+
+## Where the breaker sits
+
+```
+caller
+  ↓
+retry loop                     ← internal/retry, Soroban reads only
+  ↓
+circuit breaker transport      ← rejects here; nothing below runs
+  ↓
+metrics transport              ← nester_outbound_* recorded here
+  ↓
+net/http transport
+  ↓
+upstream
+```
+
+**Breaker above metrics.** A rejected call never reaches the metrics
+transport, so it is not counted as an outbound request and does not plant a
+near-zero sample in the latency histogram or a transport error under a
+made-up kind. `nester_outbound_*` keeps meaning "calls we actually made"; the
+shed load is reported by `nester_circuit_breaker_rejected_total` instead.
+
+**Retry above the breaker** (nester#1086), and this ordering is the one that
+matters:
+
+- Each retry attempt is a **real connection** against the upstream, so each is
+  evidence the breaker should weigh. Putting retry underneath would hide N
+  attempts behind one reported outcome.
+- Once the breaker opens, the loop's next attempt fails fast **locally**. The
+  retry stops immediately instead of burning its remaining backoff against an
+  endpoint already known to be down. `breaker.ErrOpen` is classified
+  non-retryable precisely so this happens.
+- The failure *ratio* is unaffected: three failed attempts count three
+  failures out of three observations, the same 100% as one out of one. Only
+  the sample count grows, which reaches `MIN_REQUESTS` sooner — a sick
+  upstream is detected faster, which is the desired direction.
+
+The reverse ordering — retry inside the breaker — would let a retry storm run
+to completion against a dead endpoint, holding a connection per attempt, which
+is exactly the pile-on the breaker exists to stop.
+
+Only idempotent reads are retried. `sendTransaction` is never repeated
+automatically; the write path's durability comes from the submission record.
+
+**Routing is per request URL, not per client.** `ContractInvoker` talks to
+Soroban RPC and Horizon through a single `*http.Client` — it simulates against
+the RPC, then reads the operator account from Horizon. Keying the breaker to
+the client would force those upstreams to share state. Routing per request
+keeps them independent without splitting any client.
+
+---
+
+## Observability
+
+### Metrics
+
+```promql
+# 0 = closed, 1 = half-open, 2 = open.
+nester_circuit_breaker_state{upstream="soroban_rpc"}
+nester_circuit_breaker_state{upstream="horizon"}
+
+# How close to tripping, or how fast the window is draining after recovery.
+nester_circuit_breaker_failure_ratio
+
+# Calls shed without touching the network.
+rate(nester_circuit_breaker_rejected_total[5m])
+```
+
+The state values ascend with severity, so `> 0` reads as "not fully healthy"
+and `max()` across replicas is the worst state rather than an arbitrary one.
+
+These are read at scrape time rather than pushed, because an open breaker
+becomes half-open when its open period elapses — a function of the clock, not
+of anything happening. A pushed gauge would keep reporting "open" until the
+next call arrived to move it.
+
+There is deliberately **no alert rule** in this change; the natural one is
+`nester_circuit_breaker_state > 0` sustained for a few minutes, alongside the
+existing balance-freshness alerts.
+
+### Health response
+
+`GET /health/detailed`:
+
+```json
+{
+  "status": "degraded",
+  "soroban_rpc": {
+    "ok": true,
+    "latest_ledger": 493812,
+    "circuit_breaker": {
+      "state": "open",
+      "failure_ratio": 0.83,
+      "observed_requests": 24,
+      "rejected_total": 1841,
+      "retry_in_seconds": 9
+    }
+  },
+  "horizon": {
+    "ok": true,
+    "circuit_breaker": { "state": "closed", "failure_ratio": 0, "observed_requests": 12, "rejected_total": 0 }
+  }
+}
+```
+
+An absent `circuit_breaker` field means that dependency is **not guarded**
+(the breakers are disabled), not that it is healthy.
+
+The probes (`ok`, `latest_ledger`) deliberately do **not** go through the
+breaker. A health check is a diagnostic, and an open breaker must not report an
+upstream as unreachable when it has in fact recovered. Seeing `"ok": true`
+alongside `"state": "open"` is exactly what tells an operator recovery is one
+probe away.
+
+### Readiness
+
+**An open breaker does not make the service unready.** `/readyz` continues to
+depend only on the database, as it always has.
+
+This is deliberate. Chain dependencies have never gated readiness here, and
+making an open breaker return 503 would evict the pod from its load balancer
+over an upstream outage — turning the partial failure into the total one this
+feature exists to prevent. An open breaker sets `status: "degraded"` in
+`/health/detailed`, which is the signal for humans and dashboards, not for the
+orchestrator.
+
+### API behaviour while open
+
+Vault endpoints that need the chain return **503 Service Unavailable** with
+code `UPSTREAM_UNAVAILABLE` and a `Retry-After` header set to the breaker's
+remaining open period. This is a known, temporary upstream condition with a
+known retry time, not a fault in this service, and 500 would tell a client to
+treat it as a bug rather than to back off.
+
+Rejections are **not logged individually**. An open breaker can reject
+thousands of calls a second; a log line each would turn an upstream outage into
+a logging outage. Only state transitions are logged — opening at `WARN`,
+everything else at `INFO`.
+
+---
+
+## When a breaker is open
+
+**1. Is the upstream actually down, or did we trip on something else?**
+
+```bash
+curl -s https://<api-host>/health/detailed | jq '.soroban_rpc, .horizon'
+```
+
+`"ok": true` with `"state": "open"` means the upstream has recovered and the
+breaker will close on its next probe. Wait one open duration.
+
+**1a. Were the retries already struggling before it tripped?**
+
+```promql
+rate(nester_rpc_attempts_total[5m]) / rate(nester_rpc_call_duration_seconds_count[5m])
+rate(nester_rpc_exhaustions_total[5m])
+```
+
+Average attempts per call climbs before the breaker opens, so this usually
+shows when the degradation actually started rather than when it became bad
+enough to shed.
+
+**2. What is the upstream doing?**
+
+```promql
+sum by (kind) (rate(nester_outbound_errors_total{upstream="soroban_rpc"}[5m]))
+sum by (status_class) (rate(nester_outbound_requests_total{upstream="soroban_rpc"}[5m]))
+histogram_quantile(0.95, sum by (le) (rate(nester_outbound_request_duration_seconds_bucket{upstream="soroban_rpc"}[5m])))
+```
+
+`kind="timeout"` climbing is the classic degradation. A 5xx spike is the
+upstream failing outright. A 429 spike means we are being rate limited — check
+whether a backfill or a misconfigured poll interval is the cause before blaming
+the provider.
+
+**3. Did we trip on our own traffic?**
+
+A `429` spike alongside an operator-triggered backfill is self-inflicted.
+Backfill and the admin one-shot sync are **not** routed through the breaker
+(see below), so they can still saturate an upstream that live traffic is being
+shed from.
+
+**4. Is it flapping?**
+
+```promql
+changes(nester_circuit_breaker_state{upstream="soroban_rpc"}[15m])
+```
+
+Repeated open→half-open→open means the upstream is marginal rather than down.
+Consider raising `CIRCUIT_BREAKER_OPEN_DURATION` so each probe cycle costs
+less, or failing over to a secondary endpoint.
+
+**5. Escalate or override.**
+
+If the thresholds are wrong for the environment — the breaker is shedding
+traffic an upstream could actually serve — set `CIRCUIT_BREAKER_ENABLED=false`
+and restart. That is what the kill switch is for. Fix the thresholds before
+re-enabling.
+
+### Knock-on effect: indexer staleness
+
+An open Soroban breaker stops the event indexer making progress, which is
+**intended** — it is the traffic most worth shedding. The consequence is that
+indexed balances go stale, and that is detected separately by the
+balance-freshness SLI:
+
+```
+Soroban degradation → breaker opens → indexer stops progressing
+                                    → nester_indexer_lag_seconds climbs
+                                    → IndexerStalenessBudgetExceeded pages
+```
+
+See [the balance-freshness runbook](runbooks/balance-freshness.md). The two
+mechanisms are deliberately independent: the breaker knows nothing about the
+indexer, and the freshness signal knows nothing about why the indexer stopped.
+
+---
+
+## What is not guarded
+
+| Caller | Guarded | Why |
+|---|---|---|
+| Contract reads / simulation | yes | User-facing read path |
+| Transaction submission | yes | The money path |
+| Event indexer polling | yes | Highest-volume Soroban caller |
+| Transaction confirmation polling | yes | Steadiest Horizon caller |
+| XLM/USD rate provider | yes | Horizon order book |
+| `POST /api/v1/admin/sync-events` | **no** | Operator recovery action; blocking it during an incident would remove a tool the runbook depends on |
+| `POST /api/v1/admin/backfill` | **no** | Same, and it is already bounded by its own sequential loop |
+| `/health/detailed` probes | **no** | Diagnostic; must report the upstream's real state |
+| CoinGecko, DeFiLlama, Anthropic relay, intelligence | **no** | Out of scope for this issue |
+
+The admin exclusions are a deliberate trade: an operator running a recovery
+backfill can still saturate an upstream that live traffic is being shed from.
+That is visible as a 429 or 5xx spike with the breaker already open, and step 3
+above calls it out.

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -255,6 +255,130 @@ histogram_quantile(0.99,
   sum by (le, upstream) (rate(nester_outbound_request_duration_seconds_bucket[5m])))
 ```
 
+### Soroban RPC retries
+
+Source: `internal/metrics/rpc.go`, recorded by the shared retry helper in
+`internal/retry` via `internal/stellar`'s RPC client.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `nester_rpc_attempts_total` | Counter | `upstream` | Individual attempts, retries included. |
+| `nester_rpc_exhaustions_total` | Counter | `upstream` | Logical calls that used up their attempts or budget. |
+| `nester_rpc_call_duration_seconds` | Histogram | `upstream` | End-to-end latency of a logical call, retries and backoff included. |
+
+These describe **logical calls**; the outbound metrics above describe **HTTP
+attempts**. The pair is the useful signal:
+
+```promql
+# Average attempts per call. Moves long before anything fails outright, so
+# it is the earliest warning an upstream is degrading.
+rate(nester_rpc_attempts_total[5m])
+  / rate(nester_rpc_call_duration_seconds_count[5m])
+
+# Retries have stopped being enough — these reach the user as a 503.
+rate(nester_rpc_exhaustions_total[5m])
+
+# What a user actually waited, retries included.
+histogram_quantile(0.95,
+  sum by (le, upstream) (rate(nester_rpc_call_duration_seconds_bucket[5m])))
+```
+
+**Cardinality:** three metrics × the upstreams actually called. No method
+label — per-method detail comes from the `soroban.rpc/<method>` spans, which
+already carry it without minting series.
+
+**Only idempotent reads are retried.** `sendTransaction` is never repeated
+automatically; the write path's durability comes from the submission record.
+A `sendTransaction` still appears here with `attempts=1`, so the metrics cover
+every call rather than only the retryable ones.
+
+### Circuit breakers
+
+Source: `internal/metrics/breaker.go`, a pull collector over
+`internal/breaker`. See [circuit-breakers.md](circuit-breakers.md) for the
+state machine, the failure classification, and the operator guide.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `nester_circuit_breaker_state` | Gauge | `upstream` | 0 closed, 1 half-open, 2 open. |
+| `nester_circuit_breaker_failure_ratio` | Gauge | `upstream` | Failure ratio within the rolling window. |
+| `nester_circuit_breaker_rejected_total` | Counter | `upstream` | Requests rejected without contacting the upstream. |
+
+`upstream` is `soroban_rpc` or `horizon` — the same bounded constant set the
+outbound metrics use, never a URL or a host.
+
+**Cardinality:** three metrics × two upstreams = six series, fixed at startup.
+The breakers come from configuration, so nothing about a request can move the
+count. A test asserts both the series count and that every label value is one
+of the constants.
+
+State values ascend with severity, so `> 0` reads as "not fully healthy" and
+`max()` across replicas is the worst state rather than an arbitrary one.
+
+```promql
+# Any chain upstream being shed right now.
+max by (upstream) (nester_circuit_breaker_state) > 0
+
+# Load actually shed.
+sum by (upstream) (rate(nester_circuit_breaker_rejected_total[5m]))
+
+# Flapping: repeated open/half-open cycling means a marginal upstream.
+changes(nester_circuit_breaker_state[15m])
+```
+
+### Indexer freshness
+
+Source: `internal/metrics/freshness.go`, a pull collector over
+`internal/freshness`. Nothing here is pushed.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `nester_indexer_lag_seconds` | Gauge | none | Age of the indexed view of the chain. |
+| `nester_indexer_lag_ledgers` | Gauge | none | Network tip minus last indexed ledger. **Absent until the indexer reports a position.** |
+| `nester_indexer_staleness_budget_seconds` | Gauge | none | The budget the API is enforcing (`INDEXER_STALENESS_BUDGET`). |
+| `nester_indexer_lag_last_sample_age_seconds` | Gauge | none | Seconds since the indexer last reported a position. |
+| `nester_indexer_lag_sample_errors_total` | Counter | none | Failed sampling attempts. |
+
+**Cardinality:** five series, fixed. The freshness of the indexed view is a
+single process-wide fact, so there is nothing to break it down by and no way
+for traffic to move the count. A test asserts none of these carry a label.
+
+**Why a pull collector.** These were gauges the indexer pushed on each
+successful poll, which meant a dead indexer left every one of them frozen at
+its last healthy value — lag 0, sample age 0, alerts silent. Deriving them at
+scrape time means `lag_seconds` and `lag_last_sample_age_seconds` climb on the
+clock, so an indexer that has stopped is visible without anything of ours still
+having to run. This is the failure mode the balance-freshness SLI exists to
+catch, so it is worth the collector.
+
+`lag_seconds` is `(now − last sample) + ledger lag × 5s`; see
+[the SLO document](slo.md#5-balance-freshness) for why both terms are required.
+
+#### API response headers
+
+The same freshness model annotates every `/api/` response
+(`internal/middleware/freshness.go`), so a client can degrade honestly instead
+of presenting a stale balance as live. Stale data is still served with a 2xx —
+failing the request would tell the user nothing useful about their money.
+
+| Header | Meaning |
+| --- | --- |
+| `X-Indexer-Stale` | `true` / `false`. The authoritative answer; decided by the same budget the alert uses. |
+| `X-Indexer-Lag-Seconds` | Staleness in whole seconds, rounded **up** so it never understates. |
+| `X-Indexer-Lag-Ledgers` | Lag in ledgers. **Omitted** when the indexer has not reported a position — absent means "unknown", which a `0` would misreport as "exactly at the tip". |
+| `X-Indexer-Staleness-Budget-Seconds` | The budget the flag was decided against. |
+
+All four are listed in `Access-Control-Expose-Headers`, so a browser client on
+another origin can read them.
+
+```promql
+# Is the served data inside its budget?
+nester_indexer_lag_seconds <= nester_indexer_staleness_budget_seconds
+
+# Running but behind, or stopped? Near zero is behind; climbing is stopped.
+nester_indexer_lag_last_sample_age_seconds
+```
+
 ### Runtime
 
 The standard Go and process collectors are registered: `go_goroutines`,

--- a/docs/observability/runbooks/balance-freshness.md
+++ b/docs/observability/runbooks/balance-freshness.md
@@ -1,27 +1,33 @@
 # Runbook — Balance freshness (indexer lag)
 
-**Alerts:** `IndexerLagHigh` (page), `IndexerLagStale` (page), `IndexerMetricsAbsent` (page)
+**Alerts:** `IndexerStalenessBudgetExceeded` (page), `IndexerLagHigh` (page),
+`IndexerLagStale` (page), `IndexerMetricsAbsent` (page)
 **Dashboard:** [SLO — Balance freshness](/d/nester-slo-balance/balance-freshness)
-**SLO:** indexer lag ≤ 60 ledgers (~5 minutes)
+**Staleness budget:** **300s (5 minutes)** — `INDEXER_STALENESS_BUDGET`,
+equivalently 60 ledgers at a ~5s close interval
 
 ---
 
 ## What the alert means
 
-**Read which alert fired first — they mean different things and one of them is
-a trap.**
+Balances in the app come from the event indexer's view of the chain. When the
+indexer falls behind, that view is out of date, and the API says so: past the
+budget every `/api/` response carries `X-Indexer-Stale: true`.
+
+**Read which alert fired — they mean different things.**
 
 | Alert | Meaning |
 |---|---|
-| `IndexerLagHigh` | The indexer is running but falling behind the chain tip. |
-| `IndexerLagStale` | The indexer stopped reporting. **The lag value may look perfectly healthy and must not be trusted.** |
-| `IndexerMetricsAbsent` | The freshness series is gone entirely — API down, scrape broken, or the indexer never started. |
+| `IndexerStalenessBudgetExceeded` | **The budget is blown.** Indexed data is older than 5 minutes and clients are being told their balances are stale. Fires whether the indexer is behind *or* dead. This is the authoritative one. |
+| `IndexerLagHigh` | The indexer is alive and reporting, but falling behind in ledgers. |
+| `IndexerLagStale` | The indexer stopped reporting a position. **The ledger lag figure beside it is frozen and must not be trusted.** |
+| `IndexerMetricsAbsent` | The freshness series is gone entirely — API down, scrape broken, or the process never started. |
 
-`IndexerLagStale` exists because a lag gauge alone cannot distinguish "lag is
-2 ledgers" from "the sampler died and the value is frozen at 2". The second
-silently reports perfect health, which is the worst possible failure for a
-freshness signal. If this alert is firing, **ignore the lag number entirely**
-and treat the indexer as stopped.
+`IndexerStalenessBudgetExceeded` cannot be fooled by a dead indexer:
+`nester_indexer_lag_seconds` is derived from the clock at scrape time, not
+pushed by the indexer, so it keeps climbing with nothing of ours still running
+to push it. If it is firing and `IndexerLagHigh` is not, the indexer has
+**stopped**, not slowed.
 
 **User impact:** users see stale balances. A deposit that has settled on-chain
 does not appear in the app. This pages — rather than tickets — because a
@@ -30,54 +36,120 @@ one, and users conclude their money is missing.
 
 ---
 
-## First three actions
+# 1. Diagnose
 
-**1. Establish whether the indexer is running at all.**
+## First four checks, in order
+
+**1. How stale is the data, and by how much is the budget blown?**
+
+```promql
+nester_indexer_lag_seconds
+nester_indexer_staleness_budget_seconds
+```
+
+The first number is what users are seeing, in seconds. Anything under the
+second is fine. This is the same comparison the alert and the API's stale flag
+make, so if it is over, clients are already being told.
+
+**2. Is the indexer running at all?** This is the branch that decides
+everything below.
 
 ```promql
 nester_indexer_lag_last_sample_age_seconds
 ```
 
-- Near zero and resetting → running, genuinely behind. Go to
+- **Near zero, resetting every ~6s** → running, genuinely behind. Go to
   [Cause A](#cause-a--indexer-falling-behind).
-- Climbing steadily → **stopped**. Go to
+- **Climbing steadily** → **stopped**. Go to
   [Cause B](#cause-b--indexer-stopped-or-wedged).
-- No series → go to [Cause C](#cause-c--indexer-never-started).
+- **No series at all** → go to [Cause C](#cause-c--indexer-never-started).
 
-**2. Check for sampling errors.**
+**3. How far behind in ledgers, and is it moving?**
+
+```promql
+nester_indexer_lag_ledgers
+```
+
+**No data here is itself a finding**: the gauge is withheld until the indexer
+reports a position, so an absent series means it has never committed a cursor.
+It is deliberately not published as `0`, because `0` would claim the indexer is
+exactly at the tip — the one value that looks perfect.
+
+**4. Are samples erroring?**
 
 ```promql
 rate(nester_indexer_lag_sample_errors_total[5m])
 ```
 
-Non-zero means the indexer loop is erroring — cursor load, contract load, or
-the Soroban fetch. The logs in the next section name which.
+Non-zero means the loop cannot read its cursor or reach the RPC. The logs below
+name which.
 
-**3. Check the RPC dependency.**
+## Read the numbers directly
+
+Current indexer cursor, straight from the source of truth:
+
+```bash
+docker compose exec postgres psql -U nester nester_dev -c \
+  "SELECT value AS indexed_ledger, updated_at FROM system_state WHERE key = 'event_indexer.last_ledger';"
+```
+
+`updated_at` is when the cursor last advanced. If it is minutes old, the
+indexer is not making progress regardless of what any gauge says.
+
+Current network ledger, from the same RPC the indexer polls:
+
+```bash
+curl -s -X POST "$STELLAR_RPC_URL" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger"}' | jq '.result.sequence'
+```
+
+The difference between those two numbers **is** the ledger lag, computed by
+hand. Use it when you do not trust the metric.
+
+## What a client is being told
+
+```bash
+curl -s -D - -o /dev/null https://<api-host>/api/v1/vaults -H "Authorization: Bearer $TOKEN" \
+  | grep -i '^x-indexer'
+```
+
+```
+X-Indexer-Stale: true
+X-Indexer-Lag-Seconds: 743
+X-Indexer-Lag-Ledgers: 140
+X-Indexer-Staleness-Budget-Seconds: 300
+```
+
+This is exactly what the UI sees. If support is asking "are users being shown a
+warning?", this answers it. `X-Indexer-Lag-Ledgers` absent means the indexer
+has never reported a position.
+
+## Is upstream healthy?
 
 ```promql
 sum by (kind) (rate(nester_outbound_errors_total{upstream="soroban_rpc"}[5m]))
 histogram_quantile(0.95, sum by (le) (rate(nester_outbound_request_duration_seconds_bucket{upstream="soroban_rpc"}[5m])))
 ```
 
-The indexer polls Soroban every 6s. A slow or failing endpoint stalls it
-directly.
+The indexer polls Soroban every 6s with an 8s client timeout. A slow endpoint
+stalls it directly.
 
----
+Both dependencies at once:
 
-## Dashboards
+```bash
+curl -s https://<api-host>/api/v1/admin/health -H "Authorization: Bearer $ADMIN_TOKEN" | jq
+```
 
-| Panel | Question it answers |
-|---|---|
-| **Indexer lag** | How far behind, right now |
-| **Lag sample age** | Whether the lag number can be trusted at all |
-| **Sample errors** | Whether the loop is erroring |
-| **Indexer lag over time** | Sawtooth (normal) vs monotonic climb (stall) |
+## Is storage healthy?
 
-A **sawtooth** pattern is healthy — the cursor advances in steps. A **monotonic
-climb** is a stall.
+```promql
+nester_db_pool_acquired_connections / nester_db_pool_max_connections
+rate(nester_db_pool_empty_acquire_waits_total[5m])
+```
 
----
+A saturated pool starves the indexer's per-event transaction, and every event
+it applies takes one.
 
 ## Logs
 
@@ -85,28 +157,29 @@ climb** is a stall.
 kubectl logs -l app=nester-api --since=30m | grep -i "event indexer"
 ```
 
-The loop logs a distinct message per failure mode:
-
 | Log message | Meaning |
 |---|---|
-| `event indexer failed to load cursor` | `system_state` read failing — database problem |
-| `event indexer failed to load vault contracts` | Contract query failing — database problem |
-| `event indexer fetch failed` | Soroban RPC failing |
-| `event indexer failed to apply event` | Per-event write failure; loop continues |
-| `event indexer failed to persist cursor` | **Cursor not advancing — the loop reprocesses forever** |
+| `event indexer poll failed` | The pass errored — the wrapped error names the stage (`resolve start ledger`, `load vault contracts`, `fetch events`, `apply event …`) |
+| `event indexer cold start` | First run; `start_ledger` is where it began |
 | `event indexer disabled: STELLAR_RPC_URL is empty` | Never started at all |
 
-The last two are the most consequential. A failing cursor persist means the
-indexer runs continuously without ever making progress.
+`apply event <id> (ledger N)` repeating with the same event ID is the worst
+case: one event fails permanently and the cursor cannot advance past it, so the
+indexer runs forever without progressing. Note the ledger number — you will
+need it for the catch-up path.
 
----
+## Dashboards
 
-## Traces
+| Panel | Question it answers |
+|---|---|
+| **Data staleness** | How stale, in seconds — the number the budget governs |
+| **Data staleness against the budget** | Where the crossing happened, and whether it is recovering |
+| **Indexer lag** | How far behind in ledgers |
+| **Lag sample age** | Behind, or stopped |
+| **Sample errors** | Whether the loop is erroring |
 
-Indexer polls are background work, not request-scoped, so tracing coverage is
-thinner here than on the request path. Use the outbound metrics above for RPC
-health; use Jaeger for `soroban_rpc` spans if the invoker is instrumented in
-your deployment.
+A **sawtooth** in ledger lag is healthy — the cursor advances in steps. A
+**monotonic climb** is a stall.
 
 ---
 
@@ -114,72 +187,216 @@ your deployment.
 
 ### Cause A — Indexer falling behind
 
-Running, sampling normally, but lag is climbing.
+Running and sampling normally, but lag is climbing.
 
-**Distinguishing evidence:** `sample_age_seconds` resets to zero regularly
-(loop alive) while `lag_ledgers` climbs.
+**Distinguishing evidence:** `lag_last_sample_age_seconds` resets to near zero
+every few seconds (loop alive) while `lag_ledgers` and `lag_seconds` climb.
 
-Sub-causes, in order of likelihood:
+In order of likelihood:
 
 1. **Soroban RPC slow.** p95 outbound duration elevated; each poll takes longer
    than the 6s tick, so it cannot keep up.
 2. **Event volume spike.** Many contracts or a burst of activity; the apply
-   loop is the bottleneck.
-3. **Database write contention.** `applyIndexedEvent` slow; check pool metrics.
-
-**Mitigation:** usually self-correcting once the underlying pressure clears.
-Watch the trend rather than acting immediately — if lag is falling, it is
-recovering. If it climbs past several hundred ledgers, escalate: catch-up time
-grows with the gap.
+   loop is the bottleneck. Each event is its own transaction.
+3. **Database write contention.** Check the pool metrics above.
 
 ### Cause B — Indexer stopped or wedged
 
-**Distinguishing evidence:** `sample_age_seconds` climbing steadily.
-`IndexerLagStale` firing. The lag gauge is frozen — **it will often read a
-perfectly healthy value, which is exactly the trap this alert exists for.**
+**Distinguishing evidence:** `lag_last_sample_age_seconds` climbing steadily.
+`IndexerStalenessBudgetExceeded` firing while `IndexerLagHigh` is not — the
+ledger gauge is frozen or absent, so it has nothing to fire on.
 
-Sub-causes:
-
-1. **Cursor persist failing** — `failed to persist cursor` in the logs. The
-   loop runs, reprocesses the same ledgers, never advances. Usually a database
-   write problem.
-2. **Goroutine dead.** The loop exited or panicked. Check `go_goroutines` for a
+1. **A single event failing permanently.** `apply event …` repeating for the
+   same ID. The pass stops at that event by design rather than skipping it, so
+   the cursor never advances past it. This is the most common wedge.
+2. **Cursor persist failing.** A database write problem: the loop runs,
+   reprocesses the same ledgers, never advances. `system_state.updated_at`
+   stops moving.
+3. **Goroutine dead.** The loop exited or panicked. Check `go_goroutines` for a
    step down, and the logs for a panic.
-3. **Context cancelled.** Shutdown began but the process did not exit cleanly.
-
-**Mitigation:** restart the API. The indexer starts with the process and a
-restart is the reliable way to recover a wedged loop. If cursor persistence is
-failing, fix the database problem first or it will wedge again immediately.
+4. **Context cancelled.** Shutdown began but the process did not exit cleanly.
 
 ### Cause C — Indexer never started
 
-**Distinguishing evidence:** `IndexerMetricsAbsent` firing, or the log line
-`event indexer disabled: STELLAR_RPC_URL is empty`.
+**Distinguishing evidence:** `IndexerMetricsAbsent` firing, or
+`nester_indexer_lag_ledgers` absent while `lag_seconds` climbs from zero since
+process start, or the log line `event indexer disabled: STELLAR_RPC_URL is
+empty`.
 
-The indexer disables itself silently at boot when `STELLAR_RPC_URL` is empty.
-This is a common misconfiguration after an environment change, and without
-`IndexerMetricsAbsent` it would produce no signal whatsoever.
-
-**Mitigation:** set `STELLAR_RPC_URL` and restart.
+The indexer disables itself at boot when `STELLAR_RPC_URL` is empty — a common
+misconfiguration after an environment change.
 
 ---
 
-## Immediate mitigation
+# 2. Catch up
 
-1. **Restart the API** if the indexer is wedged (Cause B). Most effective and
-   most common.
-2. **Fix the configuration** and restart if it never started (Cause C).
-3. **Fail over the RPC endpoint** if Soroban is degraded and a secondary exists.
-4. **Wait and monitor** if it is catching up under load (Cause A) — restarting
-   loses no progress, the cursor is persisted, but it also does not help.
+Pick the procedure that matches the cause. **Restarting loses no progress:**
+the cursor is committed in the same transaction as the balance write, so the
+indexer always resumes exactly where it stopped.
 
-**Communicate** if lag exceeds ~1000 ledgers (roughly 90 minutes): at that
-point users are seeing materially stale balances and will contact support.
-Telling them balances are delayed is far better than users concluding funds
-have vanished.
+### Restart the API — Cause B, and the default action
 
-**Never** silence these alerts to stop the noise. A stale balance that nobody
-is alerted about is how a trust incident starts.
+The indexer starts with the process. A restart is the reliable way to recover a
+wedged loop.
+
+```bash
+kubectl rollout restart deployment/nester-api
+kubectl rollout status deployment/nester-api
+```
+
+If cursor persistence is failing, **fix the database problem first** or it will
+wedge again immediately.
+
+### Fix the configuration and restart — Cause C
+
+Set `STELLAR_RPC_URL` and restart. On the next tick the indexer cold-starts 12
+ledgers below the tip (`DefaultColdStartOffset`) and persists that cursor
+immediately.
+
+### Let it catch up on its own — Cause A
+
+Usually self-correcting once the underlying pressure clears. Watch the trend
+rather than acting: if `lag_seconds` is falling, it is recovering, and
+restarting does not make it faster. Escalate if it is still climbing after 15
+minutes.
+
+### Force a one-shot sync — after a bounded RPC outage
+
+Runs an indexing pass synchronously from the current cursor and returns how
+many events it applied. Safe to repeat: every event is deduplicated by
+`processed_events.event_id`.
+
+```bash
+curl -s -X POST https://<api-host>/api/v1/admin/sync-events \
+  -H "Authorization: Bearer $ADMIN_TOKEN" | jq
+# => {"success":true,"data":{"processed":37}}
+```
+
+Use this when the indexer is healthy again and you want the gap closed now
+rather than at the next tick.
+
+### Replay a ledger range — when events were missed
+
+For a known window (an outage with a start and end ledger), use the backfill
+runner rather than moving the cursor by hand. It checkpoints, so a long run can
+be resumed.
+
+```bash
+# Reprocess a range; relies on processed_events deduplication.
+curl -s -X POST https://<api-host>/api/v1/admin/backfill \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"from_ledger":493000,"to_ledger":494000,"mode":"backfill","dry_run":true}' | jq
+
+# Resume an interrupted run from its last checkpoint.
+curl -s -X POST https://<api-host>/api/v1/admin/backfill/<run-id>/resume \
+  -H "Authorization: Bearer $ADMIN_TOKEN" | jq
+```
+
+**Always `dry_run` first.** `mode: "rebuild"` additionally clears derived rows
+and their `processed_events` entries so they are reapplied — it is destructive
+and should only be used when the derived state is known to be wrong, not merely
+behind.
+
+### Get past one permanently failing event — last resort
+
+Only when Cause B sub-cause 1 is confirmed: the same `apply event <id> (ledger
+N)` repeating, and the underlying defect cannot be fixed quickly.
+
+Advancing the cursor past a failing event **permanently skips it** — that
+balance mutation will never be applied and the vault's balance will be wrong
+until it is reconciled. Get a second engineer on the call, record the event ID
+and ledger, and open a reconciliation ticket in the same breath.
+
+```sql
+-- Record what you are skipping FIRST.
+SELECT * FROM processed_events WHERE ledger_sequence = <N>;
+
+UPDATE system_state
+SET value = '<N+1>', updated_at = NOW()
+WHERE key = 'event_indexer.last_ledger';
+```
+
+Prefer fixing the event handler and restarting. This is the only procedure here
+that loses data.
+
+## Communicate
+
+If staleness exceeds ~30 minutes, tell users balances are delayed. That is far
+better than users concluding funds have vanished. The API is already returning
+`X-Indexer-Stale: true`, so the app should be showing an "as of" indicator —
+confirm it is.
+
+**Never** silence these alerts to stop the noise. A stale balance nobody is
+alerted about is how a trust incident starts.
+
+---
+
+# 3. Verify recovery
+
+Work down this list. **Check 2 is not optional.**
+
+**1. The cursor is advancing.** Run it twice, ten seconds apart:
+
+```bash
+docker compose exec postgres psql -U nester nester_dev -c \
+  "SELECT value, updated_at FROM system_state WHERE key = 'event_indexer.last_ledger';"
+```
+
+`value` must increase and `updated_at` must be recent. This is ground truth and
+does not depend on any metric being correct.
+
+**2. The freshness signal is live, not frozen.**
+
+```promql
+nester_indexer_lag_last_sample_age_seconds
+```
+
+Near zero and resetting. A staleness of zero with a climbing sample age means
+the indexer is still dead and the number beside it is stale.
+
+**3. Staleness is back inside the budget and falling.**
+
+```promql
+nester_indexer_lag_seconds < nester_indexer_staleness_budget_seconds
+```
+
+The dashboard's "Data staleness against the budget" panel shows this as the
+line dropping back under the budget line. Falling matters as much as being
+under: a flat value just below the budget is not recovery.
+
+**4. Ledger lag is present and low.**
+
+```promql
+nester_indexer_lag_ledgers
+```
+
+The series must **exist** — its return is what proves the indexer is reporting
+a position again — and sit well under 60.
+
+**5. Samples are clean.**
+
+```promql
+rate(nester_indexer_lag_sample_errors_total[5m])
+```
+
+Zero.
+
+**6. The API reports fresh data to clients.**
+
+```bash
+curl -s -D - -o /dev/null https://<api-host>/api/v1/vaults -H "Authorization: Bearer $TOKEN" \
+  | grep -i '^x-indexer-stale'
+# => X-Indexer-Stale: false
+```
+
+This is the acceptance test: it is what a user's app sees.
+
+**7. The alert clears.** `IndexerStalenessBudgetExceeded` resolves within a
+scrape interval or two of check 3 passing. If it does not, the budget series
+and the lag series are not both being scraped — check the target is up.
+
+**8. Spot-check a real deposit.** Confirm one recently settled deposit appears
+in the app.
 
 ---
 
@@ -187,9 +404,10 @@ is alerted about is how a trust incident starts.
 
 Escalate when:
 
-- Lag exceeds 1000 ledgers, or is still climbing after a restart.
+- Staleness exceeds 30 minutes, or is still climbing after a restart.
 - `IndexerLagStale` persists after a restart — indicates a deeper fault.
 - Cursor persistence is failing (progress impossible until fixed).
+- You are considering skipping a failing event.
 - Users are reporting missing deposits.
 
 Escalate to the repository maintainers (CODEOWNERS). Missing-deposit reports
@@ -197,27 +415,10 @@ escalate immediately — they need reconciliation, not only recovery.
 
 ---
 
-## Recovery verification
-
-1. `nester_indexer_lag_ledgers` below 60 **and falling or stable**.
-2. `nester_indexer_lag_last_sample_age_seconds` near zero and resetting — this
-   is the one that proves the signal is live rather than frozen.
-3. `rate(nester_indexer_lag_sample_errors_total[5m])` at zero.
-4. Balance probe passing:
-   ```promql
-   nester_probe_success{probe="balance"}
-   ```
-5. Spot-check one recently settled deposit appearing in the app.
-
-**Check 2 is not optional.** A lag of zero with a climbing sample age means the
-indexer is still dead and the number is stale.
-
----
-
 ## Follow-up
 
-**Postmortem required** when lag exceeded 1000 ledgers, when users reported
-missing deposits, or when the indexer was stopped for more than 30 minutes.
+**Postmortem required** when staleness exceeded 30 minutes, when users reported
+missing deposits, or when an event was skipped.
 
 Cover cause, how long balances were stale, whether users noticed before the
 alert fired, and whether this runbook led to the cause. **If it did not, fix it
@@ -228,6 +429,6 @@ so [the error-budget policy](../error-budget-policy.md) does not apply
 mechanically. A sustained breach is still grounds for prioritising reliability
 work by judgement.
 
-If the indexer was stopped and `IndexerLagStale` did **not** fire, that is a
-serious finding for the next [SLO review](../slo-review.md): the staleness
-guard is the mechanism that makes this SLI trustworthy at all.
+If the indexer was stopped and `IndexerStalenessBudgetExceeded` did **not**
+fire, that is a serious finding for the next [SLO review](../slo-review.md):
+that alert is the mechanism that makes this SLI trustworthy at all.

--- a/docs/observability/slo-review.md
+++ b/docs/observability/slo-review.md
@@ -202,7 +202,7 @@ On-call during period:
 | Flow latency | 99% <30s | | | | |
 | Intelligence availability | 99% | | | | |
 | Intelligence TTFT | 95% <3s | | | | |
-| Balance freshness | ≤60 ledgers | n/a | n/a | | |
+| Balance freshness | ≤300s staleness | n/a | n/a | | |
 | Intelligence refusal | <30% | n/a | n/a | | |
 
 ## 2. Incidents

--- a/docs/observability/slo.md
+++ b/docs/observability/slo.md
@@ -180,32 +180,84 @@ experiences them, so the SLI does too.
 
 | | |
 |---|---|
-| **Measurement** | network ledger tip − last successfully indexed ledger |
-| **Source** | `nester_indexer_lag_ledgers` |
-| **Acceptable** | ≤ 60 ledgers (~5 minutes) |
-| **Stale threshold** | lag sample older than 300s |
+| **Measurement** | age of the indexed view of the chain, in seconds and in ledgers |
+| **Source** | `nester_indexer_lag_seconds`, `nester_indexer_lag_ledgers` |
+| **Staleness budget** | **300s (5 minutes)** — `INDEXER_STALENESS_BUDGET`, default `5m` |
+| **Equivalent in ledgers** | ≤ 60 ledgers (60 × 5s close interval = 300s) |
+| **Stale** | `lag_seconds > budget`. Strictly greater: exactly at the budget is fresh. |
 
-Sampled inside the event-indexer loop from the tip that `fetchSorobanEvents`
-already returns, so it costs no extra RPC call. Measured in ledgers rather than
-seconds because the indexer's own unit is the ledger sequence; converting to
-time would bake in an assumed close interval that varies.
+#### The staleness budget
 
-**Missing-data behaviour is the important part of this SLI.** A lag gauge alone
-cannot distinguish "lag is 0" from "the sampler died and the value is frozen at
-its last write" — and the second silently reports perfect health, which is the
-worst possible failure for a freshness signal. Three mechanisms prevent it:
+There is **one** budget, and it governs three things that must never disagree:
+the alert that pages, the `X-Indexer-Stale` header the API returns to clients,
+and this document. The application exports the value it is enforcing as
+`nester_indexer_staleness_budget_seconds`, and `IndexerStalenessBudgetExceeded`
+compares lag against that series rather than against a literal, so retuning
+`INDEXER_STALENESS_BUDGET` moves the pager and the UI together.
 
-1. `nester_indexer_lag_last_sample_age_seconds` ages between successful
-   samples, so `IndexerLagStale` fires when the signal itself goes stale.
-2. `nester_indexer_lag_sample_errors_total` counts failed samples rather than
+**Why 300 seconds.** It is the pre-existing ledger-lag SLO restated in the unit
+the API contract needs, not a new number: 60 ledgers at a ~5s close interval is
+exactly 300s. Healthy operation sits an order of magnitude inside it — the
+indexer polls every 6s and advances its cursor to the tip it just read, so a
+healthy sample is a handful of ledgers behind and at most one poll old, well
+under 20s of staleness. The gap between that and 300s absorbs a slow RPC round
+trip, a rolling restart, and the 12-ledger cold-start rewind without paging,
+while still catching a user staring at a wrong balance within minutes.
+
+#### How staleness is calculated
+
+```
+lag_seconds = (now − last successful sample)
+            + (network tip − indexed ledger) × 5s
+```
+
+The second term is the lag the indexer last observed. The first term is how
+long it has been since it observed anything, and it is what makes this SLI
+trustworthy: **both terms are required.**
+
+Dropping the first would let the number freeze at a healthy value the moment
+the indexer died — lag 0, dashboards green, pager silent — which is the single
+most dangerous failure a freshness signal can have. Dropping the second would
+report a busily-polling but hopelessly-behind indexer as perfectly fresh.
+
+Because the first term grows on the clock, the value is **derived at scrape
+time from `internal/freshness`, not pushed by the indexer**. A dead indexer
+therefore produces a climbing number with nothing of ours still running to
+produce it, and `IndexerStalenessBudgetExceeded` fires whether the indexer is
+merely behind or has stopped completely.
+
+The 5s close interval is nominal and real ledgers vary by a few hundred
+milliseconds, so the seconds figure inherits that error. At the scale the
+budget operates on — minutes — it is immaterial.
+
+#### Missing data
+
+1. `nester_indexer_lag_seconds` is always present and always moving, so an
+   indexer that never started ages past the budget and pages rather than
+   reporting zero forever.
+2. `nester_indexer_lag_last_sample_age_seconds` separates "running but behind"
+   (near zero) from "stopped" (climbing) — the first thing the runbook reads.
+3. `nester_indexer_lag_sample_errors_total` counts failed samples rather than
    writing a sentinel lag, which would be indistinguishable from a real stall.
-3. `IndexerMetricsAbsent` fires on `absent(...)`, so deleting or breaking the
+   A failed sample never resets the sample age.
+4. `IndexerMetricsAbsent` fires on `absent(...)`, so deleting or breaking the
    metric cannot buy silence.
 
-**Cold start:** a zero cursor (never indexed, or wiped `system_state`) is
-skipped rather than published, because `tip − 0` would report the entire ledger
-history as lag and page on every fresh deploy. The staleness alert then fires
-instead, which is the honest signal for "this indexer has never run".
+**Cold start:** before the indexer has committed a cursor there is no position
+to report, so `nester_indexer_lag_ledgers` is **withheld** rather than
+published as zero — `tip − 0` would report the entire ledger history as lag,
+and a zero would claim the indexer is exactly at the tip, which is the value
+that looks most perfect. The seconds view ages from process start instead, so a
+fresh deployment gets exactly one budget of grace and an indexer that never
+starts still pages.
+
+#### Client contract
+
+Stale balances are still served, with `X-Indexer-Stale: true`, rather than
+turned into a 5xx: a stale balance a user is told about is far more useful than
+an error, and failing the request would take down screens that do not depend on
+indexed data at all. See [the metrics reference](metrics.md#indexer-freshness)
+for the headers.
 
 **No burn rate.** This is a gauge, not a ratio of events. Forcing it into
 burn-rate shape would produce a number that cannot be reasoned about during an
@@ -306,7 +358,7 @@ weekday and the attainment figure does not shift with which day you read it.
 | Deposit success | 99.5% | 0.5% | ~3h 22m | page |
 | Withdrawal success | 99.5% | 0.5% | ~3h 22m | page |
 | Deposit/withdrawal latency | 99% under 30s | 1% | ~6h 43m | ticket |
-| Balance freshness | ≤60 ledgers | n/a (gauge) | n/a | page |
+| Balance freshness | ≤300s staleness (≤60 ledgers) | n/a (gauge) | n/a | page |
 | Intelligence availability | 99% | 1% | ~6h 43m | ticket |
 | Intelligence TTFT | 95% under 3s | 5% | ~33h 36m | ticket |
 | Intelligence refusal | <30% over 6h | n/a (guardrail) | n/a | ticket |
@@ -560,6 +612,7 @@ changed without updating its arithmetic fails the build.
 | `IntelligenceTTFTFastBurn` | ticket | >67.2% of streams over 3s | [intelligence-latency](runbooks/intelligence-latency.md) |
 | `IntelligenceTTFTSlowBurn` | ticket | >28% over 6h | [intelligence-latency](runbooks/intelligence-latency.md) |
 | `IntelligenceRefusalRateHigh` | ticket | >30% refusals over 6h | [intelligence-refusal](runbooks/intelligence-refusal.md) |
+| `IndexerStalenessBudgetExceeded` | page | Staleness over the budget (300s) for 2m | [balance-freshness](runbooks/balance-freshness.md) |
 | `IndexerLagHigh` | page | Lag >60 ledgers for 5m | [balance-freshness](runbooks/balance-freshness.md) |
 | `IndexerLagStale` | page | Lag sample older than 5m | [balance-freshness](runbooks/balance-freshness.md) |
 | `IndexerMetricsAbsent` | page | Freshness series absent | [balance-freshness](runbooks/balance-freshness.md) |
@@ -659,7 +712,7 @@ produces.
 | SLO — API availability | `nester-slo-api` | Availability, status classes, slow routes, dependency health |
 | SLO — Deposits and withdrawals | `nester-slo-flow` | Both flows' success and latency, outcomes, Soroban health |
 | SLO — Intelligence | `nester-slo-intel` | Availability, TTFT, refusals by reason, provider health |
-| SLO — Balance freshness | `nester-slo-balance` | Indexer lag, sample age, sample errors |
+| SLO — Balance freshness | `nester-slo-balance` | Data staleness vs budget, indexer lag, sample age, sample errors |
 | SLO — Synthetic probes | `nester-slo-probes` | Probe outcome, duration, reasons, result age |
 
 Every SLO dashboard opens with the same four panels — **attainment, budget
@@ -714,10 +767,14 @@ alert storm. Alertmanager groups by `(slo, burn, service)`, all bounded.
 
 **Monitoring failures do not break the application:**
 
-- `RecordFlowAttempt` and the lag setters are nil-safe; a service constructed
-  without metrics behaves exactly as before.
+- `RecordFlowAttempt` is nil-safe; a service constructed without metrics
+  behaves exactly as before.
 - Indexer lag sampling is inside the existing loop with a nil-checked recorder;
-  it cannot stop the indexer from indexing.
+  it cannot stop the indexer from indexing, and a failed sample does not abort
+  the poll that follows it.
+- `freshness.Tracker` is nil-safe on every path, so an API wired without an
+  indexer serves requests unannotated rather than panicking in the request
+  path.
 - The Go metrics listener failing is logged and non-fatal.
 - The Prometheus handler uses `ContinueOnError`, so a broken collector degrades
   the scrape rather than 500ing the endpoint and blinding every other metric.

--- a/scripts/build_slo_dashboards.py
+++ b/scripts/build_slo_dashboards.py
@@ -640,25 +640,49 @@ def build_intelligence_dashboard() -> dict[str, Any]:
 def build_balance_dashboard() -> dict[str, Any]:
     panels = [
         _text(
-            "Balance freshness — indexer lag under 60 ledgers",
+            "Balance freshness — staleness budget 5 minutes",
             (
-                "**SLI** network ledger tip minus last indexed ledger.\n\n"
+                "**SLI** how far behind the chain the indexed view is, in "
+                "ledgers and in seconds.\n\n"
                 "This is a gauge, not a ratio of events, so it has no burn rate "
                 "and no error budget — forcing one would produce a number that "
                 "means nothing during an incident.\n\n"
-                "The staleness panel is the important one: a lag gauge that "
-                "reads healthy because nothing is updating it is the failure "
-                "mode this SLI exists to prevent.\n\n"
+                "**Read data staleness first.** It is the number the staleness "
+                "budget, the page, and the `X-Indexer-Stale` header the API "
+                "returns to clients are all stated against, and it is the only "
+                "one that keeps climbing when the indexer has stopped "
+                "completely.\n\n"
                 "**Runbook** `docs/observability/runbooks/balance-freshness.md`"
             ),
             {"h": 5, "w": 24, "x": 0, "y": 0},
         ),
         _stat(
+            "Data staleness",
+            "indexer:freshness:lag_seconds",
+            "s",
+            {"h": 5, "w": 6, "x": 0, "y": 5},
+            description=(
+                "Age of the indexed view: time since the last freshness sample "
+                "plus that sample's ledger lag. Pages above the budget (300s), "
+                "and above it the API reports every response as stale."
+            ),
+            decimals=0,
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "orange", "value": 120},
+                {"color": "red", "value": 300},
+            ],
+        ),
+        _stat(
             "Indexer lag",
             "indexer:freshness:lag_ledgers",
             "none",
-            {"h": 5, "w": 8, "x": 0, "y": 5},
-            description="Ledgers behind the tip. Pages above 60 (~5 minutes).",
+            {"h": 5, "w": 6, "x": 6, "y": 5},
+            description=(
+                "Ledgers behind the tip. Pages above 60 (~5 minutes). No data "
+                "here means the indexer has not reported a position at all — "
+                "read data staleness instead."
+            ),
             decimals=0,
             thresholds=[
                 {"color": "green", "value": None},
@@ -670,10 +694,11 @@ def build_balance_dashboard() -> dict[str, Any]:
             "Lag sample age",
             "indexer:freshness:sample_age_seconds",
             "s",
-            {"h": 5, "w": 8, "x": 8, "y": 5},
+            {"h": 5, "w": 6, "x": 12, "y": 5},
             description=(
-                "Seconds since the lag gauge was last updated. Pages above 300. "
-                "If this is climbing, do not trust the lag value beside it."
+                "Seconds since the indexer last reported a position. Near zero "
+                "means running but behind; climbing means stopped. This is the "
+                "panel that tells the two apart."
             ),
             decimals=0,
             thresholds=[
@@ -686,7 +711,7 @@ def build_balance_dashboard() -> dict[str, Any]:
             "Sample errors",
             "indexer:freshness:sample_error_rate5m",
             "none",
-            {"h": 5, "w": 8, "x": 16, "y": 5},
+            {"h": 5, "w": 6, "x": 18, "y": 5},
             description="Failed lag samples per second. Non-zero means the indexer loop is erroring.",
             thresholds=[
                 {"color": "green", "value": None},
@@ -694,10 +719,29 @@ def build_balance_dashboard() -> dict[str, Any]:
             ],
         ),
         _timeseries(
+            "Data staleness against the budget",
+            [
+                ("indexer:freshness:lag_seconds", "staleness"),
+                ("indexer:freshness:budget_seconds", "budget"),
+            ],
+            "s",
+            {"h": 9, "w": 12, "x": 0, "y": 10},
+            description=(
+                "Staleness plotted against the budget the API is actually "
+                "enforcing, so the crossing point is exactly where clients "
+                "start being told their balances are stale. Recovery shows as "
+                "a sharp drop back under the budget line."
+            ),
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "red", "value": 300},
+            ],
+        ),
+        _timeseries(
             "Indexer lag over time",
             [("indexer:freshness:lag_ledgers", "lag (ledgers)")],
             "none",
-            {"h": 9, "w": 12, "x": 0, "y": 10},
+            {"h": 9, "w": 12, "x": 12, "y": 10},
             description="A sawtooth is normal (the cursor advances in steps). A monotonic climb is a stall.",
             thresholds=[
                 {"color": "green", "value": None},
@@ -708,11 +752,11 @@ def build_balance_dashboard() -> dict[str, Any]:
             "Freshness signal age",
             [("indexer:freshness:sample_age_seconds", "sample age")],
             "s",
-            {"h": 9, "w": 12, "x": 12, "y": 10},
+            {"h": 9, "w": 24, "x": 0, "y": 19},
             description=(
                 "Should sit near zero and reset every poll. A steady climb means "
-                "the sampler stopped, and the lag gauge is frozen at whatever it "
-                "last read."
+                "the indexer stopped reporting, and the ledger lag beside it is "
+                "frozen at whatever it last read."
             ),
             thresholds=[
                 {"color": "green", "value": None},
@@ -724,7 +768,7 @@ def build_balance_dashboard() -> dict[str, Any]:
     return _dashboard(
         "nester-slo-balance",
         "SLO — Balance freshness",
-        "Indexer lag and the staleness guard over it (nester#1056).",
+        "Indexer lag in ledgers and seconds against the staleness budget (nester#1056, nester#1088).",
         panels,
     )
 


### PR DESCRIPTION

## Summary

This PR implements the API chain-boundary resilience work across the four related testnet launch backlog issues.

The changes address transaction safety, transient RPC failures, upstream degradation, and indexer staleness.

Together, the changes provide:

- Durable and idempotent chain submissions
- Bounded retries with jittered backoff for safe RPC reads
- Circuit breaking for degraded Soroban RPC/Horizon upstreams
- Indexer lag and staleness monitoring
- API-level staleness signaling
- Operational runbooks for diagnosing and recovering chain/indexer issues

## Issues tackled

This PR addresses:

- **#1085** - `feat(api): durable submission record so a lost RPC response cannot double-submit`
- **#1086** - `feat(api): bounded retry with jittered backoff for all Soroban RPC calls`
- **#1087** - `feat(api): circuit breaker on Soroban RPC and Horizon`
- **#1088** - `feat(api): indexer lag alerting with a defined staleness budget`

Closes #1085
Closes #1086 
Closes #1087 
Closes #1088 

---

# #1085 - Durable submission record

## Problem

A Soroban RPC timeout does not necessarily mean that a transaction failed.

The transaction may have been accepted by the network while the response was lost. Blindly retrying in this situation can result in duplicate submissions.

## Implementation

Chain submissions now establish a durable intent before interacting with the chain.

The flow is:

```text
Client request
      ↓
Create durable submission intent
      ↓
Persist idempotency reference
      ↓
Submit transaction
      ↓
Record outcome