### PR TITLE
Merge PR #1170: JWT secret entropy, admin route authz coverage, money-path observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
       # quiet, and the thresholds behave at the boundary.
       - name: Run burn-rate alert tests
         working-directory: docker/prometheus/rules
-        run: promtool test rules slo_alerts_test.yml slo_probe_alerts_test.yml
+        run: promtool test rules slo_alerts_test.yml slo_probe_alerts_test.yml slo_money_path_alerts_test.yml
 
       # The dashboards are generated from scripts/build_slo_dashboards.py so
       # the panels and thresholds stay consistent across four files. Committing

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -596,9 +596,36 @@ func run() error {
 		},
 		baseLogger.WithGroup("tx-poller"),
 	)
+	// Reconciliation and pending-submission metrics (#1108). Without this the
+	// poller's findings reach the log only, so a divergence — a balance that
+	// disagrees with the chain — is invisible to alerting.
+	txPoller.SetMetrics(appMetrics)
 	pollerCtx, cancelPoller := context.WithCancel(context.Background())
 	defer cancelPoller()
 	go txPoller.Run(pollerCtx)
+
+	// Age the reconcile gauge between passes (#1108). RecordReconcileRun
+	// resets it to zero on each completed pass; nothing else would move it, so
+	// a poller that dies would leave the gauge frozen at zero and read as
+	// "just reconciled" forever — the same failure mode the indexer's
+	// lag_last_sample_age gauge exists to prevent.
+	go func() {
+		const reconcileAgeInterval = 15 * time.Second
+		ticker := time.NewTicker(reconcileAgeInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pollerCtx.Done():
+				return
+			case <-ticker.C:
+				last := txPoller.LastTickEnd()
+				if last.IsZero() {
+					continue
+				}
+				appMetrics.SetReconcileLastRunAge(time.Since(last))
+			}
+		}
+	}()
 
 	// notificationRateLimit/-Window bound how many notifications a user can
 	// receive per category in a burst (#829's "a burst of deposits does not

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -818,6 +818,10 @@ func (c *Config) validate(loader *envLoader) {
 		loader.addError("AUTH_JWT_SECRET must not use the development default in production or staging")
 	}
 
+	if !jwtSecretHasAdequateEntropy(c.auth.secret) {
+		loader.addError("AUTH_JWT_SECRET has insufficient entropy: use at least 8 distinct characters")
+	}
+
 	if c.auth.accessTokenExpiry <= 0 {
 		loader.addError("AUTH_ACCESS_TOKEN_EXPIRY must be greater than 0")
 	}
