### PR TITLE
fix(api,ci): enforce wallet binding, cover every route in the authz matrix, and run the E2E journey nightly

### DIFF
--- a/.github/workflows/e2e-testnet-nightly.yml
+++ b/.github/workflows/e2e-testnet-nightly.yml
@@ -1,0 +1,85 @@
+name: Nightly testnet E2E
+
+# The deposit/withdraw journey runs against real deployed contracts and needs
+# a funded account, so it cannot gate every pull request. Nightly is the
+# cadence the issue (#1100) allows for exactly that reason.
+#
+# Required configuration, as repository secrets/variables:
+#   TESTNET_WALLET_ADDRESS — funded Stellar testnet account (secret)
+#   VAULT_ID               — deployed vault contract ID on testnet (variable)
+#   STAGING_URL            — deployed dapp to drive (variable); defaults to a
+#                            locally built app when unset.
+#
+# When the wallet and vault are not configured the spec skips itself rather
+# than failing, so a repository without testnet infrastructure stays green.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      staging_url:
+        description: "Base URL to run against (overrides the STAGING_URL variable)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deposit-withdraw:
+    name: Deposit / withdraw journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/dapp/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      # Only needed when driving a locally served build. With STAGING_URL set
+      # the workflow tests the deployed app instead and this is wasted work,
+      # so it is skipped.
+      - name: Build dapp
+        if: ${{ !inputs.staging_url && !vars.STAGING_URL }}
+        run: pnpm build
+
+      - name: Start dapp
+        if: ${{ !inputs.staging_url && !vars.STAGING_URL }}
+        run: |
+          pnpm start -p 3001 &
+          npx wait-on http://localhost:3001 --timeout 120000
+
+      - name: Run deposit/withdraw journey
+        env:
+          TESTNET_WALLET_ADDRESS: ${{ secrets.TESTNET_WALLET_ADDRESS }}
+          VAULT_ID: ${{ vars.VAULT_ID }}
+          STAGING_URL: ${{ inputs.staging_url || vars.STAGING_URL }}
+          CI: "true"
+        run: pnpm test:e2e:testnet
+
+      # Uploaded on failure only: the trace and screenshots are what identify
+      # which step of the journey broke, per the issue's acceptance criteria.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            apps/dapp/frontend/playwright-report
+            apps/dapp/frontend/test-results
+          retention-days: 14

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -1209,24 +1209,27 @@ func run() error {
 	defer cancelAPYScheduler()
 	go apySvc.StartScheduler(apySchedulerCtx)
 
-	authRules := []middleware.RouteRule{
-		{PathPrefix: "/health", Public: true},
-		{PathPrefix: "/healthz", Public: true},
-		{PathPrefix: "/readyz", Public: true},
-		{PathPrefix: "/ws", Public: true},
-		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/challenge", Public: true},
-		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/verify", Public: true},
-		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/refresh", Public: true},
-		// No blanket "/api/v1/auth/" rule: logout, logout-all, and sessions
-		// must stay protected and fall through to the "/api/v1/" catch-all.
-		{PathPrefix: "/api/v1/banks/", Public: true},
-		{PathPrefix: "/api/v1/yields/", Public: true},
-		{PathPrefix: "/api/v1/savings-goals/shared/", Public: true},
-		{PathPrefix: "/api/v1/admin/", Public: false, Role: "admin"},
-		{PathPrefix: "/api/v1/internal/", Role: "service"},
-		{PathPrefix: "/api/v1/", Public: false},
-	}
+	// walletBindingCacheTTL bounds how long a stale wallet binding can still
+	// be accepted after the account's wallet changes. Short enough that a
+	// relink takes effect promptly, long enough to keep the check off the
+	// database on the hot path.
+	const walletBindingCacheTTL = 60 * time.Second
+
+	// Defined in the middleware package so the authorization matrix test
+	// exercises the same table the server serves, rather than a copy of it.
+	authRules := middleware.ProductionAuthRules()
 	authenticator := middleware.Authenticate(cfg.Auth().Secret(), cfg.Auth().ServiceAPIKey(), authRules, revocationCache)
+	// walletBinding ties a session to the wallet it was issued for (#1102). It
+	// rejects a token replayed against a different wallet's endpoints, and a
+	// token whose wallet is no longer the one linked to the account, so
+	// relinking a wallet invalidates sessions minted before the change.
+	//
+	// The resolver memoises the account's wallet briefly: the check runs on
+	// every authenticated request, and the lookup behind it is a row read.
+	// The TTL bounds how long a superseded binding can still be honoured.
+	walletBinding := middleware.WalletBindingCheck(
+		middleware.NewCachedWalletResolver(userRepository, walletBindingCacheTTL),
+	)
 	// Tell the rate-limit client-IP extractor how many trusted proxies sit in
 	// front of the API so it derives the originating client IP from
 	// X-Forwarded-For instead of collapsing all traffic onto the proxy address.
@@ -1312,15 +1315,17 @@ func run() error {
 							authRouteLimiter(
 								writeLimiter(
 									authenticator(
-										idempotencyMiddleware(
-											settlementLimiter(
-												walletLimiter(
-													middleware.LimitRequestBody(1 * 1024 * 1024)(
-														middleware.Logging(baseLogger)(
-															middleware.Tracing(
-																cfg.Tracing().ServiceName(),
-																cfg.Tracing().LatencyThreshold(),
-															)(mux),
+										walletBinding(
+											idempotencyMiddleware(
+												settlementLimiter(
+													walletLimiter(
+														middleware.LimitRequestBody(1 * 1024 * 1024)(
+															middleware.Logging(baseLogger)(
+																middleware.Tracing(
+																	cfg.Tracing().ServiceName(),
+																	cfg.Tracing().LatencyThreshold(),
+																)(mux),
+															),
 														),
 													),
 												),

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -795,7 +795,9 @@ func (h *SavingsGoalHandler) writeError(w http.ResponseWriter, r *http.Request, 
 	case errors.Is(err, savingsgoal.ErrRecoveryWindowExpired):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "RECOVERY_WINDOW_EXPIRED", err.Error()))
 	case errors.Is(err, savingsgoal.ErrUnauthorized):
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "vault does not belong to you"))
+		// 404, not 403 — "vault does not belong to you" confirms the vault
+		// exists to a caller who does not own it (#1101).
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 	case errors.Is(err, savingsgoal.ErrInvalidGoal):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	case errors.Is(err, goalnotification.ErrInvalidPreference):

--- a/apps/api/internal/handler/savings_goal_handler_test.go
+++ b/apps/api/internal/handler/savings_goal_handler_test.go
@@ -641,8 +641,8 @@ func TestSavingsGoalHandler_Create_ForeignVaultForbidden(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("create status = %d, want 403", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("create status = %d, want 404", resp.StatusCode)
 	}
 }
 

--- a/apps/api/internal/handler/transaction_handler.go
+++ b/apps/api/internal/handler/transaction_handler.go
@@ -56,7 +56,7 @@ type transactionView struct {
 }
 
 type listTransactionsData struct {
-	Data       []transactionView    `json:"data"`
+	Data       []transactionView     `json:"data"`
 	Pagination transactionPagination `json:"pagination"`
 }
 
@@ -209,7 +209,9 @@ func (h *TransactionHandler) createTransaction(w http.ResponseWriter, r *http.Re
 			return
 		}
 		if v.UserID.String() != user.ID {
-			response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+			// 404, not 403 — see #1101. Answering 403 confirms the vault
+			// exists to a caller who does not own it.
+			response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 			return
 		}
 	}
@@ -276,7 +278,9 @@ func (h *TransactionHandler) getTransactionByHash(w http.ResponseWriter, r *http
 			return
 		}
 		if v.UserID.String() != user.ID {
-			response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+			// 404, not 403 — see #1101. Answering 403 confirms the vault
+			// exists to a caller who does not own it.
+			response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 			return
 		}
 	}

--- a/apps/api/internal/handler/transaction_handler_test.go
+++ b/apps/api/internal/handler/transaction_handler_test.go
@@ -84,7 +84,7 @@ func (r *fakeTransactionRepository) ListUserTransactions(_ context.Context, _ tr
 	return nil, 0, nil
 }
 
-func TestCreateTransactionIDORReturns403ForOtherUser(t *testing.T) {
+func TestCreateTransactionIDORReturns404ForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 
@@ -114,8 +114,8 @@ func TestCreateTransactionIDORReturns403ForOtherUser(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403 for cross-user transaction creation, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user transaction creation, got %d", resp.StatusCode)
 	}
 }
 
@@ -321,7 +321,7 @@ func TestCreateTransactionReturns401WithoutAuth(t *testing.T) {
 	}
 }
 
-func TestGetTransactionByIDORReturns403ForOtherUser(t *testing.T) {
+func TestGetTransactionByIDORReturns404ForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 
@@ -359,8 +359,8 @@ func TestGetTransactionByIDORReturns403ForOtherUser(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403 for cross-user transaction read, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user transaction read, got %d", resp.StatusCode)
 	}
 }
 
@@ -388,13 +388,13 @@ func TestGetTransactionByHashReturns200ForOwner(t *testing.T) {
 
 	txHash := "tx_hash_owner"
 	txRepo.transactions[txHash] = transaction.Transaction{
-		ID:      uuid.New(),
-		VaultID: vaultID,
-		Type:    transaction.TypeDeposit,
-		Amount:  decimal.NewFromFloat(100.0),
+		ID:       uuid.New(),
+		VaultID:  vaultID,
+		Type:     transaction.TypeDeposit,
+		Amount:   decimal.NewFromFloat(100.0),
 		Currency: "USDC",
-		TxHash:  txHash,
-		Status:  transaction.StatusPending,
+		TxHash:   txHash,
+		Status:   transaction.StatusPending,
 	}
 
 	resp, err := http.Get(server.URL + "/api/v1/transactions/" + txHash)

--- a/apps/api/internal/handler/vault_existence_oracle_test.go
+++ b/apps/api/internal/handler/vault_existence_oracle_test.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// TestVaultNotAnExistenceOracle is the direct test for the #1101 criterion
+// "non-owner access to an existing resource returns 404, not 403, so the
+// endpoint is not an existence oracle".
+//
+// Asserting the status code alone is not enough: if a non-owner gets 404 but
+// with a distinguishable body, the oracle still works. This compares the two
+// responses a non-owner can provoke — one for a vault that exists and belongs
+// to someone else, one for a vault ID that was never created — and requires
+// them to be indistinguishable.
+func TestVaultNotAnExistenceOracle(t *testing.T) {
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	repository := newHandlerRepository(ownerID, otherID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ownerServer := httptest.NewServer(fakeAuthMiddleware(ownerID)(middleware.Logging(discard)(mux)))
+	defer ownerServer.Close()
+
+	body := bytes.NewBufferString(`{"contract_address":"` + testAddrGeneric + `","currency":"USDC"}`)
+	createResp, err := http.Post(ownerServer.URL+"/api/v1/vaults", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /api/v1/vaults error = %v", err)
+	}
+	defer createResp.Body.Close()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create vault: expected 201, got %d", createResp.StatusCode)
+	}
+	created := decodeAPIData[vault.Vault](t, createResp.Body)
+
+	otherServer := httptest.NewServer(fakeAuthMiddleware(otherID)(middleware.Logging(discard)(mux)))
+	defer otherServer.Close()
+
+	get := func(t *testing.T, path string) (int, string) {
+		t.Helper()
+		resp, err := http.Get(otherServer.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s error = %v", path, err)
+		}
+		defer resp.Body.Close()
+		payload, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body for %s: %v", path, err)
+		}
+		return resp.StatusCode, string(payload)
+	}
+
+	// A vault that exists but belongs to another user.
+	existingCode, existingBody := get(t, "/api/v1/vaults/"+created.ID.String())
+	// A vault that does not exist at all.
+	missingCode, missingBody := get(t, "/api/v1/vaults/"+uuid.NewString())
+
+	if existingCode != http.StatusNotFound {
+		t.Errorf("someone else's existing vault: got %d, want 404", existingCode)
+	}
+	if missingCode != http.StatusNotFound {
+		t.Errorf("nonexistent vault: got %d, want 404", missingCode)
+	}
+	if existingCode != missingCode || existingBody != missingBody {
+		t.Errorf("responses are distinguishable, so the endpoint is an existence oracle:\n"+
+			"  existing vault owned by another user: %d %s\n"+
+			"  vault that does not exist:            %d %s",
+			existingCode, existingBody, missingCode, missingBody)
+	}
+}
+
+// The owner must still be able to read their own vault, otherwise the test
+// above would be satisfied by an endpoint that 404s for everyone.
+func TestVaultOwnerStillReadsOwnVault(t *testing.T) {
+	ownerID := uuid.New()
+	otherID := uuid.New()
+	repository := newHandlerRepository(ownerID, otherID)
+	vaultService := service.NewVaultService(repository)
+	handler := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ownerServer := httptest.NewServer(fakeAuthMiddleware(ownerID)(middleware.Logging(discard)(mux)))
+	defer ownerServer.Close()
+
+	body := bytes.NewBufferString(`{"contract_address":"` + testAddrGeneric + `","currency":"USDC"}`)
+	createResp, err := http.Post(ownerServer.URL+"/api/v1/vaults", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /api/v1/vaults error = %v", err)
+	}
+	defer createResp.Body.Close()
+	created := decodeAPIData[vault.Vault](t, createResp.Body)
+
+	resp, err := http.Get(ownerServer.URL + "/api/v1/vaults/" + created.ID.String())
+	if err != nil {
+		t.Fatalf("owner GET error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("owner reading own vault: got %d, want 200", resp.StatusCode)
+	}
+}

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -23,9 +23,9 @@ import (
 const maxRequestBodyBytes int64 = 1 << 20
 
 type VaultHandler struct {
-	service            *service.VaultService
-	rebalanceSvc       *service.VaultRebalanceService
-	wsHub              *ws.Hub
+	service              *service.VaultService
+	rebalanceSvc         *service.VaultRebalanceService
+	wsHub                *ws.Hub
 	rebalanceRateLimiter func(http.Handler) http.Handler
 }
 
@@ -176,7 +176,10 @@ func (h *VaultHandler) getVault(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if model.UserID.String() != user.ID {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -243,7 +246,10 @@ func (h *VaultHandler) listUserVaults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if authUser.ID != userID.String() {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -397,7 +403,10 @@ func (h *VaultHandler) getAllocations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if v.UserID.String() != user.ID {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -492,7 +501,10 @@ func (h *VaultHandler) emergencyWithdraw(w http.ResponseWriter, r *http.Request)
 	}
 
 	if existing.UserID.String() != authUser.ID {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -537,18 +549,18 @@ func (h *VaultHandler) rebalancePosition(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := validateCurrencyCode(req.Currency); err != nil {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid currency: " + err.Error()))
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid currency: "+err.Error()))
 		return
 	}
 
 	result, err := h.service.RebalancePosition(r.Context(), service.RebalancePositionInput{
-		VaultID:     vaultID,
-		UserID:      userID,
+		VaultID:      vaultID,
+		UserID:       userID,
 		FromProtocol: req.FromProtocol,
 		ToProtocol:   req.ToProtocol,
-		Amount:      amount,
-		Currency:    req.Currency,
-		TxHash:      "",
+		Amount:       amount,
+		Currency:     req.Currency,
+		TxHash:       "",
 	})
 	if err != nil {
 		h.writeDomainError(w, r, err)
@@ -556,13 +568,13 @@ func (h *VaultHandler) rebalancePosition(w http.ResponseWriter, r *http.Request)
 	}
 
 	type rebalanceResponse struct {
-		Vault              vault.Vault          `json:"vault"`
-		FromProtocolBalance decimal.Decimal      `json:"from_protocol_balance"`
-		ToProtocolBalance   decimal.Decimal      `json:"to_protocol_balance"`
+		Vault               vault.Vault     `json:"vault"`
+		FromProtocolBalance decimal.Decimal `json:"from_protocol_balance"`
+		ToProtocolBalance   decimal.Decimal `json:"to_protocol_balance"`
 	}
 
 	response.WriteJSON(w, http.StatusOK, response.OK(rebalanceResponse{
-		Vault:              result.Vault,
+		Vault:               result.Vault,
 		FromProtocolBalance: result.FromProtocolBalance,
 		ToProtocolBalance:   result.ToProtocolBalance,
 	}))
@@ -652,7 +664,10 @@ func (h *VaultHandler) depositToVault(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if vaultModel.UserID.String() != user.ID {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -717,7 +732,10 @@ func (h *VaultHandler) withdrawFromVault(w http.ResponseWriter, r *http.Request)
 	}
 
 	if vault.UserID.String() != user.ID {
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 		return
 	}
 
@@ -743,7 +761,10 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 	case errors.Is(err, vault.ErrVaultNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 	case errors.Is(err, vault.ErrVaultForbidden):
-		response.WriteJSON(w, http.StatusForbidden, response.Err(http.StatusForbidden, "FORBIDDEN", "forbidden"))
+		// 404, not 403: a non-owner must not be able to tell an existing
+		// vault from one that was never there. Answering 403 here turns the
+		// endpoint into an existence oracle for other users' vault IDs.
+		response.WriteJSON(w, http.StatusNotFound, response.NotFound("vault"))
 	case errors.Is(err, vault.ErrUserNotFound):
 		response.WriteJSON(w, http.StatusNotFound, response.NotFound("user"))
 	case errors.Is(err, vault.ErrInvalidVault), errors.Is(err, vault.ErrInvalidAmount), errors.Is(err, vault.ErrInvalidAllocation), errors.Is(err, vault.ErrInvalidHarvestFrequency):

--- a/apps/api/internal/handler/vault_handler_harvest_test.go
+++ b/apps/api/internal/handler/vault_handler_harvest_test.go
@@ -64,7 +64,7 @@ func TestVaultHandlerHarvestReturnsZeroYield(t *testing.T) {
 	}
 }
 
-func TestVaultHandlerHarvestForbiddenForOtherUser(t *testing.T) {
+func TestVaultHandlerHarvestNotFoundForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 	repository := newHandlerRepository(ownerID, otherID)
@@ -98,8 +98,9 @@ func TestVaultHandlerHarvestForbiddenForOtherUser(t *testing.T) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected status 403, got %d", response.StatusCode)
+	// 404 rather than 403 — a non-owner must not learn the vault exists (#1101).
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", response.StatusCode)
 	}
 }
 

--- a/apps/api/internal/handler/vault_handler_integration_test.go
+++ b/apps/api/internal/handler/vault_handler_integration_test.go
@@ -310,7 +310,8 @@ func TestVaultHandlerDepositAndWithdrawIntegration(t *testing.T) {
 	}
 	defer forbiddenResponse.Body.Close()
 
-	if forbiddenResponse.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403 for other user's vault, got %d", forbiddenResponse.StatusCode)
+	// 404 rather than 403 — a non-owner must not learn the vault exists (#1101).
+	if forbiddenResponse.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for other user's vault, got %d", forbiddenResponse.StatusCode)
 	}
 }

--- a/apps/api/internal/handler/vault_handler_preview_harvest_test.go
+++ b/apps/api/internal/handler/vault_handler_preview_harvest_test.go
@@ -160,7 +160,7 @@ func TestVaultHandlerPreviewHarvestCompoundParam(t *testing.T) {
 	}
 }
 
-func TestVaultHandlerPreviewHarvestForbiddenForOtherUser(t *testing.T) {
+func TestVaultHandlerPreviewHarvestNotFoundForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 	repository := newHandlerRepository(ownerID, otherID)
@@ -187,7 +187,8 @@ func TestVaultHandlerPreviewHarvestForbiddenForOtherUser(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected status 403, got %d", resp.StatusCode)
+	// 404 rather than 403 — a non-owner must not learn the vault exists (#1101).
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", resp.StatusCode)
 	}
 }

--- a/apps/api/internal/handler/vault_idor_test.go
+++ b/apps/api/internal/handler/vault_idor_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 )
 
-func TestGetVaultIDORReturns403ForOtherUser(t *testing.T) {
+func TestGetVaultIDORReturns404ForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 	repository := newHandlerRepository(ownerID, otherID)
@@ -49,8 +49,10 @@ func TestGetVaultIDORReturns403ForOtherUser(t *testing.T) {
 	}
 	defer getResp.Body.Close()
 
-	if getResp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403 for cross-user vault access, got %d", getResp.StatusCode)
+	// 404 rather than 403: the response must not reveal that this vault
+	// exists. See #1101 — a 403 here is an existence oracle.
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user vault access, got %d", getResp.StatusCode)
 	}
 }
 
@@ -84,7 +86,7 @@ func TestGetVaultReturns200ForOwner(t *testing.T) {
 	}
 }
 
-func TestGetAllocationsIDORReturns403ForOtherUser(t *testing.T) {
+func TestGetAllocationsIDORReturns404ForOtherUser(t *testing.T) {
 	ownerID := uuid.New()
 	otherID := uuid.New()
 	repository := newHandlerRepository(ownerID, otherID)
@@ -113,7 +115,7 @@ func TestGetAllocationsIDORReturns403ForOtherUser(t *testing.T) {
 	}
 	defer getResp.Body.Close()
 
-	if getResp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403 for cross-user allocations access, got %d", getResp.StatusCode)
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user allocations access, got %d", getResp.StatusCode)
 	}
 }

--- a/apps/api/internal/middleware/authz_coverage_test.go
+++ b/apps/api/internal/middleware/authz_coverage_test.go
@@ -1,0 +1,277 @@
+package middleware
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file enforces the "adding a route without adding a matrix entry fails
+// the test" criterion of #1101.
+//
+// The route list is recovered from the handler sources rather than from a
+// hand-maintained list, because a hand-maintained list is the very thing that
+// goes stale. Instantiating the real handlers would be more direct, but every
+// constructor wants a database; parsing the registrations gets the same
+// answer without one.
+
+// handlerPkgDir is the directory holding the HTTP handlers, relative to this
+// package.
+const handlerPkgDir = "../handler"
+
+// registrarNames are the mux methods that bind a pattern to a handler.
+var registrarNames = map[string]bool{
+	"HandleFunc": true,
+	"Handle":     true,
+}
+
+// muxPattern is "METHOD /path" or just "/path".
+var muxPattern = regexp.MustCompile(`^(?:([A-Z]+)\s+)?(/\S*)$`)
+
+// discoveredRoute is a route the server registers.
+type discoveredRoute struct {
+	Method string
+	Path   string
+	// Source is file:line, so a failure points at the registration.
+	Source string
+}
+
+// discoverRegisteredRoutes parses the handler package and returns every route
+// registered through a mux.
+func discoverRegisteredRoutes(t *testing.T) []discoveredRoute {
+	t.Helper()
+
+	entries, err := os.ReadDir(handlerPkgDir)
+	if err != nil {
+		t.Fatalf("read handler dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var routes []discoveredRoute
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(handlerPkgDir, name)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !registrarNames[sel.Sel.Name] {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			raw, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			m := muxPattern.FindStringSubmatch(strings.TrimSpace(raw))
+			if m == nil {
+				return true
+			}
+			pos := fset.Position(lit.Pos())
+			routes = append(routes, discoveredRoute{
+				Method: m[1],
+				Path:   m[2],
+				Source: filepath.Base(pos.Filename) + ":" + strconv.Itoa(pos.Line),
+			})
+			return true
+		})
+	}
+
+	if len(routes) == 0 {
+		t.Fatalf("discovered no routes under %s — the parser is broken, not the matrix", handlerPkgDir)
+	}
+	return routes
+}
+
+// normalizePattern rewrites a route to a comparable shape: wildcard segments
+// collapse to "{}", so "/vaults/{id}" from the source and
+// "/vaults/0000-..." from the matrix compare equal.
+func normalizePattern(method, path string) string {
+	path = strings.TrimSuffix(path, "{$}")
+	segs := strings.Split(strings.Trim(path, "/"), "/")
+	for i, s := range segs {
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			segs[i] = "{}"
+		}
+	}
+	if method == "" {
+		method = "ANY"
+	}
+	return method + " /" + strings.Join(segs, "/")
+}
+
+// matrixKeys indexes the matrix by normalized pattern. Concrete IDs in matrix
+// paths are mapped to "{}" positionally against the discovered routes, so the
+// matrix keeps using real-looking URLs while still matching.
+func matrixKeys(discovered []discoveredRoute) map[string]bool {
+	// Index discovered routes by method + segment count so a matrix path can
+	// find its template and learn which segments are wildcards.
+	type shape struct {
+		method string
+		n      int
+	}
+	templates := map[shape][][]string{}
+	for _, r := range discovered {
+		segs := strings.Split(strings.Trim(strings.TrimSuffix(r.Path, "{$}"), "/"), "/")
+		method := r.Method
+		if method == "" {
+			method = "ANY"
+		}
+		templates[shape{method, len(segs)}] = append(templates[shape{method, len(segs)}], segs)
+	}
+
+	keys := map[string]bool{}
+	for _, e := range authzMatrix {
+		segs := strings.Split(strings.Trim(e.Path, "/"), "/")
+		for _, method := range []string{e.Method, "ANY"} {
+			for _, tmpl := range templates[shape{method, len(segs)}] {
+				masked := make([]string, len(segs))
+				copy(masked, segs)
+				match := true
+				for i, ts := range tmpl {
+					if strings.HasPrefix(ts, "{") && strings.HasSuffix(ts, "}") {
+						masked[i] = "{}"
+						continue
+					}
+					if !strings.EqualFold(ts, segs[i]) {
+						match = false
+						break
+					}
+				}
+				if match {
+					keys[method+" /"+strings.Join(masked, "/")] = true
+				}
+			}
+		}
+		// Also index the literal form, for routes with no wildcard.
+		m := e.Method
+		if m == "" {
+			m = "ANY"
+		}
+		keys[normalizePattern(m, e.Path)] = true
+	}
+	return keys
+}
+
+// TestAuthorizationMatrixCoversEveryRoute fails when the server registers a
+// route the matrix does not exercise. This is the guard the issue asks for:
+// adding a route without adding a matrix entry breaks the build.
+func TestAuthorizationMatrixCoversEveryRoute(t *testing.T) {
+	discovered := discoverRegisteredRoutes(t)
+	covered := matrixKeys(discovered)
+
+	var missing []discoveredRoute
+	for _, r := range discovered {
+		key := normalizePattern(r.Method, r.Path)
+		if covered[key] {
+			continue
+		}
+		// A route registered without a method is reachable by any method;
+		// accept a matrix entry that pins a specific one.
+		if r.Method == "" {
+			anyMethodCovered := false
+			for k := range covered {
+				if strings.HasSuffix(k, " "+strings.SplitN(key, " ", 2)[1]) {
+					anyMethodCovered = true
+					break
+				}
+			}
+			if anyMethodCovered {
+				continue
+			}
+		}
+		missing = append(missing, r)
+	}
+
+	if len(missing) > 0 {
+		t.Errorf("%d registered route(s) are not exercised by authzMatrix.\n"+
+			"Add an entry to authzMatrix in authz_matrix_test.go for each:", len(missing))
+		for _, r := range missing {
+			t.Errorf("  %s %s  (registered at %s)", r.Method, r.Path, r.Source)
+		}
+	}
+}
+
+// TestAuthorizationMatrixHasNoStaleEntries catches the opposite drift: a
+// matrix entry for a route the server no longer serves, which would otherwise
+// sit there asserting a policy about nothing.
+func TestAuthorizationMatrixHasNoStaleEntries(t *testing.T) {
+	discovered := discoverRegisteredRoutes(t)
+
+	live := map[string]bool{}
+	for _, r := range discovered {
+		live[normalizePattern(r.Method, r.Path)] = true
+	}
+
+	for _, e := range authzMatrix {
+		// Infrastructure routes are registered in main.go, not the handler
+		// package, so they are not discoverable here.
+		if isInfraPath(e.Path) {
+			continue
+		}
+		matched := false
+		for key := range matrixKeys(discovered) {
+			if !live[key] {
+				continue
+			}
+			segs := strings.Split(strings.Trim(e.Path, "/"), "/")
+			kSegs := strings.Split(strings.Trim(strings.SplitN(key, " ", 2)[1], "/"), "/")
+			if len(segs) != len(kSegs) {
+				continue
+			}
+			method := strings.SplitN(key, " ", 2)[0]
+			if method != e.Method && method != "ANY" {
+				continue
+			}
+			ok := true
+			for i := range segs {
+				if kSegs[i] == "{}" {
+					continue
+				}
+				if !strings.EqualFold(kSegs[i], segs[i]) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("matrix entry %s %s matches no registered route — remove it or fix the path",
+				e.Method, e.Path)
+		}
+	}
+}
+
+// isInfraPath reports whether a path is served outside the handler package
+// (health, readiness, websocket), which the source scan cannot see.
+func isInfraPath(path string) bool {
+	for _, p := range []string{"/health", "/healthz", "/readyz", "/ws", "/metrics"} {
+		if path == p || strings.HasPrefix(path, p+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/internal/middleware/authz_matrix_test.go
+++ b/apps/api/internal/middleware/authz_matrix_test.go
@@ -97,9 +97,8 @@ var authzMatrix = []AuthzRoute{
 	{Method: "GET", Path: "/api/v1/transactions/00000000000000000000-0"},
 
 	// ── Portfolio / valuation / performance ──────────────────────────────
-	{Method: "GET", Path: "/api/v1/portfolio"},
+	{Method: "GET", Path: "/api/v1/portfolio/summary"},
 	{Method: "GET", Path: "/api/v1/portfolio/valuation"},
-	{Method: "GET", Path: "/api/v1/performance"},
 	{Method: "GET", Path: "/api/v1/performance/snapshots"},
 
 	// ── Settlements ──────────────────────────────────────────────────────
@@ -108,36 +107,190 @@ var authzMatrix = []AuthzRoute{
 
 	// ── Activity / notifications ─────────────────────────────────────────
 	{Method: "GET", Path: "/api/v1/activity"},
-	{Method: "GET", Path: "/api/v1/notifications"},
-	{Method: "PATCH", Path: "/api/v1/notifications/00000000-0000-0000-0000-000000000000/read"},
 
 	// ── User ─────────────────────────────────────────────────────────────
 	{Method: "GET", Path: "/api/v1/users/me"},
-	{Method: "GET", Path: "/api/v1/users/by-wallet/" + walletA},
 
 	// ── Watchlist / savings goals / schedules ────────────────────────────
-	{Method: "GET", Path: "/api/v1/watchlist"},
-	{Method: "POST", Path: "/api/v1/watchlist"},
+	{Method: "GET", Path: "/api/v1/users/watchlist"},
+	{Method: "POST", Path: "/api/v1/users/watchlist"},
 	{Method: "GET", Path: "/api/v1/users/savings-goals"},
 	{Method: "POST", Path: "/api/v1/users/savings-goals"},
 	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
-	{Method: "PUT", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
 	{Method: "DELETE", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
 	{Method: "GET", Path: "/api/v1/users/savings-schedules"},
-	{Method: "POST", Path: "/api/v1/users/savings-schedules"},
 
 	// ── Admin (requires admin role) ──────────────────────────────────────
 	{Method: "GET", Path: "/api/v1/admin/users", RequireRole: "admin"},
-	{Method: "POST", Path: "/api/v1/admin/users", RequireRole: "admin"},
 
 	// ── Banks (public) ───────────────────────────────────────────────────
-	{Method: "GET", Path: "/api/v1/banks/supported", Public: true},
+	{Method: "GET", Path: "/api/v1/banks", Public: false},
 
 	// ── Yields (public) ───────────────────────────────────────────────
 	// NOTE: prefix rule "/api/v1/yields/" requires trailing slash; the
 	// exact path "/api/v1/yields" (no slash) falls through to protected.
 	{Method: "GET", Path: "/api/v1/yields/", Public: true},
 	{Method: "GET", Path: "/api/v1/yields/00000000-0000-0000-0000-000000000000", Public: true},
+
+	// ── Routes recovered from the handler registrations ────────────────
+	// Added when the coverage guard showed the original matrix exercised
+	// 58 of 178 registered routes, leaving the whole admin, bank-account,
+	// and intelligence surface unverified.
+	// admin
+	{Method: "DELETE", Path: "/api/v1/admin/savings-goal-templates/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "DELETE", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/allocations/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/audit/verify", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/backfill", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/backfill/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/dashboard", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/health", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/savings-goal-templates", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/scheduler/leadership", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/settlements", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/users/00000000-0000-0000-0000-000000000000/money-path", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/vaults", RequireRole: "admin"},
+	{Method: "GET", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "PATCH", Path: "/api/v1/admin/savings-goal-templates/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "PATCH", Path: "/api/v1/admin/users/00000000-0000-0000-0000-000000000000/kyc", RequireRole: "admin"},
+	{Method: "PATCH", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/allocations/00000000-0000-0000-0000-000000000000", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/backfill", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/backfill/00000000-0000-0000-0000-000000000000/resume", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/savings-goal-templates", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/sync-events", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/allocations", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/pause", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/rebalance", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/vaults/00000000-0000-0000-0000-000000000000/unpause", RequireRole: "admin"},
+
+	// analytics
+	{Method: "GET", Path: "/api/v1/analytics/users/00000000-0000-0000-0000-000000000000"},
+
+	// bank-accounts
+	{Method: "DELETE", Path: "/api/v1/bank-accounts/users/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/bank-accounts/users/00000000-0000-0000-0000-000000000000"},
+	{Method: "PATCH", Path: "/api/v1/bank-accounts/users/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000"},
+	{Method: "POST", Path: "/api/v1/bank-accounts/users/00000000-0000-0000-0000-000000000000"},
+
+	// banks
+	{Method: "GET", Path: "/api/v1/banks"},
+	{Method: "GET", Path: "/api/v1/banks/resolve", Public: true},
+
+	// intelligence
+	{Method: "GET", Path: "/api/v1/intelligence/market"},
+	{Method: "GET", Path: "/api/v1/intelligence/portfolio/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/intelligence/recommend/vault"},
+	{Method: "POST", Path: "/api/v1/intelligence/analyze"},
+	{Method: "POST", Path: "/api/v1/intelligence/chat"},
+	{Method: "POST", Path: "/api/v1/intelligence/coaching"},
+	{Method: "POST", Path: "/api/v1/intelligence/recommend/vault"},
+	{Method: "POST", Path: "/api/v1/intelligence/savings-plan"},
+	{Method: "POST", Path: "/api/v1/intelligence/tools/00000000-0000-0000-0000-000000000000/confirm"},
+
+	// internal
+	{Method: "POST", Path: "/api/v1/internal/intelligence/tool-audit", RequireRole: "service"},
+
+	// portfolio
+	{Method: "GET", Path: "/api/v1/portfolio/00000000-0000-0000-0000-000000000000/insights"},
+	{Method: "GET", Path: "/api/v1/portfolio/summary"},
+
+	// rates
+	{Method: "GET", Path: "/api/v1/rates"},
+
+	// savings-goal-templates
+	{Method: "GET", Path: "/api/v1/savings-goal-templates"},
+
+	// savings-goals
+	{Method: "GET", Path: "/api/v1/savings-goals/shared/00000000-0000-0000-0000-000000000000", Public: true},
+
+	// settlements
+	{Method: "GET", Path: "/api/v1/settlements/00000000-0000-0000-0000-000000000000"},
+	{Method: "PATCH", Path: "/api/v1/settlements/00000000-0000-0000-0000-000000000000/status"},
+
+	// tools
+	{Method: "POST", Path: "/api/v1/tools/projection"},
+	{Method: "POST", Path: "/api/v1/tools/simulation"},
+
+	// user-vaults
+	{Method: "GET", Path: "/api/v1/user-vaults/00000000-0000-0000-0000-000000000000"},
+
+	// users
+	{Method: "DELETE", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedule"},
+	{Method: "DELETE", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedules/00000000-0000-0000-0000-000000000000"},
+	{Method: "DELETE", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/share"},
+	{Method: "DELETE", Path: "/api/v1/users/watchlist/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/users/digest-ledger"},
+	{Method: "GET", Path: "/api/v1/users/digest/latest"},
+	{Method: "GET", Path: "/api/v1/users/kyc/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/users/notification-preferences"},
+	{Method: "GET", Path: "/api/v1/users/profile"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/coaching"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/contributions"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/notification-preferences"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedules"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/summary"},
+	{Method: "GET", Path: "/api/v1/users/wallet/" + walletA},
+	{Method: "GET", Path: "/api/v1/users/watchlist"},
+	{Method: "PATCH", Path: "/api/v1/users/notification-preferences"},
+	{Method: "PATCH", Path: "/api/v1/users/profile"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/archive"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/notification-preferences"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/pause"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/resume"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedule"},
+	{Method: "PATCH", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/unarchive"},
+	{Method: "POST", Path: "/api/v1/users"},
+	{Method: "POST", Path: "/api/v1/users/device-tokens"},
+	{Method: "POST", Path: "/api/v1/users/kyc/00000000-0000-0000-0000-000000000000"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/complete"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/restore"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedule"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/schedules"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000/share"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/deposit"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals/from-template"},
+	{Method: "POST", Path: "/api/v1/users/watchlist"},
+
+	// vaults
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/analytics"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/apy-history"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/emergency-queue"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/harvest/status"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/penalty-distributions"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/penalty-events"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/performance"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/performance/apy"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/performance/history"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/projection"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance-completions"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance-history"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance-legs"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/recommendations"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/risk"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/risk/history"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/tvl"},
+	{Method: "GET", Path: "/api/v1/vaults/tvl"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance/execute"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance/suggest"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/risk/refresh"},
+
+	// webhooks
+	{Method: "DELETE", Path: "/api/v1/webhooks/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/webhooks"},
+	{Method: "GET", Path: "/api/v1/webhooks/00000000-0000-0000-0000-000000000000/deliveries"},
+	{Method: "POST", Path: "/api/v1/webhooks"},
+	{Method: "POST", Path: "/api/v1/webhooks/deliveries/00000000-0000-0000-0000-000000000000/redeliver"},
+
+	// yield-opportunities
+	{Method: "GET", Path: "/api/v1/yield-opportunities"},
+	{Method: "GET", Path: "/api/v1/yield-opportunities/compare"},
+
+	// yields
+	{Method: "DELETE", Path: "/api/v1/yields/bookmarks/aave-v3", Public: true},
+	{Method: "GET", Path: "/api/v1/yields/aave-v3/apy-history", Public: true},
+	{Method: "GET", Path: "/api/v1/yields/bookmarks", Public: true},
+	{Method: "GET", Path: "/api/v1/yields/harvests", Public: true},
+	{Method: "POST", Path: "/api/v1/yields/bookmarks", Public: true},
 }
 
 // TestAuthorizationMatrix verifies the three-way authorization contract for

--- a/apps/api/internal/middleware/authz_matrix_test.go
+++ b/apps/api/internal/middleware/authz_matrix_test.go
@@ -1,0 +1,245 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+// authzMatrixRules mirrors the production route table from main.go so the
+// matrix test stays in sync with real deployments.
+var authzMatrixRules = []RouteRule{
+	{PathPrefix: "/health", Public: true},
+	{PathPrefix: "/healthz", Public: true},
+	{PathPrefix: "/readyz", Public: true},
+	{PathPrefix: "/ws", Public: true},
+	{Method: http.MethodPost, PathPrefix: "/api/v1/auth/challenge", Public: true},
+	{Method: http.MethodPost, PathPrefix: "/api/v1/auth/verify", Public: true},
+	{Method: http.MethodPost, PathPrefix: "/api/v1/auth/refresh", Public: true},
+	{PathPrefix: "/api/v1/banks/", Public: true},
+	{PathPrefix: "/api/v1/yields/", Public: true},
+	{PathPrefix: "/api/v1/savings-goals/shared/", Public: true},
+	{PathPrefix: "/api/v1/admin/", Public: false, Role: "admin"},
+	{PathPrefix: "/api/v1/internal/", Role: "service"},
+	{PathPrefix: "/api/v1/", Public: false},
+}
+
+// authzMatrixHandler wraps ok200 with Authenticate using authzMatrixRules.
+func authzMatrixHandler() http.Handler {
+	return Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(ok200)
+}
+
+// walletA and walletB represent two distinct Stellar accounts for
+// cross-user authorization testing.
+const (
+	walletA = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZP1WKU56V25HXQOPJFHM"
+	walletB = "GAZK5JWNIQIF5OFJDQ7J2ZFND3KQ2HP7FYJNKJX6H4L3Y7S5Z4PK5YYB"
+)
+
+// AuthzRoute describes a single route to exercise in the authorization matrix.
+type AuthzRoute struct {
+	Method      string
+	Path        string
+	Public      bool // expected: anonymous gets 200
+	RequireRole string
+}
+
+// authzMatrix enumerates every authenticated route the API exposes. Each entry
+// specifies the HTTP method, path, and whether it is public.
+//
+// IMPORTANT: When a new route is added to the API, it MUST appear here or the
+// TestAuthorizationMatrix route-coverage check will fail.
+var authzMatrix = []AuthzRoute{
+	// ── Health / infrastructure ──────────────────────────────────────────
+	{Method: "GET", Path: "/health", Public: true},
+	{Method: "GET", Path: "/healthz", Public: true},
+	{Method: "GET", Path: "/readyz", Public: true},
+	{Method: "GET", Path: "/ws", Public: true},
+
+	// ── Auth (public handshake) ──────────────────────────────────────────
+	{Method: "POST", Path: "/api/v1/auth/challenge", Public: true},
+	{Method: "POST", Path: "/api/v1/auth/verify", Public: true},
+	{Method: "POST", Path: "/api/v1/auth/refresh", Public: true},
+
+	// ── Auth (protected) ─────────────────────────────────────────────────
+	{Method: "POST", Path: "/api/v1/auth/logout"},
+	{Method: "POST", Path: "/api/v1/auth/logout-all"},
+	{Method: "GET", Path: "/api/v1/auth/sessions"},
+	{Method: "DELETE", Path: "/api/v1/auth/sessions/00000000-0000-0000-0000-000000000000"},
+
+	// ── Vaults ───────────────────────────────────────────────────────────
+	{Method: "POST", Path: "/api/v1/vaults"},
+	{Method: "GET", Path: "/api/v1/vaults"},
+	{Method: "GET", Path: "/api/v1/vaults/all"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/deposit"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/withdraw"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/harvest"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/harvest/preview"},
+	{Method: "PATCH", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/harvest-frequency"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/my-position"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/preview-deposit"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/preview-withdraw"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/rebalance-suggestion"},
+	{Method: "POST", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/emergency-withdraw"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/share-price"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/convert"},
+	{Method: "GET", Path: "/api/v1/vaults/00000000-0000-0000-0000-000000000000/allocations"},
+	{Method: "POST", Path: "/api/v1/vault/rebalance"},
+
+	// ── Transactions ─────────────────────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/transactions"},
+	{Method: "POST", Path: "/api/v1/transactions"},
+	{Method: "GET", Path: "/api/v1/transactions/00000000000000000000-0"},
+
+	// ── Portfolio / valuation / performance ──────────────────────────────
+	{Method: "GET", Path: "/api/v1/portfolio"},
+	{Method: "GET", Path: "/api/v1/portfolio/valuation"},
+	{Method: "GET", Path: "/api/v1/performance"},
+	{Method: "GET", Path: "/api/v1/performance/snapshots"},
+
+	// ── Settlements ──────────────────────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/settlements"},
+	{Method: "POST", Path: "/api/v1/settlements"},
+
+	// ── Activity / notifications ─────────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/activity"},
+	{Method: "GET", Path: "/api/v1/notifications"},
+	{Method: "PATCH", Path: "/api/v1/notifications/00000000-0000-0000-0000-000000000000/read"},
+
+	// ── User ─────────────────────────────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/users/me"},
+	{Method: "GET", Path: "/api/v1/users/by-wallet/" + walletA},
+
+	// ── Watchlist / savings goals / schedules ────────────────────────────
+	{Method: "GET", Path: "/api/v1/watchlist"},
+	{Method: "POST", Path: "/api/v1/watchlist"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals"},
+	{Method: "POST", Path: "/api/v1/users/savings-goals"},
+	{Method: "GET", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
+	{Method: "PUT", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
+	{Method: "DELETE", Path: "/api/v1/users/savings-goals/00000000-0000-0000-0000-000000000000"},
+	{Method: "GET", Path: "/api/v1/users/savings-schedules"},
+	{Method: "POST", Path: "/api/v1/users/savings-schedules"},
+
+	// ── Admin (requires admin role) ──────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/admin/users", RequireRole: "admin"},
+	{Method: "POST", Path: "/api/v1/admin/users", RequireRole: "admin"},
+
+	// ── Banks (public) ───────────────────────────────────────────────────
+	{Method: "GET", Path: "/api/v1/banks/supported", Public: true},
+
+	// ── Yields (public) ───────────────────────────────────────────────
+	// NOTE: prefix rule "/api/v1/yields/" requires trailing slash; the
+	// exact path "/api/v1/yields" (no slash) falls through to protected.
+	{Method: "GET", Path: "/api/v1/yields/", Public: true},
+	{Method: "GET", Path: "/api/v1/yields/00000000-0000-0000-0000-000000000000", Public: true},
+}
+
+// TestAuthorizationMatrix verifies the three-way authorization contract for
+// every route in the API:
+//
+//  1. Anonymous request (no token) → 401 for protected routes, 200 for public.
+//  2. Non-owner request (valid token, different user) → 401/403 for protected
+//     routes that require ownership; the response must NOT be 404 so the
+//     endpoint is not an existence oracle.
+//  3. Owner request (valid token, matching user) → 200.
+//
+// This test intentionally targets the auth middleware layer. Handler-level
+// ownership checks (returning 404 for non-owners) are covered by the
+// handler-level IDOR tests in vault_idor_test.go.
+func TestAuthorizationMatrix(t *testing.T) {
+	handler := authzMatrixHandler()
+
+	for _, route := range authzMatrix {
+		name := route.Method + " " + route.Path
+		t.Run(name, func(t *testing.T) {
+			// ── 1. Anonymous → 401 (or 200 if public) ────────────────────
+			t.Run("anonymous", func(t *testing.T) {
+				req := httptest.NewRequest(route.Method, route.Path, nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				if route.Public {
+					if rec.Code != http.StatusOK {
+						t.Errorf("public route %s: anonymous got %d, want 200", name, rec.Code)
+					}
+				} else {
+					if rec.Code != http.StatusUnauthorized {
+						t.Errorf("protected route %s: anonymous got %d, want 401", name, rec.Code)
+					}
+				}
+			})
+
+			// ── 2. Non-owner (valid token, wrong user) ───────────────────
+			if !route.Public {
+				t.Run("non-owner", func(t *testing.T) {
+					token := makeToken(t, auth.Claims{
+						Subject:       "user-other",
+						WalletAddress: walletB,
+						Roles:         []string{},
+						ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+					})
+					req := httptest.NewRequest(route.Method, route.Path, nil)
+					req.Header.Set("Authorization", "Bearer "+token)
+					rec := httptest.NewRecorder()
+					handler.ServeHTTP(rec, req)
+
+					// Non-owner must NOT get 404 (existence oracle leak).
+					// They should get 401 (no matching user context) or 403.
+					if rec.Code == http.StatusNotFound {
+						t.Errorf("route %s: non-owner got 404 (existence oracle leak), want 401 or 403", name)
+					}
+				})
+			}
+
+			// ── 3. Owner (valid token, correct user) ─────────────────────
+			t.Run("owner", func(t *testing.T) {
+				roles := []string{}
+				if route.RequireRole == "admin" {
+					roles = []string{"admin"}
+				}
+				token := makeToken(t, auth.Claims{
+					Subject:       "user-owner",
+					WalletAddress: walletA,
+					Roles:         roles,
+					ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+				})
+				req := httptest.NewRequest(route.Method, route.Path, nil)
+				req.Header.Set("Authorization", "Bearer "+token)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				if rec.Code == http.StatusUnauthorized {
+					t.Errorf("route %s: owner got 401 (should be authenticated)", name)
+				}
+			})
+		})
+	}
+}
+
+// TestAuthorizationMatrixRouteCount acts as a compile-time guard: if someone
+// adds a route to authzMatrixRules but forgets to add it to authzMatrix,
+// this test warns (it does not fail, since the production rules are the
+// source of truth for public/protected status).
+func TestAuthorizationMatrixRouteCount(t *testing.T) {
+	// Count non-public rules in production rules (each may match many paths).
+	protectedPrefixes := 0
+	for _, r := range authzMatrixRules {
+		if !r.Public {
+			protectedPrefixes++
+		}
+	}
+	t.Logf("production rules: %d total, %d protected", len(authzMatrixRules), protectedPrefixes)
+	t.Logf("matrix entries: %d", len(authzMatrix))
+
+	// Sanity: matrix should have at least as many entries as protected prefixes.
+	if len(authzMatrix) < protectedPrefixes {
+		t.Errorf("matrix has %d entries but production has %d protected prefixes — some routes may be untested",
+			len(authzMatrix), protectedPrefixes)
+	}
+}

--- a/apps/api/internal/middleware/authz_rules.go
+++ b/apps/api/internal/middleware/authz_rules.go
@@ -1,0 +1,33 @@
+package middleware
+
+import "net/http"
+
+// ProductionAuthRules is the authentication policy the API actually serves.
+//
+// It lives here, rather than inline in main.go, so the authorization matrix
+// test can assert against the same table the server runs. A test that copies
+// the rules instead proves only that the copy is self-consistent: production
+// can drift — a route made public, a role requirement dropped — and the test
+// stays green while describing a policy nobody deploys.
+//
+// Order matters. The first rule whose method and path prefix match wins, so
+// specific prefixes must precede the "/api/v1/" catch-all.
+func ProductionAuthRules() []RouteRule {
+	return []RouteRule{
+		{PathPrefix: "/health", Public: true},
+		{PathPrefix: "/healthz", Public: true},
+		{PathPrefix: "/readyz", Public: true},
+		{PathPrefix: "/ws", Public: true},
+		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/challenge", Public: true},
+		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/verify", Public: true},
+		{Method: http.MethodPost, PathPrefix: "/api/v1/auth/refresh", Public: true},
+		// No blanket "/api/v1/auth/" rule: logout, logout-all, and sessions
+		// must stay protected and fall through to the "/api/v1/" catch-all.
+		{PathPrefix: "/api/v1/banks/", Public: true},
+		{PathPrefix: "/api/v1/yields/", Public: true},
+		{PathPrefix: "/api/v1/savings-goals/shared/", Public: true},
+		{PathPrefix: "/api/v1/admin/", Public: false, Role: "admin"},
+		{PathPrefix: "/api/v1/internal/", Role: "service"},
+		{PathPrefix: "/api/v1/", Public: false},
+	}
+}

--- a/apps/api/internal/middleware/wallet_binding.go
+++ b/apps/api/internal/middleware/wallet_binding.go
@@ -1,48 +1,102 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 )
 
-// WalletBindingCheck returns middleware that verifies the JWT's wallet address
-// matches the {address} path parameter on wallet-scoped routes. This prevents
-// token replay across different wallets — a token minted for wallet A must not
-// be usable against wallet B's endpoints.
+// WalletResolver reports the wallet address currently linked to a user. It
+// backs the "changing the linked wallet invalidates existing sessions" rule:
+// a token carries the wallet it was minted for, and if the account's wallet
+// has since changed, that token is stale and must not be honoured.
 //
-// The middleware is a no-op for requests that don't carry a user context
-// (public routes) or whose path doesn't contain a wallet address parameter.
-func WalletBindingCheck(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, ok := auth.GetUserFromContext(r.Context())
-		if !ok || user.WalletAddress == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		pathWallet := extractWalletFromPath(r.URL.Path)
-		if pathWallet == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		if !strings.EqualFold(user.WalletAddress, pathWallet) {
-			writeMiddlewareError(w, http.StatusForbidden, "token wallet does not match the requested wallet")
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
+// An error fails the request closed. Returning ("", nil) means "no wallet on
+// record", which is treated as nothing to contradict the token.
+type WalletResolver interface {
+	WalletForUser(ctx context.Context, userID string) (string, error)
 }
 
-// extractWalletFromPath looks for a Stellar address (starting with G) in the
-// URL path. Returns "" if none is found.
+// walletScopedPrefixes lists the route prefixes that address a wallet directly
+// in their path. The segment immediately after the prefix is the wallet.
+//
+// This is an explicit allowlist rather than a scan for anything that looks
+// like a Stellar address: a heuristic scan silently changes meaning whenever
+// an unrelated route happens to take an address-shaped segment, and it cannot
+// tell "the caller's own wallet" from "some other wallet named in the path".
+var walletScopedPrefixes = []string{
+	"/api/v1/users/wallet/",
+}
+
+// WalletBindingCheck returns middleware that verifies the JWT's wallet address
+// matches the wallet named in the request path, and that it still matches the
+// wallet currently linked to the account. This closes two replay paths:
+//
+//  1. Cross-wallet replay: a token minted for wallet A used against wallet B's
+//     endpoints is rejected.
+//  2. Stale-session replay: a token minted before the account's wallet changed
+//     is rejected, so relinking a wallet invalidates sessions issued earlier.
+//
+// resolver may be nil, which disables check (2) only. Requests without a user
+// context (public routes) pass through untouched.
+func WalletBindingCheck(resolver WalletResolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, ok := auth.GetUserFromContext(r.Context())
+			if !ok || user.WalletAddress == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// (1) The token's wallet must match the wallet named in the path,
+			// on the routes that name one.
+			if pathWallet := extractWalletFromPath(r.URL.Path); pathWallet != "" {
+				if !strings.EqualFold(user.WalletAddress, pathWallet) {
+					writeMiddlewareError(w, http.StatusForbidden,
+						"token wallet does not match the requested wallet")
+					return
+				}
+			}
+
+			// (2) The token's wallet must still be the account's wallet. This
+			// runs on every authenticated request, not just wallet-scoped
+			// paths — a stale token is stale everywhere it can move money.
+			if resolver != nil && user.ID != "" {
+				current, err := resolver.WalletForUser(r.Context(), user.ID)
+				if err != nil {
+					// Fail closed: if we cannot confirm the binding is still
+					// valid, we do not get to assume it is.
+					writeMiddlewareError(w, http.StatusUnauthorized,
+						"could not verify wallet binding for this session")
+					return
+				}
+				if current != "" && !strings.EqualFold(current, user.WalletAddress) {
+					writeMiddlewareError(w, http.StatusUnauthorized,
+						"session was issued for a wallet no longer linked to this account")
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractWalletFromPath returns the wallet segment addressed by the path, or
+// "" when the path is not wallet-scoped.
 func extractWalletFromPath(path string) string {
-	for _, seg := range strings.Split(path, "/") {
-		if len(seg) == 56 && strings.HasPrefix(seg, "G") {
-			return seg
+	for _, prefix := range walletScopedPrefixes {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(path, prefix)
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			rest = rest[:i]
+		}
+		if rest != "" {
+			return rest
 		}
 	}
 	return ""

--- a/apps/api/internal/middleware/wallet_binding.go
+++ b/apps/api/internal/middleware/wallet_binding.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+// WalletBindingCheck returns middleware that verifies the JWT's wallet address
+// matches the {address} path parameter on wallet-scoped routes. This prevents
+// token replay across different wallets — a token minted for wallet A must not
+// be usable against wallet B's endpoints.
+//
+// The middleware is a no-op for requests that don't carry a user context
+// (public routes) or whose path doesn't contain a wallet address parameter.
+func WalletBindingCheck(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := auth.GetUserFromContext(r.Context())
+		if !ok || user.WalletAddress == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		pathWallet := extractWalletFromPath(r.URL.Path)
+		if pathWallet == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !strings.EqualFold(user.WalletAddress, pathWallet) {
+			writeMiddlewareError(w, http.StatusForbidden, "token wallet does not match the requested wallet")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractWalletFromPath looks for a Stellar address (starting with G) in the
+// URL path. Returns "" if none is found.
+func extractWalletFromPath(path string) string {
+	for _, seg := range strings.Split(path, "/") {
+		if len(seg) == 56 && strings.HasPrefix(seg, "G") {
+			return seg
+		}
+	}
+	return ""
+}

--- a/apps/api/internal/middleware/wallet_binding_test.go
+++ b/apps/api/internal/middleware/wallet_binding_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+func TestWalletBindingCheck_MatchingWallet(t *testing.T) {
+	token := makeToken(t, auth.Claims{
+		Subject:       "user-1",
+		WalletAddress: walletA,
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+	})
+
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletA, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("matching wallet: got %d, want 200", rec.Code)
+	}
+}
+
+func TestWalletBindingCheck_CrossWalletRejection(t *testing.T) {
+	token := makeToken(t, auth.Claims{
+		Subject:       "user-1",
+		WalletAddress: walletA,
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+	})
+
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletB, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-wallet: got %d, want 403", rec.Code)
+	}
+}
+
+func TestWalletBindingCheck_NoWalletInPath(t *testing.T) {
+	token := makeToken(t, auth.Claims{
+		Subject:       "user-1",
+		WalletAddress: walletA,
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+	})
+
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	// Routes without a wallet address in the path should pass through.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no wallet in path: got %d, want 200", rec.Code)
+	}
+}
+
+func TestWalletBindingCheck_CaseInsensitive(t *testing.T) {
+	upper := "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZP1WKU56V25HXQOPJFHM"
+	lower := "gcezwkca5vldnrln3rprjmrzox3z6g5chcgzp1wku56v25hxqopjfhm"
+
+	token := makeToken(t, auth.Claims{
+		Subject:       "user-1",
+		WalletAddress: upper,
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+	})
+
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+lower, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("case-insensitive: got %d, want 200", rec.Code)
+	}
+}
+
+func TestWalletBindingCheck_PublicRouteSkipped(t *testing.T) {
+	// Public routes don't carry a user context, so wallet binding is skipped.
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("public route: got %d, want 200", rec.Code)
+	}
+}
+
+func TestWalletBindingCheck_EmptyWalletAddress(t *testing.T) {
+	// A token with no wallet address should pass through (no binding to check).
+	token := makeToken(t, auth.Claims{
+		Subject:   "user-1",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	})
+
+	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(ok200))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletA, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty wallet in token: got %d, want 200", rec.Code)
+	}
+}

--- a/apps/api/internal/middleware/wallet_binding_test.go
+++ b/apps/api/internal/middleware/wallet_binding_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,120 +11,172 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 )
 
-func TestWalletBindingCheck_MatchingWallet(t *testing.T) {
-	token := makeToken(t, auth.Claims{
+// stubWalletResolver reports a fixed wallet (or error) for every user, so
+// tests can model "the account's linked wallet is X" without a database.
+type stubWalletResolver struct {
+	wallet string
+	err    error
+}
+
+func (s stubWalletResolver) WalletForUser(context.Context, string) (string, error) {
+	return s.wallet, s.err
+}
+
+// bindingHandler builds the production-shaped chain: authenticate, then bind.
+func bindingHandler(resolver WalletResolver) http.Handler {
+	return Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
+		WalletBindingCheck(resolver)(ok200))
+}
+
+func walletToken(t *testing.T, wallet string) string {
+	t.Helper()
+	return makeToken(t, auth.Claims{
 		Subject:       "user-1",
-		WalletAddress: walletA,
+		WalletAddress: wallet,
 		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
 	})
+}
 
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletA, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+// do issues an authenticated GET and returns the status code.
+func do(t *testing.T, h http.Handler, path, token string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	h.ServeHTTP(rec, req)
+	return rec.Code
+}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("matching wallet: got %d, want 200", rec.Code)
+func TestWalletBindingCheck_MatchingWallet(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/api/v1/users/wallet/"+walletA, walletToken(t, walletA)); code != http.StatusOK {
+		t.Fatalf("matching wallet: got %d, want 200", code)
 	}
 }
 
 func TestWalletBindingCheck_CrossWalletRejection(t *testing.T) {
-	token := makeToken(t, auth.Claims{
-		Subject:       "user-1",
-		WalletAddress: walletA,
-		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
-	})
-
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletB, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("cross-wallet: got %d, want 403", rec.Code)
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/api/v1/users/wallet/"+walletB, walletToken(t, walletA)); code != http.StatusForbidden {
+		t.Fatalf("cross-wallet replay: got %d, want 403", code)
 	}
 }
 
 func TestWalletBindingCheck_NoWalletInPath(t *testing.T) {
-	token := makeToken(t, auth.Claims{
-		Subject:       "user-1",
-		WalletAddress: walletA,
-		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
-	})
-
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
-
-	// Routes without a wallet address in the path should pass through.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/vaults", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("no wallet in path: got %d, want 200", rec.Code)
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusOK {
+		t.Fatalf("route without a wallet segment: got %d, want 200", code)
 	}
 }
 
 func TestWalletBindingCheck_CaseInsensitive(t *testing.T) {
-	upper := "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZP1WKU56V25HXQOPJFHM"
+	upper := walletA
 	lower := "gcezwkca5vldnrln3rprjmrzox3z6g5chcgzp1wku56v25hxqopjfhm"
 
-	token := makeToken(t, auth.Claims{
-		Subject:       "user-1",
-		WalletAddress: upper,
-		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
-	})
-
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+lower, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("case-insensitive: got %d, want 200", rec.Code)
+	h := bindingHandler(stubWalletResolver{wallet: upper})
+	if code := do(t, h, "/api/v1/users/wallet/"+lower, walletToken(t, upper)); code != http.StatusOK {
+		t.Fatalf("case-insensitive match: got %d, want 200", code)
 	}
 }
 
 func TestWalletBindingCheck_PublicRouteSkipped(t *testing.T) {
-	// Public routes don't carry a user context, so wallet binding is skipped.
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
-
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("public route: got %d, want 200", rec.Code)
+	// Public routes carry no user context, so there is no binding to check.
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/health", ""); code != http.StatusOK {
+		t.Fatalf("public route: got %d, want 200", code)
 	}
 }
 
 func TestWalletBindingCheck_EmptyWalletAddress(t *testing.T) {
-	// A token with no wallet address should pass through (no binding to check).
+	// A token with no wallet claim has no binding to enforce.
 	token := makeToken(t, auth.Claims{
 		Subject:   "user-1",
 		ExpiresAt: time.Now().Add(time.Hour).Unix(),
 	})
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/api/v1/users/wallet/"+walletA, token); code != http.StatusOK {
+		t.Fatalf("token without a wallet claim: got %d, want 200", code)
+	}
+}
 
-	handler := Authenticate(testSecret, "", authzMatrixRules, alwaysActiveRevocation)(
-		WalletBindingCheck(ok200))
+// ── Session invalidation on wallet change (#1102) ────────────────────────────
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/wallet/"+walletA, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+// TestWalletBindingCheck_RelinkInvalidatesSession covers the acceptance
+// criterion "changing the linked wallet invalidates existing sessions": a
+// token minted for walletA must stop working once the account's wallet of
+// record is walletB.
+func TestWalletBindingCheck_RelinkInvalidatesSession(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{wallet: walletB})
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusUnauthorized {
+		t.Fatalf("token issued before a wallet relink: got %d, want 401", code)
+	}
+}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("empty wallet in token: got %d, want 200", rec.Code)
+// A stale token must be rejected on money-path routes too, not only on the
+// routes that happen to name a wallet in their path.
+func TestWalletBindingCheck_RelinkInvalidatesOnMoneyPath(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{wallet: walletB})
+	path := "/api/v1/vaults/00000000-0000-0000-0000-000000000000/withdraw"
+	if code := do(t, h, path, walletToken(t, walletA)); code != http.StatusUnauthorized {
+		t.Fatalf("stale token on withdraw: got %d, want 401", code)
+	}
+}
+
+// Still-current bindings must pass, otherwise the check above would be
+// trivially satisfied by rejecting everything.
+func TestWalletBindingCheck_UnchangedWalletStillPasses(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{wallet: walletA})
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusOK {
+		t.Fatalf("unchanged wallet binding: got %d, want 200", code)
+	}
+}
+
+// If the account's wallet cannot be resolved, the request fails closed rather
+// than assuming the token's claim is still accurate.
+func TestWalletBindingCheck_ResolverErrorFailsClosed(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{err: errors.New("db unavailable")})
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusUnauthorized {
+		t.Fatalf("resolver error: got %d, want 401 (fail closed)", code)
+	}
+}
+
+// A nil resolver disables the relink check only; cross-wallet path binding
+// must still be enforced.
+func TestWalletBindingCheck_NilResolverStillBindsPath(t *testing.T) {
+	h := bindingHandler(nil)
+	if code := do(t, h, "/api/v1/users/wallet/"+walletB, walletToken(t, walletA)); code != http.StatusForbidden {
+		t.Fatalf("cross-wallet with nil resolver: got %d, want 403", code)
+	}
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusOK {
+		t.Fatalf("nil resolver on unscoped route: got %d, want 200", code)
+	}
+}
+
+// An account with no wallet on record has nothing to contradict the token.
+func TestWalletBindingCheck_NoWalletOnRecordPasses(t *testing.T) {
+	h := bindingHandler(stubWalletResolver{wallet: ""})
+	if code := do(t, h, "/api/v1/vaults", walletToken(t, walletA)); code != http.StatusOK {
+		t.Fatalf("no wallet on record: got %d, want 200", code)
+	}
+}
+
+// extractWalletFromPath must only treat allowlisted prefixes as wallet-scoped.
+func TestExtractWalletFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/api/v1/users/wallet/" + walletA, walletA},
+		{"/api/v1/users/wallet/" + walletA + "/vaults", walletA},
+		{"/api/v1/users/wallet/", ""},
+		{"/api/v1/vaults", ""},
+		{"/api/v1/vaults/" + walletA, ""},
+		{"/health", ""},
+	}
+	for _, c := range cases {
+		if got := extractWalletFromPath(c.path); got != c.want {
+			t.Errorf("extractWalletFromPath(%q) = %q, want %q", c.path, got, c.want)
+		}
 	}
 }

--- a/apps/api/internal/middleware/wallet_resolver.go
+++ b/apps/api/internal/middleware/wallet_resolver.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
+)
+
+// UserByIDLookup is the slice of the user repository the wallet resolver
+// needs. Declaring it here rather than importing the concrete repository
+// keeps the middleware package free of a database dependency.
+type UserByIDLookup interface {
+	GetByID(ctx context.Context, id uuid.UUID) (*user.User, error)
+}
+
+// CachedWalletResolver resolves a user's currently linked wallet, memoising
+// the answer for a short TTL.
+//
+// The binding check runs on every authenticated request, and the underlying
+// lookup is a full-row SELECT, so an uncached resolver would add a database
+// round trip to the hot path. The TTL bounds how long a revoked binding can
+// still be honoured; keep it short.
+type CachedWalletResolver struct {
+	users UserByIDLookup
+	ttl   time.Duration
+
+	mu      sync.RWMutex
+	entries map[string]walletCacheEntry
+	// now is swappable so tests can advance time without sleeping.
+	now func() time.Time
+}
+
+type walletCacheEntry struct {
+	wallet    string
+	expiresAt time.Time
+}
+
+// NewCachedWalletResolver returns a resolver over users with the given TTL.
+// A non-positive ttl disables caching.
+func NewCachedWalletResolver(users UserByIDLookup, ttl time.Duration) *CachedWalletResolver {
+	return &CachedWalletResolver{
+		users:   users,
+		ttl:     ttl,
+		entries: make(map[string]walletCacheEntry),
+		now:     time.Now,
+	}
+}
+
+// WalletForUser reports the wallet address currently linked to userID.
+//
+// A user ID that does not parse as a UUID, or that has no row, yields
+// ("", nil): there is no wallet of record to contradict the token, and the
+// authenticator has already established the caller's identity.
+func (c *CachedWalletResolver) WalletForUser(ctx context.Context, userID string) (string, error) {
+	if c == nil || c.users == nil {
+		return "", nil
+	}
+
+	id, err := uuid.Parse(userID)
+	if err != nil {
+		return "", nil
+	}
+
+	if wallet, ok := c.lookup(userID); ok {
+		return wallet, nil
+	}
+
+	u, err := c.users.GetByID(ctx, id)
+	if err != nil {
+		// Surfaced to the caller, which fails the request closed rather than
+		// assuming the token's wallet claim is still accurate.
+		return "", err
+	}
+	wallet := ""
+	if u != nil {
+		wallet = u.WalletAddress
+	}
+	c.store(userID, wallet)
+	return wallet, nil
+}
+
+// Invalidate drops any cached binding for userID, so the next request
+// re-reads it. Call this wherever a user's wallet is changed.
+func (c *CachedWalletResolver) Invalidate(userID string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	delete(c.entries, userID)
+	c.mu.Unlock()
+}
+
+func (c *CachedWalletResolver) lookup(userID string) (string, bool) {
+	if c.ttl <= 0 {
+		return "", false
+	}
+	c.mu.RLock()
+	entry, ok := c.entries[userID]
+	c.mu.RUnlock()
+	if !ok || c.now().After(entry.expiresAt) {
+		return "", false
+	}
+	return entry.wallet, true
+}
+
+func (c *CachedWalletResolver) store(userID, wallet string) {
+	if c.ttl <= 0 {
+		return
+	}
+	c.mu.Lock()
+	c.entries[userID] = walletCacheEntry{wallet: wallet, expiresAt: c.now().Add(c.ttl)}
+	c.mu.Unlock()
+}

--- a/apps/api/internal/middleware/wallet_resolver_test.go
+++ b/apps/api/internal/middleware/wallet_resolver_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
+)
+
+// countingUserLookup records how many times the database was consulted, so
+// the cache can be observed rather than assumed.
+type countingUserLookup struct {
+	wallet string
+	err    error
+	calls  int
+}
+
+func (c *countingUserLookup) GetByID(context.Context, uuid.UUID) (*user.User, error) {
+	c.calls++
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &user.User{WalletAddress: c.wallet}, nil
+}
+
+func TestCachedWalletResolver_ReturnsWallet(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+
+	got, err := r.WalletForUser(context.Background(), uuid.NewString())
+	if err != nil {
+		t.Fatalf("WalletForUser: unexpected error %v", err)
+	}
+	if got != walletA {
+		t.Fatalf("wallet = %q, want %q", got, walletA)
+	}
+}
+
+func TestCachedWalletResolver_CachesWithinTTL(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+	id := uuid.NewString()
+
+	for i := range 3 {
+		if _, err := r.WalletForUser(context.Background(), id); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if lookup.calls != 1 {
+		t.Fatalf("lookups = %d, want 1 (subsequent reads should be cached)", lookup.calls)
+	}
+}
+
+func TestCachedWalletResolver_RefetchesAfterTTL(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+
+	now := time.Now()
+	r.now = func() time.Time { return now }
+	id := uuid.NewString()
+
+	if _, err := r.WalletForUser(context.Background(), id); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := r.WalletForUser(context.Background(), id); err != nil {
+		t.Fatalf("post-expiry call: %v", err)
+	}
+	if lookup.calls != 2 {
+		t.Fatalf("lookups = %d, want 2 (entry should expire)", lookup.calls)
+	}
+}
+
+// A relink must become visible once the cached entry expires, otherwise the
+// invalidation guarantee is only as good as a stale cache.
+func TestCachedWalletResolver_SeesRelinkAfterTTL(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+
+	now := time.Now()
+	r.now = func() time.Time { return now }
+	id := uuid.NewString()
+
+	if _, err := r.WalletForUser(context.Background(), id); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	lookup.wallet = walletB
+	now = now.Add(2 * time.Minute)
+
+	got, err := r.WalletForUser(context.Background(), id)
+	if err != nil {
+		t.Fatalf("post-relink call: %v", err)
+	}
+	if got != walletB {
+		t.Fatalf("wallet = %q, want %q after relink", got, walletB)
+	}
+}
+
+func TestCachedWalletResolver_InvalidateForcesRefetch(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+	id := uuid.NewString()
+
+	if _, err := r.WalletForUser(context.Background(), id); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	lookup.wallet = walletB
+	r.Invalidate(id)
+
+	got, err := r.WalletForUser(context.Background(), id)
+	if err != nil {
+		t.Fatalf("post-invalidate call: %v", err)
+	}
+	if got != walletB {
+		t.Fatalf("wallet = %q, want %q after invalidate", got, walletB)
+	}
+	if lookup.calls != 2 {
+		t.Fatalf("lookups = %d, want 2", lookup.calls)
+	}
+}
+
+func TestCachedWalletResolver_PropagatesError(t *testing.T) {
+	lookup := &countingUserLookup{err: errors.New("db down")}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+
+	if _, err := r.WalletForUser(context.Background(), uuid.NewString()); err == nil {
+		t.Fatal("expected the lookup error to propagate so the request fails closed")
+	}
+}
+
+// Errors must not be cached as a successful empty result, or one blip would
+// disable the check for a whole TTL.
+func TestCachedWalletResolver_DoesNotCacheErrors(t *testing.T) {
+	lookup := &countingUserLookup{err: errors.New("db down")}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+	id := uuid.NewString()
+
+	_, _ = r.WalletForUser(context.Background(), id)
+	_, _ = r.WalletForUser(context.Background(), id)
+
+	if lookup.calls != 2 {
+		t.Fatalf("lookups = %d, want 2 (errors must not be cached)", lookup.calls)
+	}
+}
+
+// A non-UUID subject cannot address a row; it must not reach the database.
+func TestCachedWalletResolver_NonUUIDUserID(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, time.Minute)
+
+	got, err := r.WalletForUser(context.Background(), "user-owner")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if got != "" {
+		t.Fatalf("wallet = %q, want \"\"", got)
+	}
+	if lookup.calls != 0 {
+		t.Fatalf("lookups = %d, want 0", lookup.calls)
+	}
+}
+
+func TestCachedWalletResolver_ZeroTTLDisablesCache(t *testing.T) {
+	lookup := &countingUserLookup{wallet: walletA}
+	r := NewCachedWalletResolver(lookup, 0)
+	id := uuid.NewString()
+
+	_, _ = r.WalletForUser(context.Background(), id)
+	_, _ = r.WalletForUser(context.Background(), id)
+
+	if lookup.calls != 2 {
+		t.Fatalf("lookups = %d, want 2 (ttl<=0 disables caching)", lookup.calls)
+	}
+}
+
+// A nil resolver is the "check disabled" configuration and must be safe.
+func TestCachedWalletResolver_NilSafe(t *testing.T) {
+	var r *CachedWalletResolver
+	got, err := r.WalletForUser(context.Background(), uuid.NewString())
+	if err != nil || got != "" {
+		t.Fatalf("nil resolver: got (%q, %v), want (\"\", nil)", got, err)
+	}
+	r.Invalidate("anything")
+}

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -580,7 +580,11 @@ func (s *SavingsGoalService) validateGoalVault(ctx context.Context, userID, vaul
 	v, err := s.vaultRepo.GetVault(ctx, vaultID)
 	if err != nil {
 		if errors.Is(err, vault.ErrVaultNotFound) {
-			return fmt.Errorf("%w: vault not found", savingsgoal.ErrInvalidGoal)
+			// Same error as a vault owned by someone else, so the two cases
+			// are indistinguishable to the caller (#1101). Reporting "not
+			// found" here and "unauthorized" below would let a caller probe
+			// which vault IDs exist.
+			return savingsgoal.ErrUnauthorized
 		}
 		return err
 	}

--- a/apps/api/internal/service/savings_goal_service_test.go
+++ b/apps/api/internal/service/savings_goal_service_test.go
@@ -1319,8 +1319,11 @@ func TestSavingsGoalService_Create_VaultNotFound(t *testing.T) {
 		Deadline:     testDeadline(),
 		VaultID:      &missing,
 	})
-	if !errors.Is(err, savingsgoal.ErrInvalidGoal) {
-		t.Fatalf("Create() error = %v, want ErrInvalidGoal", err)
+	// A vault that does not exist and a vault owned by someone else must
+	// produce the same error, so the caller cannot tell them apart and use
+	// the endpoint to probe which vault IDs exist (#1101).
+	if !errors.Is(err, savingsgoal.ErrUnauthorized) {
+		t.Fatalf("Create() error = %v, want ErrUnauthorized", err)
 	}
 }
 

--- a/apps/dapp/frontend/package.json
+++ b/apps/dapp/frontend/package.json
@@ -11,6 +11,7 @@
     "test:smoke": "SMOKE_TEST=1 playwright test tests/smoke.spec.ts --run",
     "test:smoke:watch": "SMOKE_TEST=1 playwright test tests/smoke.spec.ts",
     "test:smoke:debug": "SMOKE_TEST=1 PWDEBUG=1 playwright test tests/smoke.spec.ts --headed",
+    "test:e2e:testnet": "playwright test tests/deposit-withdraw.spec.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/apps/dapp/frontend/tests/deposit-withdraw.spec.ts
+++ b/apps/dapp/frontend/tests/deposit-withdraw.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end deposit/withdraw journey test.
+ *
+ * This test exercises the full user flow:
+ *   1. Connect wallet
+ *   2. Deposit into a vault
+ *   3. Verify balance update
+ *   4. Withdraw from the vault
+ *   5. Verify settlement
+ *
+ * Environment variables (for testnet runs):
+ *   TESTNET_WALLET_ADDRESS — funded Stellar testnet address
+ *   VAULT_ID              — deployed vault contract ID on testnet
+ *
+ * When these are not set the test skips with a clear message, keeping
+ * CI green until testnet infrastructure is provisioned.
+ */
+
+const TESTNET_WALLET = process.env.TESTNET_WALLET_ADDRESS ?? '';
+const VAULT_ID = process.env.VAULT_ID ?? '';
+
+test.describe('Deposit / Withdraw journey', () => {
+  test.skip(!TESTNET_WALLET || !VAULT_ID,
+    'Set TESTNET_WALLET_ADDRESS and VAULT_ID env vars to enable testnet E2E');
+
+  test('connect wallet → deposit → balance updates → withdraw → settles', async ({ page }) => {
+    // ── 1. Navigate to the vault detail page ───────────────────────────
+    await test.step('navigate to vault', async () => {
+      await page.goto(`/vaults/${VAULT_ID}`);
+      await expect(page.getByRole('heading', { name: /vault/i })).toBeVisible();
+    });
+
+    // ── 2. Connect wallet ──────────────────────────────────────────────
+    await test.step('connect wallet', async () => {
+      const connectBtn = page.getByRole('button', { name: /connect/i });
+      if (await connectBtn.isVisible()) {
+        await connectBtn.click();
+        // Freighter popup or in-page wallet selector
+        await page.getByText(TESTNET_WALLET.slice(0, 8)).click();
+        await expect(page.getByText(/connected/i).or(page.getByText(TESTNET_WALLET.slice(0, 8)))).toBeVisible();
+      }
+    });
+
+    // ── 3. Deposit ─────────────────────────────────────────────────────
+    const depositAmount = '1';
+    await test.step(`deposit ${depositAmount} XLM`, async () => {
+      await page.getByRole('button', { name: /deposit/i }).first().click();
+
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible();
+
+      await modal.getByPlaceholder('0.00').fill(depositAmount);
+      await modal.getByRole('button', { name: /confirm/i }).click();
+
+      // Wait for transaction confirmation
+      await expect(page.getByText(/deposit successful/i).or(page.getByText(/confirmed/i))).toBeVisible({ timeout: 30_000 });
+    });
+
+    // ── 4. Verify balance updated ──────────────────────────────────────
+    await test.step('verify balance update', async () => {
+      // The position card should reflect the deposited amount
+      await expect(page.getByText(depositAmount)).toBeVisible({ timeout: 15_000 });
+    });
+
+    // ── 5. Withdraw ────────────────────────────────────────────────────
+    await test.step(`withdraw ${depositAmount} XLM`, async () => {
+      await page.getByRole('button', { name: /withdraw/i }).first().click();
+
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible();
+
+      await modal.getByPlaceholder('0.00').fill(depositAmount);
+      await modal.getByRole('button', { name: /confirm/i }).click();
+
+      await expect(page.getByText(/withdrawal successful/i).or(page.getByText(/confirmed/i))).toBeVisible({ timeout: 30_000 });
+    });
+
+    // ── 6. Verify settlement ───────────────────────────────────────────
+    await test.step('verify settlement', async () => {
+      // The position should return to zero or reflect the withdrawal
+      await expect(page.getByText(/settled/i).or(page.getByText('0.00'))).toBeVisible({ timeout: 30_000 });
+    });
+  });
+
+  test('deposit shows error for zero amount', async ({ page }) => {
+    await page.goto(`/vaults/${VAULT_ID}`);
+
+    // Connect wallet first
+    const connectBtn = page.getByRole('button', { name: /connect/i });
+    if (await connectBtn.isVisible()) {
+      await connectBtn.click();
+      await page.getByText(TESTNET_WALLET.slice(0, 8)).click();
+    }
+
+    await page.getByRole('button', { name: /deposit/i }).first().click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    await modal.getByPlaceholder('0.00').fill('0');
+    await expect(modal.getByText(/must be greater than zero/i)).toBeVisible();
+  });
+
+  test('withdraw shows error for amount exceeding balance', async ({ page }) => {
+    await page.goto(`/vaults/${VAULT_ID}`);
+
+    // Connect wallet
+    const connectBtn = page.getByRole('button', { name: /connect/i });
+    if (await connectBtn.isVisible()) {
+      await connectBtn.click();
+      await page.getByText(TESTNET_WALLET.slice(0, 8)).click();
+    }
+
+    await page.getByRole('button', { name: /withdraw/i }).first().click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    await modal.getByPlaceholder('0.00').fill('999999999');
+    await expect(modal.getByText(/insufficient balance/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Brings the testnet auth and E2E work from #1176 and #1172 onto `dev`, together with fixes for the gaps that review turned up.

Those two PRs were merged into `integration/testnet-auth-e2e-1098-1100-1101-1102` rather than straight into `dev`, so this PR carries their commits plus one commit of fixes. The contributor's authorship is preserved on the original commits.

## The gaps

The tests that landed described guarantees the code did not provide. Each one is now real.

### #1102 — wallet binding was never enforced

`WalletBindingCheck` was written and tested but never added to the middleware chain, so nothing in production ever called it. It now sits inside the authenticator, where the auth context it depends on exists.

Its path matching was also unreachable in practice: it looked for a 56-character segment starting with `G`, and the Stellar addresses used throughout this codebase are 55 characters. It now matches an explicit allowlist of wallet-scoped prefixes rather than inferring intent from the shape of a path segment.

The third acceptance criterion — changing the linked wallet invalidates existing sessions — had no implementation at all. A token must now also agree with the wallet currently linked to the account. The lookup behind that check fails closed, and is memoised for 60s so it does not put a row read on every authenticated request.

### #1101 — the matrix tested a copy of the rules, and missed most of the API

The test declared its own copy of the production route table. Production could drift — a route made public, a role requirement dropped — and the test would stay green while describing a policy nobody deployed. The table now lives in `middleware.ProductionAuthRules()` and `main.go` consumes it, so there is one table and the test exercises the real one.

The route-count guard asserted only that the matrix had at least as many entries as there were rule prefixes: 58 against 13. That passes regardless of what is missing. Replacing it with a check against the routes the server actually registers showed the matrix covered **58 of 178 routes** — the entire admin surface, bank accounts, digests and the intelligence endpoints were never exercised. All 120 are now covered, and adding a route without a matrix entry fails the test, naming the file and line of the registration.

The reverse guard found 11 matrix entries for routes that do not exist (`/api/v1/portfolio`, `/api/v1/watchlist`, `/api/v1/notifications`, `/api/v1/banks/supported` and others). They had been asserting policy about nothing. Corrected to the real paths, or dropped where no such endpoint exists.

Non-owner access returned 403, which the issue calls out specifically as an existence oracle — it confirms to an attacker that the vault is real. Nine ownership checks across vaults and transactions now return 404, and a test asserts the non-owner and not-found responses are byte-identical rather than merely sharing a status code.

### #1100 — the E2E journey ran nowhere

No workflow invoked it. Added the `test:e2e:testnet` script and a nightly workflow, which is the cadence the issue allows given it needs a funded account. The Playwright report uploads on failure, since that is what identifies which step broke.

## Verification

- `go build ./cmd/...` and `go vet ./internal/... ./cmd/api/` clean
- `go test ./internal/...` passes with no failures
- Coverage guard confirmed to fail on an unlisted route: added a canary route, saw it reported by file and line, removed it
- The E2E spec parses and skips cleanly when the testnet env vars are absent

## Note on the nightly workflow

It needs `TESTNET_WALLET_ADDRESS` (secret), plus `VAULT_ID` and optionally `STAGING_URL` (variables). Until those are configured the spec skips itself rather than failing, so the job stays green on a repository without testnet infrastructure — but it is also not testing anything until they are set.
