### PR TITLE
fix(dapp): honest transaction status with a working pending state

### DIFF
--- a/apps/dapp/frontend/components/portfolio-provider.tsx
+++ b/apps/dapp/frontend/components/portfolio-provider.tsx
@@ -32,6 +32,25 @@ export interface PortfolioTransaction {
     isOnChain?: boolean;
 }
 
+export interface PendingTransactionRecord {
+    /** The portfolio transaction id to update after on-chain confirmation. */
+    transactionId: string;
+    /** The vault id this deposit is for. */
+    vaultId: string;
+    /** Human-readable vault name. */
+    vaultName: string;
+    /** Asset deposited. */
+    asset: SupportedAsset;
+    /** Amount deposited. */
+    amount: number;
+    /** APY of the vault. */
+    apy: number;
+    /** Lock period in days. */
+    lockDays: number;
+    /** Early withdrawal penalty percentage. */
+    earlyWithdrawalPenaltyPct: number;
+}
+
 interface StoredPosition {
     id: string;
     vaultId: string;
@@ -106,6 +125,12 @@ interface PortfolioState {
     recordDeposit: (input: DepositInput) => void;
     recordTransfer: (input: TransferInput) => void;
     recordWithdrawal: (input: WithdrawalInput) => WithdrawalQuote | null;
+    /** Record a pending deposit before on-chain confirmation. Returns the transaction id. */
+    recordPendingDeposit: (input: DepositInput) => string;
+    /** Mark a pending deposit as confirmed after on-chain success. */
+    confirmPendingDeposit: (transactionId: string, txHash: string) => void;
+    /** Mark a pending deposit as failed after on-chain failure. */
+    failPendingDeposit: (transactionId: string) => void;
     /** Push a live balance update from WebSocket events */
     applyBalanceUpdate: (asset: string, newBalance: number) => void;
     /** Push a live yield accrual delta from WebSocket events */
@@ -381,6 +406,59 @@ function PortfolioStore({
         ]);
     };
 
+    /** Record a deposit as Pending before on-chain confirmation. Returns the
+     *  transaction id so the modal can update it later without touching the
+     *  wallet balance until the tx is confirmed. */
+    const recordPendingDeposit = ({ vault, amount }: DepositInput): string => {
+        const txId = crypto.randomUUID();
+        setTransactions((current) => [
+            {
+                id: txId,
+                type: "Deposit",
+                amount: `+${amount.toFixed(2)}`,
+                asset: vault.asset,
+                vaultName: vault.name,
+                timestamp: new Date().toISOString(),
+                status: "Pending",
+                txHash: "",
+                isOnChain: true,
+            },
+            ...current,
+        ]);
+        return txId;
+    };
+
+    /** Confirm a pending deposit: create the position, deduct balance, update tx status. */
+    const confirmPendingDeposit = (transactionId: string, txHash: string) => {
+        // Find the pending transaction to extract vault/amount info
+        const tx = transactions.find((t) => t.id === transactionId);
+        if (!tx) return;
+
+        const amount = parseFloat(tx.amount.replace("+", ""));
+        const vaultId = tx.vaultName; // we use vaultName as a proxy; caller should store vaultId
+        // Look up vault details from the pending transaction context
+        const storedTx = transactions.find((t) => t.id === transactionId);
+        if (!storedTx || isNaN(amount)) return;
+
+        // Find matching position — the position was NOT yet created by recordPendingDeposit,
+        // so we need the caller to pass enough info. Simplified: we update only the tx status
+        // and rely on refreshBalances to sync wallet balances after confirmation.
+        setTransactions((current) =>
+            current.map((t) =>
+                t.id === transactionId ? { ...t, status: "Confirmed" as const, txHash } : t
+            )
+        );
+    };
+
+    /** Mark a pending deposit as failed and remove the pending transaction record. */
+    const failPendingDeposit = (transactionId: string) => {
+        setTransactions((current) =>
+            current.map((t) =>
+                t.id === transactionId ? { ...t, status: "Failed" as const } : t
+            )
+        );
+    };
+
     const recordWithdrawal = ({ positionId, grossAmount, txHash, isOnChain }: WithdrawalInput) => {
         const quote = getWithdrawalQuote(positionId, grossAmount);
         if (!quote) return null;
@@ -497,6 +575,9 @@ function PortfolioStore({
                 recordDeposit,
                 recordTransfer,
                 recordWithdrawal,
+                recordPendingDeposit,
+                confirmPendingDeposit,
+                failPendingDeposit,
                 applyBalanceUpdate,
                 applyYieldAccrual,
                 refreshBalances,

--- a/apps/dapp/frontend/components/portfolio-provider.tsx
+++ b/apps/dapp/frontend/components/portfolio-provider.tsx
@@ -5,6 +5,7 @@ import {
     useContext,
     useEffect,
     useMemo,
+    useRef,
     useState,
     type ReactNode,
 } from "react";
@@ -85,6 +86,11 @@ interface DepositInput {
     isOnChain?: boolean;
 }
 
+/** Input for a deposit that has not been submitted yet. Deliberately omits
+ *  txHash: a pending deposit has no transaction hash until the chain accepts
+ *  it, and requiring one forces callers to invent a placeholder. */
+type PendingDepositInput = Omit<DepositInput, "txHash">;
+
 interface TransferInput {
     fromPositionId: string;
     toVault: {
@@ -126,7 +132,7 @@ interface PortfolioState {
     recordTransfer: (input: TransferInput) => void;
     recordWithdrawal: (input: WithdrawalInput) => WithdrawalQuote | null;
     /** Record a pending deposit before on-chain confirmation. Returns the transaction id. */
-    recordPendingDeposit: (input: DepositInput) => string;
+    recordPendingDeposit: (input: PendingDepositInput) => string;
     /** Mark a pending deposit as confirmed after on-chain success. */
     confirmPendingDeposit: (transactionId: string, txHash: string) => void;
     /** Mark a pending deposit as failed after on-chain failure. */
@@ -237,6 +243,11 @@ function PortfolioStore({
     const [transactions, setTransactions] = useState<PortfolioTransaction[]>(
         initialState.transactions
     );
+
+    // Holds the details of deposits awaiting on-chain confirmation. A ref
+    // rather than state: confirmPendingDeposit runs in the same tick the
+    // pending row is inserted, so any state read would still be stale.
+    const pendingDepositsRef = useRef<Map<string, PendingTransactionRecord>>(new Map());
 
     useEffect(() => {
         if (!address || typeof window === "undefined") return;
@@ -409,8 +420,22 @@ function PortfolioStore({
     /** Record a deposit as Pending before on-chain confirmation. Returns the
      *  transaction id so the modal can update it later without touching the
      *  wallet balance until the tx is confirmed. */
-    const recordPendingDeposit = ({ vault, amount }: DepositInput): string => {
+    const recordPendingDeposit = ({ vault, amount }: PendingDepositInput): string => {
         const txId = crypto.randomUUID();
+        // Stash everything the confirm step needs. Recovering it later by
+        // reading `transactions` fails: the confirm call happens in the same
+        // tick as this insert, so the render closure has not seen it yet, and
+        // parsing the amount back out of a display string is lossy.
+        pendingDepositsRef.current.set(txId, {
+            transactionId: txId,
+            vaultId: vault.id,
+            vaultName: vault.name,
+            asset: vault.asset,
+            amount,
+            apy: vault.apy,
+            lockDays: vault.lockDays ?? 0,
+            earlyWithdrawalPenaltyPct: vault.earlyWithdrawalPenaltyPct,
+        });
         setTransactions((current) => [
             {
                 id: txId,
@@ -430,19 +455,35 @@ function PortfolioStore({
 
     /** Confirm a pending deposit: create the position, deduct balance, update tx status. */
     const confirmPendingDeposit = (transactionId: string, txHash: string) => {
-        // Find the pending transaction to extract vault/amount info
-        const tx = transactions.find((t) => t.id === transactionId);
-        if (!tx) return;
+        const pending = pendingDepositsRef.current.get(transactionId);
+        if (!pending) return;
+        pendingDepositsRef.current.delete(transactionId);
 
-        const amount = parseFloat(tx.amount.replace("+", ""));
-        const vaultId = tx.vaultName; // we use vaultName as a proxy; caller should store vaultId
-        // Look up vault details from the pending transaction context
-        const storedTx = transactions.find((t) => t.id === transactionId);
-        if (!storedTx || isNaN(amount)) return;
+        const now = new Date();
+        const maturityAt = new Date(now);
+        maturityAt.setDate(maturityAt.getDate() + pending.lockDays);
 
-        // Find matching position — the position was NOT yet created by recordPendingDeposit,
-        // so we need the caller to pass enough info. Simplified: we update only the tx status
-        // and rely on refreshBalances to sync wallet balances after confirmation.
+        // Create the position on confirmation, not on submission. Until the
+        // chain confirms, the user holds no shares; creating it earlier would
+        // show a position for a deposit that may still fail.
+        const position: StoredPosition = {
+            id: crypto.randomUUID(),
+            vaultId: pending.vaultId,
+            vaultName: pending.vaultName,
+            asset: pending.asset,
+            principal: pending.amount,
+            shares: pending.amount,
+            apy: pending.apy,
+            depositedAt: now.toISOString(),
+            maturityAt: maturityAt.toISOString(),
+            earlyWithdrawalPenaltyPct: pending.earlyWithdrawalPenaltyPct,
+        };
+
+        setStoredPositions((current) => [position, ...current]);
+        setBalances((current) => ({
+            ...current,
+            [pending.asset]: Math.max(0, (current[pending.asset] ?? 0) - pending.amount),
+        }));
         setTransactions((current) =>
             current.map((t) =>
                 t.id === transactionId ? { ...t, status: "Confirmed" as const, txHash } : t
@@ -452,6 +493,7 @@ function PortfolioStore({
 
     /** Mark a pending deposit as failed and remove the pending transaction record. */
     const failPendingDeposit = (transactionId: string) => {
+        pendingDepositsRef.current.delete(transactionId);
         setTransactions((current) =>
             current.map((t) =>
                 t.id === transactionId ? { ...t, status: "Failed" as const } : t

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -34,6 +34,7 @@ type ActionState =
   | "building"
   | "signing"
   | "submitting"
+  | "pending"
   | "success"
   | "error";
 
@@ -127,13 +128,13 @@ function ModalShell({
 const TX_STEPS: { label: string; activeStates: ActionState[] }[] = [
   {
     label: "Build contract call",
-    activeStates: ["building", "signing", "submitting", "success"],
+    activeStates: ["building", "signing", "submitting", "pending", "success"],
   },
   {
     label: "Sign with wallet",
-    activeStates: ["signing", "submitting", "success"],
+    activeStates: ["signing", "submitting", "pending", "success"],
   },
-  { label: "Submit and confirm", activeStates: ["success"] },
+  { label: "Submit and confirm", activeStates: ["submitting", "pending", "success"] },
 ];
 
 // ── DepositModal ──────────────────────────────────────────────────────────────
@@ -174,7 +175,7 @@ function getVaultMeta(vault: VaultDefinition) {
  */
 export function DepositModal({ open, onClose, vault }: DepositModalProps) {
   const { address } = useWallet();
-  const { getAvailableBalance, recordDeposit, refreshBalances } = usePortfolio();
+  const { getAvailableBalance, recordPendingDeposit, confirmPendingDeposit, failPendingDeposit, refreshBalances } = usePortfolio();
   const { isOffline } = useOfflineStatus();
 
   const [amountInput, setAmountInput] = useState("");
@@ -259,8 +260,8 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
         amount,
       });
 
-      // Record in portfolio state
-      recordDeposit({
+      // Record as pending — wallet balance is NOT yet deducted
+      const pendingTxId = recordPendingDeposit({
         vault: {
           id: vault.id,
           name: vault.name,
@@ -274,9 +275,13 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
         isOnChain: true,
       });
 
+      setState("pending");
       setReceipt(txReceipt);
+
+      // Now confirm: create the position, deduct balance, update tx status
+      confirmPendingDeposit(pendingTxId, txReceipt.txHash);
+
       setState("success");
-      // Re-fetch true on-chain balance so UI reflects what actually happened
       refreshBalances();
     } catch (err) {
       setErrorMsg(humanizeError(err));
@@ -289,7 +294,7 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
   return (
     <ModalShell
       open={open && !!vault}
-      onClose={state === "signing" || state === "submitting" ? () => {} : reset}
+      onClose={state === "signing" || state === "submitting" || state === "pending" ? () => {} : reset}
       title={`Deposit into ${vault?.name ?? "Vault"}`}
       subtitle={`Build and sign a Soroban transaction to deposit ${selectedAsset} into this vault.`}
     >
@@ -572,7 +577,7 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
           <div className="flex gap-3">
             <button
               onClick={reset}
-              disabled={state === "signing" || state === "submitting"}
+              disabled={state === "signing" || state === "submitting" || state === "pending"}
               className="flex-1 rounded-full border border-border bg-white dark:bg-[#100F0F] px-5 py-3 text-sm font-medium text-foreground transition-colors hover:border-black/15 dark:hover:border-white/15 disabled:opacity-40"
             >
               {state === "success" ? "Close" : "Cancel"}
@@ -589,6 +594,7 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
                   state === "building" ||
                   state === "signing" ||
                   state === "submitting" ||
+                  state === "pending" ||
                   (state === "input" && !canSubmit)
                 }
                 className="flex-1 rounded-full bg-[#0a0a0a] px-5 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
@@ -609,6 +615,12 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
                   <span className="inline-flex items-center justify-center gap-2">
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Submitting
+                  </span>
+                )}
+                {state === "pending" && (
+                  <span className="inline-flex items-center justify-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Waiting for confirmation
                   </span>
                 )}
                 {state === "error" && "Try Again"}

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -125,16 +125,20 @@ function ModalShell({
 
 // ── Transaction steps ─────────────────────────────────────────────────────────
 
+// executeVaultDeposit builds, signs and submits in one call without exposing
+// intermediate stages, so "signing" and "submitting" are never assigned. Keep
+// the steps mapped to states that actually occur; listing unreachable ones
+// leaves the indicator permanently stuck on the first step.
 const TX_STEPS: { label: string; activeStates: ActionState[] }[] = [
   {
-    label: "Build contract call",
-    activeStates: ["building", "signing", "submitting", "pending", "success"],
+    label: "Build and sign",
+    activeStates: ["building", "pending", "success"],
   },
   {
-    label: "Sign with wallet",
-    activeStates: ["signing", "submitting", "pending", "success"],
+    label: "Submit to network",
+    activeStates: ["pending", "success"],
   },
-  { label: "Submit and confirm", activeStates: ["submitting", "pending", "success"] },
+  { label: "Confirmed on-chain", activeStates: ["success"] },
 ];
 
 // ── DepositModal ──────────────────────────────────────────────────────────────
@@ -250,8 +254,25 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
 
     submittingRef.current = true;
 
+    // Record the pending row and enter the pending state BEFORE awaiting.
+    // Setting them after the await batches them with setState("success") in a
+    // single render, so the "waiting for confirmation" state never paints —
+    // which is the whole point of this change.
+    const pendingTxId = recordPendingDeposit({
+      vault: {
+        id: vault.id,
+        name: vault.name,
+        asset: selectedAsset,
+        apy: meta?.apy || 0,
+        lockDays: meta?.lockDays || 0,
+        earlyWithdrawalPenaltyPct: 0.1,
+      },
+      amount,
+      isOnChain: true,
+    });
+
     try {
-      setState("building");
+      setState("pending");
       const txReceipt = await executeVaultDeposit({
         walletAddress: address,
         vaultId: vault.id,
@@ -260,30 +281,18 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
         amount,
       });
 
-      // Record as pending — wallet balance is NOT yet deducted
-      const pendingTxId = recordPendingDeposit({
-        vault: {
-          id: vault.id,
-          name: vault.name,
-          asset: selectedAsset,
-          apy: meta?.apy || 0,
-          lockDays: meta?.lockDays || 0,
-          earlyWithdrawalPenaltyPct: 0.1,
-        },
-        amount,
-        txHash: txReceipt.txHash,
-        isOnChain: true,
-      });
-
-      setState("pending");
       setReceipt(txReceipt);
 
-      // Now confirm: create the position, deduct balance, update tx status
+      // Confirmation creates the position and deducts the balance. Until the
+      // chain confirms, the user holds no shares and their balance is intact.
       confirmPendingDeposit(pendingTxId, txReceipt.txHash);
 
       setState("success");
       refreshBalances();
     } catch (err) {
+      // Without this the pending row is orphaned and persists to
+      // localStorage as "Pending" forever.
+      failPendingDeposit(pendingTxId);
       setErrorMsg(humanizeError(err));
       setState("error");
     } finally {

--- a/apps/dapp/frontend/components/vault/depositModal.tsx
+++ b/apps/dapp/frontend/components/vault/depositModal.tsx
@@ -129,16 +129,28 @@ function ModalShell({
 // intermediate stages, so "signing" and "submitting" are never assigned. Keep
 // the steps mapped to states that actually occur; listing unreachable ones
 // leaves the indicator permanently stuck on the first step.
-const TX_STEPS: { label: string; activeStates: ActionState[] }[] = [
+const TX_STEPS: {
+  label: string;
+  /** States in which this step counts as already done. */
+  activeStates: ActionState[];
+  /** The single state in which this step is the one currently running. */
+  currentState: ActionState;
+}[] = [
   {
     label: "Build and sign",
     activeStates: ["building", "pending", "success"],
+    currentState: "building",
   },
   {
     label: "Submit to network",
     activeStates: ["pending", "success"],
+    currentState: "pending",
   },
-  { label: "Confirmed on-chain", activeStates: ["success"] },
+  {
+    label: "Confirmed on-chain",
+    activeStates: ["success"],
+    currentState: "success",
+  },
 ];
 
 // ── DepositModal ──────────────────────────────────────────────────────────────
@@ -488,12 +500,12 @@ export function DepositModal({ open, onClose, vault }: DepositModalProps) {
                 Transaction Flow
               </p>
               <div className="mt-4 space-y-3">
-                {TX_STEPS.map(({ label, activeStates }) => {
+                {TX_STEPS.map(({ label, activeStates, currentState }) => {
                   const done = activeStates.includes(state);
-                  const active =
-                    (label === "Build contract call" && state === "building") ||
-                    (label === "Sign with wallet" && state === "signing") ||
-                    (label === "Submit and confirm" && state === "submitting");
+                  // Match on the state, not the label. Comparing against
+                  // label strings silently breaks the moment a label is
+                  // reworded.
+                  const active = state === currentState;
                   return (
                     <div
                       key={label}

--- a/apps/dapp/frontend/components/vault/withdrawModal.tsx
+++ b/apps/dapp/frontend/components/vault/withdrawModal.tsx
@@ -33,7 +33,7 @@ import { getVaultContractById as getVaultById } from "@/lib/vault-contracts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type ActionState = "input" | "building" | "signing" | "submitting" | "success" | "error";
+type ActionState = "input" | "building" | "signing" | "submitting" | "pending" | "success" | "error";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -116,9 +116,9 @@ function ModalShell({
 // ── Transaction steps ─────────────────────────────────────────────────────────
 
 const TX_STEPS: { label: string; activeStates: ActionState[] }[] = [
-  { label: "Build contract call", activeStates: ["building", "signing", "submitting", "success"] },
-  { label: "Sign with wallet",    activeStates: ["signing", "submitting", "success"] },
-  { label: "Submit and confirm",  activeStates: ["success"] },
+  { label: "Build contract call", activeStates: ["building", "signing", "submitting", "pending", "success"] },
+  { label: "Sign with wallet",    activeStates: ["signing", "submitting", "pending", "success"] },
+  { label: "Submit and confirm",  activeStates: ["submitting", "pending", "success"] },
 ];
 
 // ── WithdrawModal ─────────────────────────────────────────────────────────────
@@ -202,6 +202,8 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
         minAssetsOut: quote.netAmount,
       });
 
+      setState("pending");
+
       const result = recordWithdrawal({
         positionId: position.id,
         grossAmount: quote.grossAmount,
@@ -229,7 +231,7 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
   return (
     <ModalShell
       open={open && !!position}
-      onClose={state === "signing" || state === "submitting" ? () => {} : reset}
+      onClose={state === "signing" || state === "submitting" || state === "pending" ? () => {} : reset}
       title={`Withdraw from ${position?.vaultName ?? "Vault"}`}
       subtitle="Review shares, lock period, and net proceeds before signing."
     >
@@ -453,7 +455,7 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
               <div className="mt-5 flex gap-3">
                 <button
                   onClick={reset}
-                  disabled={state === "signing" || state === "submitting"}
+                  disabled={state === "signing" || state === "submitting" || state === "pending"}
                   className="flex-1 rounded-full border border-border bg-white dark:bg-[#100F0F] px-5 py-3 text-sm font-medium text-foreground transition-colors hover:border-black/15 dark:hover:border-white/15 disabled:opacity-40"
                 >
                   {state === "success" ? "Close" : "Cancel"}
@@ -466,6 +468,7 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
                       state === "building" ||
                       state === "signing" ||
                       state === "submitting" ||
+                      state === "pending" ||
                       (state === "input" && !canSubmit)
                     }
                     className="flex-1 rounded-full bg-[#0a0a0a] px-5 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
@@ -486,6 +489,12 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
                       <span className="inline-flex items-center justify-center gap-2">
                         <Loader2 className="h-4 w-4 animate-spin" />
                         Submitting
+                      </span>
+                    )}
+                    {state === "pending" && (
+                      <span className="inline-flex items-center justify-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Waiting for confirmation
                       </span>
                     )}
                     {state === "error" && "Try Again"}

--- a/apps/dapp/frontend/components/vault/withdrawModal.tsx
+++ b/apps/dapp/frontend/components/vault/withdrawModal.tsx
@@ -191,8 +191,11 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
     setErrorMsg("");
 
     try {
-      setState("building");
       const vaultDef = getVaultById(position.vaultId);
+      // Enter the pending state before awaiting. Setting it afterwards
+      // batches it with setState("success") into one render, so the user
+      // never sees "waiting for confirmation".
+      setState("pending");
       const txReceipt = await executeVaultWithdraw({
         walletAddress: address,
         vaultId: position.vaultId,
@@ -201,8 +204,6 @@ export function WithdrawModal({ open, onClose, position }: WithdrawModalProps) {
         shares: quote.sharesBurned,
         minAssetsOut: quote.netAmount,
       });
-
-      setState("pending");
 
       const result = recordWithdrawal({
         positionId: position.id,


### PR DESCRIPTION
## What this is

`staging/honest-tx-status` — the real change from PR #1172 (honest transaction status with a pending state), cherry-picked onto `dev` and then repaired.

#1172 targeted `main`, which is 104 commits behind `dev`, so the branch carried four of `main`'s own commits and presented as ~690 changed files. Only `95af076` was the contributor's work: **3 files, +117/-15**. Cherry-picking that one commit was cleaner than merging the branch and dragging `main`'s history into `dev`.

## Why it needed repair

As written the feature was inert. A successful on-chain deposit produced **no position, no balance change, and a transaction stuck on "Pending" forever** — and the pending state never rendered at all.

**`portfolio-provider.tsx`**

- `confirmPendingDeposit` read `transactions` from the render closure in the same tick `recordPendingDeposit` queued the insert, so the lookup always failed and it returned early. Pending details now live in a ref keyed by transaction id.
- Neither function called `setStoredPositions`, so the position was never created. Confirm now creates it — on confirmation rather than submission, since until the chain confirms the user holds no shares.
- The wallet balance was never deducted. It relied on `refreshBalances`, which swallows fetch failures, letting a user over-deposit against a stale balance.
- The amount was recovered via `parseFloat` on a display-formatted string. The exact value is carried through instead.
- `PendingTransactionRecord` was exported, fully documented, and referenced nowhere — it is exactly the payload the confirm path needed. Now used.

**`depositModal.tsx` / `withdrawModal.tsx`**

- `setState("pending")` ran *after* the await, batching with `setState("success")` into a single render, so the pending spinner never painted. That was the PR's stated purpose. Both now set it before awaiting.
- `failPendingDeposit` was destructured but never called, orphaning a "Pending" row that persisted to localStorage. Wired into the catch.
- `TX_STEPS` listed `"signing"` and `"submitting"`, neither of which is ever assigned (`executeVaultDeposit` exposes no intermediate stages), so the indicator was stuck on step one. Remapped to states that actually occur.

Also added `PendingDepositInput` (`DepositInput` without `txHash`) — a pending deposit has no hash until the chain accepts it, and requiring one forced callers to invent a placeholder.

## Issues

Closes #1098.

**Not** closing #1100, #1101 or #1102, which #1172 also claimed. Those are the E2E deposit/withdraw journey, the API authorization matrix test, and wallet-session binding — none of them are touched by this change. Nothing in the diff goes near `apps/api`.

## Verification

`tsc --noEmit` clean for all three files. Note #1172's own CI ran only 2 checks because it targeted `main`; this PR gets the full `dev` suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pending states for deposits and withdrawals while transactions await on-chain confirmation.
  * Deposits now appear as pending before confirmation and are automatically marked successful or failed afterward.
  * Added transaction progress indicators and “Waiting for confirmation” messaging.
  * Disabled modal closing and action buttons while transactions are pending.

* **Bug Fixes**
  * Prevented failed deposits from leaving behind incorrect portfolio entries or balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->