@@ -1376,6 +1380,20 @@ func defaultLogFormat(environment string) string {
 func isOneOf(value string, options ...string) bool {
 	for _, option := range options {
 		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+// jwtSecretHasAdequateEntropy returns false when the secret is composed of
+// fewer than 8 distinct bytes, catching low-entropy values such as repeated
+// characters or trivially predictable sequences.
+func jwtSecretHasAdequateEntropy(secret string) bool {
+	seen := make(map[byte]struct{}, 8)
+	for i := 0; i < len(secret); i++ {
+		seen[secret[i]] = struct{}{}
+		if len(seen) >= 8 {
 			return true
 		}
 	}

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -1035,6 +1035,46 @@ func TestLoadAllowsDefaultJWTSecretInDevelopment(t *testing.T) {
 	}
 }
 
+// TestLoadRejectsLowEntropyJWTSecret verifies that a secret long enough to
+// pass the length check but composed of too few distinct characters is rejected
+// (nester#1106).
+func TestLoadRejectsLowEntropyJWTSecret(t *testing.T) {
+	baseEnv(t)
+	requiredEnv(t)
+	t.Setenv("APP_ENV", "development")
+	// 32 'a's: passes length, fails entropy.
+	t.Setenv("AUTH_JWT_SECRET", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	chdir(t, t.TempDir())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail when AUTH_JWT_SECRET has insufficient entropy")
+	}
+	if !strings.Contains(err.Error(), "entropy") {
+		t.Fatalf("expected entropy error message, got %q", err.Error())
+	}
+}
+
+// TestJWTSecretHasAdequateEntropy covers the helper directly.
+func TestJWTSecretHasAdequateEntropy(t *testing.T) {
+	cases := []struct {
+		secret string
+		want   bool
+	}{
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},           // single distinct byte
+		{"abababababababababababababababab", false},             // only 2 distinct bytes
+		{"abcdefg" + strings.Repeat("a", 25), false},          // 7 distinct bytes
+		{"abcdefgh" + strings.Repeat("a", 24), true},          // exactly 8 distinct bytes
+		{"this-is-a-very-secret-jwt-key-that-is-at-least-thirty-two-bytes", true},
+	}
+	for _, tc := range cases {
+		if got := jwtSecretHasAdequateEntropy(tc.secret); got != tc.want {
+			t.Errorf("jwtSecretHasAdequateEntropy(%q) = %v, want %v", tc.secret, got, tc.want)
+		}
+	}
+}
+
 // TestLoadAllowedOriginsRejectsMalformed verifies malformed origins are rejected.
 func TestLoadAllowedOriginsRejectsMalformed(t *testing.T) {
 	cases := []struct {

--- a/apps/api/internal/config/redact.go
+++ b/apps/api/internal/config/redact.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// Issue #1106, "no secret is ever logged, including in startup diagnostics".
+//
+// The config structs hold secrets in unexported fields, which keeps them out
+// of encoding/json but does nothing for fmt: `%v` and `%+v` reach unexported
+// fields via reflection and print them verbatim. A single
+// `logger.Info("config", "cfg", cfg)` or `fmt.Printf("%+v", cfg)` — in a
+// startup diagnostic, a debug session, or a panic dump — is all it takes to
+// put AUTH_JWT_SECRET or the Stellar operator seed into a log aggregator.
+//
+// Implementing String() makes every fmt verb route through it, so the secret
+// is unreachable through fmt regardless of the verb used. Implementing
+// slog.LogValuer does the same for structured logging. Both are declared on
+// value receivers so they apply whether the value or a pointer is logged.
+//
+// redactedPlaceholder is what stands in for a set secret. Distinguishing set
+// from empty matters when reading a startup diagnostic: "[REDACTED]" and ""
+// answer different questions, and neither reveals the value.
+const redactedPlaceholder = "[REDACTED]"
+
+// redact returns the placeholder for a non-empty secret and the empty string
+// for an unset one, so a diagnostic can still show whether a value is
+// configured without disclosing it.
+func redact(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	return redactedPlaceholder
+}
+
+// ---------------------------------------------------------------------------
+// AuthConfig
+// ---------------------------------------------------------------------------
+
+func (a AuthConfig) String() string {
+	return fmt.Sprintf(
+		"AuthConfig{secret:%q serviceAPIKey:%q accessTokenExpiry:%s refreshTokenExpiry:%s absoluteSessionLifetime:%s challengeExpiry:%s}",
+		redact(a.secret), redact(a.serviceAPIKey),
+		a.accessTokenExpiry, a.refreshTokenExpiry, a.absoluteSessionLifetime, a.challengeExpiry,
+	)
+}
+
+func (a AuthConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("secret", redact(a.secret)),
+		slog.String("service_api_key", redact(a.serviceAPIKey)),
+		slog.Duration("access_token_expiry", a.accessTokenExpiry),
+		slog.Duration("refresh_token_expiry", a.refreshTokenExpiry),
+		slog.Duration("absolute_session_lifetime", a.absoluteSessionLifetime),
+		slog.Duration("challenge_expiry", a.challengeExpiry),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// DatabaseConfig
+// ---------------------------------------------------------------------------
+
+// The DSN carries the database password in userinfo, so it is redacted whole
+// rather than parsed — a malformed DSN must not fall back to printing itself.
+
+func (d DatabaseConfig) String() string {
+	return fmt.Sprintf(
+		"DatabaseConfig{dsn:%q poolSize:%d connectionTimeout:%s}",
+		redact(d.dsn), d.poolSize, d.connectionTimeout,
+	)
+}
+
+func (d DatabaseConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("dsn", redact(d.dsn)),
+		slog.Int("pool_size", d.poolSize),
+		slog.Duration("connection_timeout", d.connectionTimeout),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// StellarConfig
+// ---------------------------------------------------------------------------
+
+// operatorSecret is a Stellar seed (S...) with signing authority over
+// protocol funds — the highest-value secret in this config.
+
+func (s StellarConfig) String() string {
+	return fmt.Sprintf(
+		"StellarConfig{operatorSecret:%q operatorAddress:%q horizonURL:%q rpcURL:%q networkPassphrase:%q}",
+		redact(s.operatorSecret), s.operatorAddress, s.horizonURL, s.rpcURL, s.networkPassphrase,
+	)
+}
+
+func (s StellarConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("operator_secret", redact(s.operatorSecret)),
+		// operatorAddress is the PUBLIC key — safe to log, and useful for
+		// confirming which operator account an instance is running as.
+		slog.String("operator_address", s.operatorAddress),
+		slog.String("horizon_url", s.horizonURL),
+		slog.String("rpc_url", s.rpcURL),
+		slog.String("network_passphrase", s.networkPassphrase),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// BankConfig
+// ---------------------------------------------------------------------------
+
+func (b BankConfig) String() string {
+	return fmt.Sprintf(
+		"BankConfig{paystackKey:%q flutterwaveKey:%q}",
+		redact(b.paystackKey), redact(b.flutterwaveKey),
+	)
+}
+
+func (b BankConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("paystack_key", redact(b.paystackKey)),
+		slog.String("flutterwave_key", redact(b.flutterwaveKey)),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// AccountCipherConfig
+// ---------------------------------------------------------------------------
+
+// keys maps a version label to an account-encryption key. Only the count and
+// the active version label are reported — never a key, and never the map,
+// whose default formatting would print every value.
+
+func (a AccountCipherConfig) String() string {
+	return fmt.Sprintf(
+		"AccountCipherConfig{activeVersion:%q keys:%d configured fingerprintKey:%q}",
+		a.activeVersion, len(a.keys), redact(a.fingerprintKey),
+	)
+}
+
+func (a AccountCipherConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("active_version", a.activeVersion),
+		slog.Int("key_count", len(a.keys)),
+		slog.String("fingerprint_key", redact(a.fingerprintKey)),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// IntelligenceConfig
+// ---------------------------------------------------------------------------
+
+func (i IntelligenceConfig) String() string {
+	return fmt.Sprintf(
+		"IntelligenceConfig{serviceAPIKey:%q timeout:%s}",
+		redact(i.serviceAPIKey), i.timeout,
+	)
+}
+
+func (i IntelligenceConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("service_api_key", redact(i.serviceAPIKey)),
+		slog.Duration("timeout", i.timeout),
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// Config is the struct most likely to be logged wholesale, and it both holds
+// a secret directly (bankAccountCipherKey) and embeds every struct above.
+// Without String()/LogValue() here, `%+v` on a Config would walk into those
+// nested structs by reflection and never call their String() methods.
+
+func (c Config) String() string {
+	return fmt.Sprintf(
+		"Config{environment:%q bankAccountCipherKey:%q auth:%s database:%s stellar:%s bank:%s intelligence:%s accountCipher:%s}",
+		c.environment, redact(c.bankAccountCipherKey),
+		c.auth, c.database, c.stellar, c.bank, c.intelligence, c.accountCipher,
+	)
+}
+
+func (c Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("environment", c.environment),
+		slog.String("bank_account_cipher_key", redact(c.bankAccountCipherKey)),
+		slog.Any("auth", c.auth),
+		slog.Any("database", c.database),
+		slog.Any("stellar", c.stellar),
+		slog.Any("bank", c.bank),
+		slog.Any("intelligence", c.intelligence),
+		slog.Any("account_cipher", c.accountCipher),
+	)
+}

--- a/apps/api/internal/config/redact_test.go
+++ b/apps/api/internal/config/redact_test.go
@@ -1,0 +1,281 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Issue #1106, "no secret is ever logged, including in startup diagnostics".
+//
+// These tests are about a leak that is invisible in review: config secrets sit
+// in unexported fields, which feels safe, but fmt's reflection reaches them and
+// prints them for %v and %+v alike. The redaction in redact.go closes that; the
+// tests below pin it shut, including for secret fields added later.
+
+// sentinel values are distinctive enough that a substring search cannot
+// plausibly match them by accident.
+//
+// They are deliberately written as readable words rather than as
+// random-looking hex. A high-entropy literal in a file named *_test.go still
+// looks exactly like a leaked credential to a secret scanner, and the honest
+// fix is a value that is not key-shaped rather than an allowlist entry
+// teaching the scanner to ignore this file. These only need to be unique
+// enough that strings.Contains cannot match them by chance, which
+// "not-a-real-secret" satisfies as well as a hex blob does.
+const (
+	sentinelJWTSecret     = "SENTINEL-jwt-secret-not-a-real-secret"
+	sentinelDSN           = "postgres://user:SENTINEL-db-password-not-real@host:5432/db"
+	sentinelOperatorSeed  = "SENTINEL-stellar-operator-seed-not-real"
+	sentinelPaystack      = "SENTINEL-paystack-key-not-real"
+	sentinelFlutterwave   = "SENTINEL-flutterwave-key-not-real"
+	sentinelServiceAPIKey = "SENTINEL-service-api-key-not-real"
+	sentinelIntelKey      = "SENTINEL-intelligence-key-not-real"
+	sentinelCipherKey     = "SENTINEL-bank-cipher-key-not-real"
+	sentinelFingerprint   = "SENTINEL-fingerprint-key-not-real"
+	sentinelAccountKey    = "SENTINEL-account-cipher-key-not-real"
+)
+
+// allSentinels is every secret planted below, so a test can assert none of
+// them survive into rendered output.
+var allSentinels = []string{
+	sentinelJWTSecret, sentinelDSN, sentinelOperatorSeed,
+	sentinelPaystack, sentinelFlutterwave, sentinelServiceAPIKey,
+	sentinelIntelKey, sentinelCipherKey, sentinelFingerprint,
+	sentinelAccountKey,
+}
+
+// configWithSecrets builds a Config with every credential field populated by a
+// sentinel, so any leak shows up as a recognizable substring.
+func configWithSecrets() Config {
+	return Config{
+		environment:          "production",
+		bankAccountCipherKey: sentinelCipherKey,
+		auth: AuthConfig{
+			secret:                  sentinelJWTSecret,
+			serviceAPIKey:           sentinelServiceAPIKey,
+			accessTokenExpiry:       5 * time.Minute,
+			refreshTokenExpiry:      7 * 24 * time.Hour,
+			absoluteSessionLifetime: 30 * 24 * time.Hour,
+			challengeExpiry:         5 * time.Minute,
+		},
+		database: DatabaseConfig{
+			dsn:               sentinelDSN,
+			poolSize:          10,
+			connectionTimeout: 5 * time.Second,
+		},
+		stellar: StellarConfig{
+			operatorSecret:    sentinelOperatorSeed,
+			operatorAddress:   "GPUBLICADDRESSNOTSECRET",
+			horizonURL:        "https://horizon-testnet.stellar.org",
+			rpcURL:            "https://soroban-testnet.stellar.org",
+			networkPassphrase: "Test SDF Network ; September 2015",
+		},
+		bank: BankConfig{
+			paystackKey:    sentinelPaystack,
+			flutterwaveKey: sentinelFlutterwave,
+		},
+		intelligence: IntelligenceConfig{
+			baseURL:       "http://intelligence:8000",
+			serviceAPIKey: sentinelIntelKey,
+			timeout:       10 * time.Second,
+		},
+		accountCipher: AccountCipherConfig{
+			activeVersion:  "v1",
+			keys:           map[string]string{"v1": sentinelAccountKey},
+			fingerprintKey: sentinelFingerprint,
+		},
+	}
+}
+
+// assertNoSentinels fails when any planted secret appears in rendered.
+func assertNoSentinels(t *testing.T, label, rendered string) {
+	t.Helper()
+
+	for _, secret := range allSentinels {
+		if strings.Contains(rendered, secret) {
+			t.Errorf("%s leaked a secret (%s):\n%s", label, secret, rendered)
+		}
+	}
+}
+
+// TestConfigFormattingNeverLeaksSecrets covers the fmt verbs that reach
+// unexported fields by reflection. %+v and %#v are the ones a developer
+// reaches for when dumping a struct, and both must go through String().
+func TestConfigFormattingNeverLeaksSecrets(t *testing.T) {
+	cfg := configWithSecrets()
+
+	for _, verb := range []string{"%v", "%+v", "%s", "%q"} {
+		t.Run(verb, func(t *testing.T) {
+			assertNoSentinels(t, "fmt.Sprintf("+verb+", cfg)", fmt.Sprintf(verb, cfg))
+			assertNoSentinels(t, "fmt.Sprintf("+verb+", &cfg)", fmt.Sprintf(verb, &cfg))
+		})
+	}
+}
+
+// TestNestedConfigFormattingNeverLeaksSecrets checks each sub-struct on its
+// own, since they are passed around and logged independently of Config.
+func TestNestedConfigFormattingNeverLeaksSecrets(t *testing.T) {
+	cfg := configWithSecrets()
+
+	cases := map[string]any{
+		"AuthConfig":          cfg.auth,
+		"DatabaseConfig":      cfg.database,
+		"StellarConfig":       cfg.stellar,
+		"BankConfig":          cfg.bank,
+		"IntelligenceConfig":  cfg.intelligence,
+		"AccountCipherConfig": cfg.accountCipher,
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			for _, verb := range []string{"%v", "%+v", "%s"} {
+				assertNoSentinels(t, name+" "+verb, fmt.Sprintf(verb, value))
+			}
+		})
+	}
+}
+
+// TestConfigSlogNeverLeaksSecrets covers the structured-logging path, which is
+// how this service actually logs. slog resolves LogValuer, so a config logged
+// as an attribute value must come out redacted.
+func TestConfigSlogNeverLeaksSecrets(t *testing.T) {
+	cfg := configWithSecrets()
+
+	for _, handlerName := range []string{"json", "text"} {
+		t.Run(handlerName, func(t *testing.T) {
+			var buf bytes.Buffer
+			var h slog.Handler
+			if handlerName == "json" {
+				h = slog.NewJSONHandler(&buf, nil)
+			} else {
+				h = slog.NewTextHandler(&buf, nil)
+			}
+
+			logger := slog.New(h)
+			logger.Info("startup configuration", "config", cfg)
+			logger.Info("auth configuration", "auth", cfg.auth)
+			logger.Info("pointer form", "config", &cfg)
+
+			assertNoSentinels(t, "slog "+handlerName, buf.String())
+		})
+	}
+}
+
+// TestRedactedConfigStillReportsWhetherSecretsAreSet asserts redaction did not
+// go so far as to make startup diagnostics useless: an operator must still be
+// able to see that a secret is configured, and that an unset one is not.
+func TestRedactedConfigStillReportsWhetherSecretsAreSet(t *testing.T) {
+	set := fmt.Sprintf("%v", configWithSecrets().auth)
+	if !strings.Contains(set, redactedPlaceholder) {
+		t.Errorf("a configured secret should render as %s, got:\n%s", redactedPlaceholder, set)
+	}
+
+	empty := fmt.Sprintf("%v", AuthConfig{})
+	if strings.Contains(empty, redactedPlaceholder) {
+		t.Errorf("an unset secret should render as empty, not %s, got:\n%s", redactedPlaceholder, empty)
+	}
+}
+
+// TestRedactedConfigKeepsNonSecretFieldsVisible guards the opposite failure:
+// redaction that hides the operational values a diagnostic exists to show.
+func TestRedactedConfigKeepsNonSecretFieldsVisible(t *testing.T) {
+	cfg := configWithSecrets()
+	rendered := fmt.Sprintf("%v", cfg)
+
+	for _, want := range []string{
+		"production",                  // environment
+		"horizon-testnet.stellar.org", // Horizon URL
+		"GPUBLICADDRESSNOTSECRET",     // operator PUBLIC address
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("redacted config dropped non-secret value %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// secretFieldPattern names the field-name substrings that indicate a
+// credential. Matching is case-insensitive.
+var secretFieldPattern = []string{"secret", "password", "dsn", "apikey", "cipherkey", "fingerprintkey", "privatekey", "token"}
+
+// looksSecret reports whether a field name suggests it holds a credential.
+// operatorAddress and similar public values are excluded by name.
+func looksSecret(fieldName string) bool {
+	lower := strings.ToLower(fieldName)
+
+	// Explicit non-secrets whose names would otherwise match.
+	switch lower {
+	case "accesstokenexpiry", "refreshtokenexpiry", "challengeexpiry", "absolutesessionlifetime":
+		return false
+	}
+
+	for _, pattern := range secretFieldPattern {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEverySecretBearingStructRedacts is the tripwire for fields added later.
+//
+// It walks Config by reflection, finds every struct holding a field whose name
+// looks like a credential, and asserts that struct implements both String()
+// and slog.LogValuer. A new `webhookSecret string` on a config struct with no
+// redaction fails here, naming the struct — rather than silently shipping a
+// value that %+v will print.
+func TestEverySecretBearingStructRedacts(t *testing.T) {
+	stringerType := reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+	logValuerType := reflect.TypeOf((*slog.LogValuer)(nil)).Elem()
+
+	seen := make(map[reflect.Type]bool)
+
+	var walk func(t *testing.T, typ reflect.Type, path string)
+	walk = func(t *testing.T, typ reflect.Type, path string) {
+		if typ.Kind() != reflect.Struct || seen[typ] {
+			return
+		}
+		seen[typ] = true
+
+		var secretFields []string
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			if field.Type.Kind() == reflect.String && looksSecret(field.Name) {
+				secretFields = append(secretFields, field.Name)
+			}
+			// Recurse into nested config structs.
+			if field.Type.Kind() == reflect.Struct {
+				walk(t, field.Type, path+"."+field.Name)
+			}
+		}
+
+		if len(secretFields) == 0 {
+			return
+		}
+
+		if !typ.Implements(stringerType) {
+			t.Errorf(
+				"%s (at %s) holds secret field(s) %v but does not implement String(); "+
+					"fmt %%v/%%+v would print them. Add a String() method in redact.go.",
+				typ.Name(), path, secretFields,
+			)
+		}
+		if !typ.Implements(logValuerType) {
+			t.Errorf(
+				"%s (at %s) holds secret field(s) %v but does not implement slog.LogValue(); "+
+					"structured logging would print them. Add a LogValue() method in redact.go.",
+				typ.Name(), path, secretFields,
+			)
+		}
+	}
+
+	walk(t, reflect.TypeOf(Config{}), "Config")
+
+	if len(seen) < 5 {
+		t.Fatalf("reflection walk visited only %d struct types; traversal is broken", len(seen))
+	}
+}

--- a/apps/api/internal/handler/admin_handler.go
+++ b/apps/api/internal/handler/admin_handler.go
@@ -210,7 +210,15 @@ func (h *AdminHandler) SetLeadership(l LeadershipStatus) {
 	h.leadership = l
 }
 
-func (h *AdminHandler) Register(mux *http.ServeMux) {
+// routeMux is the subset of *http.ServeMux that Register needs. Taking an
+// interface rather than the concrete type lets the authorization tests in
+// admin_route_authz_test.go enumerate what Register actually mounts (#1105),
+// instead of hand-maintaining a route list that goes stale silently.
+type routeMux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+}
+
+func (h *AdminHandler) Register(mux routeMux) {
 	mux.HandleFunc("GET /api/v1/admin/dashboard", h.getDashboard)
 	mux.HandleFunc("GET /api/v1/admin/vaults", h.listVaults)
 	mux.HandleFunc("GET /api/v1/admin/vaults/{id}", h.getVaultDetail)

--- a/apps/api/internal/handler/admin_route_authz_test.go
+++ b/apps/api/internal/handler/admin_route_authz_test.go
@@ -1,0 +1,271 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+)
+
+// Issue #1105: a single missing role check on an admin route is a total
+// compromise, and enumerating those routes by hand in a test is exactly the
+// kind of list that silently goes stale the first time someone adds a route.
+//
+// So this file does not hand-maintain the list. It records what
+// AdminHandler.Register actually registers, and asserts a property over every
+// recorded route. A new admin route is picked up automatically; if it is not
+// gated, these tests fail without anyone having to remember to add an entry.
+
+// recordingMux captures the "METHOD /path" patterns passed to HandleFunc
+// instead of building a real router, so a test can enumerate exactly what
+// Register mounted.
+type recordingMux struct {
+	patterns []string
+}
+
+func (m *recordingMux) HandleFunc(pattern string, _ func(http.ResponseWriter, *http.Request)) {
+	m.patterns = append(m.patterns, pattern)
+}
+
+// registeredAdminRoutes returns every pattern AdminHandler.Register mounts.
+func registeredAdminRoutes(t *testing.T) []string {
+	t.Helper()
+
+	rec := &recordingMux{}
+	h := NewAdminHandler(newAdminHandlerStubService(uuid.New()), nil)
+	h.Register(rec)
+
+	if len(rec.patterns) == 0 {
+		t.Fatal("Register mounted no routes; the recording mux is not wired correctly")
+	}
+	return rec.patterns
+}
+
+// splitPattern splits "GET /api/v1/admin/x" into method and path.
+func splitPattern(t *testing.T, pattern string) (method, path string) {
+	t.Helper()
+
+	parts := strings.SplitN(pattern, " ", 2)
+	if len(parts) != 2 {
+		t.Fatalf("route pattern %q is not in %q form", pattern, "METHOD /path")
+	}
+	return parts[0], parts[1]
+}
+
+// concreteize replaces {placeholder} path segments with real values so the
+// pattern can be used as a request target. Authorization is decided by the
+// middleware on path prefix alone, before any handler or router matching, so
+// the substituted values only need to be well-formed.
+func concreteize(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+			segments[i] = uuid.NewString()
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// adminAuthRules mirrors the production rule table in cmd/api/main.go for the
+// prefixes that decide admin access. If the production table changes shape,
+// TestAdminRouteRulesMatchProduction below is the tripwire.
+var adminAuthRules = []middleware.RouteRule{
+	{PathPrefix: "/api/v1/admin/", Public: false, Role: "admin"},
+	{PathPrefix: "/api/v1/", Public: false},
+}
+
+func authzChain(t *testing.T) http.Handler {
+	t.Helper()
+
+	return middleware.Authenticate(
+		testAuthSecret,
+		"",
+		adminAuthRules,
+		noopRevocationChecker{},
+	)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Reaching here means authorization allowed the request through.
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+const testAuthSecret = "admin-route-authz-test-hmac-secret"
+
+func tokenWithRoles(t *testing.T, roles []string) string {
+	t.Helper()
+
+	tok, err := auth.MakeJWT(auth.Claims{
+		Subject:   uuid.NewString(),
+		Roles:     roles,
+		SessionID: uuid.NewString(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}, testAuthSecret)
+	if err != nil {
+		t.Fatalf("MakeJWT: %v", err)
+	}
+	return tok
+}
+
+// nonAdminAllowlist names the routes AdminHandler registers that are
+// deliberately NOT admin-gated, each with the reason. Anything registered
+// outside /api/v1/admin/ that is not in this map fails the test below, so
+// putting a route here is a conscious, reviewable decision rather than an
+// oversight.
+var nonAdminAllowlist = map[string]string{
+	// Introduced in d1187714 alongside the public audit page. Rebalance
+	// history is vault-level transparency data — which protocols a vault
+	// moved between and when. It contains no per-user balances or PII, and
+	// is intended to be readable by any authenticated user.
+	"GET /api/v1/vaults/{id}/rebalance-history": "vault-level transparency data, no PII",
+}
+
+// TestEveryAdminRouteRejectsNonAdmin is the core assertion of #1105: for every
+// route AdminHandler registers under /api/v1/admin/, a caller holding a valid
+// token WITHOUT the admin role must be rejected with 403.
+func TestEveryAdminRouteRejectsNonAdmin(t *testing.T) {
+	token := tokenWithRoles(t, []string{"operator"})
+	chain := authzChain(t)
+
+	var checked int
+	for _, pattern := range registeredAdminRoutes(t) {
+		method, path := splitPattern(t, pattern)
+		if !strings.HasPrefix(path, "/api/v1/admin/") {
+			continue
+		}
+		checked++
+
+		t.Run(pattern, func(t *testing.T) {
+			req := httptest.NewRequest(method, concreteize(path), nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+
+			chain.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("got %d, want 403 — %s is reachable by a non-admin", rec.Code, pattern)
+			}
+		})
+	}
+
+	if checked == 0 {
+		t.Fatal("no /api/v1/admin/ routes were checked; enumeration is broken")
+	}
+}
+
+// TestEveryAdminRouteRejectsAnonymous asserts the same routes are not
+// reachable without a token at all. A 403-only test would still pass if the
+// middleware were somehow skipped for unauthenticated callers.
+func TestEveryAdminRouteRejectsAnonymous(t *testing.T) {
+	chain := authzChain(t)
+
+	for _, pattern := range registeredAdminRoutes(t) {
+		method, path := splitPattern(t, pattern)
+		if !strings.HasPrefix(path, "/api/v1/admin/") {
+			continue
+		}
+
+		t.Run(pattern, func(t *testing.T) {
+			req := httptest.NewRequest(method, concreteize(path), nil)
+			rec := httptest.NewRecorder()
+
+			chain.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("got %d, want 401 — %s is reachable anonymously", rec.Code, pattern)
+			}
+		})
+	}
+}
+
+// TestAdminRouteAcceptsAdmin is the positive control. Without it, a middleware
+// that rejected everything would pass both tests above.
+func TestAdminRouteAcceptsAdmin(t *testing.T) {
+	token := tokenWithRoles(t, []string{"admin"})
+	chain := authzChain(t)
+
+	for _, pattern := range registeredAdminRoutes(t) {
+		method, path := splitPattern(t, pattern)
+		if !strings.HasPrefix(path, "/api/v1/admin/") {
+			continue
+		}
+
+		t.Run(pattern, func(t *testing.T) {
+			req := httptest.NewRequest(method, concreteize(path), nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+
+			chain.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("got %d, want 200 — admin is blocked from %s", rec.Code, pattern)
+			}
+		})
+	}
+}
+
+// TestAdminHandlerRoutesAreAdminScoped is the "adding an admin route without a
+// test entry fails CI" criterion from #1105. Every route AdminHandler mounts
+// must either sit under /api/v1/admin/ (and so be covered by the tests above)
+// or be named in nonAdminAllowlist with a documented reason.
+//
+// A new route that is neither fails here, naming itself in the message.
+func TestAdminHandlerRoutesAreAdminScoped(t *testing.T) {
+	var unaccounted []string
+
+	for _, pattern := range registeredAdminRoutes(t) {
+		_, path := splitPattern(t, pattern)
+		if strings.HasPrefix(path, "/api/v1/admin/") {
+			continue
+		}
+		if _, ok := nonAdminAllowlist[pattern]; ok {
+			continue
+		}
+		unaccounted = append(unaccounted, pattern)
+	}
+
+	if len(unaccounted) > 0 {
+		sort.Strings(unaccounted)
+		t.Fatalf(
+			"AdminHandler registers %d route(s) outside /api/v1/admin/ that are not admin-gated:\n  %s\n\n"+
+				"Either move the route under /api/v1/admin/, or add it to nonAdminAllowlist in this file "+
+				"with the reason it is safe for any authenticated user to call.",
+			len(unaccounted), strings.Join(unaccounted, "\n  "),
+		)
+	}
+}
+
+// TestNonAdminAllowlistIsNotStale keeps the allowlist honest in the other
+// direction: an entry for a route that no longer exists (renamed, moved under
+// /api/v1/admin/, or deleted) is dead config that would silently excuse a
+// future route of the same name.
+func TestNonAdminAllowlistIsNotStale(t *testing.T) {
+	registered := make(map[string]bool)
+	for _, pattern := range registeredAdminRoutes(t) {
+		registered[pattern] = true
+	}
+
+	for pattern := range nonAdminAllowlist {
+		if !registered[pattern] {
+			t.Errorf("nonAdminAllowlist names %q, which AdminHandler no longer registers; remove the entry", pattern)
+		}
+	}
+}
+
+// TestNonAdminAllowlistRoutesAreReadOnly bounds what the allowlist can excuse.
+// A route exempt from the admin gate must at least be non-mutating: allowing a
+// POST/PATCH/DELETE through to any authenticated user is never a transparency
+// argument.
+func TestNonAdminAllowlistRoutesAreReadOnly(t *testing.T) {
+	for pattern := range nonAdminAllowlist {
+		method, _ := splitPattern(t, pattern)
+		if method != http.MethodGet && method != http.MethodHead {
+			t.Errorf("nonAdminAllowlist contains %q: only GET/HEAD routes may skip the admin gate", pattern)
+		}
+	}
+}

--- a/apps/api/internal/metrics/slo.go
+++ b/apps/api/internal/metrics/slo.go
@@ -103,7 +103,52 @@ type sloCollectors struct {
 	indexerLagLedgers      prometheus.Gauge
 	indexerLagStaleness    prometheus.Gauge
 	indexerLagScrapeErrors prometheus.Counter
+
+	reconcileRunsTotal      *prometheus.CounterVec
+	reconcileDivergences    *prometheus.CounterVec
+	reconcileLastRunAge     prometheus.Gauge
+	pendingSubmissions      prometheus.Gauge
+	pendingSubmissionOldest prometheus.Gauge
 }
+
+// ReconcileOutcome is the terminal classification of one reconciliation pass.
+//
+// A pass that could not even list its work (succeeded == false, the
+// list-pending query failed) is a different operational event from one that
+// ran and found nothing wrong, and folding them together would let a
+// permanently broken reconciler report a clean divergence count forever.
+type ReconcileOutcome string
+
+const (
+	// ReconcileCompleted means the pass ran to completion. It says nothing
+	// about whether divergences were found — that is the divergence counter.
+	ReconcileCompleted ReconcileOutcome = "completed"
+	// ReconcileFailed means the pass could not enumerate its work and did
+	// not inspect anything.
+	ReconcileFailed ReconcileOutcome = "failed"
+)
+
+// DivergenceKind classifies a single reconciliation finding.
+//
+// The values mirror reconciliation.DiscrepancyType rather than inventing a
+// parallel vocabulary, so an operator reading an alert and an engineer reading
+// the reconciliation engine are using the same words. It is a closed set, so
+// cardinality is fixed at compile time in line with the package policy.
+type DivergenceKind string
+
+const (
+	// DivergenceMissing is a record the chain has and we do not.
+	DivergenceMissing DivergenceKind = "missing"
+	// DivergenceExtra is a record we have and the chain does not.
+	DivergenceExtra DivergenceKind = "extra"
+	// DivergenceMismatch is a record both sides have with differing values —
+	// the most serious kind, since it means a balance is wrong rather than
+	// absent.
+	DivergenceMismatch DivergenceKind = "mismatch"
+	// DivergenceStuck is a record that has not reached a terminal state
+	// within its expected window.
+	DivergenceStuck DivergenceKind = "stuck"
+)
 
 func newSLOCollectors() *sloCollectors {
 	return &sloCollectors{
@@ -167,6 +212,66 @@ func newSLOCollectors() *sloCollectors {
 			Name:      "lag_sample_errors_total",
 			Help:      "Failed attempts to sample indexer lag.",
 		}),
+
+		// Reconciliation (nester#1108). The reconciler compares our record of
+		// the money path against the chain. Until now it reported only to the
+		// log, which means a divergence — the single most serious signal this
+		// system can produce, since it says a balance is wrong — was visible
+		// only to whoever happened to read the logs.
+		//
+		// Runs are counted by outcome so an alert can tell "reconciled, all
+		// clean" from "could not reconcile at all". The latter is the
+		// dangerous silence: no divergences are reported precisely because
+		// nothing was checked.
+		reconcileRunsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "reconcile",
+			Name:      "runs_total",
+			Help:      "Reconciliation passes by outcome.",
+		}, []string{"outcome"}),
+
+		// Divergences are counted, never gauged. A gauge would report the
+		// current pass's count and silently erase a divergence that was
+		// found and then resolved by a correction, losing exactly the
+		// history an incident review needs. The kind label carries the
+		// reconciliation engine's own discrepancy vocabulary.
+		reconcileDivergences: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "reconcile",
+			Name:      "divergences_total",
+			Help:      "Reconciliation findings where our record and the chain disagree, by kind.",
+		}, []string{"kind"}),
+
+		// As with indexer lag, a divergence counter alone cannot distinguish
+		// "no divergences" from "the reconciler stopped running an hour ago".
+		// This gauge is the age of the last completed pass, so an alert can
+		// require the checker itself to be alive.
+		reconcileLastRunAge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "reconcile",
+			Name:      "last_run_age_seconds",
+			Help:      "Seconds since the last reconciliation pass completed.",
+		}),
+
+		// Pending submissions (nester#1108). A submission that never reaches
+		// a terminal state is money in flight that the user cannot see and
+		// the protocol has not settled. Depth alone is ambiguous — a large
+		// queue that drains is healthy, a small one that never drains is not
+		// — so the age of the oldest entry is published alongside it and is
+		// the value worth alerting on.
+		pendingSubmissions: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "submission",
+			Name:      "pending_count",
+			Help:      "Transactions submitted to the chain still awaiting a terminal status.",
+		}),
+
+		pendingSubmissionOldest: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "submission",
+			Name:      "pending_oldest_age_seconds",
+			Help:      "Age of the oldest transaction still awaiting a terminal status.",
+		}),
 	}
 }
 
@@ -177,6 +282,11 @@ func (c *sloCollectors) collectors() []prometheus.Collector {
 		c.indexerLagLedgers,
 		c.indexerLagStaleness,
 		c.indexerLagScrapeErrors,
+		c.reconcileRunsTotal,
+		c.reconcileDivergences,
+		c.reconcileLastRunAge,
+		c.pendingSubmissions,
+		c.pendingSubmissionOldest,
 	}
 }
 
@@ -230,4 +340,60 @@ func (m *Metrics) RecordIndexerLagSampleError() {
 	}
 
 	m.slo.indexerLagScrapeErrors.Inc()
+}
+
+// RecordReconcileRun records one completed reconciliation pass and resets the
+// last-run age, so an alert can distinguish a clean pass from a reconciler
+// that has stopped running.
+//
+// Call this on every return path of a pass, including the early return when
+// the work could not be listed — a pass that failed to enumerate is exactly
+// the case an operator must not mistake for a clean result.
+func (m *Metrics) RecordReconcileRun(outcome ReconcileOutcome) {
+	if m == nil {
+		return
+	}
+
+	m.slo.reconcileRunsTotal.WithLabelValues(string(outcome)).Inc()
+	m.slo.reconcileLastRunAge.Set(0)
+}
+
+// RecordReconcileDivergence counts one finding where our record and the chain
+// disagree. Call it once per finding, not once per pass, so the counter
+// reflects how much disagreement exists rather than how often any was seen.
+func (m *Metrics) RecordReconcileDivergence(kind DivergenceKind) {
+	if m == nil {
+		return
+	}
+
+	m.slo.reconcileDivergences.WithLabelValues(string(kind)).Inc()
+}
+
+// SetReconcileLastRunAge publishes how long ago the last pass completed. The
+// reconciler's own ticker ages this between passes.
+func (m *Metrics) SetReconcileLastRunAge(age time.Duration) {
+	if m == nil {
+		return
+	}
+
+	m.slo.reconcileLastRunAge.Set(age.Seconds())
+}
+
+// SetPendingSubmissions publishes the current in-flight submission backlog:
+// how many transactions await a terminal status, and how old the oldest is.
+//
+// oldest is zero when the queue is empty, which reads correctly on a graph —
+// an empty queue has no waiting time — and keeps the alert on this gauge from
+// firing on a drained queue.
+func (m *Metrics) SetPendingSubmissions(count int, oldest time.Duration) {
+	if m == nil {
+		return
+	}
+
+	m.slo.pendingSubmissions.Set(float64(count))
+	if count == 0 {
+		m.slo.pendingSubmissionOldest.Set(0)
+		return
+	}
+	m.slo.pendingSubmissionOldest.Set(oldest.Seconds())
 }

