### PR TITLE
fix: bound async goroutines, effectiveness stats, reconciliation logging, valuation pagination

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -546,7 +546,7 @@ func run() error {
 		Goals:     valuation.NewGoalAllocationSource(postgres.NewSavingsGoalRepository(db)),
 		Oracle:    valuation.NewStaticOracle(nil),
 		Cache:     valuation.NewCache(30 * time.Second),
-		Notifier:  valuation.NewWSNotifier(wsHub),
+		Notifier:  valuation.NewWSNotifier(wsHub, baseLogger.WithGroup("valuation")),
 		Logger:    baseLogger.WithGroup("valuation"),
 	})
 	valuationHandler := handler.NewValuationHandler(valuationService)

--- a/apps/api/internal/domain/nudge/ranking.go
+++ b/apps/api/internal/domain/nudge/ranking.go
@@ -42,6 +42,12 @@ type Outcome struct {
 
 type EffectivenessStats struct {
 	ConversionRate float64 // 0 to 1
+	// HasData is false for a cold-start nudge type (no dispatches yet in the
+	// measurement window). Rank treats a cold-start entry the same as a
+	// missing one — no effectiveness boost — rather than the misleading
+	// "perfect conversion" a zero-value ConversionRate would otherwise imply
+	// (nester#1196).
+	HasData bool
 }
 
 type HistoryRepository interface {
@@ -69,7 +75,7 @@ func Rank(candidates []Candidate, segment usersignal.Segment, engagement usersig
 		score := def.BaseImpact
 
 		stats, ok := effectiveness[c.Type]
-		if ok {
+		if ok && stats.HasData {
 			score = score * (0.5 + stats.ConversionRate) // just a heuristic for the test
 		}
 

--- a/apps/api/internal/domain/nudge/ranking_test.go
+++ b/apps/api/internal/domain/nudge/ranking_test.go
@@ -51,13 +51,38 @@ func TestRank_EffectivenessBreaksTieBetweenEqualBaseImpact(t *testing.T) {
 	// Both types share BaseImpact 0.7 in the catalog; a higher historical
 	// conversion rate for one should be what breaks the tie.
 	stats := map[NudgeType]EffectivenessStats{
-		NudgeTypeMilestone:       {ConversionRate: 0.1},
-		NudgeTypeStreakMilestone: {ConversionRate: 0.9},
+		NudgeTypeMilestone:       {ConversionRate: 0.1, HasData: true},
+		NudgeTypeStreakMilestone: {ConversionRate: 0.9, HasData: true},
 	}
 
 	ranked := Rank(candidates, usersignal.SegmentActiveSaver, usersignal.TierEngaged, stats)
 
 	if ranked[0].Candidate.Type != NudgeTypeStreakMilestone {
 		t.Fatalf("expected the higher-converting nudge type to rank first, got %s", ranked[0].Candidate.Type)
+	}
+}
+
+func TestRank_ColdStartEntryDoesNotOutrankRealData(t *testing.T) {
+	userID := uuid.New()
+	candidates := []Candidate{
+		{Type: NudgeTypeMilestone, UserID: userID},
+		{Type: NudgeTypeStreakMilestone, UserID: userID},
+	}
+	// Both types share BaseImpact 0.7. A cold-start entry (HasData: false,
+	// the zero-value ConversionRate) must not be treated as a perfect 1.0
+	// conversion rate: with the old behavior a cold-start entry would score
+	// 0.7*(0.5+1.0)=1.05, beating even this strong 0.7 measured conversion
+	// rate (0.7*(0.5+0.7)=0.84). With the fix, cold start gets no boost at
+	// all and stays at the unscaled BaseImpact of 0.7 — so the type with
+	// real, strong measured performance must win (nester#1196).
+	stats := map[NudgeType]EffectivenessStats{
+		NudgeTypeMilestone:       {ConversionRate: 0.7, HasData: true},
+		NudgeTypeStreakMilestone: {HasData: false}, // cold start: zero-value ConversionRate
+	}
+
+	ranked := Rank(candidates, usersignal.SegmentActiveSaver, usersignal.TierEngaged, stats)
+
+	if ranked[0].Candidate.Type != NudgeTypeMilestone {
+		t.Fatalf("expected the nudge type with real measured data to rank first over a cold-start entry, got %s", ranked[0].Candidate.Type)
 	}
 }

--- a/apps/api/internal/reconciliation/engine.go
+++ b/apps/api/internal/reconciliation/engine.go
@@ -95,7 +95,7 @@ func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope
 
 	result, err := comparator.Reconcile(ctx, scope)
 	if err != nil {
-		_ = e.repo.FailRun(ctx, run.ID, err.Error())
+		e.recordFailedRun(ctx, run.ID, err)
 		return Stats{}, fmt.Errorf("reconciliation: %s: %w", comparator.Name(), err)
 	}
 
@@ -112,7 +112,7 @@ func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope
 
 		stored, err := e.repo.AddFinding(ctx, finding)
 		if err != nil {
-			_ = e.repo.FailRun(ctx, run.ID, err.Error())
+			e.recordFailedRun(ctx, run.ID, err)
 			return stats, fmt.Errorf("reconciliation: store finding: %w", err)
 		}
 		if stored.Severity == SeverityCritical {
@@ -127,6 +127,22 @@ func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope
 		return stats, fmt.Errorf("reconciliation: complete run: %w", err)
 	}
 	return stats, nil
+}
+
+// recordFailedRun marks a run failed and records the original error that
+// caused it. If the FailRun write itself fails — the error path of the
+// error path — the run would otherwise end with no durable trace: the
+// operator sees a run that started and never reported, indistinguishable
+// from one that was simply killed, and runErr is lost. Logging it here means
+// the cause survives even when the write does not (nester#1194).
+func (e *Engine) recordFailedRun(ctx context.Context, runID uuid.UUID, runErr error) {
+	if failErr := e.repo.FailRun(ctx, runID, runErr.Error()); failErr != nil {
+		e.logger.Error("reconciliation: failed to record run failure",
+			"run_id", runID,
+			"original_error", runErr,
+			"fail_run_error", failErr,
+		)
+	}
 }
 
 func (e *Engine) dispatchAlert(ctx context.Context, finding Finding) error {

--- a/apps/api/internal/reconciliation/engine_test.go
+++ b/apps/api/internal/reconciliation/engine_test.go
@@ -2,6 +2,9 @@ package reconciliation
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,11 +14,15 @@ import (
 
 type fakeComparator struct {
 	result ComparisonResult
+	err    error
 }
 
 func (c fakeComparator) Name() string { return "fake_balance" }
 func (c fakeComparator) Level() Level { return LevelBalance }
 func (c fakeComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
+	if c.err != nil {
+		return ComparisonResult{}, c.err
+	}
 	return c.result, nil
 }
 
@@ -24,6 +31,9 @@ type fakeRepo struct {
 	findings    []Finding
 	corrections int
 	completed   Stats
+	// failRunErr, when set, makes FailRun itself fail — simulating the
+	// "error path of the error path" nester#1194 is about.
+	failRunErr error
 }
 
 func (r *fakeRepo) CreateRun(ctx context.Context, run Run) (Run, error) {
@@ -42,7 +52,7 @@ func (r *fakeRepo) CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats
 }
 
 func (r *fakeRepo) FailRun(ctx context.Context, runID uuid.UUID, errText string) error {
-	return nil
+	return r.failRunErr
 }
 
 func (r *fakeRepo) GetCheckpoint(ctx context.Context, key string) (string, bool, error) {
@@ -108,5 +118,78 @@ func TestEngineRecordsFindingAndDoesNotAutoCorrect(t *testing.T) {
 	}
 	if alerter.critical != 1 {
 		t.Fatalf("critical alerts = %d, want 1", alerter.critical)
+	}
+}
+
+// captureHandler is a minimal slog.Handler that records emitted records as
+// plain strings, so a test can assert on the logged fields without pulling
+// in a full logging test-helper library.
+type captureHandler struct {
+	records *[]string
+}
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteString(" " + a.Key + "=" + a.Value.String())
+		return true
+	})
+	*h.records = append(*h.records, sb.String())
+	return nil
+}
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestEngineLogsOriginalErrorWhenFailRunItselfFails(t *testing.T) {
+	reconcileErr := errors.New("upstream comparator exploded")
+	failRunErr := errors.New("db connection reset")
+
+	repo := &fakeRepo{failRunErr: failRunErr}
+	alerter := &fakeAlerter{}
+	var logs []string
+	logger := slog.New(captureHandler{records: &logs})
+
+	engine := NewEngine(repo, []Comparator{fakeComparator{err: reconcileErr}}, alerter).
+		WithLogger(logger)
+
+	_, err := engine.Run(context.Background(), Scope{FullSweep: true})
+	if err == nil {
+		t.Fatal("Run() error = nil, want the original reconcile error")
+	}
+	if !errors.Is(err, reconcileErr) {
+		t.Fatalf("Run() error = %v, want it to wrap %v", err, reconcileErr)
+	}
+
+	if len(logs) != 1 {
+		t.Fatalf("expected exactly one log record, got %d: %v", len(logs), logs)
+	}
+	entry := logs[0]
+	if !strings.Contains(entry, reconcileErr.Error()) {
+		t.Fatalf("log entry missing the original error: %q", entry)
+	}
+	if !strings.Contains(entry, failRunErr.Error()) {
+		t.Fatalf("log entry missing the FailRun error: %q", entry)
+	}
+}
+
+func TestEngineDoesNotLogWhenFailRunSucceeds(t *testing.T) {
+	reconcileErr := errors.New("upstream comparator exploded")
+
+	repo := &fakeRepo{} // FailRun succeeds (failRunErr is nil)
+	alerter := &fakeAlerter{}
+	var logs []string
+	logger := slog.New(captureHandler{records: &logs})
+
+	engine := NewEngine(repo, []Comparator{fakeComparator{err: reconcileErr}}, alerter).
+		WithLogger(logger)
+
+	_, err := engine.Run(context.Background(), Scope{FullSweep: true})
+	if err == nil {
+		t.Fatal("Run() error = nil, want the original reconcile error")
+	}
+	if len(logs) != 0 {
+		t.Fatalf("expected no log records when FailRun succeeds, got %d: %v", len(logs), logs)
 	}
 }

--- a/apps/api/internal/repository/postgres/nudge_history_repository.go
+++ b/apps/api/internal/repository/postgres/nudge_history_repository.go
@@ -49,23 +49,40 @@ func (r *NudgeHistoryRepository) RecordDispatch(ctx context.Context, record nudg
 	return err
 }
 
+// effectivenessWindow bounds GetEffectivenessStats to recent dispatches, so
+// a nudge type's ranking reflects current behavior rather than an all-time
+// average that a stale early cohort could permanently skew.
+const effectivenessWindow = 90 * 24 * time.Hour
+
+// GetEffectivenessStats reports the measured conversion rate for a nudge
+// type/segment pair over the last effectivenessWindow. A query error is
+// returned to the caller rather than folded into the result (nester#1196):
+// the ranking engine needs to tell "unknown" apart from "measured," which
+// it previously could not — a broken query and a perfect conversion rate
+// produced the identical result.
 func (r *NudgeHistoryRepository) GetEffectivenessStats(ctx context.Context, nudgeType string, segment string) (nudge.EffectivenessStats, error) {
-	// Simple heuristic: 1.0 by default if small sample size
-	// We could do a complex query here joining nudge_dispatch_log and nudge_outcomes.
-	// For the sake of the MVP test, let's just return a stub.
 	var sent, converted int
 	err := r.db.QueryRowContext(ctx, `
-		SELECT count(*), count(o.id)
+		SELECT count(DISTINCT d.id), count(DISTINCT o.dispatch_id)
 		FROM nudge_dispatch_log d
 		LEFT JOIN nudge_outcomes o ON o.dispatch_id = d.id
-		WHERE d.nudge_type = $1 AND d.segment = $2
-	`, nudgeType, segment).Scan(&sent, &converted)
-
-	if err != nil || sent == 0 {
-		return nudge.EffectivenessStats{ConversionRate: 1.0}, nil // Cold start safe
+		WHERE d.nudge_type = $1 AND d.segment = $2 AND d.sent_at >= $3
+	`, nudgeType, segment, time.Now().Add(-effectivenessWindow)).Scan(&sent, &converted)
+	if err != nil {
+		return nudge.EffectivenessStats{}, err
+	}
+	if sent == 0 {
+		// Cold start: no dispatches yet in the window. Distinct from a
+		// measured 0% conversion rate — HasData false tells the ranking
+		// engine to skip the effectiveness boost entirely rather than
+		// scoring this as either "perfect" or "worst."
+		return nudge.EffectivenessStats{HasData: false}, nil
 	}
 
-	return nudge.EffectivenessStats{ConversionRate: float64(converted) / float64(sent)}, nil
+	return nudge.EffectivenessStats{
+		ConversionRate: float64(converted) / float64(sent),
+		HasData:        true,
+	}, nil
 }
 
 func (r *NudgeHistoryRepository) GetLatestDispatchByType(ctx context.Context, userID uuid.UUID, nudgeType string) (*nudge.DispatchRecord, error) {

--- a/apps/api/internal/repository/postgres/nudge_history_repository_test.go
+++ b/apps/api/internal/repository/postgres/nudge_history_repository_test.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestGetEffectivenessStats_QueryErrorIsReturnedNotSwallowed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewNudgeHistoryRepository(db)
+	wantErr := errors.New("connection reset")
+	mock.ExpectQuery(`SELECT count\(DISTINCT d\.id\), count\(DISTINCT o\.dispatch_id\)`).
+		WillReturnError(wantErr)
+
+	stats, err := repository.GetEffectivenessStats(context.Background(), "milestone", "active_saver")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if stats.HasData {
+		t.Fatalf("expected HasData = false on error, got true (stats: %+v)", stats)
+	}
+	if stats.ConversionRate != 0 {
+		t.Fatalf("expected zero-value ConversionRate on error, got %v", stats.ConversionRate)
+	}
+}
+
+func TestGetEffectivenessStats_ColdStartHasNoData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewNudgeHistoryRepository(db)
+	rows := sqlmock.NewRows([]string{"count", "count"}).AddRow(0, 0)
+	mock.ExpectQuery(`SELECT count\(DISTINCT d\.id\), count\(DISTINCT o\.dispatch_id\)`).
+		WillReturnRows(rows)
+
+	stats, err := repository.GetEffectivenessStats(context.Background(), "milestone", "active_saver")
+	if err != nil {
+		t.Fatalf("GetEffectivenessStats() error = %v, want nil", err)
+	}
+	if stats.HasData {
+		t.Fatal("expected HasData = false for a cold-start nudge type (zero dispatches)")
+	}
+	if stats.ConversionRate != 0 {
+		t.Fatalf("expected zero-value ConversionRate for cold start, got %v — a cold start must never read as a perfect conversion rate", stats.ConversionRate)
+	}
+}
+
+func TestGetEffectivenessStats_MeasuredDataReturnsRealRate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewNudgeHistoryRepository(db)
+	rows := sqlmock.NewRows([]string{"count", "count"}).AddRow(20, 5)
+	mock.ExpectQuery(`SELECT count\(DISTINCT d\.id\), count\(DISTINCT o\.dispatch_id\)`).
+		WillReturnRows(rows)
+
+	stats, err := repository.GetEffectivenessStats(context.Background(), "milestone", "active_saver")
+	if err != nil {
+		t.Fatalf("GetEffectivenessStats() error = %v, want nil", err)
+	}
+	if !stats.HasData {
+		t.Fatal("expected HasData = true when dispatches exist in the window")
+	}
+	if want := 0.25; stats.ConversionRate != want {
+		t.Fatalf("ConversionRate = %v, want %v (5/20)", stats.ConversionRate, want)
+	}
+}
+
+func TestGetEffectivenessStats_BindsNudgeTypeSegmentAndTimeWindow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	repository := NewNudgeHistoryRepository(db)
+	rows := sqlmock.NewRows([]string{"count", "count"}).AddRow(0, 0)
+	mock.ExpectQuery(`SELECT count\(DISTINCT d\.id\), count\(DISTINCT o\.dispatch_id\)`).
+		WithArgs("streak_milestone", "dormant", sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	if _, err := repository.GetEffectivenessStats(context.Background(), "streak_milestone", "dormant"); err != nil {
+		t.Fatalf("GetEffectivenessStats() error = %v, want nil", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/apps/api/internal/service/nudge_copy.go
+++ b/apps/api/internal/service/nudge_copy.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/intelligence"
@@ -22,7 +23,12 @@ type CompositeCopyGenerator struct {
 // back to the deterministic template on any failure or empty response, and
 // reports which source actually produced the copy so callers (dispatch
 // logging, effectiveness tracking) record the truth rather than the intent.
-func (c CompositeCopyGenerator) Generate(nudgeType nudge.NudgeType, facts nudge.Facts, segment usersignal.Segment) (string, string, string, error) {
+//
+// The LLM call is bounded by llmCopyTimeout and derived from ctx, so the
+// caller can abort it (request cancellation, a tighter deadline further up
+// the call chain) instead of the outbound call being uncancellable
+// (nester#1198).
+func (c CompositeCopyGenerator) Generate(ctx context.Context, nudgeType nudge.NudgeType, facts nudge.Facts, segment usersignal.Segment) (string, string, string, error) {
 	def := nudge.Catalog[nudgeType]
 	if def.UsesLLMCopy && c.LLM != nil {
 		req := intelligence.NudgeCopyRequest{
@@ -31,7 +37,9 @@ func (c CompositeCopyGenerator) Generate(nudgeType nudge.NudgeType, facts nudge.
 			Facts:     facts.AllowedFacts(),
 			RequestID: uuid.New().String(),
 		}
-		resp, err := c.LLM.GenerateNudgeCopy(context.Background(), req)
+		llmCtx, cancel := context.WithTimeout(ctx, llmCopyTimeout)
+		resp, err := c.LLM.GenerateNudgeCopy(llmCtx, req)
+		cancel()
 		if err == nil && resp.Title != "" && resp.Body != "" {
 			return resp.Title, resp.Body, "llm", nil
 		}
@@ -39,6 +47,11 @@ func (c CompositeCopyGenerator) Generate(nudgeType nudge.NudgeType, facts nudge.
 	title, body, err := c.Template.Generate(nudgeType, facts)
 	return title, body, "template", err
 }
+
+// llmCopyTimeout bounds the outbound LLM call for nudge copy generation, so
+// a slow/hung provider falls back to the deterministic template within a
+// bounded time rather than blocking the caller indefinitely (nester#1198).
+const llmCopyTimeout = 10 * time.Second
 
 type LLMCopyGenerator struct {
 	Client LLMCopyClient

--- a/apps/api/internal/service/nudge_engine_service.go
+++ b/apps/api/internal/service/nudge_engine_service.go
@@ -20,7 +20,7 @@ import (
 // generated it ("template" or "llm") so effectiveness tracking and the
 // dispatch log reflect what was really sent, not just what was requested.
 type NudgeCopyGenerator interface {
-	Generate(nudgeType nudge.NudgeType, facts nudge.Facts, segment usersignal.Segment) (title, body, source string, err error)
+	Generate(ctx context.Context, nudgeType nudge.NudgeType, facts nudge.Facts, segment usersignal.Segment) (title, body, source string, err error)
 }
 
 type NudgeEngineService struct {
@@ -148,7 +148,7 @@ func (s *NudgeEngineService) evaluate(ctx context.Context, userID uuid.UUID, hin
 		return nil
 	}
 
-	title, body, copySource, err := s.copyGen.Generate(best.Candidate.Type, best.Candidate.Facts, segment)
+	title, body, copySource, err := s.copyGen.Generate(ctx, best.Candidate.Type, best.Candidate.Facts, segment)
 	if err != nil {
 		return err
 	}

--- a/apps/api/internal/service/performance/service.go
+++ b/apps/api/internal/service/performance/service.go
@@ -217,7 +217,16 @@ type BalanceProvider interface {
 	VaultBalance(ctx context.Context, contractAddress string) (decimal.Decimal, error)
 }
 
-// GetUserAnalytics returns aggregated analytics data for a user's vaults
+// GetUserAnalytics returns aggregated analytics data for a user's vaults.
+//
+// The 1000-vault ceiling below is bounded by vault count (how many a user
+// can plausibly create through the product UI), same reasoning as
+// portfolio_service.go's 10,000 ceiling — not by transaction volume that
+// grows with usage, which is what made the pending-deposit ceiling in
+// valuation/adapters.go unsafe (nester#1193). This handler does sum
+// vault.CurrentBalance across the page below into totalBalance for display,
+// so if vault creation ever becomes bulk/programmatic this reasoning stops
+// holding and needs real pagination, same as that fix.
 func (s *Service) GetUserAnalytics(ctx context.Context, userID uuid.UUID, fromTime, toTime time.Time) (*analytics.AnalyticsResponse, error) {
 	// Get user's vaults
 	userVaults, _, err := s.vaultRepo.ListUserVaults(ctx, userID, vault.UserListFilter{Page: 1, PerPage: 1000})

--- a/apps/api/internal/service/portfolio_service.go
+++ b/apps/api/internal/service/portfolio_service.go
@@ -25,10 +25,17 @@ func NewPortfolioService(vaultRepository vault.Repository) *PortfolioService {
 // GetUserPortfolioSummary returns an aggregated view of all user positions across their vaults.
 // Returns an empty portfolio with zero totals if user has no vaults (not an error).
 func (s *PortfolioService) GetUserPortfolioSummary(ctx context.Context, userID uuid.UUID) (portfolio.Summary, error) {
-	// Fetch all vaults for the user with minimal pagination
+	// Fetch all vaults for the user with minimal pagination.
+	//
+	// A 10,000-vault ceiling is safe here in a way the pending-deposit and
+	// reconciliation ceilings were not (nester#1193): vault count is bounded
+	// by how many a person can plausibly create through the product UI, not
+	// by transaction volume that grows with usage over time. If vault
+	// creation ever becomes bulk/programmatic this reasoning stops holding
+	// and this call needs real pagination.
 	vaults, _, err := s.vaultRepository.ListUserVaults(ctx, userID, vault.UserListFilter{
 		Page:    1,
-		PerPage: 10000, // Reasonable upper limit for number of vaults per user
+		PerPage: 10000,
 	})
 	if err != nil {
 		return portfolio.Summary{}, err

--- a/apps/api/internal/service/savings_goal_service.go
+++ b/apps/api/internal/service/savings_goal_service.go
@@ -18,10 +18,11 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/pkg/listquery"
 )
 
-// streakNotifyTimeout bounds the detached streak-milestone notification. It is
-// generous enough for a slow notifier but finite, so a wedged downstream cannot
-// accumulate goroutines.
-const streakNotifyTimeout = 30 * time.Second
+// asyncNotifyTimeout bounds detached notification goroutines fired from this
+// service (streak and goal milestones). It is generous enough for a slow
+// notifier but finite, so a wedged downstream cannot accumulate goroutines
+// without limit (nester#1198).
+const asyncNotifyTimeout = 30 * time.Second
 
 // VaultReader exposes the single read the savings goal service needs from the
 // vault store: looking up a vault to validate ownership/currency at link time
@@ -952,7 +953,7 @@ func (s *SavingsGoalService) updateStreak(ctx context.Context, userID uuid.UUID)
 		// G118). It is bounded by its own timeout so a wedged notifier cannot
 		// leak the goroutine indefinitely.
 		go func() { // #nosec G118 -- intentionally detached background work, bounded by its own timeout
-			nctx, cancel := context.WithTimeout(context.Background(), streakNotifyTimeout)
+			nctx, cancel := context.WithTimeout(context.Background(), asyncNotifyTimeout)
 			defer cancel()
 			s.streakNotifier.SendStreakMilestone(nctx, uid, milestone)
 		}()
@@ -965,8 +966,16 @@ func (s *SavingsGoalService) notifyMilestonesAsync(goal savingsgoal.SavingsGoal,
 	for _, milestone := range milestones {
 		m := milestone
 		goalCopy := goal
-		go func() {
-			s.notifier.SendGoalMilestone(context.Background(), goalCopy.UserID, goalCopy, m)
+		// Deliberately detached from the request context (same reasoning as
+		// the streak-milestone goroutine above): the caller's context is
+		// cancelled once the HTTP response is written, and inheriting it
+		// would cancel the notification before it is sent. Bounded by its
+		// own timeout so a wedged notifier cannot leak the goroutine
+		// indefinitely (nester#1198).
+		go func() { // #nosec G118 -- intentionally detached background work, bounded by its own timeout
+			nctx, cancel := context.WithTimeout(context.Background(), asyncNotifyTimeout)
+			defer cancel()
+			s.notifier.SendGoalMilestone(nctx, goalCopy.UserID, goalCopy, m)
 		}()
 	}
 }

--- a/apps/api/internal/valuation/adapters.go
+++ b/apps/api/internal/valuation/adapters.go
@@ -2,6 +2,8 @@ package valuation
 
 import (
 	"context"
+	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
@@ -11,6 +13,12 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 )
+
+// wsPushTimeout bounds the WebSocket push in WSNotifier.PushValuation. It is
+// called with a background context (the request that triggered the
+// recompute has typically already returned), so without a bound a stalled
+// hub could hang the call indefinitely (nester#1198).
+const wsPushTimeout = 10 * time.Second
 
 // VaultLister is the subset of the vault repository the position source needs.
 type VaultLister interface {
@@ -123,7 +131,8 @@ func (s *GoalAllocationSource) Goals(ctx context.Context, userID uuid.UUID) ([]G
 
 // WSNotifier pushes valuations to a user's WebSocket channel.
 type WSNotifier struct {
-	hub UserPusher
+	hub    UserPusher
+	logger *slog.Logger
 }
 
 // UserPusher is the WebSocket hub method used to push to a single user.
@@ -131,12 +140,22 @@ type UserPusher interface {
 	PushToUser(ctx context.Context, userID uuid.UUID, eventName string, payload any) error
 }
 
-// NewWSNotifier constructs a WSNotifier.
-func NewWSNotifier(hub UserPusher) *WSNotifier { return &WSNotifier{hub: hub} }
+// NewWSNotifier constructs a WSNotifier. A nil logger discards push failures
+// (matching Service's own nil-Logger fallback in NewService).
+func NewWSNotifier(hub UserPusher, logger *slog.Logger) *WSNotifier {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	return &WSNotifier{hub: hub, logger: logger}
+}
 
 // PushValuation implements Notifier by pushing a portfolio_valuation event.
 func (n *WSNotifier) PushValuation(userID uuid.UUID, val portfolio.Valuation) {
-	_ = n.hub.PushToUser(context.Background(), userID, "portfolio_valuation", val)
+	ctx, cancel := context.WithTimeout(context.Background(), wsPushTimeout)
+	defer cancel()
+	if err := n.hub.PushToUser(ctx, userID, "portfolio_valuation", val); err != nil {
+		n.logger.Error("valuation: websocket push failed", "user_id", userID, "error", err)
+	}
 }
 
 var _ Notifier = (*WSNotifier)(nil)

--- a/apps/api/internal/valuation/adapters.go
+++ b/apps/api/internal/valuation/adapters.go
@@ -39,6 +39,13 @@ func NewVaultPositionSource(vaults VaultLister) *VaultPositionSource {
 }
 
 // Positions implements PositionSource.
+//
+// The 10,000-vault ceiling is safe here for the same reason as
+// portfolio_service.go's identical one (nester#1193): it's bounded by vault
+// count, which a user can only grow through the product UI, not by
+// transaction volume that grows with usage over time — unlike
+// TxPendingSource.PendingDeposits below, which paginates through every row
+// for exactly that reason.
 func (s *VaultPositionSource) Positions(ctx context.Context, userID uuid.UUID) ([]Position, error) {
 	vaults, _, err := s.vaults.ListUserVaults(ctx, userID, vault.UserListFilter{Page: 1, PerPage: 10000})
 	if err != nil {
@@ -77,20 +84,44 @@ func NewTxPendingSource(txs TxLister) *TxPendingSource {
 	return &TxPendingSource{txs: txs}
 }
 
-// PendingDeposits implements PendingSource.
+// pendingDepositsPageSize is the page size PendingDeposits fetches at a time.
+// It exists to bound single-query memory/row cost, not to cap how many
+// pending deposits a user can have — PendingDeposits pages through every
+// row ListUserTransactions reports via its total count (nester#1193: this
+// feeds a user's valuation, so silently dropping rows past a fixed limit
+// would undercount real money, not just paginate badly).
+const pendingDepositsPageSize = 500
+
+// PendingDeposits implements PendingSource. It sums every pending deposit
+// for the user — see pendingDepositsPageSize's comment for why this must
+// page through all of them rather than truncating at a fixed row count.
 func (s *TxPendingSource) PendingDeposits(ctx context.Context, userID uuid.UUID) ([]AssetAmount, error) {
-	txs, _, err := s.txs.ListUserTransactions(ctx, transaction.ListFilter{
-		UserID: userID,
-		Type:   string(transaction.TypeDeposit),
-		Status: string(transaction.StatusPending),
-		Limit:  10000,
-	})
-	if err != nil {
-		return nil, err
-	}
-	out := make([]AssetAmount, 0, len(txs))
-	for _, t := range txs {
-		out = append(out, AssetAmount{Asset: t.Currency, Amount: t.Amount})
+	var out []AssetAmount
+	offset := 0
+	for {
+		txs, total, err := s.txs.ListUserTransactions(ctx, transaction.ListFilter{
+			UserID: userID,
+			Type:   string(transaction.TypeDeposit),
+			Status: string(transaction.StatusPending),
+			Limit:  pendingDepositsPageSize,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if out == nil {
+			out = make([]AssetAmount, 0, total)
+		}
+		for _, t := range txs {
+			out = append(out, AssetAmount{Asset: t.Currency, Amount: t.Amount})
+		}
+		offset += len(txs)
+		// len(txs) == 0 guards against an implementation whose total count
+		// disagrees with what it actually returns, so a mismatch can never
+		// spin this loop forever.
+		if offset >= total || len(txs) == 0 {
+			break
+		}
 	}
 	return out, nil
 }

--- a/apps/api/internal/valuation/adapters_test.go
+++ b/apps/api/internal/valuation/adapters_test.go
@@ -9,9 +9,147 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/portfolio"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
 )
+
+// fakeTxLister is an in-memory TxLister that honors Limit/Offset like the
+// real postgres-backed implementation: it returns a genuine total count
+// independent of the page size, so a caller that pages via that count
+// eventually terminates and collects every row.
+type fakeTxLister struct {
+	txs []transaction.Transaction
+	// calls records each (Limit, Offset) pair PendingDeposits requested, so
+	// tests can assert on the exact paging behavior, not just the result.
+	calls []transaction.ListFilter
+}
+
+func (f *fakeTxLister) ListUserTransactions(ctx context.Context, filter transaction.ListFilter) ([]transaction.Transaction, int, error) {
+	f.calls = append(f.calls, filter)
+	total := len(f.txs)
+	start := filter.Offset
+	if start > total {
+		start = total
+	}
+	end := start + filter.Limit
+	if end > total {
+		end = total
+	}
+	return f.txs[start:end], total, nil
+}
+
+func makePendingDeposit(currency string, amount int64) transaction.Transaction {
+	return transaction.Transaction{
+		ID:       uuid.New(),
+		Type:     transaction.TypeDeposit,
+		Status:   transaction.StatusPending,
+		Currency: currency,
+		Amount:   decimal.NewFromInt(amount),
+	}
+}
+
+func TestTxPendingSource_PendingDeposits_ReturnsAllRowsAcrossPages(t *testing.T) {
+	// More rows than a single page (pendingDepositsPageSize) would return,
+	// so this only passes if PendingDeposits actually pages rather than
+	// truncating at the first response (nester#1193).
+	var txs []transaction.Transaction
+	rowCount := pendingDepositsPageSize*2 + 37
+	for i := 0; i < rowCount; i++ {
+		txs = append(txs, makePendingDeposit("USDC", 10))
+	}
+	lister := &fakeTxLister{txs: txs}
+	source := NewTxPendingSource(lister)
+
+	deposits, err := source.PendingDeposits(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("PendingDeposits() error = %v", err)
+	}
+	if len(deposits) != rowCount {
+		t.Fatalf("got %d deposits, want %d (some rows were silently dropped)", len(deposits), rowCount)
+	}
+
+	if len(lister.calls) < 3 {
+		t.Fatalf("expected at least 3 paged calls for %d rows at page size %d, got %d calls", rowCount, pendingDepositsPageSize, len(lister.calls))
+	}
+	for i, call := range lister.calls {
+		if call.Limit != pendingDepositsPageSize {
+			t.Fatalf("call %d: Limit = %d, want %d", i, call.Limit, pendingDepositsPageSize)
+		}
+	}
+}
+
+func TestTxPendingSource_PendingDeposits_SumsCorrectlyAcrossPages(t *testing.T) {
+	lister := &fakeTxLister{txs: []transaction.Transaction{
+		makePendingDeposit("USDC", 100),
+		makePendingDeposit("USDC", 250),
+		makePendingDeposit("XLM", 5),
+	}}
+	source := NewTxPendingSource(lister)
+
+	deposits, err := source.PendingDeposits(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("PendingDeposits() error = %v", err)
+	}
+
+	var totalUSDC decimal.Decimal
+	for _, d := range deposits {
+		if d.Asset == "USDC" {
+			totalUSDC = totalUSDC.Add(d.Amount)
+		}
+	}
+	if want := decimal.NewFromInt(350); !totalUSDC.Equal(want) {
+		t.Fatalf("total USDC = %s, want %s — this is exactly the undercount nester#1193 is about", totalUSDC, want)
+	}
+}
+
+func TestTxPendingSource_PendingDeposits_EmptyResultNoRequests(t *testing.T) {
+	lister := &fakeTxLister{}
+	source := NewTxPendingSource(lister)
+
+	deposits, err := source.PendingDeposits(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("PendingDeposits() error = %v", err)
+	}
+	if len(deposits) != 0 {
+		t.Fatalf("got %d deposits, want 0", len(deposits))
+	}
+	if len(lister.calls) != 1 {
+		t.Fatalf("expected exactly one call for an empty result, got %d", len(lister.calls))
+	}
+}
+
+func TestTxPendingSource_PendingDeposits_SinglePageDoesNotOverFetch(t *testing.T) {
+	lister := &fakeTxLister{txs: []transaction.Transaction{
+		makePendingDeposit("USDC", 10),
+		makePendingDeposit("USDC", 20),
+	}}
+	source := NewTxPendingSource(lister)
+
+	if _, err := source.PendingDeposits(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("PendingDeposits() error = %v", err)
+	}
+	if len(lister.calls) != 1 {
+		t.Fatalf("expected exactly one call when everything fits on one page, got %d", len(lister.calls))
+	}
+}
+
+func TestTxPendingSource_PendingDeposits_PropagatesListerError(t *testing.T) {
+	wantErr := errors.New("db unavailable")
+	source := NewTxPendingSource(erroringTxLister{err: wantErr})
+
+	_, err := source.PendingDeposits(context.Background(), uuid.New())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PendingDeposits() error = %v, want %v", err, wantErr)
+	}
+}
+
+type erroringTxLister struct{ err error }
+
+func (e erroringTxLister) ListUserTransactions(context.Context, transaction.ListFilter) ([]transaction.Transaction, int, error) {
+	return nil, 0, e.err
+}
 
 // captureHandler is a minimal slog.Handler that records emitted records as
 // plain strings for assertion, mirroring the one in

--- a/apps/api/internal/valuation/adapters_test.go
+++ b/apps/api/internal/valuation/adapters_test.go
@@ -1,0 +1,78 @@
+package valuation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/portfolio"
+)
+
+// captureHandler is a minimal slog.Handler that records emitted records as
+// plain strings for assertion, mirroring the one in
+// reconciliation/engine_test.go.
+type captureHandler struct {
+	records *[]string
+}
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteString(fmt.Sprintf(" %s=%v", a.Key, a.Value))
+		return true
+	})
+	*h.records = append(*h.records, sb.String())
+	return nil
+}
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+type erroringUserPusher struct{ err error }
+
+func (e erroringUserPusher) PushToUser(context.Context, uuid.UUID, string, any) error {
+	return e.err
+}
+
+func TestWSNotifier_PushValuation_LogsFailurePushError(t *testing.T) {
+	pushErr := errors.New("hub unavailable")
+	var logs []string
+	logger := slog.New(captureHandler{records: &logs})
+	notifier := NewWSNotifier(erroringUserPusher{err: pushErr}, logger)
+
+	notifier.PushValuation(uuid.New(), portfolio.Valuation{})
+
+	if len(logs) != 1 {
+		t.Fatalf("expected exactly one log record, got %d: %v", len(logs), logs)
+	}
+	if !strings.Contains(logs[0], pushErr.Error()) {
+		t.Fatalf("log entry missing the push error: %q", logs[0])
+	}
+}
+
+type noopUserPusher struct{}
+
+func (noopUserPusher) PushToUser(context.Context, uuid.UUID, string, any) error { return nil }
+
+func TestWSNotifier_PushValuation_NoLogOnSuccess(t *testing.T) {
+	var logs []string
+	logger := slog.New(captureHandler{records: &logs})
+	notifier := NewWSNotifier(noopUserPusher{}, logger)
+
+	notifier.PushValuation(uuid.New(), portfolio.Valuation{})
+
+	if len(logs) != 0 {
+		t.Fatalf("expected no log records on a successful push, got %d: %v", len(logs), logs)
+	}
+}
+
+func TestNewWSNotifier_NilLoggerDoesNotPanic(t *testing.T) {
+	notifier := NewWSNotifier(noopUserPusher{}, nil)
+	notifier.PushValuation(uuid.New(), portfolio.Valuation{})
+}


### PR DESCRIPTION
## Summary

Four independent backend bug fixes from a post-testnet codebase audit, each in its own commit.

### #1198 — Milestone notification goroutines have no timeout

`notifyMilestonesAsync` spawned a goroutine per milestone with an uncancellable `context.Background()` and no deadline — a hung notifier could leak goroutines per milestone indefinitely. Bounded it the same way the sibling streak-milestone goroutine already was (renamed `streakNotifyTimeout` → `asyncNotifyTimeout` since it now covers both call sites).

Also fixed the two related sites the issue flagged:
- `WSNotifier.PushValuation` — was called with `context.Background()` and no bound, and dropped its error. Now bounded by a 10s timeout and logs the push failure instead of discarding it.
- `CompositeCopyGenerator`'s outbound LLM call — didn't take a `context.Context` at all, so the caller genuinely could not abort it. Threaded `ctx` through from `NudgeEngineService` (the one caller), bounded by a 10s timeout on the LLM call specifically so a slow/hung provider falls back to the template within a bounded time.

### #1196 — Nudge effectiveness reports perfect conversion on any query error

`GetEffectivenessStats` returned `ConversionRate: 1.0, nil` for both a database error and a genuine cold start (zero dispatches). The ranking engine then promoted a failing query above every nudge type with real measured performance.

`EffectivenessStats` now carries a `HasData` flag. A query error is returned to the caller instead of swallowed; cold start reports `HasData: false` (zero-value `ConversionRate`, distinct from a measured 0%). `Rank()` skips the effectiveness multiplier entirely when `HasData` is false — same treatment it already gave a missing map entry.

Also fixed the query itself: bounded to a 90-day window, and switched `COUNT(*)` to `COUNT(DISTINCT ...)` on both sides of the `LEFT JOIN` — the original was double-counting a dispatch once per matching outcome row.

### #1194 — Reconciliation failures can go unrecorded

Both `FailRun` call sites in the reconciliation engine discarded their own error (`_ = e.repo.FailRun(...)`). If `FailRun` itself failed, the run ended with no durable trace at all — indistinguishable from a killed process, with the real error gone. This is the error path of the error path: it only triggers when something's already wrong, exactly when the evidence matters most.

Added `recordFailedRun`, which logs both the original error and the `FailRun` error together when the write fails, so the cause survives even when the write doesn't.

Left the sibling swallowed-error sites the issue notes (`admin_handler.go:317`, `auth_handler.go:190`) untouched — the issue itself frames those as "worth a single decision" about which best-effort writes may fail silently, not something to decide unilaterally as part of this fix.

### #1193 — Pending-deposit valuation silently truncates at 10,000 rows

`TxPendingSource.PendingDeposits` capped at `Limit: 10000` with no pagination. Pending deposits feed a user's valuation directly, so a user past that cap saw an undercounted total with nothing indicating truncation. Now pages through every row via `ListUserTransactions`' own reported total count (`ListUserTransactions` already supports real `Limit`/`Offset` pagination with an independent `COUNT(*)`, so this was straightforward to wire up correctly).

The other two `10000`/`1000`-row constants the issue flagged (`VaultPositionSource.Positions`, `GetUserPortfolioSummary`, `GetUserAnalytics`) are bounded by **vault count**, not transaction volume — a user can only grow that number through the product UI, not through ordinary usage over time. Documented that reasoning explicitly at each site instead of rewriting them to paginate, per the issue's own "either paginate or document why the ceiling is safe" framing.

## Testing

- `go build ./...`: clean.
- `go vet ./...`: clean.
- `go test ./...`: full module passes, no failures (integration tests requiring `TEST_DATABASE_DSN` skip as expected, same as before this change).
- `gofmt -l`: clean on every file I authored or touched meaningfully. (This repo has substantial pre-existing `gofmt` drift across ~70 unrelated files, confirmed via `git show upstream/dev:<path> | gofmt -l` before touching anything — not introduced or worsened here.)
- New/expanded test coverage: `TestRank_ColdStartEntryDoesNotOutrankRealData`, `TestGetEffectivenessStats_*` (4 cases, via sqlmock matching this repo's existing `postgres` package convention), `TestEngineLogsOriginalErrorWhenFailRunItselfFails` / `TestEngineDoesNotLogWhenFailRunSucceeds`, `TestTxPendingSource_PendingDeposits_*` (5 cases covering pagination, summing, empty/single-page, and error propagation), `TestWSNotifier_PushValuation_*` (3 cases).

Closes #1198
Closes #1196
Closes #1194
Closes #1193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nudge ranking by preventing cold-start entries from receiving an unwarranted conversion boost.
  - Limited effectiveness calculations to recent measured activity and surfaced data errors correctly.
  - Preserved original reconciliation errors when failure recording also fails.
  - Ensured valuation data includes all pending deposits across multiple pages.

- **Reliability**
  - Added time limits and fallback behavior for generated nudge copy and milestone notifications.
  - Added timeout handling and failure logging for valuation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->