### PR TITLE
feat(api): idempotency keys and on-chain withdrawal verification

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -331,7 +331,7 @@ func run() error {
 	}
 
 	if cfg.Stellar().RPCURL() != "" {
-		vaultService.SetChainEventVerifier(stellarpkg.NewRPCChainEventVerifier(cfg.Stellar().RPCURL()))
+		vaultService.SetChainEventVerifier(service.NewStellarChainEventVerifier(cfg.Stellar().RPCURL()))
 	}
 
 	adminService := service.NewAdminService(

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -330,6 +330,10 @@ func run() error {
 		baseLogger.Info("no signing configured: chain write operations are unavailable")
 	}
 
+	if cfg.Stellar().RPCURL() != "" {
+		vaultService.SetChainEventVerifier(stellarpkg.NewRPCChainEventVerifier(cfg.Stellar().RPCURL()))
+	}
+
 	adminService := service.NewAdminService(
 		adminRepository,
 		vaultRepository,
@@ -1234,10 +1238,12 @@ func run() error {
 	// posted as a transaction, and creating a savings goal). Requires auth
 	// context, so it must sit after authenticator.
 	idempotencyStore := postgres.NewIdempotencyRepository(db)
-	idempotencyMiddleware := middleware.IdempotencyMiddleware(idempotencyStore, []middleware.RouteMatch{
+	idempotencyRoutes := []middleware.RouteMatch{
 		{Method: http.MethodPost, Path: "/api/v1/transactions"},
 		{Method: http.MethodPost, Path: "/api/v1/users/savings-goals"},
-	})
+	}
+	idempotencyRoutes = append(idempotencyRoutes, middleware.VaultMoneyPathIdempotencyRoutes()...)
+	idempotencyMiddleware := middleware.IdempotencyMiddleware(idempotencyStore, idempotencyRoutes)
 	idempotencyPurgeCtx, cancelIdempotencyPurge := context.WithCancel(context.Background())
 	defer cancelIdempotencyPurge()
 	go runIdempotencyPurge(idempotencyPurgeCtx, idempotencyStore, baseLogger.WithGroup("idempotency-purge"))

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -29,6 +29,16 @@ var (
 	ErrVaultClosed          = errors.New("vault is closed")
 	ErrVaultNotActive       = errors.New("vault is not active")
 	ErrInsufficientBalance  = errors.New("vault balance must be zero before closing")
+	// ErrWithdrawalExceedsPosition is returned when a withdraw would take the
+	// caller's vault position below zero. Checked before any on-chain submit
+	// (nester#1076).
+	ErrWithdrawalExceedsPosition = errors.New("withdrawal would take the position below zero")
+	// ErrTxHashRequired is returned when a withdrawal is recorded without a
+	// verified on-chain transaction hash (nester#1076).
+	ErrTxHashRequired = errors.New("transaction hash is required")
+	// ErrUnverifiedChainTx is returned when the supplied hash cannot be
+	// reconciled against a matching vault contract event.
+	ErrUnverifiedChainTx = errors.New("on-chain transaction could not be verified")
 	ErrVaultForbidden       = errors.New("vault does not belong to caller")
 	ErrAllocationNotFound   = errors.New("allocation not found")
 	ErrAllocationHasBalance = errors.New("allocation has non-zero balance; set force=true to remove")

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -43,6 +43,7 @@ type depositRequest struct {
 type withdrawRequest struct {
 	Amount string `json:"amount"`
 	Asset  string `json:"asset"`
+	TxHash string `json:"tx_hash,omitempty"`
 }
 
 type rebalanceRequest struct {
@@ -718,7 +719,7 @@ func (h *VaultHandler) withdrawFromVault(w http.ResponseWriter, r *http.Request)
 	updatedVault, err := h.service.RecordWithdrawal(r.Context(), service.RecordWithdrawalInput{
 		VaultID: vaultID,
 		Amount:  amount,
-		TxHash:  "", // TxHash would be set by the on-chain invoker or blockchain confirmation listener
+		TxHash:  strings.TrimSpace(request.TxHash),
 	})
 	if err != nil {
 		h.writeDomainError(w, r, err)
@@ -738,7 +739,11 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("user"))
 	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation), errors.Is(err, vault.ErrInvalidHarvestFrequency):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
-	case errors.Is(err, vault.ErrBelowMinDeposit):
+	case errors.Is(err, vault.ErrBelowMinDeposit), errors.Is(err, vault.ErrWithdrawalExceedsPosition), errors.Is(err, vault.ErrTxHashRequired), errors.Is(err, vault.ErrUnverifiedChainTx):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	case errors.Is(err, vault.ErrDuplicateTransaction):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "DUPLICATE_TRANSACTION", err.Error()))
+	case errors.Is(err, vault.ErrInsufficientBalance), errors.Is(err, vault.ErrVaultClosed), errors.Is(err, vault.ErrVaultNotActive):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:
 		logpkg.FromContext(r.Context()).Error("vault handler failed", "error", err.Error())

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -332,6 +332,13 @@ func (r *handlerRepository) RecordWithdrawal(_ context.Context, id uuid.UUID, re
 	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
+	if record.TransactionHash != "" {
+		for _, txn := range r.transactions {
+			if txn.TransactionHash == record.TransactionHash {
+				return vault.ErrDuplicateTransaction
+			}
+		}
+	}
 
 	model.CurrentBalance = model.CurrentBalance.Sub(record.Amount)
 	model.UpdatedAt = time.Now().UTC()

--- a/apps/api/internal/handler/vault_handler_withdraw_verify_test.go
+++ b/apps/api/internal/handler/vault_handler_withdraw_verify_test.go
@@ -1,0 +1,260 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+type handlerChainVerifier struct {
+	amount decimal.Decimal
+}
+
+func (h handlerChainVerifier) VerifyVaultEvent(_ context.Context, txHash, _, _ string) (service.VerifiedVaultEvent, error) {
+	return service.VerifiedVaultEvent{TxHash: txHash, EventType: "withdraw", Amount: h.amount}, nil
+}
+
+func TestVaultHandlerWithdrawForgedAmountRecordsEventAmount(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	vaultService.SetChainEventVerifier(handlerChainVerifier{amount: decimal.RequireFromString("40")})
+	h := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(mux))
+	t.Cleanup(server.Close)
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID: userID, ContractAddress: testAddrGeneric, Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := vaultService.RecordDeposit(context.Background(), service.RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	resp, err := http.Post(
+		server.URL+"/api/v1/vaults/"+created.ID.String()+"/withdraw",
+		"application/json",
+		bytes.NewBufferString(`{"amount":"10","asset":"USDC","tx_hash":"hash-forged"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST withdraw: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status %d, body %s", resp.StatusCode, body)
+	}
+	updated := decodeAPIData[vault.Vault](t, resp.Body)
+	if !updated.CurrentBalance.Equal(decimal.RequireFromString("60")) {
+		t.Fatalf("balance = %s, want 60 (event 40, not forged body 10)", updated.CurrentBalance)
+	}
+}
+
+func TestVaultHandlerWithdrawExceedingPositionRejected(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	h := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(mux))
+	t.Cleanup(server.Close)
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID: userID, ContractAddress: testAddrGeneric, Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := vaultService.RecordDeposit(context.Background(), service.RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("20"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	resp, err := http.Post(
+		server.URL+"/api/v1/vaults/"+created.ID.String()+"/withdraw",
+		"application/json",
+		bytes.NewBufferString(`{"amount":"50","asset":"USDC"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST withdraw: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestVaultHandlerDepositMissingIdempotencyKeyIs400(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	h := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	store := newHandlerIdempotencyStore()
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(
+		middleware.IdempotencyMiddleware(store, middleware.VaultMoneyPathIdempotencyRoutes())(mux),
+	))
+	t.Cleanup(server.Close)
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID: userID, ContractAddress: testAddrGeneric, Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	resp, err := http.Post(
+		server.URL+"/api/v1/vaults/"+created.ID.String()+"/deposit",
+		"application/json",
+		bytes.NewBufferString(`{"amount":"10","asset":"USDC"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST deposit: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400 for missing Idempotency-Key", resp.StatusCode)
+	}
+}
+
+func TestVaultHandlerDepositIdempotencyKeyTwentyConcurrentOneEffect(t *testing.T) {
+	userID := uuid.New()
+	repository := newHandlerRepository(userID)
+	vaultService := service.NewVaultService(repository)
+	h := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	store := newHandlerIdempotencyStore()
+	server := httptest.NewServer(fakeAuthMiddleware(userID)(
+		middleware.IdempotencyMiddleware(store, middleware.VaultMoneyPathIdempotencyRoutes())(mux),
+	))
+	t.Cleanup(server.Close)
+
+	created, err := vaultService.CreateVault(context.Background(), service.CreateVaultInput{
+		UserID: userID, ContractAddress: testAddrGeneric, Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	codes := make([]int, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/vaults/"+created.ID.String()+"/deposit", bytes.NewBufferString(`{"amount":"25","asset":"USDC"}`))
+			if err != nil {
+				t.Errorf("NewRequest: %v", err)
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Idempotency-Key", "same-deposit-key")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("POST: %v", err)
+				return
+			}
+			defer resp.Body.Close()
+			codes[i] = resp.StatusCode
+			_, _ = io.Copy(io.Discard, resp.Body)
+		}(i)
+	}
+	wg.Wait()
+
+	updated, err := vaultService.GetVault(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetVault: %v", err)
+	}
+	if !updated.TotalDeposited.Equal(decimal.RequireFromString("25")) {
+		t.Fatalf("total_deposited = %s, want 25 (one effect from 20 concurrent retries)", updated.TotalDeposited)
+	}
+
+	var ok int
+	for _, c := range codes {
+		if c == http.StatusCreated || c == http.StatusOK {
+			ok++
+		}
+	}
+	if ok != n {
+		t.Fatalf("successful responses = %d / %d, codes=%v (waiters must return the stored result)", ok, n, codes)
+	}
+}
+
+type handlerIdempotencyStore struct {
+	mu      sync.Mutex
+	records map[string]middleware.IdempotencyRecord
+}
+
+func newHandlerIdempotencyStore() *handlerIdempotencyStore {
+	return &handlerIdempotencyStore{records: make(map[string]middleware.IdempotencyRecord)}
+}
+
+func (s *handlerIdempotencyStore) storeKey(userID uuid.UUID, key string) string {
+	return userID.String() + ":" + key
+}
+
+func (s *handlerIdempotencyStore) Claim(_ context.Context, userID uuid.UUID, key, fingerprint string, _ time.Duration) (bool, middleware.IdempotencyRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := s.storeKey(userID, key)
+	if existing, ok := s.records[k]; ok {
+		return false, existing, nil
+	}
+	s.records[k] = middleware.IdempotencyRecord{Fingerprint: fingerprint, Status: "in_progress"}
+	return true, middleware.IdempotencyRecord{}, nil
+}
+
+func (s *handlerIdempotencyStore) Complete(_ context.Context, userID uuid.UUID, key string, status int, body []byte, contentType string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := s.storeKey(userID, key)
+	rec := s.records[k]
+	rec.Status = "completed"
+	rec.ResponseStatus = status
+	rec.ResponseBody = append([]byte(nil), body...)
+	rec.ResponseContentType = contentType
+	s.records[k] = rec
+	return nil
+}
+
+func (s *handlerIdempotencyStore) Release(_ context.Context, userID uuid.UUID, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, s.storeKey(userID, key))
+	return nil
+}
+
+func (s *handlerIdempotencyStore) Get(_ context.Context, userID uuid.UUID, key string) (middleware.IdempotencyRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[s.storeKey(userID, key)]
+	if !ok {
+		return middleware.IdempotencyRecord{}, middleware.ErrIdempotencyKeyNotFound
+	}
+	return rec, nil
+}

--- a/apps/api/internal/middleware/idempotency.go
+++ b/apps/api/internal/middleware/idempotency.go
@@ -123,11 +123,14 @@ func IdempotencyMiddleware(store IdempotencyStore, routes []RouteMatch) func(htt
 				return
 			}
 
-			key := r.Header.Get(idempotencyHeader)
-			if key == "" {
+			clientKey := r.Header.Get(idempotencyHeader)
+			if clientKey == "" {
 				http.Error(w, "Idempotency-Key header is required for this endpoint", http.StatusBadRequest)
 				return
 			}
+			// Uniqueness is (user, key, endpoint). The same client key used
+			// on a different method+path is a different operation — nester#1077.
+			key := scopedIdempotencyKey(r.Method, r.URL.Path, clientKey)
 
 			// Read one byte past the limit so an oversized body can be told
 			// apart from one that lands exactly at maxIdempotencyBodyBytes —
@@ -253,6 +256,24 @@ func writeStoredResponse(w http.ResponseWriter, rec IdempotencyRecord) {
 	}
 	w.WriteHeader(status)
 	_, _ = w.Write(rec.ResponseBody)
+}
+
+// scopedIdempotencyKey binds a client-supplied key to one HTTP endpoint so
+// the stored row is (user, key, endpoint) as required by nester#1077.
+func scopedIdempotencyKey(method, path, clientKey string) string {
+	return method + " " + path + "\x1f" + clientKey
+}
+
+// VaultMoneyPathIdempotencyRoutes is the nester#1077 set: every
+// state-changing vault money path requires an Idempotency-Key.
+func VaultMoneyPathIdempotencyRoutes() []RouteMatch {
+	return []RouteMatch{
+		{Method: http.MethodPost, Path: "/api/v1/vaults/{id}/deposit"},
+		{Method: http.MethodPost, Path: "/api/v1/vaults/{id}/withdraw"},
+		{Method: http.MethodPost, Path: "/api/v1/vaults/{id}/harvest"},
+		{Method: http.MethodPost, Path: "/api/v1/vaults/{id}/rebalance"},
+		{Method: http.MethodPost, Path: "/api/v1/vault/rebalance"},
+	}
 }
 
 // fingerprintRequest hashes method+path+body so a key reused with a

--- a/apps/api/internal/middleware/ratelimit_routes.go
+++ b/apps/api/internal/middleware/ratelimit_routes.go
@@ -8,7 +8,11 @@ import (
 )
 
 // RouteMatch identifies a single method+path endpoint that a route-scoped
-// limiter applies to. Path is matched exactly against r.URL.Path.
+// limiter (or the idempotency middleware) applies to.
+//
+// Path is matched against r.URL.Path. A segment of the form `{name}` is a
+// wildcard, so `/api/v1/vaults/{id}/deposit` matches any vault id. Paths
+// without braces still match exactly, preserving every existing caller.
 type RouteMatch struct {
 	Method string
 	Path   string
@@ -103,12 +107,50 @@ func sensitiveRouteLimiter(l Limiter, routes []RouteMatch, keyFn func(*http.Requ
 	}
 }
 
-// matchesRoute reports whether r matches any of routes by exact method and path.
+// matchesRoute reports whether r matches any of routes by method and path
+// pattern (see RouteMatch).
 func matchesRoute(routes []RouteMatch, r *http.Request) bool {
 	for _, rt := range routes {
-		if r.Method == rt.Method && r.URL.Path == rt.Path {
+		if r.Method == rt.Method && matchPathPattern(rt.Path, r.URL.Path) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchPathPattern reports whether path matches pattern. `{param}` segments
+// match any non-empty path segment; every other segment must be identical.
+func matchPathPattern(pattern, path string) bool {
+	if pattern == path {
+		return true
+	}
+	pSegs := splitPath(pattern)
+	pathSegs := splitPath(path)
+	if len(pSegs) != len(pathSegs) {
+		return false
+	}
+	for i, seg := range pSegs {
+		if isPathWildcard(seg) {
+			if pathSegs[i] == "" {
+				return false
+			}
+			continue
+		}
+		if seg != pathSegs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func splitPath(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+func isPathWildcard(seg string) bool {
+	return len(seg) >= 2 && seg[0] == '{' && seg[len(seg)-1] == '}'
 }

--- a/apps/api/internal/middleware/ratelimit_routes_test.go
+++ b/apps/api/internal/middleware/ratelimit_routes_test.go
@@ -200,6 +200,26 @@ func TestSensitiveUserRouteLimiterPerUser(t *testing.T) {
 	}
 }
 
+func TestMatchPathPatternWildcard(t *testing.T) {
+	routes := []RouteMatch{{Method: http.MethodPost, Path: "/api/v1/vaults/{id}/deposit"}}
+	match := func(method, path string) bool {
+		req := httptest.NewRequest(method, path, nil)
+		return matchesRoute(routes, req)
+	}
+	if !match(http.MethodPost, "/api/v1/vaults/11111111-1111-1111-1111-111111111111/deposit") {
+		t.Fatal("expected wildcard path to match a vault deposit")
+	}
+	if match(http.MethodPost, "/api/v1/vaults/11111111-1111-1111-1111-111111111111/withdraw") {
+		t.Fatal("deposit pattern must not match withdraw")
+	}
+	if match(http.MethodGet, "/api/v1/vaults/11111111-1111-1111-1111-111111111111/deposit") {
+		t.Fatal("POST pattern must not match GET")
+	}
+	if match(http.MethodPost, "/api/v1/vaults") {
+		t.Fatal("must not match a shorter path")
+	}
+}
+
 // --- Proxy-aware client IP keying ---
 
 func TestClientIPUsesForwardedForBehindTrustedProxies(t *testing.T) {

--- a/apps/api/internal/service/chain_event_adapter.go
+++ b/apps/api/internal/service/chain_event_adapter.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/stellar"
+)
+
+// rpcChainEventAdapter maps stellar.RPCChainEventVerifier onto
+// ChainEventVerifier. The two packages keep distinct result types so stellar
+// does not import service (which already depends on stellar).
+type rpcChainEventAdapter struct {
+	inner *stellar.RPCChainEventVerifier
+}
+
+// NewStellarChainEventVerifier builds the production on-chain event verifier
+// used by VaultService to record withdrawals from a confirmed tx hash.
+func NewStellarChainEventVerifier(rpcURL string) ChainEventVerifier {
+	return rpcChainEventAdapter{inner: stellar.NewRPCChainEventVerifier(rpcURL)}
+}
+
+func (a rpcChainEventAdapter) VerifyVaultEvent(ctx context.Context, txHash, contractID, eventType string) (VerifiedVaultEvent, error) {
+	ev, err := a.inner.VerifyVaultEvent(ctx, txHash, contractID, eventType)
+	if err != nil {
+		return VerifiedVaultEvent{}, err
+	}
+	return VerifiedVaultEvent{
+		TxHash:     ev.TxHash,
+		EventType:  ev.EventType,
+		Amount:     ev.Amount,
+		ContractID: ev.ContractID,
+	}, nil
+}

--- a/apps/api/internal/service/soroban_vault_chain_invoker.go
+++ b/apps/api/internal/service/soroban_vault_chain_invoker.go
@@ -93,7 +93,8 @@ func (s *SorobanVaultChainInvoker) SetAllocationWeights(
 // operator as both caller and depositing user, passing amount and zero
 // as the minimum-shares-out slippage guard.
 func (s *SorobanVaultChainInvoker) DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error {
-	return s.invoker.InvokeWithI128Pair(ctx, contractAddress, "deposit", amountStroops, 0)
+	_, err := s.invoker.InvokeWithI128Pair(ctx, contractAddress, "deposit", amountStroops, 0)
+	return err
 }
 
 // WithdrawFromVault invokes the vault contract's withdraw function with a
@@ -103,15 +104,15 @@ func (s *SorobanVaultChainInvoker) WithdrawFromVault(
 	contractAddress string,
 	sharesStroops int64,
 	slippageBps int,
-) error {
+) (string, error) {
 	bps, err := stellar.ResolveSlippageBps(slippageBps, s.defaultSlippageBps)
 	if err != nil {
-		return fmt.Errorf("invalid slippage: %w", err)
+		return "", fmt.Errorf("invalid slippage: %w", err)
 	}
 
 	previewNet, err := s.invoker.PreviewWithdrawNet(ctx, contractAddress, sharesStroops)
 	if err != nil {
-		return fmt.Errorf("preview withdrawal: %w", err)
+		return "", fmt.Errorf("preview withdrawal: %w", err)
 	}
 
 	minAssetsOut := stellar.ComputeMinAssetsOut(previewNet, bps)

--- a/apps/api/internal/service/vault_flow_metrics.go
+++ b/apps/api/internal/service/vault_flow_metrics.go
@@ -43,6 +43,9 @@ func classifyFlowError(err error) metrics.FlowOutcome {
 		errors.Is(err, vault.ErrVaultClosed),
 		errors.Is(err, vault.ErrVaultNotActive),
 		errors.Is(err, vault.ErrInsufficientBalance),
+		errors.Is(err, vault.ErrWithdrawalExceedsPosition),
+		errors.Is(err, vault.ErrTxHashRequired),
+		errors.Is(err, vault.ErrUnverifiedChainTx),
 		errors.Is(err, vault.ErrCapacityExceeded),
 		errors.Is(err, vault.ErrDuplicateTransaction),
 		// The contract refused a sub-minimum deposit. Classified as rejected

--- a/apps/api/internal/service/vault_flow_metrics_test.go
+++ b/apps/api/internal/service/vault_flow_metrics_test.go
@@ -33,6 +33,9 @@ func TestClassifyRejectedErrors(t *testing.T) {
 		{"vault closed", vault.ErrVaultClosed},
 		{"vault not active", vault.ErrVaultNotActive},
 		{"insufficient balance", vault.ErrInsufficientBalance},
+		{"withdrawal exceeds position", vault.ErrWithdrawalExceedsPosition},
+		{"tx hash required", vault.ErrTxHashRequired},
+		{"unverified chain tx", vault.ErrUnverifiedChainTx},
 		{"capacity exceeded", vault.ErrCapacityExceeded},
 		{"duplicate transaction", vault.ErrDuplicateTransaction},
 		// The contract refused a sub-minimum deposit. Classified as rejected

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -82,7 +82,7 @@ type ConvertResponse struct {
 // no operator secret is configured.
 type VaultDepositInvoker interface {
 	DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error
-	WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64, slippageBps int) error
+	WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64, slippageBps int) (txHash string, err error)
 	PreviewDeposit(ctx context.Context, contractAddress string, amountStroops int64) (int64, error)
 	PreviewWithdraw(ctx context.Context, contractAddress string, sharesStroops int64) (int64, error)
 	HarvestVault(ctx context.Context, contractAddress, userAddress string, compound bool) (string, error)
@@ -96,8 +96,8 @@ type VaultDepositInvoker interface {
 type NoopVaultDepositInvoker struct{}
 
 func (NoopVaultDepositInvoker) DepositToVault(_ context.Context, _ string, _ int64) error { return nil }
-func (NoopVaultDepositInvoker) WithdrawFromVault(_ context.Context, _ string, _ int64, _ int) error {
-	return nil
+func (NoopVaultDepositInvoker) WithdrawFromVault(_ context.Context, _ string, _ int64, _ int) (string, error) {
+	return "", nil
 }
 func (NoopVaultDepositInvoker) PreviewDeposit(_ context.Context, _ string, _ int64) (int64, error) {
 	return 0, nil
@@ -126,6 +126,7 @@ type HarvestResult struct {
 type VaultService struct {
 	repository             vault.Repository
 	depositInvoker         VaultDepositInvoker
+	chainVerifier          ChainEventVerifier
 	defaultHarvestCompound bool
 	yieldRecorder          YieldHarvestRecorder
 	goalYieldRouter        GoalYieldRouter
@@ -220,6 +221,27 @@ func NewVaultService(repository vault.Repository) *VaultService {
 // Call this after NewVaultService when an operator key is available.
 func (s *VaultService) SetDepositInvoker(invoker VaultDepositInvoker) {
 	s.depositInvoker = invoker
+}
+
+// ChainEventVerifier looks up a transaction hash and returns the matching
+// vault contract event. Implemented by stellar.RPCChainEventVerifier; tests
+// inject a fake. Shared by deposit and withdrawal recording (nester#1076).
+type ChainEventVerifier interface {
+	VerifyVaultEvent(ctx context.Context, txHash, contractID, eventType string) (VerifiedVaultEvent, error)
+}
+
+// VerifiedVaultEvent is the amount taken from a confirmed on-chain vault event.
+type VerifiedVaultEvent struct {
+	TxHash     string
+	EventType  string
+	Amount     decimal.Decimal
+	ContractID string
+}
+
+// SetChainEventVerifier wires on-chain event verification used to record
+// withdrawals from a confirmed transaction hash rather than the request body.
+func (s *VaultService) SetChainEventVerifier(verifier ChainEventVerifier) {
+	s.chainVerifier = verifier
 }
 
 // SetMetrics wires the SLI recorder for the deposit and withdrawal service
@@ -580,8 +602,12 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 	if existing.Status == vault.StatusClosed {
 		return vault.Vault{}, vault.ErrVaultClosed
 	}
-	if existing.CurrentBalance.LessThan(input.Amount) {
-		return vault.Vault{}, vault.ErrInsufficientBalance
+	// Reject before any on-chain submit: a withdrawal that would take the
+	// position below zero must not be sent to the contract (nester#1076).
+	// When a tx hash is already supplied the withdraw landed on-chain; the
+	// event amount is checked after verification instead of this hint.
+	if strings.TrimSpace(input.TxHash) == "" && existing.CurrentBalance.LessThan(input.Amount) {
+		return vault.Vault{}, vault.ErrWithdrawalExceedsPosition
 	}
 
 	userID := input.UserID
@@ -589,20 +615,44 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 		userID = existing.UserID
 	}
 
-	sharePrice := vault.ComputeSharePrice(existing)
-	shares := input.Amount.Div(sharePrice).Round(6)
-
-	if s.depositInvoker != nil {
+	txHash := strings.TrimSpace(input.TxHash)
+	// A client-supplied hash means the withdraw already landed on-chain
+	// (wallet-signed). Do not submit again.
+	if txHash == "" && s.depositInvoker != nil {
 		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
-		if err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, stroops, input.SlippageBps); err != nil {
+		submitted, err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, stroops, input.SlippageBps)
+		if err != nil {
 			return vault.Vault{}, fmt.Errorf("on-chain withdrawal failed: %w", err)
+		}
+		txHash = strings.TrimSpace(submitted)
+	}
+
+	amount := input.Amount
+	if s.chainVerifier != nil {
+		if txHash == "" {
+			return vault.Vault{}, vault.ErrTxHashRequired
+		}
+		event, err := s.chainVerifier.VerifyVaultEvent(ctx, txHash, existing.ContractAddress, "withdraw")
+		if err != nil {
+			return vault.Vault{}, err
+		}
+		// Record the contract-event amount, never the request body.
+		amount = event.Amount
+		if amount.Cmp(decimal.Zero) <= 0 {
+			return vault.Vault{}, vault.ErrInvalidAmount
+		}
+		if existing.CurrentBalance.LessThan(amount) {
+			return vault.Vault{}, vault.ErrWithdrawalExceedsPosition
 		}
 	}
 
+	sharePrice := vault.ComputeSharePrice(existing)
+	shares := amount.Div(sharePrice).Round(6)
+
 	record := vault.TransactionRecord{
 		UserID:               userID,
-		Amount:               input.Amount,
-		TransactionHash:      input.TxHash,
+		Amount:               amount,
+		TransactionHash:      txHash,
 		SharesMintedOrBurned: shares,
 		SharePriceAtTime:     sharePrice,
 		FeeCharged:           input.Fee,

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -440,6 +440,13 @@ func (r *memoryVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID
 	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
 	}
+	if record.TransactionHash != "" {
+		for _, txn := range r.transactions {
+			if txn.TransactionHash == record.TransactionHash {
+				return vault.ErrDuplicateTransaction
+			}
+		}
+	}
 
 	model.CurrentBalance = model.CurrentBalance.Sub(record.Amount)
 	model.UpdatedAt = time.Now().UTC()

--- a/apps/api/internal/service/vault_service_withdrawal_verify_test.go
+++ b/apps/api/internal/service/vault_service_withdrawal_verify_test.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+type fakeChainVerifier struct {
+	events map[string]VerifiedVaultEvent
+	err    error
+}
+
+func (f *fakeChainVerifier) VerifyVaultEvent(_ context.Context, txHash, contractID, eventType string) (VerifiedVaultEvent, error) {
+	if f.err != nil {
+		return VerifiedVaultEvent{}, f.err
+	}
+	ev, ok := f.events[txHash]
+	if !ok {
+		return VerifiedVaultEvent{}, vault.ErrUnverifiedChainTx
+	}
+	if contractID != "" && ev.ContractID != "" && ev.ContractID != contractID {
+		return VerifiedVaultEvent{}, vault.ErrUnverifiedChainTx
+	}
+	if eventType != "" && ev.EventType != "" && ev.EventType != eventType {
+		return VerifiedVaultEvent{}, vault.ErrUnverifiedChainTx
+	}
+	ev.TxHash = txHash
+	return ev, nil
+}
+
+type recordingWithdrawInvoker struct {
+	calls atomic.Int32
+	hash  string
+}
+
+func (r *recordingWithdrawInvoker) DepositToVault(context.Context, string, int64) error { return nil }
+func (r *recordingWithdrawInvoker) WithdrawFromVault(context.Context, string, int64, int) (string, error) {
+	r.calls.Add(1)
+	if r.hash == "" {
+		return "on-chain-hash", nil
+	}
+	return r.hash, nil
+}
+func (r *recordingWithdrawInvoker) PreviewDeposit(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+func (r *recordingWithdrawInvoker) PreviewWithdraw(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+func (r *recordingWithdrawInvoker) HarvestVault(context.Context, string, string, bool) (string, error) {
+	return "", nil
+}
+func (r *recordingWithdrawInvoker) EmergencyWithdrawAll(context.Context, string) error { return nil }
+
+func TestRecordWithdrawal_ForgedAmountUsesContractEvent(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID: userID, ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	svc.SetChainEventVerifier(&fakeChainVerifier{events: map[string]VerifiedVaultEvent{
+		"hash-real": {Amount: decimal.RequireFromString("40"), EventType: "withdraw", ContractID: created.ContractAddress},
+	}})
+
+	updated, err := svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("10"), // forged smaller than the event
+		TxHash:  "hash-real",
+	})
+	if err != nil {
+		t.Fatalf("RecordWithdrawal: %v", err)
+	}
+	if !updated.CurrentBalance.Equal(decimal.RequireFromString("60")) {
+		t.Fatalf("balance = %s, want 60 (event amount 40, not request body 10)", updated.CurrentBalance)
+	}
+
+	txns, err := repo.ListUserVaultTransactions(context.Background(), userID, created.ID)
+	if err != nil {
+		t.Fatalf("ListUserVaultTransactions: %v", err)
+	}
+	var recorded decimal.Decimal
+	for _, txn := range txns {
+		if txn.Type == "withdrawal" {
+			recorded = txn.Amount
+		}
+	}
+	if !recorded.Equal(decimal.RequireFromString("40")) {
+		t.Fatalf("recorded withdrawal = %s, want 40 from the contract event", recorded)
+	}
+}
+
+func TestRecordWithdrawal_ReplayedHashRejected(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID: userID, ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	svc.SetChainEventVerifier(&fakeChainVerifier{events: map[string]VerifiedVaultEvent{
+		"hash-once": {Amount: decimal.RequireFromString("25"), EventType: "withdraw", ContractID: created.ContractAddress},
+	}})
+
+	if _, err := svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("25"), TxHash: "hash-once",
+	}); err != nil {
+		t.Fatalf("first withdrawal: %v", err)
+	}
+	_, err = svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("25"), TxHash: "hash-once",
+	})
+	if !errors.Is(err, vault.ErrDuplicateTransaction) {
+		t.Fatalf("replay err = %v, want ErrDuplicateTransaction", err)
+	}
+
+	updated, err := svc.GetVault(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetVault: %v", err)
+	}
+	if !updated.CurrentBalance.Equal(decimal.RequireFromString("75")) {
+		t.Fatalf("balance = %s, want 75 (replay must not debit again)", updated.CurrentBalance)
+	}
+}
+
+func TestRecordWithdrawal_PartialWithdrawalLeavesRemainder(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID: userID, ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	svc.SetChainEventVerifier(&fakeChainVerifier{events: map[string]VerifiedVaultEvent{
+		"hash-partial": {Amount: decimal.RequireFromString("30"), EventType: "withdraw", ContractID: created.ContractAddress},
+	}})
+
+	updated, err := svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("30"), TxHash: "hash-partial",
+	})
+	if err != nil {
+		t.Fatalf("RecordWithdrawal: %v", err)
+	}
+	if !updated.CurrentBalance.Equal(decimal.RequireFromString("70")) {
+		t.Fatalf("balance = %s, want 70 after partial withdrawal", updated.CurrentBalance)
+	}
+	if !updated.TotalDeposited.Equal(decimal.RequireFromString("100")) {
+		t.Fatalf("total_deposited = %s, want 100 (withdrawals never reverse deposits)", updated.TotalDeposited)
+	}
+}
+
+func TestRecordWithdrawal_ExceedingPositionRejectedBeforeSubmit(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	invoker := &recordingWithdrawInvoker{}
+	svc.SetDepositInvoker(invoker)
+
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID: userID, ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("50"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	_, err = svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("80"),
+	})
+	if !errors.Is(err, vault.ErrWithdrawalExceedsPosition) {
+		t.Fatalf("err = %v, want ErrWithdrawalExceedsPosition", err)
+	}
+	if invoker.calls.Load() != 0 {
+		t.Fatalf("invoker called %d times, want 0 (must reject before on-chain submit)", invoker.calls.Load())
+	}
+}
+
+func TestRecordWithdrawal_RequiresHashWhenVerifierWired(t *testing.T) {
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+	svc.SetChainEventVerifier(&fakeChainVerifier{events: map[string]VerifiedVaultEvent{}})
+
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID: userID, ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Currency: "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("50"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	_, err = svc.RecordWithdrawal(context.Background(), RecordWithdrawalInput{
+		VaultID: created.ID, Amount: decimal.RequireFromString("10"),
+	})
+	if !errors.Is(err, vault.ErrTxHashRequired) {
+		t.Fatalf("err = %v, want ErrTxHashRequired", err)
+	}
+}

--- a/apps/api/internal/stellar/chain_event_verifier.go
+++ b/apps/api/internal/stellar/chain_event_verifier.go
@@ -158,8 +158,10 @@ func collectContractEvents(meta xdr.TransactionMeta) []xdr.ContractEvent {
 	if v3 := meta.V3; v3 != nil && v3.SorobanMeta != nil {
 		events = append(events, v3.SorobanMeta.Events...)
 	}
-	if v4, err := meta.V4(); err == nil && v4 != nil && v4.SorobanMeta != nil {
-		events = append(events, v4.SorobanMeta.Events...)
+	if v4 := meta.V4; v4 != nil {
+		for _, te := range v4.Events {
+			events = append(events, te.Event)
+		}
 	}
 	return events
 }

--- a/apps/api/internal/stellar/chain_event_verifier.go
+++ b/apps/api/internal/stellar/chain_event_verifier.go
@@ -1,0 +1,271 @@
+package stellar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/xdr"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+const stroopsPerUnit int64 = 10_000_000
+
+// VerifiedVaultEvent is a vault contract event taken from a confirmed
+// on-chain transaction. Amount is in display units (stroops / 1e7), matching
+// the vault ledger — never the client-supplied request body (nester#1076).
+type VerifiedVaultEvent struct {
+	TxHash     string
+	EventType  string
+	Amount     decimal.Decimal
+	ContractID string
+}
+
+// ChainEventVerifier looks up a transaction hash and returns the matching
+// vault contract event. Shared by deposit and withdrawal recording so both
+// money paths reconcile against the same on-chain source of truth.
+type ChainEventVerifier interface {
+	VerifyVaultEvent(ctx context.Context, txHash, contractID, eventType string) (VerifiedVaultEvent, error)
+}
+
+// RPCChainEventVerifier implements ChainEventVerifier against a Soroban RPC
+// getTransaction endpoint. It requires status=SUCCESS and a contract event
+// on the given vault whose topic matches eventType.
+type RPCChainEventVerifier struct {
+	rpcURL string
+	client *http.Client
+}
+
+func NewRPCChainEventVerifier(rpcURL string) *RPCChainEventVerifier {
+	return &RPCChainEventVerifier{
+		rpcURL: strings.TrimSpace(rpcURL),
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+type rpcGetTxResult struct {
+	Status        string `json:"status"`
+	ResultMetaXdr string `json:"resultMetaXdr"`
+}
+
+func (v *RPCChainEventVerifier) VerifyVaultEvent(
+	ctx context.Context,
+	txHash, contractID, eventType string,
+) (VerifiedVaultEvent, error) {
+	txHash = strings.TrimSpace(txHash)
+	contractID = strings.TrimSpace(contractID)
+	eventType = strings.ToLower(strings.TrimSpace(eventType))
+	if txHash == "" {
+		return VerifiedVaultEvent{}, vault.ErrTxHashRequired
+	}
+	if v.rpcURL == "" {
+		return VerifiedVaultEvent{}, vault.ErrUnverifiedChainTx
+	}
+
+	var resp rpcResponse[rpcGetTxResult]
+	if err := v.rpcCall(ctx, "getTransaction", getTxParams{Hash: txHash}, &resp); err != nil {
+		return VerifiedVaultEvent{}, fmt.Errorf("%w: %v", vault.ErrUnverifiedChainTx, err)
+	}
+	if resp.Error != nil {
+		return VerifiedVaultEvent{}, fmt.Errorf("%w: %s", vault.ErrUnverifiedChainTx, resp.Error.Message)
+	}
+
+	switch strings.ToUpper(resp.Result.Status) {
+	case "SUCCESS":
+		// continue
+	case "NOT_FOUND", "":
+		return VerifiedVaultEvent{}, fmt.Errorf("%w: transaction not found", vault.ErrUnverifiedChainTx)
+	default:
+		return VerifiedVaultEvent{}, fmt.Errorf("%w: transaction status %s", vault.ErrUnverifiedChainTx, resp.Result.Status)
+	}
+
+	events, err := parseContractEventsFromMeta(resp.Result.ResultMetaXdr)
+	if err != nil {
+		return VerifiedVaultEvent{}, fmt.Errorf("%w: %v", vault.ErrUnverifiedChainTx, err)
+	}
+
+	wantType := normalizeEventType(eventType)
+	for _, ev := range events {
+		if contractID != "" && ev.ContractID != contractID {
+			continue
+		}
+		if normalizeEventType(ev.EventType) != wantType {
+			continue
+		}
+		if ev.Amount.Cmp(decimal.Zero) <= 0 {
+			continue
+		}
+		ev.TxHash = txHash
+		return ev, nil
+	}
+
+	return VerifiedVaultEvent{}, fmt.Errorf("%w: no %s event for contract %s", vault.ErrUnverifiedChainTx, eventType, contractID)
+}
+
+func (v *RPCChainEventVerifier) rpcCall(ctx context.Context, method string, params, result any) error {
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.rpcURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("rpc returned %d: %s", resp.StatusCode, string(payload))
+	}
+	return json.NewDecoder(resp.Body).Decode(result)
+}
+
+func parseContractEventsFromMeta(metaB64 string) ([]VerifiedVaultEvent, error) {
+	metaB64 = strings.TrimSpace(metaB64)
+	if metaB64 == "" {
+		return nil, errors.New("missing resultMetaXdr")
+	}
+	var meta xdr.TransactionMeta
+	if err := xdr.SafeUnmarshalBase64(metaB64, &meta); err != nil {
+		return nil, fmt.Errorf("decode resultMetaXdr: %w", err)
+	}
+
+	var out []VerifiedVaultEvent
+	for _, ce := range collectContractEvents(meta) {
+		ev, ok := verifiedEventFromXDR(ce)
+		if ok {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+func collectContractEvents(meta xdr.TransactionMeta) []xdr.ContractEvent {
+	events := make([]xdr.ContractEvent, 0)
+	if v3 := meta.V3; v3 != nil && v3.SorobanMeta != nil {
+		events = append(events, v3.SorobanMeta.Events...)
+	}
+	if v4, err := meta.V4(); err == nil && v4 != nil && v4.SorobanMeta != nil {
+		events = append(events, v4.SorobanMeta.Events...)
+	}
+	return events
+}
+
+func verifiedEventFromXDR(ce xdr.ContractEvent) (VerifiedVaultEvent, bool) {
+	if ce.ContractId == nil {
+		return VerifiedVaultEvent{}, false
+	}
+	encoded, err := strkey.Encode(strkey.VersionByteContract, (*ce.ContractId)[:])
+	if err != nil {
+		return VerifiedVaultEvent{}, false
+	}
+
+	body, ok := ce.Body.GetV0()
+	if !ok {
+		return VerifiedVaultEvent{}, false
+	}
+
+	eventType := ""
+	if len(body.Topics) > 0 {
+		eventType = scValSymbol(body.Topics[0])
+	}
+	if eventType == "" && len(body.Topics) > 1 {
+		eventType = scValSymbol(body.Topics[1])
+	}
+	amount, ok := scValAmount(body.Data)
+	if !ok || amount.Cmp(decimal.Zero) <= 0 {
+		return VerifiedVaultEvent{}, false
+	}
+
+	return VerifiedVaultEvent{
+		EventType:  eventType,
+		Amount:     stroopsToDisplay(amount),
+		ContractID: encoded,
+	}, true
+}
+
+func scValSymbol(val xdr.ScVal) string {
+	switch val.Type {
+	case xdr.ScValTypeScvSymbol:
+		if val.Sym != nil {
+			return string(*val.Sym)
+		}
+	case xdr.ScValTypeScvString:
+		if val.Str != nil {
+			return string(*val.Str)
+		}
+	}
+	return ""
+}
+
+func scValAmount(val xdr.ScVal) (decimal.Decimal, bool) {
+	switch val.Type {
+	case xdr.ScValTypeScvI128:
+		if val.I128 == nil {
+			return decimal.Zero, false
+		}
+		return i128PartsToDecimal(*val.I128)
+	case xdr.ScValTypeScvU64:
+		if val.U64 == nil {
+			return decimal.Zero, false
+		}
+		return decimal.NewFromUint64(uint64(*val.U64)), true
+	case xdr.ScValTypeScvI64:
+		if val.I64 == nil {
+			return decimal.Zero, false
+		}
+		return decimal.NewFromInt(int64(*val.I64)), true
+	case xdr.ScValTypeScvMap:
+		if val.Map == nil || *val.Map == nil {
+			return decimal.Zero, false
+		}
+		for _, entry := range **val.Map {
+			name := scValSymbol(entry.Key)
+			if name != "amount" && name != "value" {
+				continue
+			}
+			return scValAmount(entry.Val)
+		}
+	}
+	return decimal.Zero, false
+}
+
+func i128PartsToDecimal(parts xdr.Int128Parts) (decimal.Decimal, bool) {
+	if parts.Hi != 0 {
+		return decimal.Zero, false
+	}
+	return decimal.NewFromUint64(uint64(parts.Lo)), true
+}
+
+func stroopsToDisplay(stroops decimal.Decimal) decimal.Decimal {
+	return stroops.Div(decimal.NewFromInt(stroopsPerUnit))
+}
+
+func normalizeEventType(eventType string) string {
+	s := strings.ToLower(strings.TrimSpace(eventType))
+	switch s {
+	case "withdraw", "withdrawal", "withdrawn":
+		return "withdraw"
+	case "deposit", "deposited":
+		return "deposit"
+	case "harvest", "harvested", "yield_harvest":
+		return "harvest"
+	case "rebalance", "rebal_cmp":
+		return "rebalance"
+	default:
+		return s
+	}
+}

--- a/apps/api/internal/stellar/chain_event_verifier_test.go
+++ b/apps/api/internal/stellar/chain_event_verifier_test.go
@@ -1,0 +1,121 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/xdr"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+func TestRPCChainEventVerifier_RequiresHash(t *testing.T) {
+	v := NewRPCChainEventVerifier("http://rpc")
+	_, err := v.VerifyVaultEvent(context.Background(), "", "CABC", "withdraw")
+	if !errors.Is(err, vault.ErrTxHashRequired) {
+		t.Fatalf("err = %v, want ErrTxHashRequired", err)
+	}
+}
+
+func TestRPCChainEventVerifier_RejectsFailedTx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  map[string]any{"status": "FAILED"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	v := NewRPCChainEventVerifier(srv.URL)
+	_, err := v.VerifyVaultEvent(context.Background(), "abc", "CABC", "withdraw")
+	if !errors.Is(err, vault.ErrUnverifiedChainTx) {
+		t.Fatalf("err = %v, want ErrUnverifiedChainTx", err)
+	}
+}
+
+func TestRPCChainEventVerifier_ReadsWithdrawAmountFromMeta(t *testing.T) {
+	contract := "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	raw, err := strkey.Decode(strkey.VersionByteContract, contract)
+	if err != nil {
+		t.Fatalf("decode contract: %v", err)
+	}
+	var contractID xdr.ContractId
+	copy(contractID[:], raw)
+
+	amountSym := xdr.ScSymbol("amount")
+	withdrawSym := xdr.ScSymbol("WITHDRAW")
+	stroops := xdr.Int128Parts{Hi: 0, Lo: xdr.Uint64(250_000_000)} // 25.0000000 USDC
+	body := xdr.ContractEventBody{
+		V: 0,
+		V0: &xdr.ContractEventV0{
+			Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &withdrawSym}},
+			Data: xdr.ScVal{
+				Type: xdr.ScValTypeScvMap,
+				Map: &xdr.ScMap{
+					{
+						Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &amountSym},
+						Val: xdr.ScVal{Type: xdr.ScValTypeScvI128, I128: &stroops},
+					},
+				},
+			},
+		},
+	}
+	ce := xdr.ContractEvent{
+		ContractId: &contractID,
+		Body:       body,
+	}
+	meta := xdr.TransactionMeta{
+		V: 3,
+		V3: &xdr.TransactionMetaV3{
+			SorobanMeta: &xdr.SorobanTransactionMeta{Events: []xdr.ContractEvent{ce}},
+		},
+	}
+	metaB64, err := xdr.MarshalBase64(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": map[string]any{
+				"status":        "SUCCESS",
+				"resultMetaXdr": metaB64,
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	v := NewRPCChainEventVerifier(srv.URL)
+	got, err := v.VerifyVaultEvent(context.Background(), "tx-1", contract, "withdraw")
+	if err != nil {
+		t.Fatalf("VerifyVaultEvent: %v", err)
+	}
+	want := decimal.RequireFromString("25")
+	if !got.Amount.Equal(want) {
+		t.Fatalf("amount = %s, want %s (event stroops, not a client body)", got.Amount, want)
+	}
+	if got.ContractID != contract {
+		t.Fatalf("contract = %s, want %s", got.ContractID, contract)
+	}
+	if got.TxHash != "tx-1" {
+		t.Fatalf("tx hash = %s, want tx-1", got.TxHash)
+	}
+}
+
+func TestNormalizeEventType(t *testing.T) {
+	if got := normalizeEventType("WITHDRAW"); got != "withdraw" {
+		t.Fatalf("got %q", got)
+	}
+	if got := normalizeEventType("withdrawal"); got != "withdraw" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/apps/api/internal/stellar/chain_event_verifier_test.go
+++ b/apps/api/internal/stellar/chain_event_verifier_test.go
@@ -41,7 +41,7 @@ func TestRPCChainEventVerifier_RejectsFailedTx(t *testing.T) {
 }
 
 func TestRPCChainEventVerifier_ReadsWithdrawAmountFromMeta(t *testing.T) {
-	contract := "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	contract := "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
 	raw, err := strkey.Decode(strkey.VersionByteContract, contract)
 	if err != nil {
 		t.Fatalf("decode contract: %v", err)
@@ -52,29 +52,35 @@ func TestRPCChainEventVerifier_ReadsWithdrawAmountFromMeta(t *testing.T) {
 	amountSym := xdr.ScSymbol("amount")
 	withdrawSym := xdr.ScSymbol("WITHDRAW")
 	stroops := xdr.Int128Parts{Hi: 0, Lo: xdr.Uint64(250_000_000)} // 25.0000000 USDC
+	amountMap := xdr.ScMap{
+		{
+			Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &amountSym},
+			Val: xdr.ScVal{Type: xdr.ScValTypeScvI128, I128: &stroops},
+		},
+	}
+	amountMapPtr := &amountMap
 	body := xdr.ContractEventBody{
 		V: 0,
 		V0: &xdr.ContractEventV0{
 			Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &withdrawSym}},
 			Data: xdr.ScVal{
 				Type: xdr.ScValTypeScvMap,
-				Map: &xdr.ScMap{
-					{
-						Key: xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &amountSym},
-						Val: xdr.ScVal{Type: xdr.ScValTypeScvI128, I128: &stroops},
-					},
-				},
+				Map:  &amountMapPtr,
 			},
 		},
 	}
 	ce := xdr.ContractEvent{
 		ContractId: &contractID,
+		Type:       xdr.ContractEventTypeContract,
 		Body:       body,
 	}
 	meta := xdr.TransactionMeta{
 		V: 3,
 		V3: &xdr.TransactionMetaV3{
-			SorobanMeta: &xdr.SorobanTransactionMeta{Events: []xdr.ContractEvent{ce}},
+			SorobanMeta: &xdr.SorobanTransactionMeta{
+				Events:      []xdr.ContractEvent{ce},
+				ReturnValue: xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+			},
 		},
 	}
 	metaB64, err := xdr.MarshalBase64(meta)

--- a/apps/api/internal/stellar/invoker.go
+++ b/apps/api/internal/stellar/invoker.go
@@ -588,19 +588,19 @@ func i128ScValToInt64(val xdr.ScVal) (int64, error) {
 // InvokeWithI128Pair calls a contract function with signature
 // (caller: Address, arg0: i128, arg1: i128). Suitable for deposit and withdraw
 // where the operator acts as the transaction source and user.
-func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddress, functionName string, arg0, arg1 int64) error {
+func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddress, functionName string, arg0, arg1 int64) (string, error) {
 	contractScAddr, err := contractAddressToXDR(contractAddress)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	operatorAddr, err := c.requireOperatorAddress()
 	if err != nil {
-		return err
+		return "", err
 	}
 	callerScAddr, err := accountAddressToXDR(operatorAddr)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	hostFn := xdr.HostFunction{
@@ -618,7 +618,7 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 
 	seq, err := c.getSequenceNumber(ctx)
 	if err != nil {
-		return fmt.Errorf("get sequence number: %w", err)
+		return "", fmt.Errorf("get sequence number: %w", err)
 	}
 
 	sourceAccount := txnbuild.NewSimpleAccount(operatorAddr, seq)
@@ -635,22 +635,22 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 		Preconditions: txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(int64((5 * time.Minute).Seconds()))},
 	})
 	if err != nil {
-		return fmt.Errorf("build transaction: %w", err)
+		return "", fmt.Errorf("build transaction: %w", err)
 	}
 
 	txB64, err := tx.Base64()
 	if err != nil {
-		return fmt.Errorf("encode transaction: %w", err)
+		return "", fmt.Errorf("encode transaction: %w", err)
 	}
 
 	simResult, err := c.simulate(ctx, txB64)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var sorobanData xdr.SorobanTransactionData
 	if err := xdr.SafeUnmarshalBase64(simResult.TransactionData, &sorobanData); err != nil {
-		return fmt.Errorf("decode soroban data: %w", err)
+		return "", fmt.Errorf("decode soroban data: %w", err)
 	}
 
 	envelope := tx.ToXDR()
@@ -660,28 +660,28 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 	}
 	minFee, err := strconv.ParseInt(simResult.MinResourceFee, 10, 64)
 	if err != nil {
-		return fmt.Errorf("parse simulation min resource fee %q: %w", simResult.MinResourceFee, err)
+		return "", fmt.Errorf("parse simulation min resource fee %q: %w", simResult.MinResourceFee, err)
 	}
 	envelope.V1.Tx.Fee = xdr.Uint32(txnbuild.MinBaseFee + minFee)
 
 	envB64, err := xdr.MarshalBase64(envelope)
 	if err != nil {
-		return fmt.Errorf("encode patched envelope: %w", err)
+		return "", fmt.Errorf("encode patched envelope: %w", err)
 	}
 
 	generic, err := txnbuild.TransactionFromXDR(envB64)
 	if err != nil {
-		return fmt.Errorf("parse patched tx: %w", err)
+		return "", fmt.Errorf("parse patched tx: %w", err)
 	}
 
 	inner, ok := generic.Transaction()
 	if !ok {
-		return errors.New("expected a transaction, got fee-bump")
+		return "", errors.New("expected a transaction, got fee-bump")
 	}
 
 	envelopeB64, err := inner.Base64()
 	if err != nil {
-		return fmt.Errorf("encode transaction for signing: %w", err)
+		return "", fmt.Errorf("encode transaction for signing: %w", err)
 	}
 	signedB64, err := c.signEnvelope(ctx, SignRequest{
 		EnvelopeXDR:     envelopeB64,
@@ -691,15 +691,18 @@ func (c *ContractInvoker) InvokeWithI128Pair(ctx context.Context, contractAddres
 		Arg1:            arg1,
 	})
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	hash, err := c.send(ctx, signedB64)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return c.waitForTx(ctx, hash)
+	if err := c.waitForTx(ctx, hash); err != nil {
+		return "", err
+	}
+	return hash, nil
 }
 
 // QueryWithI128Arg simulates a contract call with one i128 arg and returns the decoded XDR result.

--- a/apps/dapp/frontend/lib/api/vaults.ts
+++ b/apps/dapp/frontend/lib/api/vaults.ts
@@ -75,6 +75,10 @@ export interface HarvestResult {
   tx_hash?: string;
 }
 
+function newIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
 export const vaultsApi = {
   getProjection: (vaultId: string) =>
     apiRequest<Projection>(`/vaults/${vaultId}/projection`),
@@ -101,12 +105,14 @@ export const vaultsApi = {
   harvest: (vaultId: string, compound: boolean) =>
     apiRequest<HarvestResult>(`/vaults/${vaultId}/harvest`, {
       method: "POST",
+      headers: { "Idempotency-Key": newIdempotencyKey() },
       body: JSON.stringify({ compound }),
     }),
 
   applyRebalance: (vaultId: string, allocations: AllocationPct[]) =>
     apiRequest<unknown>(`/vaults/${vaultId}/rebalance`, {
       method: "POST",
+      headers: { "Idempotency-Key": newIdempotencyKey() },
       body: JSON.stringify({ allocations }),
     }),
 }


### PR DESCRIPTION
## Summary

Closes #1077 and #1076 (testnet launch backlog — E1 money-path integrity). Deposit, withdraw, harvest, and rebalance are now retry-safe, and withdrawals are recorded from a verified on-chain event rather than the request body.

- **#1077 Idempotency-Key on every state-changing vault endpoint.** `POST /vaults/{id}/deposit`, `/withdraw`, `/harvest`, `/rebalance`, and `POST /vault/rebalance` require an `Idempotency-Key`. The stored row is keyed by user + key + endpoint; a repeat inside the retention window returns the original response without re-executing. Concurrent retries: one request runs, the rest wait and replay the same result. Missing header is `400`.
- **#1076 Withdrawals verified on-chain.** Records are created only from a verified transaction hash. The ledger amount is the contract `WITHDRAW` event, not the client body. A withdrawal that would take the position below zero is rejected before on-chain submit. Shared `ChainEventVerifier` helper (same path deposits can reuse).

## What changed

### Idempotency (#1077)
- Extended existing `#835` middleware with `{id}` path matching and endpoint-scoped keys.
- Wired vault money-path routes in `cmd/api/main.go`.
- Dapp harvest and rebalance clients send `Idempotency-Key`.

### Withdrawal verification (#1076)
- `RPCChainEventVerifier` loads `getTransaction`, requires `SUCCESS`, and reads the vault event amount from `resultMetaXdr`.
- `RecordWithdrawal` skips a second submit when a hash is already present; with a verifier wired, the hash is required and the event amount is what gets persisted.
- Replay of the same hash is `409` (`ErrDuplicateTransaction`). Overdraft is `400` (`ErrWithdrawalExceedsPosition`) and does not call the invoker.

## Test plan

- [ ] `POST` deposit/withdraw/harvest/rebalance without `Idempotency-Key` → `400`
- [ ] Same key + same body replayed → original response, `Idempotency-Replayed: true`, no second credit/debit
- [ ] Same key, different body → `409`
- [ ] 20 concurrent requests with the same key → one effect (`TestVaultHandlerDepositIdempotencyKeyTwentyConcurrentOneEffect`)
- [ ] Forged withdraw amount in the body → recorded amount is the contract event
- [ ] Replayed withdraw hash → rejected, balance unchanged
- [ ] Partial withdraw → remainder left on the position
- [ ] Withdrawal larger than position → rejected before on-chain submit


Made with [Cursor](https://cursor.com)