--- a/apps/api/internal/metrics/slo_test.go
+++ b/apps/api/internal/metrics/slo_test.go
@@ -20,6 +20,12 @@ func TestNilMetricsIsSafeOnEveryPath(t *testing.T) {
 	m.SetIndexerLag(42)
 	m.SetIndexerLagSampleAge(time.Minute)
 	m.RecordIndexerLagSampleError()
+	m.RecordReconcileRun(ReconcileCompleted)
+	m.RecordReconcileRun(ReconcileFailed)
+	m.RecordReconcileDivergence(DivergenceMismatch)
+	m.SetReconcileLastRunAge(time.Minute)
+	m.SetPendingSubmissions(3, time.Hour)
+	m.SetPendingSubmissions(0, 0)
 }
 
 func TestFlowAttemptRecordsCounterAndHistogram(t *testing.T) {
@@ -176,5 +182,97 @@ func TestIndexerLagSampleErrorsAreCounted(t *testing.T) {
 
 	if got := counterValue(t, m.Registry(), "nester_indexer_lag_sample_errors_total", nil); got != 2 {
 		t.Fatalf("sample errors = %v, want 2", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation and pending submissions (nester#1108)
+// ---------------------------------------------------------------------------
+
+// A pass that could not list its work must be counted separately from one that
+// ran and found nothing. Collapsing them would let a permanently broken
+// reconciler report a clean divergence count indefinitely, which is the one
+// reading an operator must never get wrong.
+func TestReconcileRunOutcomesAreCountedSeparately(t *testing.T) {
+	m := New()
+
+	m.RecordReconcileRun(ReconcileCompleted)
+	m.RecordReconcileRun(ReconcileCompleted)
+	m.RecordReconcileRun(ReconcileFailed)
+
+	completed := counterValue(t, m.Registry(), "nester_reconcile_runs_total", map[string]string{"outcome": "completed"})
+	if completed != 2 {
+		t.Fatalf("completed runs = %v, want 2", completed)
+	}
+	failed := counterValue(t, m.Registry(), "nester_reconcile_runs_total", map[string]string{"outcome": "failed"})
+	if failed != 1 {
+		t.Fatalf("failed runs = %v, want 1", failed)
+	}
+}
+
+// Divergences are counted per finding and per kind, so an alert can treat a
+// mismatch (a wrong balance) differently from a stuck submission.
+func TestReconcileDivergencesAreCountedByKind(t *testing.T) {
+	m := New()
+
+	m.RecordReconcileDivergence(DivergenceMismatch)
+	m.RecordReconcileDivergence(DivergenceStuck)
+	m.RecordReconcileDivergence(DivergenceStuck)
+
+	if got := counterValue(t, m.Registry(), "nester_reconcile_divergences_total", map[string]string{"kind": "mismatch"}); got != 1 {
+		t.Fatalf("mismatch divergences = %v, want 1", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_reconcile_divergences_total", map[string]string{"kind": "stuck"}); got != 2 {
+		t.Fatalf("stuck divergences = %v, want 2", got)
+	}
+}
+
+// A completed pass resets the age gauge, so the "reconciler is alive" signal
+// cannot be satisfied by a pass that never finished.
+func TestReconcileRunResetsLastRunAge(t *testing.T) {
+	m := New()
+
+	m.SetReconcileLastRunAge(900 * time.Second)
+	if got := gaugeValue(t, m.Registry(), "nester_reconcile_last_run_age_seconds"); got != 900 {
+		t.Fatalf("pre-run age = %v, want 900", got)
+	}
+
+	m.RecordReconcileRun(ReconcileCompleted)
+
+	if got := gaugeValue(t, m.Registry(), "nester_reconcile_last_run_age_seconds"); got != 0 {
+		t.Fatalf("post-run age = %v, want 0", got)
+	}
+}
+
+// Depth and oldest-age are published together because depth alone is
+// ambiguous: a large queue that drains is healthy, a small one that never
+// drains is not.
+func TestPendingSubmissionsPublishesDepthAndOldestAge(t *testing.T) {
+	m := New()
+
+	m.SetPendingSubmissions(4, 90*time.Second)
+
+	if got := gaugeValue(t, m.Registry(), "nester_submission_pending_count"); got != 4 {
+		t.Fatalf("pending count = %v, want 4", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_submission_pending_oldest_age_seconds"); got != 90 {
+		t.Fatalf("oldest age = %v, want 90", got)
+	}
+}
+
+// An empty queue must report zero age, not the last non-empty reading. A
+// carried-over age would keep the pending-submission alert firing after the
+// backlog had actually drained.
+func TestEmptyPendingQueueZeroesOldestAge(t *testing.T) {
+	m := New()
+
+	m.SetPendingSubmissions(4, 90*time.Second)
+	m.SetPendingSubmissions(0, 0)
+
+	if got := gaugeValue(t, m.Registry(), "nester_submission_pending_count"); got != 0 {
+		t.Fatalf("pending count = %v, want 0", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_submission_pending_oldest_age_seconds"); got != 0 {
+		t.Fatalf("oldest age = %v, want 0 for a drained queue", got)
 	}
 }

--- a/apps/api/internal/service/transaction_poller.go
+++ b/apps/api/internal/service/transaction_poller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
 )
 
 // TransactionStatusNotifier is invoked once per transaction whose status
@@ -43,7 +44,36 @@ type TransactionPoller struct {
 	service     *TransactionService
 	notify      TransactionStatusNotifier
 	logger      *slog.Logger
+	metrics     PollerMetricsRecorder
 	lastTickEnd atomic.Int64 // unix nanos; observability hook
+}
+
+// PollerMetricsRecorder is the slice of metrics recording this poller needs
+// (nester#1108). Declared here as an interface, matching the event indexer's
+// approach, so the service package does not depend on the metrics package and
+// tests can record calls without a Prometheus registry.
+type PollerMetricsRecorder interface {
+	RecordReconcileRun(outcome metrics.ReconcileOutcome)
+	RecordReconcileDivergence(kind metrics.DivergenceKind)
+	SetPendingSubmissions(count int, oldest time.Duration)
+}
+
+// noopPollerMetrics is used when no recorder is supplied, so Tick never has to
+// nil-check.
+type noopPollerMetrics struct{}
+
+func (noopPollerMetrics) RecordReconcileRun(metrics.ReconcileOutcome)      {}
+func (noopPollerMetrics) RecordReconcileDivergence(metrics.DivergenceKind) {}
+func (noopPollerMetrics) SetPendingSubmissions(int, time.Duration)         {}
+
+// SetMetrics wires metrics recording. Call before Run. A nil recorder leaves
+// the poller unmetered rather than panicking, so a caller that has not built a
+// registry still works.
+func (p *TransactionPoller) SetMetrics(rec PollerMetricsRecorder) {
+	if rec == nil {
+		return
+	}
+	p.metrics = rec
 }
 
 // NewTransactionPoller builds a poller. logger may be nil (a discarding logger
@@ -66,6 +96,7 @@ func NewTransactionPoller(cfg TransactionPollerConfig, svc *TransactionService, 
 		service: svc,
 		notify:  notify,
 		logger:  logger,
+		metrics: noopPollerMetrics{},
 	}
 }
 
@@ -105,8 +136,24 @@ func (p *TransactionPoller) Tick(ctx context.Context) {
 	pending, err := p.service.ListPendingOlderThan(ctx, p.cfg.MinAge)
 	if err != nil {
 		p.logger.Error("transaction poller: list pending failed", "error", err)
+		// Recorded as a failed run rather than left silent (nester#1108): a
+		// pass that could not list its work found no divergences because it
+		// inspected nothing, which must not read as a clean result.
+		p.metrics.RecordReconcileRun(metrics.ReconcileFailed)
 		return
 	}
+
+	// Backlog depth and the age of its oldest entry, published once per pass.
+	// The list is already filtered to transactions older than MinAge, so this
+	// measures exactly the in-flight money the user cannot yet see.
+	now := time.Now()
+	var oldest time.Duration
+	for _, tx := range pending {
+		if age := now.Sub(tx.CreatedAt); age > oldest {
+			oldest = age
+		}
+	}
+	p.metrics.SetPendingSubmissions(len(pending), oldest)
 
 	for _, tx := range pending {
 		updated, changed, err := p.service.ReconcileTransaction(ctx, tx)
@@ -118,6 +165,10 @@ func (p *TransactionPoller) Tick(ctx context.Context) {
 			continue
 		}
 		if !changed {
+			// Still not terminal after being old enough to poll: the chain
+			// has not resolved it and neither have we. That is the "stuck"
+			// discrepancy kind, and it is the shape a lost submission takes.
+			p.metrics.RecordReconcileDivergence(metrics.DivergenceStuck)
 			continue
 		}
 		p.logger.Info("transaction poller: status reconciled",
@@ -128,6 +179,8 @@ func (p *TransactionPoller) Tick(ctx context.Context) {
 		)
 		p.notify(ctx, updated)
 	}
+
+	p.metrics.RecordReconcileRun(metrics.ReconcileCompleted)
 }
 
 // LastTickEnd returns the wall-clock time of the last completed tick, or zero

--- a/apps/api/internal/service/transaction_poller_test.go
+++ b/apps/api/internal/service/transaction_poller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
 )
 
 // fakeTransactionRepo is an in-memory transaction.Repository for poller tests.
@@ -316,5 +317,152 @@ func TestTransactionPoller_Run_NoOpWhenDisabled(t *testing.T) {
 
 	if len(notifier.calls) != 0 {
 		t.Errorf("disabled poller must never broadcast, got %d", len(notifier.calls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation and pending-submission metrics (nester#1108)
+// ---------------------------------------------------------------------------
+
+// recordingPollerMetrics captures what the poller reports, so the tests below
+// assert on the operational signal rather than on Prometheus internals.
+type recordingPollerMetrics struct {
+	runs        []metrics.ReconcileOutcome
+	divergences []metrics.DivergenceKind
+	pendingLast struct {
+		count  int
+		oldest time.Duration
+		set    bool
+	}
+}
+
+func (r *recordingPollerMetrics) RecordReconcileRun(outcome metrics.ReconcileOutcome) {
+	r.runs = append(r.runs, outcome)
+}
+
+func (r *recordingPollerMetrics) RecordReconcileDivergence(kind metrics.DivergenceKind) {
+	r.divergences = append(r.divergences, kind)
+}
+
+func (r *recordingPollerMetrics) SetPendingSubmissions(count int, oldest time.Duration) {
+	r.pendingLast.count = count
+	r.pendingLast.oldest = oldest
+	r.pendingLast.set = true
+}
+
+// A transaction old enough to poll that the chain still has not resolved is a
+// stuck submission — money in flight the user cannot see. Before #1108 this
+// was logged at most; it must now reach the metrics an alert reads.
+func TestTransactionPoller_Tick_RecordsStuckDivergence(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "stuck1", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, nil) // 404: not yet resolved on chain
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	rec := &recordingPollerMetrics{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.SetMetrics(rec)
+
+	poller.Tick(context.Background())
+
+	if len(rec.divergences) != 1 || rec.divergences[0] != metrics.DivergenceStuck {
+		t.Fatalf("divergences = %v, want exactly one stuck", rec.divergences)
+	}
+	if len(rec.runs) != 1 || rec.runs[0] != metrics.ReconcileCompleted {
+		t.Fatalf("runs = %v, want one completed", rec.runs)
+	}
+}
+
+// A transaction that reconciles to a terminal state is not a divergence: the
+// system worked. Counting it would make the divergence signal fire on healthy
+// traffic and train operators to ignore it.
+func TestTransactionPoller_Tick_ResolvedTransactionIsNotADivergence(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "good77", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, map[string]horizonTransactionResponse{
+		"good77": {Successful: true, CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+	})
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	rec := &recordingPollerMetrics{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.SetMetrics(rec)
+
+	poller.Tick(context.Background())
+
+	if len(rec.divergences) != 0 {
+		t.Fatalf("divergences = %v, want none for a transaction that resolved", rec.divergences)
+	}
+	if len(rec.runs) != 1 || rec.runs[0] != metrics.ReconcileCompleted {
+		t.Fatalf("runs = %v, want one completed", rec.runs)
+	}
+}
+
+// The backlog gauges are published every pass, including when the queue is
+// empty — otherwise a drained queue would leave the previous non-zero reading
+// in place and the alert would never clear.
+func TestTransactionPoller_Tick_PublishesPendingBacklog(t *testing.T) {
+	older := newPendingTx(transaction.TypeDeposit, "old01", 10*time.Minute)
+	newer := newPendingTx(transaction.TypeWithdrawal, "new01", time.Minute)
+	repo := newFakeTransactionRepo(older, newer)
+
+	horizon := horizonStub(t, nil)
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	rec := &recordingPollerMetrics{}
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.SetMetrics(rec)
+
+	poller.Tick(context.Background())
+
+	if !rec.pendingLast.set {
+		t.Fatal("pending backlog was never published")
+	}
+	if rec.pendingLast.count != 2 {
+		t.Fatalf("pending count = %d, want 2", rec.pendingLast.count)
+	}
+	// The oldest entry drives the age, not the most recent one.
+	if rec.pendingLast.oldest < 9*time.Minute {
+		t.Fatalf("oldest age = %s, want at least 9m (the older of the two)", rec.pendingLast.oldest)
+	}
+}
+
+// A poller with no recorder wired must behave exactly as before. Losing
+// observability must never be able to break reconciliation itself.
+func TestTransactionPoller_Tick_WorksWithoutMetrics(t *testing.T) {
+	tx := newPendingTx(transaction.TypeDeposit, "nom001", time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	horizon := horizonStub(t, map[string]horizonTransactionResponse{
+		"nom001": {Successful: true, CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+	})
+	defer horizon.Close()
+
+	svc := NewTransactionService(repo, horizon.URL)
+	poller := NewTransactionPoller(
+		TransactionPollerConfig{Enabled: true, Interval: time.Hour, MinAge: 30 * time.Second},
+		svc, nil, nil,
+	)
+	poller.SetMetrics(nil) // explicitly nil: must not panic
+
+	poller.Tick(context.Background())
+
+	stored, _ := repo.GetByHash(context.Background(), "nom001")
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("status = %q, want completed", stored.Status)
 	}
 }

--- a/docker/grafana/dashboards/slo-money-path-integrity.json
+++ b/docker/grafana/dashboards/slo-money-path-integrity.json
@@ -1,0 +1,615 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "Reconciliation divergences and in-flight submission backlog (nester#1108).",
+  "editable": false,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "content": "The deposit/withdrawal SLO answers *are transactions succeeding*. Balance freshness answers *is the indexer keeping up*. This board answers what neither can: **does our record of the money still agree with the chain, and is anything stuck in flight** (nester#1108).\n\n**Read the liveness panels first.** A divergence count of zero means one of two opposite things \u2014 *we checked and everything agrees*, or *we did not check*. The reconciler age and failed-pass panels are what tell those apart. If the reconciler is stalled, treat divergence silence as unknown, not clean.\n\n**Runbook** `docs/observability/runbooks/money-path-integrity.md`",
+        "mode": "markdown"
+      },
+      "title": "Money path integrity \u2014 reconciliation and in-flight submissions",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Seconds since a pass completed, against a 15s interval. Pages above 600. If this is climbing, the divergence panels below are meaningless.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 120
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:health:last_run_age_seconds",
+          "instant": true,
+          "legendFormat": "Reconciler last run",
+          "range": false,
+          "refId": "Reconcil"
+        }
+      ],
+      "title": "Reconciler last run",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Passes per second that aborted before inspecting anything. Non-zero means the divergence count is falsely clean.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:health:failed_run_rate5m",
+          "instant": true,
+          "legendFormat": "Failed passes",
+          "range": false,
+          "refId": "Failed p"
+        }
+      ],
+      "title": "Failed passes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Findings where our record and the chain disagree. Pages above zero \u2014 there is no acceptable steady-state rate.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:divergence:increase1h",
+          "instant": true,
+          "legendFormat": "Divergences (1h)",
+          "range": false,
+          "refId": "Divergen"
+        }
+      ],
+      "title": "Divergences (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Age of the oldest transaction awaiting a terminal status. Pages above 1800. This is money the user cannot see or reach.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "submission:pending:oldest_age_seconds",
+          "instant": true,
+          "legendFormat": "Oldest pending submission",
+          "range": false,
+          "refId": "Oldest p"
+        }
+      ],
+      "title": "Oldest pending submission",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Split by kind because they are not equally serious. mismatch means both sides have the record and the values differ \u2014 a displayed balance is wrong, and re-indexing will not fix it. missing/extra mean a record exists on one side only. stuck means a submission has not reached a terminal state; a low steady rate is expected, a growing one is not.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:divergence:rate5m",
+          "instant": false,
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "{{kind}}"
+        }
+      ],
+      "title": "Divergences by kind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "completed vs failed. A healthy reconciler shows a flat completed line and no failed line. failed means passes are running but inspecting nothing \u2014 usually a database error on the list-pending query.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (outcome) (rate(nester_reconcile_runs_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "{{outcom"
+        }
+      ],
+      "title": "Reconciliation passes by outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Depth alone is ambiguous \u2014 a large queue that drains is healthy, a small one that never drains is not. Watch whether the oldest-age line resets or climbs monotonically; a climb with steady depth means the same transactions are stuck.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "submission:pending:count",
+          "instant": false,
+          "legendFormat": "queue depth",
+          "range": true,
+          "refId": "queue de"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "submission:pending:oldest_age_seconds",
+          "instant": false,
+          "legendFormat": "oldest age (s)",
+          "range": true,
+          "refId": "oldest a"
+        }
+      ],
+      "title": "Pending submission backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Should sawtooth near zero, resetting every pass. A monotonic climb means the poller stopped, and every integrity signal on this board froze with it.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:health:last_run_age_seconds",
+          "instant": false,
+          "legendFormat": "last run age",
+          "range": true,
+          "refId": "last run"
+        }
+      ],
+      "title": "Reconciler age over time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "slo",
+    "nester"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "SLO \u2014 Money path integrity",
+  "uid": "nester-slo-money-path",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/prometheus/rules/slo_alerts.yml
+++ b/docker/prometheus/rules/slo_alerts.yml
@@ -523,6 +523,140 @@ groups:
   # An SLO stack that cannot tell you it has stopped working is worse than no
   # SLO stack, because it produces confident silence. These alerts cover the
   # failure mode where every dashboard is green because no data is arriving.
+  # Money-path integrity (nester#1108). The flow and freshness alerts above
+  # catch deposits failing and balances going stale. These catch the two
+  # conditions those miss entirely: our record disagreeing with the chain, and
+  # money stuck in flight.
+  - name: slo_alerts_money_path_integrity
+    rules:
+      - alert: ReconciliationDivergence
+        # Any divergence, not a rate over a threshold. #1108 asks to alert on
+        # "any reconciliation divergence" because there is no acceptable
+        # steady-state rate of our ledger disagreeing with the chain — one is
+        # a bug, and the question is only how many users it touched.
+        expr: reconcile:divergence:increase1h > 0
+        for: 5m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Reconciliation found {{ $value | printf "%.0f" }} divergence(s)
+            between our records and the chain in the last hour
+          description: >-
+            The reconciler compared our transaction records against the chain
+            and they disagree. Breakdown by kind:
+            {{ with query "reconcile:divergence:rate30m" }}
+            {{ range . }}{{ .Labels.kind }}={{ .Value | printf "%.4f" }}/s
+            {{ end }}{{ end }}
+            A "mismatch" is the most serious — both sides have the record and
+            the values differ, which means a displayed balance is wrong.
+            "missing" and "extra" mean a record exists on one side only.
+            "stuck" means a submission has not reached a terminal state.
+            Paging rather than ticketing because a savings product whose
+            balance disagrees with the chain cannot be allowed to keep taking
+            deposits while someone reads a ticket queue.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: ReconciliationStalled
+        # The counterpart to the alert above. Zero divergences is only good
+        # news if the reconciler actually ran; a dead reconciler reports zero
+        # forever. Threshold is well above the 15s poll interval so a slow
+        # tick or a restart does not page.
+        expr: reconcile:health:last_run_age_seconds > 600
+        for: 5m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Reconciliation has not completed a pass for
+            {{ $value | humanizeDuration }}
+          description: >-
+            The transaction poller has not finished a reconciliation pass in
+            over 10 minutes, against a 15s interval. While this is firing the
+            ReconciliationDivergence alert above is meaningless: it reports
+            zero because nothing is being checked, not because everything
+            agrees. Treat divergence silence as unknown, not clean, until this
+            clears. Check the poller goroutine and
+            nester_reconcile_runs_total{outcome="failed"}.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: ReconciliationFailing
+        # A pass that cannot list its work. Distinct from the stall above: the
+        # loop is alive and ticking, but every pass aborts before inspecting
+        # anything, which also produces a false-clean divergence count.
+        expr: reconcile:health:failed_run_rate5m > 0
+        for: 15m
+        labels:
+          severity: ticket
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Reconciliation passes are failing before inspecting anything
+          description: >-
+            The poller is running but its passes abort while listing pending
+            transactions, so nothing is being reconciled and the divergence
+            count is falsely clean. Usually a database error on the
+            list-pending query. Ticketing rather than paging because
+            ReconciliationStalled pages if the loop stops entirely; this is
+            the narrower case where it keeps ticking without doing work.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: PendingSubmissionsBacklogged
+        # Age, not depth. A queue of 200 that drains in seconds is healthy; a
+        # queue of 3 that has not moved in 30 minutes is money the user cannot
+        # see and cannot get back.
+        expr: submission:pending:oldest_age_seconds > 1800
+        for: 10m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Oldest pending submission is {{ $value | humanizeDuration }} old
+          description: >-
+            A transaction submitted to the chain has been awaiting a terminal
+            status for over 30 minutes. Current queue depth:
+            {{ with query "submission:pending:count" }}
+            {{ . | first | value | printf "%.0f" }}{{ end }}.
+            This is a user whose deposit or withdrawal is in limbo — the funds
+            have left their visible balance and have not arrived anywhere they
+            can act on. Check Horizon ingestion and the submission pipeline
+            before assuming the chain is at fault.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: MoneyPathMetricsAbsent
+        # The same protection the indexer has: if these series vanish, every
+        # alert in this group silently stops evaluating and the money path
+        # becomes unmonitored without anything firing.
+        expr: absent(nester_reconcile_last_run_age_seconds)
+        for: 10m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Money-path integrity metrics are absent
+          description: >-
+            nester_reconcile_last_run_age_seconds has not been reported for 10
+            minutes. Every alert in this group evaluates against it, so
+            reconciliation and pending-submission monitoring are both dark.
+            Either the API is down (in which case other alerts are firing) or
+            the transaction poller was never started — TX_POLLER_ENABLED unset
+            disables it silently at boot.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
   - name: slo_alerts_meta
     rules:
       - alert: SLOTargetDown

--- a/docker/prometheus/rules/slo_money_path_alerts_test.yml
+++ b/docker/prometheus/rules/slo_money_path_alerts_test.yml
@@ -1,0 +1,292 @@
+# promtool unit tests for the money-path integrity alerts (nester#1108).
+#
+# Run:
+#   promtool test rules docker/prometheus/rules/slo_money_path_alerts_test.yml
+#
+# Executed in CI (.github/workflows/ci.yml, "SLO rules" job) against the same
+# rule files Prometheus loads.
+#
+# What is being proven:
+#
+#   1. A healthy money path — reconciler ticking, no divergences, queue
+#      draining — pages nobody.
+#   2. Any divergence at all pages, since there is no acceptable steady-state
+#      rate of our ledger disagreeing with the chain (#1108 asks to alert on
+#      "any reconciliation divergence").
+#   3. The liveness alerts fire when the reconciler stops or its passes abort.
+#      These are the tests that matter most: without them a dead reconciler
+#      reports zero divergences forever and the whole group reads healthy
+#      while nothing is being checked.
+#   4. Pending-submission alerting keys on the AGE of the oldest entry, not on
+#      queue depth — a deep queue that drains is healthy, a shallow one that
+#      never drains is not.
+#   5. Absent metrics page rather than silently disabling the group.
+
+rule_files:
+  - slo_recording.yml
+  - slo_alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  # ---------------------------------------------------------------------
+  # 1. Healthy steady state
+  # ---------------------------------------------------------------------
+  - interval: 1m
+    name: a healthy money path alerts on nothing
+    input_series:
+      # Reconciler completing passes: age resets, so it stays low.
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '0+4x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0x60'
+      # No divergences at all.
+      - series: 'nester_reconcile_divergences_total{kind="mismatch"}'
+        values: '0x60'
+      # A queue that exists but drains: depth varies, age stays low.
+      - series: 'nester_submission_pending_count'
+        values: '3 5 2 4 1 3 2 5 3 1 4 2 3 1 2 4 3 2 1 3 2 4 1 3 2 5 3 1 2 4 3 2 1 3 2 4 1 3 2 5 3 1 2 4 3 2 1 3 2 4 1 3 2 5 3 1 2 4 3 2 1'
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '45x60'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: ReconciliationDivergence
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: ReconciliationStalled
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: ReconciliationFailing
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: PendingSubmissionsBacklogged
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: MoneyPathMetricsAbsent
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------
+  # 2. Any divergence pages
+  # ---------------------------------------------------------------------
+  # A single mismatch is enough. This is deliberately not a rate threshold:
+  # one wrong balance is a bug, and the only open question is blast radius.
+  - interval: 1m
+    name: a single divergence pages
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '0+4x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0x60'
+      # One divergence appears at minute 10 and the counter stays there.
+      - series: 'nester_reconcile_divergences_total{kind="mismatch"}'
+        values: '0x10 1x50'
+      - series: 'nester_submission_pending_count'
+        values: '0x60'
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ReconciliationDivergence
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Reconciliation found 1 divergence(s) between our records and the chain in the last hour
+              description: >-
+                The reconciler compared our transaction records against the chain and they disagree. Breakdown by kind:  mismatch=0.0006/s  A "mismatch" is the most serious — both sides have the record and the values differ, which means a displayed balance is wrong. "missing" and "extra" mean a record exists on one side only. "stuck" means a submission has not reached a terminal state. Paging rather than ticketing because a savings product whose balance disagrees with the chain cannot be allowed to keep taking deposits while someone reads a ticket queue.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+
+  # ---------------------------------------------------------------------
+  # 3. Liveness — the false-clean cases
+  # ---------------------------------------------------------------------
+  # The most important test in this file. The reconciler stops, so the
+  # divergence counter is frozen and reports zero. ReconciliationDivergence
+  # correctly stays silent — there is genuinely no new divergence data — and
+  # ReconciliationStalled is what tells the operator that silence is
+  # meaningless rather than reassuring.
+  - interval: 1m
+    name: a stalled reconciler pages even though divergences read zero
+    input_series:
+      # Age climbing: no pass has completed since minute 0.
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+60x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '10x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0x60'
+      - series: 'nester_reconcile_divergences_total{kind="mismatch"}'
+        values: '0x60'
+      - series: 'nester_submission_pending_count'
+        values: '0x60'
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ReconciliationStalled
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Reconciliation has not completed a pass for 20m 0s
+              description: >-
+                The transaction poller has not finished a reconciliation pass in over 10 minutes, against a 15s interval. While this is firing the ReconciliationDivergence alert above is meaningless: it reports zero because nothing is being checked, not because everything agrees. Treat divergence silence as unknown, not clean, until this clears. Check the poller goroutine and nester_reconcile_runs_total{outcome="failed"}.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+      # The divergence alert stays quiet, which is exactly why the stall alert
+      # has to exist.
+      - eval_time: 20m
+        alertname: ReconciliationDivergence
+        exp_alerts: []
+
+  # A brief stall must not page. Restarts and slow ticks are routine; the
+  # 600s threshold plus for:5m absorbs them.
+  - interval: 1m
+    name: a brief reconciler gap is tolerated
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+60x8 0+0x50'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '0+4x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: ReconciliationStalled
+        exp_alerts: []
+
+  # The loop is alive and ticking, but every pass aborts before inspecting
+  # anything. Divergences again read zero for the wrong reason.
+  - interval: 1m
+    name: passes that abort before inspecting anything open a ticket
+    input_series:
+      # Age resets, so the loop is running — ReconciliationStalled will not fire.
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '10x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0+4x60'
+      - series: 'nester_reconcile_divergences_total{kind="mismatch"}'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ReconciliationFailing
+        exp_alerts:
+          - exp_labels:
+              severity: ticket
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Reconciliation passes are failing before inspecting anything
+              description: >-
+                The poller is running but its passes abort while listing pending transactions, so nothing is being reconciled and the divergence count is falsely clean. Usually a database error on the list-pending query. Ticketing rather than paging because ReconciliationStalled pages if the loop stops entirely; this is the narrower case where it keeps ticking without doing work.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+      # A ticking loop is not a stalled one.
+      - eval_time: 30m
+        alertname: ReconciliationStalled
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------
+  # 4. Pending submissions — age, not depth
+  # ---------------------------------------------------------------------
+  # A deep queue that keeps draining is healthy. If this alert keyed on depth
+  # it would page here, which would be wrong and would train people to ignore
+  # it during exactly the traffic spikes when the money path matters most.
+  - interval: 1m
+    name: a deep but draining queue does not alert
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_submission_pending_count'
+        values: '250x60'
+      # Entries turn over quickly: the oldest is always young.
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '90x60'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PendingSubmissionsBacklogged
+        exp_alerts: []
+
+  # A shallow queue that never moves is the real failure: the same few
+  # transactions, stuck, with someone's money in limbo.
+  - interval: 1m
+    name: a shallow queue that never drains pages
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_submission_pending_count'
+        values: '2x60'
+      # Age climbing past the 1800s threshold.
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '1500+60x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: PendingSubmissionsBacklogged
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Oldest pending submission is 44m 0s old
+              description: >-
+                A transaction submitted to the chain has been awaiting a terminal status for over 30 minutes. Current queue depth:  2. This is a user whose deposit or withdrawal is in limbo — the funds have left their visible balance and have not arrived anywhere they can act on. Check Horizon ingestion and the submission pipeline before assuming the chain is at fault.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+
+  # Boundary: just under the threshold stays quiet.
+  - interval: 1m
+    name: a pending submission just under the threshold does not page
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_submission_pending_count'
+        values: '1x60'
+      - series: 'nester_submission_pending_oldest_age_seconds'
+        values: '1700x60'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: PendingSubmissionsBacklogged
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------
+  # 5. Absent metrics
+  # ---------------------------------------------------------------------
+  # Every alert in this group evaluates against the reconcile age series. If
+  # it disappears, the group silently stops evaluating and the money path
+  # becomes unmonitored — so its absence has to be an alert of its own.
+  - interval: 1m
+    name: absent money-path metrics page
+    input_series:
+      # Deliberately unrelated: the reconcile series is simply not present.
+      - series: 'nester_flow_attempts_total{flow="deposit",outcome="succeeded"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MoneyPathMetricsAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Money-path integrity metrics are absent
+              description: >-
+                nester_reconcile_last_run_age_seconds has not been reported for 10 minutes. Every alert in this group evaluates against it, so reconciliation and pending-submission monitoring are both dark. Either the API is down (in which case other alerts are firing) or the transaction poller was never started — TX_POLLER_ENABLED unset disables it silently at boot.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md

--- a/docker/prometheus/rules/slo_money_path_alerts_test.yml
+++ b/docker/prometheus/rules/slo_money_path_alerts_test.yml
@@ -115,9 +115,14 @@ tests:
   - interval: 1m
     name: a stalled reconciler pages even though divergences read zero
     input_series:
-      # Age climbing: no pass has completed since minute 0.
+      # A constant well past the 600s threshold rather than a climbing ramp.
+      # The summary humanizes this value, and with a ramp the rendered figure
+      # depends on which sample the evaluation lands on at the boundary — the
+      # assertion would then be about scrape alignment rather than about the
+      # alert. The behaviour under test is "age over threshold pages", which a
+      # constant exercises exactly.
       - series: 'nester_reconcile_last_run_age_seconds'
-        values: '0+60x60'
+        values: '1200x60'
       - series: 'nester_reconcile_runs_total{outcome="completed"}'
         values: '10x60'
       - series: 'nester_reconcile_runs_total{outcome="failed"}'
@@ -229,9 +234,14 @@ tests:
         values: '0+0x60'
       - series: 'nester_submission_pending_count'
         values: '2x60'
-      # Age climbing past the 1800s threshold.
+      # Constant past the 1800s threshold rather than a ramp, for the same
+      # reason as the stalled-reconciler case above: the summary humanizes
+      # this value, and a ramp makes the rendered figure depend on scrape
+      # alignment at the evaluation boundary. Depth stays flat at 2 while the
+      # age sits high, which is the shape this alert exists to catch — the
+      # same few transactions, stuck.
       - series: 'nester_submission_pending_oldest_age_seconds'
-        values: '1500+60x60'
+        values: '2700x60'
     alert_rule_test:
       - eval_time: 20m
         alertname: PendingSubmissionsBacklogged
@@ -242,7 +252,7 @@ tests:
               service: api
             exp_annotations:
               summary: >-
-                Oldest pending submission is 44m 0s old
+                Oldest pending submission is 45m 0s old
               description: >-
                 A transaction submitted to the chain has been awaiting a terminal status for over 30 minutes. Current queue depth:  2. This is a user whose deposit or withdrawal is in limbo — the funds have left their visible balance and have not arrived anywhere they can act on. Check Horizon ingestion and the submission pipeline before assuming the chain is at fault.
               dashboard: /d/nester-slo-money-path/money-path-integrity

--- a/docker/prometheus/rules/slo_recording.yml
+++ b/docker/prometheus/rules/slo_recording.yml
@@ -603,3 +603,46 @@ groups:
 
       - record: indexer:freshness:sample_error_rate5m
         expr: sum(rate(nester_indexer_lag_sample_errors_total[5m]))
+
+  # Money-path integrity (nester#1108). The SLIs above answer "are deposits and
+  # withdrawals succeeding, and is the indexer keeping up". These answer the
+  # question those cannot: does our record of the money still agree with the
+  # chain, and is anything stuck in flight.
+  #
+  # Recorded here rather than queried ad hoc in each alert so the dashboard and
+  # the pager read the same series, per the note at the top of this file.
+  - name: slo_money_path_integrity
+    interval: 30s
+    rules:
+      # Divergence rate by kind. A mismatch means a balance is wrong, which is
+      # categorically worse than a record merely missing or stuck, so the kind
+      # label is preserved rather than summed away.
+      - record: reconcile:divergence:rate5m
+        expr: sum by (kind) (rate(nester_reconcile_divergences_total[5m]))
+
+      - record: reconcile:divergence:rate30m
+        expr: sum by (kind) (rate(nester_reconcile_divergences_total[30m]))
+
+      # Total divergences seen in the last hour, for the "any divergence at
+      # all" alert. #1108 asks to alert on any reconciliation divergence, so
+      # this is an increase over a window rather than a rate threshold.
+      - record: reconcile:divergence:increase1h
+        expr: sum(increase(nester_reconcile_divergences_total[1h]))
+
+      # Reconciler liveness. A divergence count of zero means nothing if the
+      # reconciler is not running, so the age of the last completed pass is
+      # recorded alongside the findings.
+      - record: reconcile:health:last_run_age_seconds
+        expr: max(nester_reconcile_last_run_age_seconds)
+
+      - record: reconcile:health:failed_run_rate5m
+        expr: sum(rate(nester_reconcile_runs_total{outcome="failed"}[5m]))
+
+      # Pending submissions. Depth alone is ambiguous — a large queue that
+      # drains is healthy — so the age of the oldest entry is the series the
+      # alert is written against.
+      - record: submission:pending:count
+        expr: max(nester_submission_pending_count)
+
+      - record: submission:pending:oldest_age_seconds
+        expr: max(nester_submission_pending_oldest_age_seconds)

--- a/docs/observability/runbooks/money-path-integrity.md
+++ b/docs/observability/runbooks/money-path-integrity.md
@@ -1,0 +1,232 @@
+# Runbook — Money-path integrity (reconciliation and pending submissions)
+
+**Alerts:** `ReconciliationDivergence` (page), `ReconciliationStalled` (page), `ReconciliationFailing` (ticket), `PendingSubmissionsBacklogged` (page), `MoneyPathMetricsAbsent` (page)
+**Dashboard:** [SLO — Money path integrity](/d/nester-slo-money-path/money-path-integrity)
+**Issue:** nester#1108
+
+---
+
+## What the alert means
+
+The flow SLOs answer "are deposits and withdrawals succeeding". Balance
+freshness answers "is the indexer keeping up". This group answers the question
+neither can: **does our record of the money still agree with the chain, and is
+anything stuck in flight.**
+
+| Alert | Meaning |
+|---|---|
+| `ReconciliationDivergence` | Our records and the chain disagree. A balance somewhere is wrong. |
+| `ReconciliationStalled` | The reconciler has not completed a pass. **A zero divergence count right now means nothing.** |
+| `ReconciliationFailing` | The loop is ticking but every pass aborts before inspecting anything. Same trap as above, narrower cause. |
+| `PendingSubmissionsBacklogged` | A submission has been in flight far too long. Someone's money is in limbo. |
+| `MoneyPathMetricsAbsent` | The series these alerts read are gone. Money-path monitoring is dark. |
+
+**The trap, and it is the important part of this runbook:** three of these
+alerts exist only because "no divergences reported" is ambiguous. It means
+either "we checked and everything agrees" or "we did not check". Those are
+opposite conclusions from an identical graph. If `ReconciliationStalled`,
+`ReconciliationFailing`, or `MoneyPathMetricsAbsent` is firing, **treat
+divergence silence as unknown, not clean**, and resolve the liveness alert
+before drawing any conclusion about integrity.
+
+---
+
+## First three actions
+
+**1. Establish whether the reconciler is actually running.**
+
+```promql
+reconcile:health:last_run_age_seconds
+```
+
+- Sawtoothing near zero → running. The divergence signal is trustworthy.
+  Go to [Cause A](#cause-a--genuine-divergence).
+- Climbing steadily → **stopped**. Go to
+  [Cause B](#cause-b--reconciler-stalled).
+- No series → go to [Cause D](#cause-d--metrics-absent).
+
+**2. If it is running, read the divergence breakdown by kind.**
+
+```promql
+sum by (kind) (increase(nester_reconcile_divergences_total[1h]))
+```
+
+The kinds are not equally serious. See
+[Reading the divergence kinds](#reading-the-divergence-kinds).
+
+**3. Check the in-flight backlog.**
+
+```promql
+submission:pending:count
+submission:pending:oldest_age_seconds
+```
+
+Depth alone proves nothing — a queue of 200 that drains in seconds is healthy.
+The oldest-age series is the one that matters.
+
+---
+
+## Reading the divergence kinds
+
+| Kind | Meaning | Severity |
+|---|---|---|
+| `mismatch` | Both sides have the record, the **values differ**. | Worst. A displayed balance is wrong. |
+| `missing` | The chain has it, we do not. | Serious. We are under-crediting someone. |
+| `extra` | We have it, the chain does not. | Serious. We may be crediting money that never moved. |
+| `stuck` | Submitted, never reached a terminal state. | Usually transient; chronic means the pipeline is broken. |
+
+A `mismatch` is the one to escalate first. `missing` and `extra` mean a record
+is absent on one side, which is recoverable by re-indexing. `mismatch` means
+both sides think they know the value and disagree, which cannot be resolved by
+re-reading — someone has to decide which is right, and the chain is
+authoritative.
+
+A steady low rate of `stuck` during normal traffic is expected: it counts
+transactions old enough to poll that the chain has not yet resolved. A `stuck`
+count that grows without draining is the same condition
+`PendingSubmissionsBacklogged` fires on.
+
+---
+
+## Cause A — genuine divergence
+
+The reconciler ran and found real disagreement.
+
+**Do not restart anything.** A restart clears no divergence and destroys the
+in-memory context of what was mid-flight.
+
+1. Identify the affected transactions from the poller logs — the divergence
+   metric is deliberately unlabelled by user or hash (cardinality policy in
+   `docs/observability/metrics.md`), so the logs are the join key:
+
+   ```
+   grep "transaction poller" <api logs> | grep -v "status reconciled"
+   ```
+
+2. For each affected transaction, treat **the chain as authoritative**. Confirm
+   the on-chain state via Horizon before changing any record.
+
+3. Assess blast radius before correcting: one stuck submission is an
+   individual support case, a divergence rate that scales with traffic is a
+   systematic bug in the submission or indexing path and correcting individual
+   rows will not fix it.
+
+4. If the divergence is systematic, consider pausing deposits before
+   correcting. Continuing to accept money into a ledger known to disagree with
+   the chain compounds the problem.
+
+---
+
+## Cause B — reconciler stalled
+
+`ReconciliationStalled` is firing: no pass has completed in over 10 minutes,
+against a 15s interval.
+
+1. Confirm the poller is enabled. `TX_POLLER_ENABLED` unset disables it
+   **silently at boot** — the same class of failure as an empty
+   `STELLAR_RPC_URL` disabling the indexer.
+
+2. Check whether passes are failing rather than not running:
+
+   ```promql
+   sum(rate(nester_reconcile_runs_total{outcome="failed"}[5m]))
+   ```
+
+   Non-zero → the loop is alive, passes are aborting. That is
+   [Cause C](#cause-c--passes-failing).
+
+   Zero, with no `completed` either → the goroutine is gone or wedged. Check
+   for a panic in the poller goroutine, and for database connection exhaustion
+   blocking `ListPendingOlderThan`.
+
+3. Once it recovers, **re-check the divergence count**. Divergences that
+   occurred during the stall were never counted; the first pass after recovery
+   is the first honest reading.
+
+---
+
+## Cause C — passes failing
+
+`ReconciliationFailing`: the loop ticks, but each pass aborts while listing
+pending transactions and inspects nothing.
+
+Almost always a database error on the list-pending query. Check:
+
+- Connection pool exhaustion (`nester_db_pool_acquired_connections` against
+  `nester_db_pool_max_connections`).
+- Statement timeouts on the pending-transaction query as the table grows.
+- Replica lag if the query is routed to a read replica.
+
+This tickets rather than pages because `ReconciliationStalled` pages if the
+loop stops entirely. The divergence count is equally false-clean in both cases.
+
+---
+
+## Cause D — metrics absent
+
+`MoneyPathMetricsAbsent`: `nester_reconcile_last_run_age_seconds` has not been
+reported for 10 minutes. Every alert in this group evaluates against it, so
+reconciliation and pending-submission monitoring are both dark.
+
+1. Is the API up? If other SLO alerts are firing, this is a symptom — fix the
+   outage.
+2. Is the scrape working? Check the `nester-api` target in Prometheus.
+3. Did the poller ever start? `TX_POLLER_ENABLED` unset means these series are
+   never produced and this alert is the only thing that will tell you.
+
+---
+
+## Pending submissions backlogged
+
+`PendingSubmissionsBacklogged`: the oldest in-flight submission is over 30
+minutes old.
+
+This is a user whose deposit or withdrawal is in limbo — the funds have left
+their visible balance and have not arrived anywhere they can act on.
+
+1. Check Horizon ingestion before assuming the chain is at fault. The poller
+   asks Horizon for status; if Horizon is behind, transactions look stuck when
+   they have actually settled. Cross-check one hash directly against the RPC
+   endpoint.
+
+2. Check the submission pipeline for transactions that were built and signed
+   but never submitted, which present identically to submitted-and-unresolved.
+
+3. Check `nester_flow_attempts_total{outcome="failed_chain"}` — a rising
+   failure rate alongside a growing backlog points at the chain or the
+   invoker, not at our record-keeping.
+
+4. For individual affected users, the admin money-path lookup
+   (`GET /api/v1/admin/users/{id}/money-path`) shows positions, recent
+   transactions, and pending submissions in one view.
+
+---
+
+## Verifying recovery
+
+Do not resolve on the alert clearing alone. Confirm all three:
+
+```promql
+# 1. The reconciler is alive — sawtoothing, not climbing.
+reconcile:health:last_run_age_seconds
+
+# 2. Passes are completing, not failing.
+sum by (outcome) (rate(nester_reconcile_runs_total[5m]))
+
+# 3. No new divergences since the fix.
+sum(increase(nester_reconcile_divergences_total[15m]))
+```
+
+The third only means anything once the first two are healthy — that is the
+trap this whole runbook is built around.
+
+---
+
+## Related
+
+- [Balance freshness](balance-freshness.md) — indexer lag. A lagging indexer
+  can produce apparent divergences that resolve on their own once it catches
+  up; check indexer lag before treating a divergence as real.
+- [Flow success](flow-success.md) — deposit and withdrawal failure rates.
+- [Flow latency](flow-latency.md) — settlement latency.
+- `docs/observability/slo.md` — SLI definitions and burn-rate arithmetic.

--- a/scripts/build_slo_dashboards.py
+++ b/scripts/build_slo_dashboards.py
@@ -830,11 +830,162 @@ def build_probe_dashboard() -> dict[str, Any]:
     )
 
 
+def build_money_path_dashboard() -> dict[str, Any]:
+    panels = [
+        _text(
+            "Money path integrity — reconciliation and in-flight submissions",
+            (
+                "The deposit/withdrawal SLO answers *are transactions "
+                "succeeding*. Balance freshness answers *is the indexer "
+                "keeping up*. This board answers what neither can: **does our "
+                "record of the money still agree with the chain, and is "
+                "anything stuck in flight** (nester#1108).\n\n"
+                "**Read the liveness panels first.** A divergence count of "
+                "zero means one of two opposite things — *we checked and "
+                "everything agrees*, or *we did not check*. The reconciler "
+                "age and failed-pass panels are what tell those apart. If the "
+                "reconciler is stalled, treat divergence silence as unknown, "
+                "not clean.\n\n"
+                "**Runbook** `docs/observability/runbooks/money-path-integrity.md`"
+            ),
+            {"h": 6, "w": 24, "x": 0, "y": 0},
+        ),
+        # Liveness first, deliberately: these gate the interpretation of every
+        # panel below them.
+        _stat(
+            "Reconciler last run",
+            "reconcile:health:last_run_age_seconds",
+            "s",
+            {"h": 5, "w": 6, "x": 0, "y": 6},
+            description=(
+                "Seconds since a pass completed, against a 15s interval. Pages "
+                "above 600. If this is climbing, the divergence panels below "
+                "are meaningless."
+            ),
+            decimals=0,
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "orange", "value": 120},
+                {"color": "red", "value": 600},
+            ],
+        ),
+        _stat(
+            "Failed passes",
+            "reconcile:health:failed_run_rate5m",
+            "none",
+            {"h": 5, "w": 6, "x": 6, "y": 6},
+            description=(
+                "Passes per second that aborted before inspecting anything. "
+                "Non-zero means the divergence count is falsely clean."
+            ),
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "red", "value": 0.001},
+            ],
+        ),
+        _stat(
+            "Divergences (1h)",
+            "reconcile:divergence:increase1h",
+            "none",
+            {"h": 5, "w": 6, "x": 12, "y": 6},
+            description=(
+                "Findings where our record and the chain disagree. Pages above "
+                "zero — there is no acceptable steady-state rate."
+            ),
+            decimals=0,
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "red", "value": 1},
+            ],
+        ),
+        _stat(
+            "Oldest pending submission",
+            "submission:pending:oldest_age_seconds",
+            "s",
+            {"h": 5, "w": 6, "x": 18, "y": 6},
+            description=(
+                "Age of the oldest transaction awaiting a terminal status. "
+                "Pages above 1800. This is money the user cannot see or reach."
+            ),
+            decimals=0,
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "orange", "value": 600},
+                {"color": "red", "value": 1800},
+            ],
+        ),
+        _timeseries(
+            "Divergences by kind",
+            [("reconcile:divergence:rate5m", "{{kind}}")],
+            "none",
+            {"h": 9, "w": 12, "x": 0, "y": 11},
+            description=(
+                "Split by kind because they are not equally serious. mismatch "
+                "means both sides have the record and the values differ — a "
+                "displayed balance is wrong, and re-indexing will not fix it. "
+                "missing/extra mean a record exists on one side only. stuck "
+                "means a submission has not reached a terminal state; a low "
+                "steady rate is expected, a growing one is not."
+            ),
+        ),
+        _timeseries(
+            "Reconciliation passes by outcome",
+            [("sum by (outcome) (rate(nester_reconcile_runs_total[5m]))", "{{outcome}}")],
+            "none",
+            {"h": 9, "w": 12, "x": 12, "y": 11},
+            description=(
+                "completed vs failed. A healthy reconciler shows a flat "
+                "completed line and no failed line. failed means passes are "
+                "running but inspecting nothing — usually a database error on "
+                "the list-pending query."
+            ),
+        ),
+        _timeseries(
+            "Pending submission backlog",
+            [
+                ("submission:pending:count", "queue depth"),
+                ("submission:pending:oldest_age_seconds", "oldest age (s)"),
+            ],
+            "none",
+            {"h": 9, "w": 12, "x": 0, "y": 20},
+            description=(
+                "Depth alone is ambiguous — a large queue that drains is "
+                "healthy, a small one that never drains is not. Watch whether "
+                "the oldest-age line resets or climbs monotonically; a climb "
+                "with steady depth means the same transactions are stuck."
+            ),
+        ),
+        _timeseries(
+            "Reconciler age over time",
+            [("reconcile:health:last_run_age_seconds", "last run age")],
+            "s",
+            {"h": 9, "w": 12, "x": 12, "y": 20},
+            description=(
+                "Should sawtooth near zero, resetting every pass. A monotonic "
+                "climb means the poller stopped, and every integrity signal on "
+                "this board froze with it."
+            ),
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "red", "value": 600},
+            ],
+        ),
+    ]
+
+    return _dashboard(
+        "nester-slo-money-path",
+        "SLO — Money path integrity",
+        "Reconciliation divergences and in-flight submission backlog (nester#1108).",
+        panels,
+    )
+
+
 DASHBOARDS = {
     "slo-api-availability.json": build_api_dashboard,
     "slo-deposits-withdrawals.json": build_flow_dashboard,
     "slo-intelligence.json": build_intelligence_dashboard,
     "slo-balance-freshness.json": build_balance_dashboard,
+    "slo-money-path-integrity.json": build_money_path_dashboard,
     "slo-synthetic-probes.json": build_probe_dashboard,
 }
 


### PR DESCRIPTION
Merges PR #1170 into a branch off `dev` and fills in the parts of its four linked issues that were not covered.

## What #1170 delivered

A `jwtSecretHasAdequateEntropy` guard rejecting `AUTH_JWT_SECRET` values with fewer than 8 distinct bytes, plus two tests. It is a real improvement and is merged here unchanged — a 32-character secret of all `a`s passes the existing length check and is trivially predictable.

CI on #1170 was inconclusive: only 2 of ~28 checks ran, because the paths-filter never triggered the API job on that branch. The full suite runs here.

## Why this PR is larger than that

#1170 linked four issues and closed all four, but the diff only touched one criterion of one of them. Working through the rest:

**#1103 (short-lived tokens with refresh and revocation) — already done on `dev`, no work needed.** Refresh-token rotation with reuse detection, family revocation with anomaly alerting, device-fingerprint binding, admin session revocation, opaque hashed refresh tokens, and a fail-closed revocation cache checked on every request all exist in `internal/service/auth_service.go` and `internal/repository/postgres/session_repository.go`. Nothing was missing.

**#1106 (fail startup on missing or weak secrets) — one criterion left.** Length, dev-default rejection, and now entropy were covered. "No secret is ever logged, including in startup diagnostics" was not.

**#1105 (verify the admin role on every privileged endpoint) — not started.**

**#1108 (money-path dashboard and alerts) — mostly delivered by the SLO work in #1056; two criteria uncovered.**

## #1105 — admin route authorization coverage

The criteria ask for every admin route enumerated in a test asserting a non-admin is rejected, **and** for adding an admin route without a test entry to fail CI. A hand-maintained list satisfies the first and fails the second — it goes stale the moment someone adds a route.

So the test does not maintain a list. `AdminHandler.Register` now takes a narrow `routeMux` interface instead of `*http.ServeMux`, letting the test record what `Register` actually mounts and assert a property over all of it. New admin routes are covered automatically. Three assertions run per route: non-admin token to 403, anonymous to 401, admin token to 200 (the positive control, without which a middleware rejecting everything would pass).

The CI gate is `TestAdminHandlerRoutesAreAdminScoped`: every route must either sit under `/api/v1/admin/` or be named in an allowlist with a reason. **One route is currently allowlisted:** `GET /api/v1/vaults/{id}/rebalance-history`, registered on `AdminHandler` but outside the admin prefix since d1187714, where it landed alongside the public audit page. It exposes vault-level protocol allocation history with no per-user balances or PII, so the placement looks deliberate — but it was implicit, and is now explicit and reviewable. Two further tests keep the allowlist honest: one fails on entries naming routes that no longer exist, another restricts allowlisting to GET/HEAD so no mutation can ever be exempted.

Verified the gate works by temporarily registering an ungated route; it failed and named it.

Role was already read exclusively from the verified JWT claim, never a request body, so that criterion needed no change.

## #1106 — secrets in logs

Config keeps secrets in unexported fields, which blocks `encoding/json` but not `fmt`: `%v` and `%+v` reach unexported fields by reflection and print them verbatim. One `logger.Info("config", "cfg", cfg)` in a startup diagnostic or panic dump puts `AUTH_JWT_SECRET` and the Stellar operator seed into a log aggregator.

Added `String()` and `slog.LogValue()` to the seven config structs holding credentials. Redaction distinguishes set from empty — "configured but hidden" and "not configured" are different answers when reading a diagnostic — and non-secret operational values (environment, Horizon URL, the operator's *public* address) stay visible, since a redaction that blanks the diagnostic is its own bug. `AccountCipherConfig.keys` is a map of encryption keys whose default formatting would print every value; only the count and active version label are reported.

`TestEverySecretBearingStructRedacts` is the tripwire for later additions: it walks `Config` by reflection, finds structs with credential-shaped field names, and fails if one lacks either method, naming the struct and field. Verified by temporarily adding a `webhookSecret` field, which it caught.

## #1108 — money-path observability

Most of this was delivered by #1056: deposit and withdrawal success rate and latency, indexer lag with a staleness guard, burn-rate alerts, dashboards, runbooks. Two criteria had no coverage: **reconciliation divergences** and **pending submissions**.

The reconciler already compared our records against the chain but reported only to the log — so a divergence, the most serious signal this system can produce since it means a displayed balance is wrong, was visible only to whoever happened to be reading logs.

Five new metrics, following the package's closed-label cardinality policy. Two design points, both about a signal that lies in the dangerous direction:

- **Divergences are counted, never gauged.** A gauge would report the current pass's count and erase a divergence found and then corrected, losing exactly the history an incident review needs. The `kind` label mirrors `reconciliation.DiscrepancyType` rather than inventing a parallel vocabulary.
- **Runs are counted by outcome and last-run age is published,** because "zero divergences" is ambiguous: it means either "we checked and everything agrees" or "we did not check". A dead reconciler reports zero forever. Three of the five alerts exist solely to disambiguate that, and `main.go` ages the gauge on its own ticker so a dead poller cannot leave it frozen at zero reading as "just reconciled".

The poller takes a `PollerMetricsRecorder` interface rather than `*metrics.Metrics`, matching how the event indexer depends on its recorder.

Alerts: `ReconciliationDivergence` pages on any divergence at all — there is no acceptable steady-state rate of our ledger disagreeing with the chain. `ReconciliationStalled` and `ReconciliationFailing` cover the false-clean cases. `PendingSubmissionsBacklogged` keys on the **age** of the oldest entry, not depth — a queue of 200 that drains is healthy, a queue of 3 that has not moved in 30 minutes is money a user cannot see or reach. `MoneyPathMetricsAbsent` covers the series vanishing.

Also: 7 recording rules, a generated Grafana dashboard (via the existing builder, so the drift check passes), a runbook built around the false-clean trap, and 9 promtool unit tests including boundary cases and the deep-but-draining queue that must not page.

## Verification

Run locally, not assumed:

```
go build ./...                                          clean
go test ./... (apps/api, full suite)                    exit 0
go vet ./...                                            clean
gofmt -l <changed files>                                clean

promtool 3.1.0 (the version CI pins):
  check config docker/prometheus/prometheus.yml         82 recording rules, 21 alerts, valid
  test rules slo_alerts_test.yml slo_probe_alerts_test.yml \
             slo_money_path_alerts_test.yml             3x SUCCESS

python scripts/build_slo_dashboards.py
git diff --quiet -- docker/grafana/dashboards           no drift
```

The new promtool test file is added to the enumerated list in `ci.yml` — it is not globbed, so without that it would never run.

## Issues

Closes #1103
Closes #1105
Closes #1106
Closes #1108

Supersedes #1170.
