### PR TITLE
fix: reconciliation pagination, KYC identity+storage, lp_aggregator real reserves

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
 	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
+	"github.com/suncrestlabs/nester/apps/api/internal/objectstorage"
 	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
@@ -304,6 +305,25 @@ func run() error {
 	userHandler := handler.NewUserHandler(userService)
 	userVaultsSvc := service.NewUserVaultsService(vaultRepository)
 	userHandler.SetUserVaultsService(userVaultsSvc)
+
+	// KYC document storage (nester#1191). KYC_STORAGE_DIR defaults to a local
+	// directory rather than requiring a cloud object-storage decision to be
+	// made before the endpoint can accept uploads at all — see
+	// internal/objectstorage's package doc for why this is a real store, not
+	// a placeholder, and what a production cloud store would replace it
+	// with. Left unset (nil) only if the directory genuinely cannot be
+	// created, in which case submitKYC rejects uploads (503) rather than
+	// silently discarding them.
+	kycStorageDir := os.Getenv("KYC_STORAGE_DIR")
+	if kycStorageDir == "" {
+		kycStorageDir = "./data/kyc-documents"
+	}
+	kycStore, kycStoreErr := objectstorage.NewLocalDiskStore(kycStorageDir, handler.MaxKYCDocumentBytes, handler.KYCAllowedContentTypes)
+	if kycStoreErr != nil {
+		slog.Warn("KYC document storage unavailable — submitKYC will reject uploads until this is fixed", "error", kycStoreErr, "dir", kycStorageDir)
+	} else {
+		userHandler.SetKYCStore(kycStore)
+	}
 	notificationRepository := postgres.NewNotificationRepository(db)
 	notificationHandler := handler.NewNotificationHandler(notificationRepository)
 

--- a/apps/api/internal/domain/user/kyc_validation.go
+++ b/apps/api/internal/domain/user/kyc_validation.go
@@ -1,0 +1,82 @@
+package user
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrInvalidDateOfBirth = errors.New("date_of_birth must be a valid date in the past, formatted YYYY-MM-DD")
+	ErrInvalidCountry     = errors.New("country must be a valid ISO 3166-1 alpha-2 code")
+	ErrMissingIdentity    = errors.New("full_name, date_of_birth, and country are required")
+)
+
+// KYCIdentity holds the identity fields a KYC submission carries alongside
+// the ID document itself. Previously read from the request and silently
+// discarded rather than validated or persisted (nester#1190).
+type KYCIdentity struct {
+	FullName    string
+	DateOfBirth time.Time
+	Country     string
+}
+
+// ParseDateOfBirth parses a YYYY-MM-DD date string and rejects anything that
+// isn't a real calendar date strictly in the past (an empty string, a
+// malformed value, or a future date are all rejected the same way a client
+// simply omitting the field should be — the endpoint must not accept and
+// silently drop it, nor accept and silently store nonsense).
+func ParseDateOfBirth(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, ErrInvalidDateOfBirth
+	}
+	parsed, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return time.Time{}, ErrInvalidDateOfBirth
+	}
+	if !parsed.Before(time.Now()) {
+		return time.Time{}, ErrInvalidDateOfBirth
+	}
+	return parsed, nil
+}
+
+// IsValidCountryCode reports whether code is a real ISO 3166-1 alpha-2
+// country code (case-sensitive, uppercase — the canonical form). Checked
+// against a fixed, real set rather than accepting any two-letter string, so
+// a typo or a placeholder value is rejected at submission time instead of
+// silently persisted as if it identified a real jurisdiction.
+func IsValidCountryCode(code string) bool {
+	_, ok := iso3166Alpha2Countries[code]
+	return ok
+}
+
+// iso3166Alpha2Countries is the current set of assigned ISO 3166-1 alpha-2
+// country codes (249 entries, including exceptionally reserved codes in
+// active use such as GB, per the ISO 3166-1 maintenance agency's published
+// list). Deliberately excludes withdrawn/unassigned codes.
+var iso3166Alpha2Countries = map[string]struct{}{
+	"AD": {}, "AE": {}, "AF": {}, "AG": {}, "AI": {}, "AL": {}, "AM": {}, "AO": {}, "AQ": {}, "AR": {},
+	"AS": {}, "AT": {}, "AU": {}, "AW": {}, "AX": {}, "AZ": {}, "BA": {}, "BB": {}, "BD": {}, "BE": {},
+	"BF": {}, "BG": {}, "BH": {}, "BI": {}, "BJ": {}, "BL": {}, "BM": {}, "BN": {}, "BO": {}, "BQ": {},
+	"BR": {}, "BS": {}, "BT": {}, "BV": {}, "BW": {}, "BY": {}, "BZ": {}, "CA": {}, "CC": {}, "CD": {},
+	"CF": {}, "CG": {}, "CH": {}, "CI": {}, "CK": {}, "CL": {}, "CM": {}, "CN": {}, "CO": {}, "CR": {},
+	"CU": {}, "CV": {}, "CW": {}, "CX": {}, "CY": {}, "CZ": {}, "DE": {}, "DJ": {}, "DK": {}, "DM": {},
+	"DO": {}, "DZ": {}, "EC": {}, "EE": {}, "EG": {}, "EH": {}, "ER": {}, "ES": {}, "ET": {}, "FI": {},
+	"FJ": {}, "FK": {}, "FM": {}, "FO": {}, "FR": {}, "GA": {}, "GB": {}, "GD": {}, "GE": {}, "GF": {},
+	"GG": {}, "GH": {}, "GI": {}, "GL": {}, "GM": {}, "GN": {}, "GP": {}, "GQ": {}, "GR": {}, "GS": {},
+	"GT": {}, "GU": {}, "GW": {}, "GY": {}, "HK": {}, "HM": {}, "HN": {}, "HR": {}, "HT": {}, "HU": {},
+	"ID": {}, "IE": {}, "IL": {}, "IM": {}, "IN": {}, "IO": {}, "IQ": {}, "IR": {}, "IS": {}, "IT": {},
+	"JE": {}, "JM": {}, "JO": {}, "JP": {}, "KE": {}, "KG": {}, "KH": {}, "KI": {}, "KM": {}, "KN": {},
+	"KP": {}, "KR": {}, "KW": {}, "KY": {}, "KZ": {}, "LA": {}, "LB": {}, "LC": {}, "LI": {}, "LK": {},
+	"LR": {}, "LS": {}, "LT": {}, "LU": {}, "LV": {}, "LY": {}, "MA": {}, "MC": {}, "MD": {}, "ME": {},
+	"MF": {}, "MG": {}, "MH": {}, "MK": {}, "ML": {}, "MM": {}, "MN": {}, "MO": {}, "MP": {}, "MQ": {},
+	"MR": {}, "MS": {}, "MT": {}, "MU": {}, "MV": {}, "MW": {}, "MX": {}, "MY": {}, "MZ": {}, "NA": {},
+	"NC": {}, "NE": {}, "NF": {}, "NG": {}, "NI": {}, "NL": {}, "NO": {}, "NP": {}, "NR": {}, "NU": {},
+	"NZ": {}, "OM": {}, "PA": {}, "PE": {}, "PF": {}, "PG": {}, "PH": {}, "PK": {}, "PL": {}, "PM": {},
+	"PN": {}, "PR": {}, "PS": {}, "PT": {}, "PW": {}, "PY": {}, "QA": {}, "RE": {}, "RO": {}, "RS": {},
+	"RU": {}, "RW": {}, "SA": {}, "SB": {}, "SC": {}, "SD": {}, "SE": {}, "SG": {}, "SH": {}, "SI": {},
+	"SJ": {}, "SK": {}, "SL": {}, "SM": {}, "SN": {}, "SO": {}, "SR": {}, "SS": {}, "ST": {}, "SV": {},
+	"SX": {}, "SY": {}, "SZ": {}, "TC": {}, "TD": {}, "TF": {}, "TG": {}, "TH": {}, "TJ": {}, "TK": {},
+	"TL": {}, "TM": {}, "TN": {}, "TO": {}, "TR": {}, "TT": {}, "TV": {}, "TW": {}, "TZ": {}, "UA": {},
+	"UG": {}, "UM": {}, "US": {}, "UY": {}, "UZ": {}, "VA": {}, "VC": {}, "VE": {}, "VG": {}, "VI": {},
+	"VN": {}, "VU": {}, "WF": {}, "WS": {}, "YE": {}, "YT": {}, "ZA": {}, "ZM": {}, "ZW": {},
+}

--- a/apps/api/internal/domain/user/kyc_validation_test.go
+++ b/apps/api/internal/domain/user/kyc_validation_test.go
@@ -1,0 +1,67 @@
+package user
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseDateOfBirth_AcceptsAValidPastDate(t *testing.T) {
+	got, err := ParseDateOfBirth("1990-05-14")
+	if err != nil {
+		t.Fatalf("ParseDateOfBirth() error = %v", err)
+	}
+	want := time.Date(1990, 5, 14, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseDateOfBirth_RejectsEmptyString(t *testing.T) {
+	_, err := ParseDateOfBirth("")
+	if !errors.Is(err, ErrInvalidDateOfBirth) {
+		t.Fatalf("error = %v, want ErrInvalidDateOfBirth", err)
+	}
+}
+
+func TestParseDateOfBirth_RejectsMalformedDate(t *testing.T) {
+	cases := []string{"not-a-date", "1990/05/14", "14-05-1990", "1990-13-01", "1990-05-32"}
+	for _, c := range cases {
+		if _, err := ParseDateOfBirth(c); !errors.Is(err, ErrInvalidDateOfBirth) {
+			t.Fatalf("ParseDateOfBirth(%q) error = %v, want ErrInvalidDateOfBirth", c, err)
+		}
+	}
+}
+
+func TestParseDateOfBirth_RejectsAFutureDate(t *testing.T) {
+	future := time.Now().AddDate(1, 0, 0).Format("2006-01-02")
+	if _, err := ParseDateOfBirth(future); !errors.Is(err, ErrInvalidDateOfBirth) {
+		t.Fatalf("ParseDateOfBirth(future) error = %v, want ErrInvalidDateOfBirth", err)
+	}
+}
+
+func TestIsValidCountryCode_AcceptsRealCodes(t *testing.T) {
+	for _, code := range []string{"US", "GB", "NG", "DE", "JP", "BR"} {
+		if !IsValidCountryCode(code) {
+			t.Fatalf("IsValidCountryCode(%q) = false, want true", code)
+		}
+	}
+}
+
+func TestIsValidCountryCode_RejectsUnknownOrMalformedCodes(t *testing.T) {
+	cases := []string{"", "XX", "ZZ", "USA", "us", "12", "  "}
+	for _, c := range cases {
+		if IsValidCountryCode(c) {
+			t.Fatalf("IsValidCountryCode(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestIsValidCountryCode_IsCaseSensitiveToTheCanonicalUppercaseForm(t *testing.T) {
+	if IsValidCountryCode("us") {
+		t.Fatal("expected lowercase 'us' to be rejected — callers must normalize to uppercase before calling")
+	}
+	if !IsValidCountryCode("US") {
+		t.Fatal("expected uppercase 'US' to be accepted")
+	}
+}

--- a/apps/api/internal/domain/user/model.go
+++ b/apps/api/internal/domain/user/model.go
@@ -26,21 +26,21 @@ const (
 )
 
 type User struct {
-	ID                 uuid.UUID  `json:"id"`
-	WalletAddress      string     `json:"wallet_address"`
-	DisplayName        string     `json:"display_name"`
-	KYCStatus          KYCStatus  `json:"kyc_status"`
-	Tier               string     `json:"tier"`
-	KYCSubmittedAt     *time.Time `json:"kyc_submitted_at,omitempty"`
-	KYCReviewedAt      *time.Time `json:"kyc_reviewed_at,omitempty"`
-	KYCRejectionReason *string    `json:"kyc_rejection_reason,omitempty"`
-  RiskProfile         *RiskProfile `json:"risk_profile,omitempty"`
-	SavingsGoal         *string     `json:"savings_goal,omitempty"`
-	OnboardingCompleted bool        `json:"onboarding_completed"`
-	LastLoginAt        *time.Time `json:"last_login_at,omitempty"`
-	Timezone           string     `json:"timezone"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	ID                  uuid.UUID    `json:"id"`
+	WalletAddress       string       `json:"wallet_address"`
+	DisplayName         string       `json:"display_name"`
+	KYCStatus           KYCStatus    `json:"kyc_status"`
+	Tier                string       `json:"tier"`
+	KYCSubmittedAt      *time.Time   `json:"kyc_submitted_at,omitempty"`
+	KYCReviewedAt       *time.Time   `json:"kyc_reviewed_at,omitempty"`
+	KYCRejectionReason  *string      `json:"kyc_rejection_reason,omitempty"`
+	RiskProfile         *RiskProfile `json:"risk_profile,omitempty"`
+	SavingsGoal         *string      `json:"savings_goal,omitempty"`
+	OnboardingCompleted bool         `json:"onboarding_completed"`
+	LastLoginAt         *time.Time   `json:"last_login_at,omitempty"`
+	Timezone            string       `json:"timezone"`
+	CreatedAt           time.Time    `json:"created_at"`
+	UpdatedAt           time.Time    `json:"updated_at"`
 }
 
 type KYCDocument struct {
@@ -50,13 +50,20 @@ type KYCDocument struct {
 	IDNumber       string    `json:"id_number"`
 	FrontObjectKey string    `json:"front_object_key"`
 	BackObjectKey  *string   `json:"back_object_key,omitempty"`
-	SubmittedAt    time.Time `json:"submitted_at"`
+	// FullName, DateOfBirth, and Country are the identity fields the
+	// submission form carries alongside the ID document. Previously read
+	// from the request and silently discarded rather than persisted
+	// (nester#1190).
+	FullName    string    `json:"full_name"`
+	DateOfBirth time.Time `json:"date_of_birth"`
+	Country     string    `json:"country"`
+	SubmittedAt time.Time `json:"submitted_at"`
 }
 
 var (
-	ErrUserNotFound      = errors.New("user not found")
-	ErrDuplicateWallet   = errors.New("wallet address already registered")
-	ErrInvalidWallet     = errors.New("invalid wallet address")
+	ErrUserNotFound    = errors.New("user not found")
+	ErrDuplicateWallet = errors.New("wallet address already registered")
+	ErrInvalidWallet   = errors.New("invalid wallet address")
 )
 
 // EncryptedKYCDoc holds the ciphertext and key version for each encrypted KYC

--- a/apps/api/internal/handler/user_handler.go
+++ b/apps/api/internal/handler/user_handler.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"strings"
 
@@ -12,6 +14,7 @@ import (
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
+	"github.com/suncrestlabs/nester/apps/api/internal/objectstorage"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 	logpkg "github.com/suncrestlabs/nester/apps/api/pkg/logger"
 	"github.com/suncrestlabs/nester/apps/api/pkg/response"
@@ -21,6 +24,7 @@ type UserHandler struct {
 	service       *service.UserService
 	userVaultsSvc *service.UserVaultsService
 	validator     *validator.Validate
+	kycStore      objectstorage.Store
 }
 
 func NewUserHandler(service *service.UserService) *UserHandler {
@@ -28,6 +32,15 @@ func NewUserHandler(service *service.UserService) *UserHandler {
 		service:   service,
 		validator: validator.New(validator.WithRequiredStructEnabled()),
 	}
+}
+
+// SetKYCStore wires the object store submitKYC uploads identity documents
+// to. Left unset (nil) in an environment where object storage hasn't been
+// provisioned yet — submitKYC treats that the same as "storage is not
+// ready" and rejects the upload (503) rather than accepting and discarding
+// it (nester#1191).
+func (h *UserHandler) SetKYCStore(store objectstorage.Store) {
+	h.kycStore = store
 }
 
 // SetUserVaultsService wires the intelligence-facing user vaults list.
@@ -214,13 +227,30 @@ const (
 	// kycInMemoryBytes is how much of the multipart form is buffered in memory
 	// before the remainder spills to temporary files.
 	kycInMemoryBytes = 10 << 20
+	// MaxKYCDocumentBytes bounds a single id_front/id_back file, distinct
+	// from maxKYCUploadBytes which bounds the whole multipart body (both
+	// files plus form fields together).
+	MaxKYCDocumentBytes = 8 << 20
 )
+
+// KYCAllowedContentTypes are the only content types submitKYC will store —
+// identity documents are photographs or scans, never an arbitrary file
+// (nester#1191's third acceptance criterion).
+var KYCAllowedContentTypes = []string{"image/jpeg", "image/png", "application/pdf"}
 
 func (h *UserHandler) submitKYC(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	userID, err := uuid.Parse(idStr)
 	if err != nil {
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid user ID"))
+		return
+	}
+
+	if h.kycStore == nil {
+		// Storage is not ready in this environment — reject the upload
+		// rather than accept and discard it (nester#1191's explicit
+		// guidance for this situation).
+		response.WriteJSON(w, http.StatusServiceUnavailable, response.Err(http.StatusServiceUnavailable, "STORAGE_UNAVAILABLE", "document storage is not available"))
 		return
 	}
 
@@ -235,9 +265,9 @@ func (h *UserHandler) submitKYC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fullName := r.FormValue("full_name")
-	dateOfBirth := r.FormValue("date_of_birth") // ignored for now
-	country := r.FormValue("country")           // ignored for now
+	fullName := strings.TrimSpace(r.FormValue("full_name"))
+	dateOfBirthRaw := r.FormValue("date_of_birth")
+	country := strings.ToUpper(strings.TrimSpace(r.FormValue("country")))
 	idType := r.FormValue("id_type")
 	idNumber := r.FormValue("id_number")
 
@@ -245,6 +275,20 @@ func (h *UserHandler) submitKYC(w http.ResponseWriter, r *http.Request) {
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("id_type and id_number are required"))
 		return
 	}
+	if fullName == "" {
+		h.writeDomainError(w, r, user.ErrMissingIdentity)
+		return
+	}
+	dateOfBirth, err := user.ParseDateOfBirth(dateOfBirthRaw)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+	if !user.IsValidCountryCode(country) {
+		h.writeDomainError(w, r, user.ErrInvalidCountry)
+		return
+	}
+	identity := user.KYCIdentity{FullName: fullName, DateOfBirth: dateOfBirth, Country: country}
 
 	idFrontFile, idFrontHeader, err := r.FormFile("id_front")
 	if err != nil {
@@ -253,27 +297,62 @@ func (h *UserHandler) submitKYC(w http.ResponseWriter, r *http.Request) {
 	}
 	defer idFrontFile.Close()
 
-	// In a real implementation we would upload to S3 here.
-	frontKey := "s3://mock-bucket/" + idFrontHeader.Filename
+	frontContentType := idFrontHeader.Header.Get("Content-Type")
+	frontKey, err := h.storeKYCDocument(r.Context(), userID, frontContentType, idFrontFile)
+	if err != nil {
+		h.writeKYCUploadError(w, r, err)
+		return
+	}
 
 	var backKey *string
 	idBackFile, idBackHeader, err := r.FormFile("id_back")
 	if err == nil {
 		defer idBackFile.Close()
-		bk := "s3://mock-bucket/" + idBackHeader.Filename
+		backContentType := idBackHeader.Header.Get("Content-Type")
+		bk, err := h.storeKYCDocument(r.Context(), userID, backContentType, idBackFile)
+		if err != nil {
+			h.writeKYCUploadError(w, r, err)
+			return
+		}
 		backKey = &bk
 	}
 
-	_ = fullName
-	_ = dateOfBirth
-	_ = country
-
-	if err := h.service.SubmitKYC(r.Context(), userID, idType, idNumber, frontKey, backKey); err != nil {
+	if err := h.service.SubmitKYC(r.Context(), userID, identity, idType, idNumber, frontKey, backKey); err != nil {
 		h.writeDomainError(w, r, err)
 		return
 	}
 
 	response.WriteJSON(w, http.StatusAccepted, response.OK(map[string]string{"status": "pending"}))
+}
+
+// storeKYCDocument uploads one id_front/id_back file to real object
+// storage and returns the server-generated key. The client's filename is
+// never read here at all — it plays no part in the generated key
+// (nester#1191).
+func (h *UserHandler) storeKYCDocument(ctx context.Context, userID uuid.UUID, contentType string, file multipart.File) (string, error) {
+	limited := io.LimitReader(file, MaxKYCDocumentBytes+1)
+	key, err := h.kycStore.Put(ctx, userID.String(), contentType, limited)
+	if err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// writeKYCUploadError maps a storage-layer failure to an HTTP response. A
+// failed upload fails the request rather than persisting a KYC record that
+// points at nothing (nester#1191's fourth acceptance criterion) — the
+// caller in submitKYC returns immediately after calling this and never
+// reaches the SubmitKYC persistence call.
+func (h *UserHandler) writeKYCUploadError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, objectstorage.ErrContentTypeNotAllowed):
+		response.WriteJSON(w, http.StatusUnsupportedMediaType, response.ValidationErr(err.Error()))
+	case errors.Is(err, objectstorage.ErrTooLarge):
+		response.WriteJSON(w, http.StatusRequestEntityTooLarge, response.ValidationErr(err.Error()))
+	default:
+		logpkg.FromContext(r.Context()).Error("kyc document upload failed", "error", err.Error())
+		response.WriteJSON(w, http.StatusInternalServerError, response.Err(http.StatusInternalServerError, "UPLOAD_FAILED", "document upload failed"))
+	}
 }
 
 func (h *UserHandler) getKYCStatus(w http.ResponseWriter, r *http.Request) {
@@ -328,6 +407,8 @@ func (h *UserHandler) writeDomainError(w http.ResponseWriter, r *http.Request, e
 	case errors.Is(err, user.ErrDuplicateWallet):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "CONFLICT", err.Error()))
 	case errors.Is(err, user.ErrInvalidWallet):
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
+	case errors.Is(err, user.ErrInvalidDateOfBirth), errors.Is(err, user.ErrInvalidCountry), errors.Is(err, user.ErrMissingIdentity):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	default:
 		logpkg.FromContext(r.Context()).Error("user handler failed", "error", err.Error())

--- a/apps/api/internal/handler/user_kyc_handler_test.go
+++ b/apps/api/internal/handler/user_kyc_handler_test.go
@@ -1,0 +1,341 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/objectstorage"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// recordingKYCRepository wraps mockUserRepository and captures the exact
+// KYCDocument SaveKYCDocument was called with, so tests can assert on what
+// was actually persisted rather than only on the HTTP response.
+type recordingKYCRepository struct {
+	*mockUserRepository
+	mu    sync.Mutex
+	saved *user.KYCDocument
+}
+
+func (r *recordingKYCRepository) SaveKYCDocument(ctx context.Context, doc *user.KYCDocument, encrypted *user.EncryptedKYCDoc) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	saved := *doc
+	r.saved = &saved
+	return r.mockUserRepository.SaveKYCDocument(ctx, doc, encrypted)
+}
+
+func testCipherKey(b byte) string {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func newKYCTestHandler(t *testing.T, withStore bool) (*UserHandler, *recordingKYCRepository, uuid.UUID) {
+	t.Helper()
+	repo := &recordingKYCRepository{mockUserRepository: newMockUserRepository()}
+	userID := uuid.New()
+	repo.users[userID] = &user.User{ID: userID, WalletAddress: "G-KYC-TEST"}
+
+	cipher, err := crypto.NewAccountCipher(testCipherKey(7))
+	if err != nil {
+		t.Fatalf("NewAccountCipher() error = %v", err)
+	}
+	svc := service.NewUserService(repo).WithCipher(cipher)
+	h := NewUserHandler(svc)
+
+	if withStore {
+		store, err := objectstorage.NewLocalDiskStore(t.TempDir(), 8<<20, []string{"image/jpeg", "image/png", "application/pdf"})
+		if err != nil {
+			t.Fatalf("NewLocalDiskStore() error = %v", err)
+		}
+		h.SetKYCStore(store)
+	}
+
+	return h, repo, userID
+}
+
+func newTestServer(h *UserHandler) *httptest.Server {
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux))
+}
+
+// buildKYCMultipartBody constructs a multipart/form-data body for the
+// submitKYC endpoint. filename lets a test supply a hostile filename to
+// verify it never influences the stored object key.
+func buildKYCMultipartBody(t *testing.T, fields map[string]string, filename string, fileContent []byte) (io.Reader, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField(%q) error = %v", k, err)
+		}
+	}
+	if filename != "" {
+		part, err := w.CreatePart(map[string][]string{
+			"Content-Disposition": {`form-data; name="id_front"; filename="` + filename + `"`},
+			"Content-Type":        {"image/jpeg"},
+		})
+		if err != nil {
+			t.Fatalf("CreatePart() error = %v", err)
+		}
+		if _, err := part.Write(fileContent); err != nil {
+			t.Fatalf("part.Write() error = %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("multipart writer Close() error = %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}
+
+func TestSubmitKYC_FullSubmissionRoundTrips(t *testing.T) {
+	h, repo, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name":     "Ada Lovelace",
+		"date_of_birth": "1990-05-14",
+		"country":       "GB",
+		"id_type":       "passport",
+		"id_number":     "X12345678",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "passport.jpg", []byte("fake jpeg bytes"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202 Accepted, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	repo.mu.Lock()
+	saved := repo.saved
+	repo.mu.Unlock()
+	if saved == nil {
+		t.Fatal("expected SaveKYCDocument to have been called")
+	}
+
+	// nester#1190: every identity field round-trips, none silently dropped.
+	if saved.FullName != "Ada Lovelace" {
+		t.Fatalf("FullName = %q, want %q", saved.FullName, "Ada Lovelace")
+	}
+	if saved.Country != "GB" {
+		t.Fatalf("Country = %q, want %q", saved.Country, "GB")
+	}
+	if saved.DateOfBirth.Format("2006-01-02") != "1990-05-14" {
+		t.Fatalf("DateOfBirth = %v, want 1990-05-14", saved.DateOfBirth)
+	}
+
+	// nester#1191: the stored key is server-generated, never the client's
+	// literal filename or a mock placeholder.
+	if strings.Contains(saved.FrontObjectKey, "passport.jpg") {
+		t.Fatalf("FrontObjectKey %q must not contain the client-supplied filename", saved.FrontObjectKey)
+	}
+	if strings.HasPrefix(saved.FrontObjectKey, "s3://mock-bucket/") {
+		t.Fatalf("FrontObjectKey %q still looks like the old mock placeholder", saved.FrontObjectKey)
+	}
+	if saved.FrontObjectKey == "" {
+		t.Fatal("expected a non-empty stored key")
+	}
+}
+
+func TestSubmitKYC_HostileFilenameDoesNotInfluenceTheStoredKey(t *testing.T) {
+	h, repo, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name": "Grace Hopper", "date_of_birth": "1985-01-01", "country": "US",
+		"id_type": "passport", "id_number": "Y98765",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "../../../etc/passwd", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 202 Accepted, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	repo.mu.Lock()
+	saved := repo.saved
+	repo.mu.Unlock()
+	if saved == nil {
+		t.Fatal("expected SaveKYCDocument to have been called")
+	}
+	if strings.Contains(saved.FrontObjectKey, "..") || strings.Contains(saved.FrontObjectKey, "passwd") {
+		t.Fatalf("stored key %q was influenced by the hostile filename", saved.FrontObjectKey)
+	}
+}
+
+func TestSubmitKYC_MissingFullNameIsRejected(t *testing.T) {
+	h, _, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"date_of_birth": "1990-05-14", "country": "GB", "id_type": "passport", "id_number": "X1",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "id.jpg", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request for a missing full_name, got %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitKYC_InvalidDateOfBirthIsRejected(t *testing.T) {
+	h, _, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name": "A B", "date_of_birth": "not-a-date", "country": "GB", "id_type": "passport", "id_number": "X1",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "id.jpg", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request for a malformed date_of_birth, got %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitKYC_UnknownCountryCodeIsRejected(t *testing.T) {
+	h, _, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name": "A B", "date_of_birth": "1990-05-14", "country": "ZZ", "id_type": "passport", "id_number": "X1",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "id.jpg", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request for an unknown country code, got %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitKYC_RejectsUploadWhenStorageIsNotConfigured(t *testing.T) {
+	h, repo, userID := newKYCTestHandler(t, false) // no SetKYCStore call
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name": "A B", "date_of_birth": "1990-05-14", "country": "GB", "id_type": "passport", "id_number": "X1",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "id.jpg", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// nester#1191: storage not ready => reject, never accept-and-discard.
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable when storage is unset, got %d", resp.StatusCode)
+	}
+	repo.mu.Lock()
+	saved := repo.saved
+	repo.mu.Unlock()
+	if saved != nil {
+		t.Fatal("expected no KYC document to be persisted when storage is unavailable")
+	}
+}
+
+func TestSubmitKYC_RejectsDisallowedContentType(t *testing.T) {
+	h, _, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range map[string]string{
+		"full_name": "A B", "date_of_birth": "1990-05-14", "country": "GB", "id_type": "passport", "id_number": "X1",
+	} {
+		_ = w.WriteField(k, v)
+	}
+	part, _ := w.CreatePart(map[string][]string{
+		"Content-Disposition": {`form-data; name="id_front"; filename="script.sh"`},
+		"Content-Type":        {"application/x-sh"},
+	})
+	_, _ = part.Write([]byte("#!/bin/sh\necho hi"))
+	_ = w.Close()
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), w.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("expected 415 Unsupported Media Type, got %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitKYC_ResponseBodyDoesNotLeakTheStorageKey(t *testing.T) {
+	// The response only ever needs to tell the client the submission is
+	// pending — no reason to echo storage internals back.
+	h, _, userID := newKYCTestHandler(t, true)
+	server := newTestServer(h)
+	defer server.Close()
+
+	fields := map[string]string{
+		"full_name": "A B", "date_of_birth": "1990-05-14", "country": "GB", "id_type": "passport", "id_number": "X1",
+	}
+	body, contentType := buildKYCMultipartBody(t, fields, "id.jpg", []byte("x"))
+
+	resp, err := http.Post(server.URL+"/api/v1/users/kyc/"+userID.String(), contentType, body)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var parsed map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := parsed["front_object_key"]; ok {
+		t.Fatal("response body must not include the storage key")
+	}
+}

--- a/apps/api/internal/objectstorage/objectstorage.go
+++ b/apps/api/internal/objectstorage/objectstorage.go
@@ -1,0 +1,141 @@
+// Package objectstorage stores uploaded files (currently: KYC identity
+// documents) behind a small interface, so the handler that accepts an
+// upload never has to know whether the bytes land on local disk, S3, or
+// anywhere else.
+//
+// Before this package existed, the KYC upload handler never uploaded
+// anything: it synthesized a storage key from the client-supplied filename
+// and discarded the file bytes entirely (nester#1191). This is a real,
+// working implementation — not a mock — but it is deliberately a local-disk
+// store rather than a cloud client: no S3/GCS credential, bucket, or SDK
+// decision has been made for this repo yet (confirmed: no AWS/GCS SDK
+// dependency exists in go.mod). The issue's own guidance is explicit for
+// this situation — "If storage is not ready, the endpoint should reject
+// document uploads rather than accept and discard them" — so Store's
+// contract is designed so a production cloud implementation is a drop-in
+// Store replacement later, and the handler treats a nil Store the same as
+// "storage is not ready" (503), never as "skip the upload."
+package objectstorage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// ErrContentTypeNotAllowed is returned when the upload's declared
+	// content type is not in the caller-supplied allowlist.
+	ErrContentTypeNotAllowed = errors.New("content type not allowed")
+	// ErrTooLarge is returned when the upload exceeds MaxBytes.
+	ErrTooLarge = errors.New("upload exceeds maximum allowed size")
+)
+
+// Store persists uploaded file content and returns a storage key a later
+// read can use to retrieve it. The key is never derived from anything the
+// caller supplies (nester#1191's second acceptance criterion) — Store
+// generates it itself.
+type Store interface {
+	// Put reads up to MaxBytes from r, validates contentType against
+	// allowedContentTypes, and persists the content. keyPrefix scopes the
+	// generated key (e.g. to a user id) without letting the caller choose
+	// the key itself. Returns the server-generated key on success.
+	Put(ctx context.Context, keyPrefix string, contentType string, r io.Reader) (key string, err error)
+}
+
+// LocalDiskStore is a real, working Store backed by the local filesystem.
+// Suitable for local development and as a functioning default in
+// environments that haven't provisioned cloud object storage yet — not
+// intended as the production store for a multi-instance deployment, where
+// a shared bucket (S3/GCS) is the right choice once that decision is made.
+type LocalDiskStore struct {
+	// BaseDir is the root directory files are written under. Created if it
+	// does not already exist.
+	BaseDir string
+	// MaxBytes bounds how much of r is read, regardless of any
+	// Content-Length the caller claims. A caller that provides more than
+	// MaxBytes fails with ErrTooLarge rather than exhausting disk.
+	MaxBytes int64
+	// AllowedContentTypes is the exact set of content types Put will
+	// accept. Anything else is rejected with ErrContentTypeNotAllowed
+	// before any bytes are written.
+	AllowedContentTypes map[string]struct{}
+}
+
+// NewLocalDiskStore constructs a LocalDiskStore and ensures baseDir exists.
+func NewLocalDiskStore(baseDir string, maxBytes int64, allowedContentTypes []string) (*LocalDiskStore, error) {
+	if err := os.MkdirAll(baseDir, 0o750); err != nil {
+		return nil, fmt.Errorf("objectstorage: create base dir: %w", err)
+	}
+	allowed := make(map[string]struct{}, len(allowedContentTypes))
+	for _, ct := range allowedContentTypes {
+		allowed[ct] = struct{}{}
+	}
+	return &LocalDiskStore{BaseDir: baseDir, MaxBytes: maxBytes, AllowedContentTypes: allowed}, nil
+}
+
+func (s *LocalDiskStore) Put(_ context.Context, keyPrefix string, contentType string, r io.Reader) (string, error) {
+	if _, ok := s.AllowedContentTypes[contentType]; !ok {
+		return "", fmt.Errorf("%w: %q", ErrContentTypeNotAllowed, contentType)
+	}
+
+	key, err := generateKey(keyPrefix)
+	if err != nil {
+		return "", fmt.Errorf("objectstorage: generate key: %w", err)
+	}
+
+	destPath := filepath.Join(s.BaseDir, key)
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o750); err != nil {
+		return "", fmt.Errorf("objectstorage: create key dir: %w", err)
+	}
+
+	// #nosec G304 -- destPath is built entirely from generateKey's own
+	// output (a fresh UUID-shaped random hex string) and keyPrefix, which
+	// callers pass as a trusted internal value (a user id), never from
+	// unsanitized client input — see generateKey's own doc comment.
+	f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o640)
+	if err != nil {
+		return "", fmt.Errorf("objectstorage: open destination: %w", err)
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(r, s.MaxBytes+1)
+	written, err := io.Copy(f, limited)
+	if err != nil {
+		_ = os.Remove(destPath)
+		return "", fmt.Errorf("objectstorage: write: %w", err)
+	}
+	if written > s.MaxBytes {
+		_ = os.Remove(destPath)
+		return "", ErrTooLarge
+	}
+
+	return key, nil
+}
+
+// generateKey builds a storage key from keyPrefix and a fresh random
+// component — never from anything a client supplies (e.g. an uploaded
+// file's declared filename), so a hostile filename (path separators,
+// traversal sequences, an attempt to overwrite another user's key) cannot
+// influence what gets stored or where (nester#1191).
+func generateKey(keyPrefix string) (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	safePrefix := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			return r
+		default:
+			return '_'
+		}
+	}, keyPrefix)
+	return filepath.Join(safePrefix, hex.EncodeToString(buf)), nil
+}

--- a/apps/api/internal/objectstorage/objectstorage_test.go
+++ b/apps/api/internal/objectstorage/objectstorage_test.go
@@ -1,0 +1,133 @@
+package objectstorage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *LocalDiskStore {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewLocalDiskStore(dir, 1024, []string{"image/jpeg", "image/png"})
+	if err != nil {
+		t.Fatalf("NewLocalDiskStore() error = %v", err)
+	}
+	return store
+}
+
+func TestLocalDiskStore_PutWritesRealBytesToDisk(t *testing.T) {
+	store := newTestStore(t)
+	content := []byte("this is a real uploaded file, not a mock")
+
+	key, err := store.Put(context.Background(), "user-123", "image/jpeg", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	fullPath := filepath.Join(store.BaseDir, key)
+	got, err := os.ReadFile(fullPath) // #nosec G304 -- test reads back exactly what Put wrote
+	if err != nil {
+		t.Fatalf("expected the file to exist on disk at %s: %v", fullPath, err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("stored content = %q, want %q", got, content)
+	}
+}
+
+func TestLocalDiskStore_KeyIsServerGeneratedNotClientInfluenced(t *testing.T) {
+	store := newTestStore(t)
+
+	hostileFilenames := []string{
+		"../../../etc/passwd",
+		"..\\..\\windows\\system32\\config",
+		"/etc/shadow",
+		"a" + strings.Repeat("/../", 20) + "b",
+	}
+
+	for _, hostile := range hostileFilenames {
+		// The Store interface never even accepts a filename — Put's
+		// signature has no parameter a caller could use to influence the
+		// key. This test documents that guarantee explicitly: passing a
+		// hostile string as the keyPrefix (the only caller-influenced
+		// input Put accepts, normally a trusted user id) is neutralized
+		// rather than used verbatim.
+		key, err := store.Put(context.Background(), hostile, "image/jpeg", bytes.NewReader([]byte("x")))
+		if err != nil {
+			t.Fatalf("Put() error = %v for keyPrefix %q", err, hostile)
+		}
+		if strings.Contains(key, "..") {
+			t.Fatalf("generated key %q retains a path-traversal sequence from keyPrefix %q", key, hostile)
+		}
+		if filepath.IsAbs(key) {
+			t.Fatalf("generated key %q is absolute (escapes BaseDir) for keyPrefix %q", key, hostile)
+		}
+		resolved := filepath.Join(store.BaseDir, key)
+		if !strings.HasPrefix(resolved, filepath.Clean(store.BaseDir)+string(filepath.Separator)) {
+			t.Fatalf("resolved path %q escapes BaseDir %q for keyPrefix %q", resolved, store.BaseDir, hostile)
+		}
+	}
+}
+
+func TestLocalDiskStore_RejectsDisallowedContentType(t *testing.T) {
+	store := newTestStore(t)
+
+	_, err := store.Put(context.Background(), "user-1", "application/x-executable", bytes.NewReader([]byte("x")))
+	if !errors.Is(err, ErrContentTypeNotAllowed) {
+		t.Fatalf("Put() error = %v, want ErrContentTypeNotAllowed", err)
+	}
+}
+
+func TestLocalDiskStore_RejectsUploadsOverMaxBytes(t *testing.T) {
+	store := newTestStore(t)
+	oversized := bytes.Repeat([]byte("a"), int(store.MaxBytes)+1)
+
+	_, err := store.Put(context.Background(), "user-1", "image/jpeg", bytes.NewReader(oversized))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("Put() error = %v, want ErrTooLarge", err)
+	}
+}
+
+func TestLocalDiskStore_RejectsUploadsAtExactlyMaxBytesPlusOne(t *testing.T) {
+	store := newTestStore(t)
+	exact := bytes.Repeat([]byte("a"), int(store.MaxBytes))
+
+	if _, err := store.Put(context.Background(), "user-1", "image/jpeg", bytes.NewReader(exact)); err != nil {
+		t.Fatalf("Put() at exactly MaxBytes should succeed, got error = %v", err)
+	}
+}
+
+func TestLocalDiskStore_DoesNotLeaveAPartialFileOnOversizedUpload(t *testing.T) {
+	store := newTestStore(t)
+	oversized := bytes.Repeat([]byte("a"), int(store.MaxBytes)*2)
+
+	key, err := store.Put(context.Background(), "user-1", "image/jpeg", bytes.NewReader(oversized))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("Put() error = %v, want ErrTooLarge", err)
+	}
+	if key != "" {
+		if _, statErr := os.Stat(filepath.Join(store.BaseDir, key)); statErr == nil {
+			t.Fatalf("expected the oversized upload's partial file to be removed, but it still exists")
+		}
+	}
+}
+
+func TestLocalDiskStore_TwoUploadsFromTheSameUserGetDifferentKeys(t *testing.T) {
+	store := newTestStore(t)
+
+	key1, err := store.Put(context.Background(), "user-1", "image/jpeg", bytes.NewReader([]byte("first")))
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	key2, err := store.Put(context.Background(), "user-1", "image/jpeg", bytes.NewReader([]byte("second")))
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if key1 == key2 {
+		t.Fatalf("expected distinct keys for two separate uploads, got the same key %q twice", key1)
+	}
+}

--- a/apps/api/internal/reconciliation/comparators.go
+++ b/apps/api/internal/reconciliation/comparators.go
@@ -29,46 +29,71 @@ type BalanceComparator struct {
 func (c BalanceComparator) Name() string { return "vault_balance" }
 func (c BalanceComparator) Level() Level { return LevelBalance }
 
+// vaultReconcilePageSize is the page size Reconcile fetches at a time. It
+// bounds single-query memory/row cost, not how many active vaults are
+// checked — Reconcile pages through every vault ListVaults reports via its
+// total count. Reconciliation exists specifically to catch balances that
+// have drifted from on-chain state; checking only the first page silently
+// shrinks the fraction of the book actually verified as the vault count
+// grows past it, while every run still reports success (nester#1192).
+const vaultReconcilePageSize = 500
+
 func (c BalanceComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
 	now := clock(c.Clock)
-	filter := vault.ListFilter{Status: string(vault.StatusActive), Limit: 500, Offset: 0}
-	vaults, _, err := c.Vaults.ListVaults(ctx, filter)
-	if err != nil {
-		return ComparisonResult{}, err
-	}
 
 	var findings []Finding
 	classifier := NewClassifier(c.Classifier)
 	checked := 0
-	for _, v := range vaults {
-		if scope.VaultID != uuid.Nil && v.ID != scope.VaultID {
-			continue
-		}
-		checked++
-		if v.ContractAddress == "" {
-			continue
-		}
-		onChain, err := c.Chain.TotalAssets(ctx, v.ContractAddress)
+	offset := 0
+	for {
+		filter := vault.ListFilter{Status: string(vault.StatusActive), Limit: vaultReconcilePageSize, Offset: offset}
+		vaults, total, err := c.Vaults.ListVaults(ctx, filter)
 		if err != nil {
-			return ComparisonResult{}, err
+			// A page-fetch failure mid-run fails the whole run rather than
+			// silently returning only what was checked so far as if it were
+			// complete (nester#1192's fourth acceptance criterion).
+			return ComparisonResult{Checked: checked}, err
 		}
-		if !v.CurrentBalance.Equal(onChain) {
-			recorded := v.CurrentBalance
-			chain := onChain
-			findings = append(findings, classifier.Classify(FindingInput{
-				Level:         LevelBalance,
-				Type:          TypeMismatch,
-				EntityType:    "vault",
-				EntityID:      v.ID.String(),
-				RecordedValue: &recorded,
-				OnChainValue:  &chain,
-				Details: map[string]string{
-					"contract_address": v.ContractAddress,
-					"currency":         v.Currency,
-				},
-			}, now))
+
+		for _, v := range vaults {
+			if scope.VaultID != uuid.Nil && v.ID != scope.VaultID {
+				continue
+			}
+			checked++
+			if v.ContractAddress == "" {
+				continue
+			}
+			onChain, err := c.Chain.TotalAssets(ctx, v.ContractAddress)
+			if err != nil {
+				return ComparisonResult{Checked: checked}, err
+			}
+			if !v.CurrentBalance.Equal(onChain) {
+				recorded := v.CurrentBalance
+				chain := onChain
+				findings = append(findings, classifier.Classify(FindingInput{
+					Level:         LevelBalance,
+					Type:          TypeMismatch,
+					EntityType:    "vault",
+					EntityID:      v.ID.String(),
+					RecordedValue: &recorded,
+					OnChainValue:  &chain,
+					Details: map[string]string{
+						"contract_address": v.ContractAddress,
+						"currency":         v.Currency,
+					},
+				}, now))
+			}
+		}
+
+		offset += len(vaults)
+		// len(vaults) == 0 guards against an implementation whose total
+		// count disagrees with what it actually returns, so a mismatch can
+		// never spin this loop forever.
+		if offset >= total || len(vaults) == 0 {
+			break
 		}
 	}
+
 	return ComparisonResult{Checked: checked, Findings: findings}, nil
 }
 

--- a/apps/api/internal/reconciliation/comparators_test.go
+++ b/apps/api/internal/reconciliation/comparators_test.go
@@ -1,0 +1,224 @@
+package reconciliation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// fakeVaultLister is an in-memory VaultLister that honors Limit/Offset like
+// the real postgres-backed implementation: it returns a genuine total count
+// independent of the page size, so a caller that pages via that count
+// eventually terminates and collects every vault.
+type fakeVaultLister struct {
+	vaults []vault.Vault
+	// calls records each (Limit, Offset) pair Reconcile requested, so tests
+	// can assert on the exact paging behavior, not just the result.
+	calls []vault.ListFilter
+	// failOnCall, when > 0, makes the Nth ListVaults call (1-indexed) return
+	// an error instead of a page — simulating a page fetch failing mid-run.
+	failOnCall int
+}
+
+func (f *fakeVaultLister) ListVaults(_ context.Context, filter vault.ListFilter) ([]vault.Vault, int, error) {
+	f.calls = append(f.calls, filter)
+	if f.failOnCall > 0 && len(f.calls) == f.failOnCall {
+		return nil, 0, errors.New("db unavailable")
+	}
+	total := len(f.vaults)
+	start := filter.Offset
+	if start > total {
+		start = total
+	}
+	end := start + filter.Limit
+	if end > total {
+		end = total
+	}
+	return f.vaults[start:end], total, nil
+}
+
+// fakeChainReader reports a fixed on-chain balance per contract address; any
+// address not in balances is treated as matching whatever CurrentBalance the
+// test set, i.e. no finding.
+type fakeChainReader struct {
+	balances map[string]decimal.Decimal
+}
+
+func (f *fakeChainReader) TotalAssets(_ context.Context, contractAddress string) (decimal.Decimal, error) {
+	if bal, ok := f.balances[contractAddress]; ok {
+		return bal, nil
+	}
+	return decimal.Zero, nil
+}
+
+func makeVault(contractAddress string, balance decimal.Decimal) vault.Vault {
+	return vault.Vault{
+		ID:              uuid.New(),
+		ContractAddress: contractAddress,
+		CurrentBalance:  balance,
+		Currency:        "USDC",
+		Status:          vault.StatusActive,
+	}
+}
+
+func TestBalanceComparator_Reconcile_ChecksEveryVaultAcrossPages(t *testing.T) {
+	// More vaults than a single page (vaultReconcilePageSize) would return,
+	// so this only passes if Reconcile actually pages rather than
+	// truncating at the first response (nester#1192).
+	var vaults []vault.Vault
+	balances := map[string]decimal.Decimal{}
+	vaultCount := vaultReconcilePageSize*2 + 37
+	for i := 0; i < vaultCount; i++ {
+		addr := uuid.New().String()
+		bal := decimal.NewFromInt(int64(i))
+		vaults = append(vaults, makeVault(addr, bal))
+		balances[addr] = bal // matches, so no findings — this test is about coverage, not mismatches
+	}
+
+	lister := &fakeVaultLister{vaults: vaults}
+	chain := &fakeChainReader{balances: balances}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.Checked != vaultCount {
+		t.Fatalf("Checked = %d, want %d (some vaults were silently skipped)", result.Checked, vaultCount)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings (balances match), got %d", len(result.Findings))
+	}
+
+	if len(lister.calls) < 3 {
+		t.Fatalf("expected at least 3 paged calls for %d vaults at page size %d, got %d calls",
+			vaultCount, vaultReconcilePageSize, len(lister.calls))
+	}
+	for i, call := range lister.calls {
+		if call.Limit != vaultReconcilePageSize {
+			t.Fatalf("call %d: Limit = %d, want %d", i, call.Limit, vaultReconcilePageSize)
+		}
+		if call.Status != string(vault.StatusActive) {
+			t.Fatalf("call %d: Status = %q, want %q", i, call.Status, vault.StatusActive)
+		}
+	}
+}
+
+func TestBalanceComparator_Reconcile_DetectsMismatchOnASecondPage(t *testing.T) {
+	// A drifted balance on a vault that only exists past the first page must
+	// still be caught — proves comparison logic runs on every page, not just
+	// the first.
+	var vaults []vault.Vault
+	balances := map[string]decimal.Decimal{}
+	for i := 0; i < vaultReconcilePageSize+5; i++ {
+		addr := uuid.New().String()
+		bal := decimal.NewFromInt(int64(i))
+		vaults = append(vaults, makeVault(addr, bal))
+		balances[addr] = bal
+	}
+	// The last vault (past page 1) has drifted on-chain.
+	driftedAddr := vaults[len(vaults)-1].ContractAddress
+	balances[driftedAddr] = decimal.NewFromInt(999999)
+
+	lister := &fakeVaultLister{vaults: vaults}
+	chain := &fakeChainReader{balances: balances}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected exactly 1 finding for the drifted vault past page 1, got %d", len(result.Findings))
+	}
+}
+
+func TestBalanceComparator_Reconcile_EmptyResultSinglePage(t *testing.T) {
+	lister := &fakeVaultLister{}
+	chain := &fakeChainReader{}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.Checked != 0 {
+		t.Fatalf("Checked = %d, want 0", result.Checked)
+	}
+	if len(lister.calls) != 1 {
+		t.Fatalf("expected exactly one call for an empty result, got %d", len(lister.calls))
+	}
+}
+
+func TestBalanceComparator_Reconcile_SinglePageDoesNotOverFetch(t *testing.T) {
+	vaults := []vault.Vault{makeVault("addr-1", decimal.NewFromInt(1)), makeVault("addr-2", decimal.NewFromInt(2))}
+	lister := &fakeVaultLister{vaults: vaults}
+	chain := &fakeChainReader{}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	if _, err := comparator.Reconcile(context.Background(), Scope{}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if len(lister.calls) != 1 {
+		t.Fatalf("expected exactly one call when everything fits on one page, got %d", len(lister.calls))
+	}
+}
+
+func TestBalanceComparator_Reconcile_PageFetchFailureMidRunFailsTheWholeRun(t *testing.T) {
+	// Enough vaults to require a second page, which is made to fail.
+	var vaults []vault.Vault
+	for i := 0; i < vaultReconcilePageSize+5; i++ {
+		vaults = append(vaults, makeVault(uuid.New().String(), decimal.NewFromInt(int64(i))))
+	}
+	lister := &fakeVaultLister{vaults: vaults, failOnCall: 2}
+	chain := &fakeChainReader{}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{})
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want the page-fetch error to propagate")
+	}
+	// The run must not silently report success/partial coverage as if it
+	// were complete — nester#1192's fourth acceptance criterion.
+	if result.Checked != vaultReconcilePageSize {
+		t.Fatalf("Checked = %d, want %d (only the vaults from the successful first page)",
+			result.Checked, vaultReconcilePageSize)
+	}
+}
+
+func TestBalanceComparator_Reconcile_ScopedToOneVaultStillPagesThroughAll(t *testing.T) {
+	// scope.VaultID filters which vault produces findings, but Reconcile
+	// must still fetch every page to find it — it cannot stop paging just
+	// because the target vault might be on an earlier page.
+	var vaults []vault.Vault
+	balances := map[string]decimal.Decimal{}
+	for i := 0; i < vaultReconcilePageSize+5; i++ {
+		addr := uuid.New().String()
+		bal := decimal.NewFromInt(int64(i))
+		vaults = append(vaults, makeVault(addr, bal))
+		balances[addr] = bal
+	}
+	target := vaults[len(vaults)-1]
+	balances[target.ContractAddress] = decimal.NewFromInt(999999)
+
+	lister := &fakeVaultLister{vaults: vaults}
+	chain := &fakeChainReader{balances: balances}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{VaultID: target.ID})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected the scoped vault's drift to be found even though it's past page 1, got %d findings", len(result.Findings))
+	}
+	if len(lister.calls) < 2 {
+		t.Fatalf("expected Reconcile to page past the first page even when scoped to one vault, got %d calls", len(lister.calls))
+	}
+}

--- a/apps/api/internal/repository/postgres/user_repository.go
+++ b/apps/api/internal/repository/postgres/user_repository.go
@@ -229,14 +229,15 @@ func (r *UserRepository) SaveKYCDocument(ctx context.Context, doc *user.KYCDocum
 		INSERT INTO kyc_documents (
 			id, user_id, id_type, id_number, front_object_key, back_object_key,
 			id_number_encrypted, id_number_fingerprint, front_object_key_encrypted,
-			back_object_key_encrypted, key_version
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			back_object_key_encrypted, key_version, full_name, date_of_birth, country
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		RETURNING submitted_at
 	`
 	err := r.db.QueryRowContext(ctx, query,
 		doc.ID.String(), doc.UserID.String(), doc.IDType, doc.IDNumber, doc.FrontObjectKey, doc.BackObjectKey,
 		encrypted.IDNumberEncrypted, encrypted.IDNumberFingerprint, encrypted.FrontKeyEncrypted,
 		nullOptionalBytes(encrypted.BackKeyEncrypted), encrypted.KeyVersion,
+		doc.FullName, doc.DateOfBirth, doc.Country,
 	).Scan(&doc.SubmittedAt)
 	return err
 }
@@ -245,7 +246,7 @@ func (r *UserRepository) GetKYCDocument(ctx context.Context, userID uuid.UUID) (
 	query := `
 		SELECT id, user_id, id_type, id_number, front_object_key, back_object_key,
 		       id_number_encrypted, id_number_fingerprint, front_object_key_encrypted,
-		       back_object_key_encrypted, key_version, submitted_at
+		       back_object_key_encrypted, key_version, full_name, date_of_birth, country, submitted_at
 		FROM kyc_documents
 		WHERE user_id = $1
 		ORDER BY submitted_at DESC
@@ -256,10 +257,12 @@ func (r *UserRepository) GetKYCDocument(ctx context.Context, userID uuid.UUID) (
 	var id, uid string
 	var backKey sql.NullString
 	var idNumFingerprint, kv sql.NullString
+	var fullName, country sql.NullString
+	var dateOfBirth sql.NullTime
 	if err := r.db.QueryRowContext(ctx, query, userID.String()).Scan(
 		&id, &uid, &doc.IDType, &doc.IDNumber, &doc.FrontObjectKey, &backKey,
 		&encrypted.IDNumberEncrypted, &idNumFingerprint, &encrypted.FrontKeyEncrypted,
-		&encrypted.BackKeyEncrypted, &kv, &doc.SubmittedAt,
+		&encrypted.BackKeyEncrypted, &kv, &fullName, &dateOfBirth, &country, &doc.SubmittedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, errors.New("no kyc document found")
@@ -276,6 +279,15 @@ func (r *UserRepository) GetKYCDocument(ctx context.Context, userID uuid.UUID) (
 	}
 	if kv.Valid {
 		encrypted.KeyVersion = kv.String
+	}
+	if fullName.Valid {
+		doc.FullName = fullName.String
+	}
+	if country.Valid {
+		doc.Country = country.String
+	}
+	if dateOfBirth.Valid {
+		doc.DateOfBirth = dateOfBirth.Time
 	}
 	return &doc, &encrypted, nil
 }

--- a/apps/api/internal/service/user_service.go
+++ b/apps/api/internal/service/user_service.go
@@ -54,7 +54,7 @@ func (s *UserService) GetUserRoles(ctx context.Context, id uuid.UUID) ([]string,
 
 var ErrEncryptionUnavailable = errors.New("encryption is not configured")
 
-func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, idType, idNumber, frontKey string, backKey *string) error {
+func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, identity user.KYCIdentity, idType, idNumber, frontKey string, backKey *string) error {
 	if s.cipher == nil {
 		return ErrEncryptionUnavailable
 	}
@@ -86,6 +86,9 @@ func (s *UserService) SubmitKYC(ctx context.Context, userID uuid.UUID, idType, i
 		IDNumber:       idNumber,
 		FrontObjectKey: frontKey,
 		BackObjectKey:  backKey,
+		FullName:       identity.FullName,
+		DateOfBirth:    identity.DateOfBirth,
+		Country:        identity.Country,
 	}
 
 	encrypted := &user.EncryptedKYCDoc{

--- a/apps/api/migrations/107_add_kyc_identity_fields.down.sql
+++ b/apps/api/migrations/107_add_kyc_identity_fields.down.sql
@@ -1,0 +1,5 @@
+-- Reverses 107_add_kyc_identity_fields.up.sql (nester#1190).
+ALTER TABLE kyc_documents
+    DROP COLUMN IF EXISTS full_name,
+    DROP COLUMN IF EXISTS date_of_birth,
+    DROP COLUMN IF EXISTS country;

--- a/apps/api/migrations/107_add_kyc_identity_fields.up.sql
+++ b/apps/api/migrations/107_add_kyc_identity_fields.up.sql
@@ -1,0 +1,17 @@
+-- Adds the identity fields the KYC submission handler already reads from
+-- the request but has never persisted (nester#1190): full_name,
+-- date_of_birth, country. A user who submitted a complete KYC record had
+-- no way to tell these were silently dropped — the record looked accepted
+-- from the outside while missing the fields a compliance review needs.
+--
+-- Plaintext for now, matching kyc_documents' own original shape before the
+-- later id_number/object-key encryption pass (migration 069) — full_name
+-- and date_of_birth are sensitive PII and a genuine candidate for the same
+-- encrypted-column treatment, but that is a separate, deliberate follow-up
+-- rather than silently bundled into the fix for the underlying data-loss
+-- bug. country is a coarse jurisdiction identifier, not sensitive on its
+-- own.
+ALTER TABLE kyc_documents
+    ADD COLUMN full_name     TEXT,
+    ADD COLUMN date_of_birth DATE,
+    ADD COLUMN country       TEXT;

--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -717,6 +717,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 name = "lp_aggregator"
 version = "0.1.0"
 dependencies = [
+ "nester-test-utils",
  "soroban-sdk",
 ]
 

--- a/packages/contracts/contracts/lp_aggregator/Cargo.toml
+++ b/packages/contracts/contracts/lp_aggregator/Cargo.toml
@@ -11,3 +11,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+nester-test-utils = { path = "../../libs/test_utils" }

--- a/packages/contracts/contracts/lp_aggregator/src/lib.rs
+++ b/packages/contracts/contracts/lp_aggregator/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, contracterror, panic_with_error, symbol_short,
-    Address, Env, Vec, Symbol, vec, Val, IntoVal,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, vec,
+    Address, Env, IntoVal, Symbol, Val, Vec,
 };
 
 // ── Error codes ───────────────────────────────────────────────────────────────
@@ -10,11 +10,12 @@ use soroban_sdk::{
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum AggregatorError {
-    NoRoutesFound    = 1,
+    NoRoutesFound = 1,
     SlippageExceeded = 2,
-    MaxHopsExceeded  = 3,
-    EmptyPath        = 4,
-    InvalidMaxHops   = 5,
+    MaxHopsExceeded = 3,
+    EmptyPath = 4,
+    InvalidMaxHops = 5,
+    ReservesUnavailable = 6,
 }
 
 // ── Data types ────────────────────────────────────────────────────────────────
@@ -23,16 +24,16 @@ pub enum AggregatorError {
 #[derive(Clone)]
 pub struct SwapHop {
     pub pool_address: Address,
-    pub token_in:     Address,
-    pub token_out:    Address,
-    pub amount_in:    i128,
+    pub token_in: Address,
+    pub token_out: Address,
+    pub amount_in: i128,
 }
 
 #[contracttype]
 #[derive(Clone)]
 pub struct SwapRoute {
-    pub hops:             Vec<SwapHop>,
-    pub expected_out:     i128,
+    pub hops: Vec<SwapHop>,
+    pub expected_out: i128,
     pub price_impact_bps: u32,
 }
 
@@ -41,7 +42,7 @@ pub struct SwapRoute {
 /// Default maximum hops for execute_path_payment (prevents unbounded execution cost).
 const MAX_HOPS_DEFAULT: u32 = 3;
 /// Hard ceiling for find_paths max_hops parameter.
-const MAX_HOPS_LIMIT: u32   = 5;
+const MAX_HOPS_LIMIT: u32 = 5;
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -59,20 +60,29 @@ impl LpAggregator {
             .unwrap_or(vec![env])
     }
 
-    /// Simulate a single-pool swap using the constant-product formula.
-    /// Attempts to call the pool's `get_reserves` for live reserve data; falls back
-    /// to 1:1 reserves when the call is unavailable (e.g. in unit tests).
-    fn simulate_swap(env: &Env, pool: Address, amount_in: i128) -> SwapRoute {
+    /// Simulate a single-pool swap using the constant-product formula, priced
+    /// off the pool's real, live reserves.
+    ///
+    /// Calls the pool's `get_reserves` and returns `None` if the call fails
+    /// or the pool reports non-positive reserves (e.g. an unregistered or
+    /// misbehaving pool address) — callers skip that route rather than
+    /// pricing a swap against fabricated 1:1 reserves (nester#1189).
+    fn simulate_swap(env: &Env, pool: Address, amount_in: i128) -> Option<SwapRoute> {
         let args: Vec<Val> = vec![env];
-        // Use try_invoke_contract so tests with unregistered pool addresses don't panic.
-        let _ = env.try_invoke_contract::<Val, AggregatorError>(
-            &pool,
-            &Symbol::new(env, "get_reserves"),
-            args,
-        );
+        let (reserve_in, reserve_out) = match env
+            .try_invoke_contract::<(i128, i128), AggregatorError>(
+                &pool,
+                &Symbol::new(env, "get_reserves"),
+                args,
+            ) {
+            Ok(Ok(reserves)) => reserves,
+            _ => return None,
+        };
+        if reserve_in <= 0 || reserve_out <= 0 {
+            return None;
+        }
 
         // Constant product: output = (amount_in * reserve_out) / (reserve_in + amount_in)
-        let (reserve_in, reserve_out): (i128, i128) = (1_000_000, 1_000_000);
         let expected_out = (amount_in * reserve_out) / (reserve_in + amount_in);
 
         let price_impact_bps = if amount_in > 0 {
@@ -83,11 +93,15 @@ impl LpAggregator {
 
         let hop = SwapHop {
             pool_address: pool.clone(),
-            token_in:     pool.clone(),
-            token_out:    pool.clone(),
+            token_in: pool.clone(),
+            token_out: pool.clone(),
             amount_in,
         };
-        SwapRoute { hops: vec![env, hop], expected_out, price_impact_bps }
+        Some(SwapRoute {
+            hops: vec![env, hop],
+            expected_out,
+            price_impact_bps,
+        })
     }
 
     /// Execute one hop via cross-contract call to the pool's `swap` function.
@@ -123,17 +137,20 @@ impl LpAggregator {
         let mut best: Option<SwapRoute> = None;
 
         for pool in pools.iter() {
-            let route = Self::simulate_swap(&env, pool, amount_in);
+            let route = match Self::simulate_swap(&env, pool, amount_in) {
+                Some(r) => r,
+                None => continue,
+            };
             best = Some(match best {
-                None                                        => route,
+                None => route,
                 Some(b) if route.expected_out > b.expected_out => route,
-                Some(b)                                     => b,
+                Some(b) => b,
             });
         }
 
         match best {
             Some(r) => r,
-            None    => panic_with_error!(&env, AggregatorError::NoRoutesFound),
+            None => panic_with_error!(&env, AggregatorError::NoRoutesFound),
         }
     }
 
@@ -158,7 +175,9 @@ impl LpAggregator {
 
         // 1-hop: one pool directly
         for pool in pools.iter() {
-            routes.push_back(Self::simulate_swap(&env, pool, amount_in));
+            if let Some(route) = Self::simulate_swap(&env, pool, amount_in) {
+                routes.push_back(route);
+            }
         }
 
         if max_hops >= 2 {
@@ -168,26 +187,34 @@ impl LpAggregator {
                         continue;
                     }
 
-                    let first   = Self::simulate_swap(&env, pool_a.clone(), amount_in);
+                    let first = match Self::simulate_swap(&env, pool_a.clone(), amount_in) {
+                        Some(r) => r,
+                        None => continue,
+                    };
                     let mid_out = first.expected_out;
                     if mid_out <= 0 {
                         continue;
                     }
 
-                    let second = Self::simulate_swap(&env, pool_b.clone(), mid_out);
-                    let impact2 = first.price_impact_bps.saturating_add(second.price_impact_bps);
+                    let second = match Self::simulate_swap(&env, pool_b.clone(), mid_out) {
+                        Some(r) => r,
+                        None => continue,
+                    };
+                    let impact2 = first
+                        .price_impact_bps
+                        .saturating_add(second.price_impact_bps);
 
                     let hop_a = SwapHop {
                         pool_address: pool_a.clone(),
-                        token_in:     token_in.clone(),
-                        token_out:    pool_a.clone(),
+                        token_in: token_in.clone(),
+                        token_out: pool_a.clone(),
                         amount_in,
                     };
                     let hop_b = SwapHop {
                         pool_address: pool_b.clone(),
-                        token_in:     pool_a.clone(),
-                        token_out:    token_out.clone(),
-                        amount_in:    mid_out,
+                        token_in: pool_a.clone(),
+                        token_out: token_out.clone(),
+                        amount_in: mid_out,
                     };
                     let mut hops2: Vec<SwapHop> = vec![&env];
                     hops2.push_back(hop_a);
@@ -199,30 +226,37 @@ impl LpAggregator {
                             if pool_c == pool_a || pool_c == pool_b {
                                 continue;
                             }
-                            let third = Self::simulate_swap(&env, pool_c.clone(), second.expected_out);
+                            let third = match Self::simulate_swap(
+                                &env,
+                                pool_c.clone(),
+                                second.expected_out,
+                            ) {
+                                Some(r) => r,
+                                None => continue,
+                            };
                             if third.expected_out <= 0 {
                                 continue;
                             }
                             let impact3 = impact2.saturating_add(third.price_impact_bps);
                             let hop_c = SwapHop {
                                 pool_address: pool_c.clone(),
-                                token_in:     pool_b.clone(),
-                                token_out:    token_out.clone(),
-                                amount_in:    second.expected_out,
+                                token_in: pool_b.clone(),
+                                token_out: token_out.clone(),
+                                amount_in: second.expected_out,
                             };
                             let mut hops3 = hops2.clone();
                             hops3.push_back(hop_c);
                             routes.push_back(SwapRoute {
-                                hops:             hops3,
-                                expected_out:     third.expected_out,
+                                hops: hops3,
+                                expected_out: third.expected_out,
                                 price_impact_bps: impact3,
                             });
                         }
                     }
 
                     routes.push_back(SwapRoute {
-                        hops:             hops2,
-                        expected_out:     second.expected_out,
+                        hops: hops2,
+                        expected_out: second.expected_out,
                         price_impact_bps: impact2,
                     });
                 }
@@ -273,14 +307,14 @@ impl LpAggregator {
         let mut running = amount_in;
 
         for i in 0..hops {
-            let pool = pools.get(0).unwrap_or_else(|| {
-                panic_with_error!(&env, AggregatorError::NoRoutesFound)
-            });
+            let pool = pools
+                .get(0)
+                .unwrap_or_else(|| panic_with_error!(&env, AggregatorError::NoRoutesFound));
             let hop = SwapHop {
                 pool_address: pool,
-                token_in:     path.get(i).unwrap(),
-                token_out:    path.get(i + 1).unwrap(),
-                amount_in:    running,
+                token_in: path.get(i).unwrap(),
+                token_out: path.get(i + 1).unwrap(),
+                amount_in: running,
             };
             running = Self::execute_hop(&env, hop, running);
         }
@@ -314,20 +348,50 @@ impl LpAggregator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nester_test_utils::mocks::{MockAmmPool, MockAmmPoolClient};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::Env;
 
+    /// Registers `n` real `MockAmmPool` contracts (not bare generated
+    /// addresses) so `simulate_swap`'s `get_reserves` cross-contract call has
+    /// a live pool to read from, each seeded with balanced 1_000_000/1_000_000
+    /// reserves — the same shape the old hardcoded fallback assumed, but now
+    /// actually read from the pool rather than fabricated (nester#1189).
     fn setup_with_pools(n: u32) -> (Env, Address, Vec<Address>) {
         let env = Env::default();
         let contract_id = env.register_contract(None, LpAggregator);
         let mut pools: Vec<Address> = vec![&env];
         for _ in 0..n {
-            pools.push_back(Address::generate(&env));
+            let pool_id = env.register_contract(None, MockAmmPool);
+            let pool = MockAmmPoolClient::new(&env, &pool_id);
+            let token_a = Address::generate(&env);
+            pool.initialize(&token_a, &1_000_000, &1_000_000);
+            pools.push_back(pool_id);
         }
         env.as_contract(&contract_id, || {
-            env.storage().instance().set(&symbol_short!("POOLS"), &pools);
+            env.storage()
+                .instance()
+                .set(&symbol_short!("POOLS"), &pools);
         });
         (env, contract_id, pools)
+    }
+
+    /// Registers a single `MockAmmPool` with the given reserves, for tests
+    /// that need to control the reserve ratio or size directly.
+    fn setup_with_pool_reserves(reserve_a: i128, reserve_b: i128) -> (Env, Address, Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, LpAggregator);
+        let pool_id = env.register_contract(None, MockAmmPool);
+        let pool = MockAmmPoolClient::new(&env, &pool_id);
+        let token_a = Address::generate(&env);
+        pool.initialize(&token_a, &reserve_a, &reserve_b);
+        let pools: Vec<Address> = vec![&env, pool_id.clone()];
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("POOLS"), &pools);
+        });
+        (env, contract_id, pool_id)
     }
 
     // ── find_paths ────────────────────────────────────────────────────────────
@@ -364,9 +428,7 @@ mod tests {
 
         let routes = client.find_paths(&ti, &to, &1_000_000, &3);
         for i in 1..routes.len() {
-            assert!(
-                routes.get(i - 1).unwrap().expected_out >= routes.get(i).unwrap().expected_out
-            );
+            assert!(routes.get(i - 1).unwrap().expected_out >= routes.get(i).unwrap().expected_out);
         }
     }
 
@@ -397,7 +459,7 @@ mod tests {
         let (env, contract_id, _) = setup_with_pools(2);
         let client = LpAggregatorClient::new(&env, &contract_id);
         let usdc = Address::generate(&env);
-        let xlm  = Address::generate(&env);
+        let xlm = Address::generate(&env);
         let yxlm = Address::generate(&env);
         let path: Vec<Address> = vec![&env, usdc, xlm, yxlm];
         // execute_hop returns 0; min_amount_out = 0 passes
@@ -454,6 +516,83 @@ mod tests {
         client.execute_path_payment(&path, &1_000_000, &0);
     }
 
+    // ── simulate_swap uses real reserves (nester#1189) ───────────────────────
+
+    #[test]
+    fn test_get_best_route_prices_off_real_balanced_reserves() {
+        let (env, contract_id, pool_id) = setup_with_pool_reserves(1_000_000, 1_000_000);
+        let client = LpAggregatorClient::new(&env, &contract_id);
+        let ti = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let route = client.get_best_route(&ti, &to, &100_000);
+        // Constant product with a balanced 1_000_000/1_000_000 pool:
+        // out = 100_000 * 1_000_000 / (1_000_000 + 100_000) = 90_909
+        assert_eq!(route.expected_out, 90_909);
+        assert_eq!(route.hops.get(0).unwrap().pool_address, pool_id);
+    }
+
+    #[test]
+    fn test_get_best_route_prices_off_real_imbalanced_reserves() {
+        // Heavily imbalanced pool: 10x more of the out-token than the in-token,
+        // so a real read must produce a very different (much larger) output
+        // than the old hardcoded 1:1 fallback would have.
+        let (env, contract_id, _pool_id) = setup_with_pool_reserves(1_000_000, 10_000_000);
+        let client = LpAggregatorClient::new(&env, &contract_id);
+        let ti = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let route = client.get_best_route(&ti, &to, &100_000);
+        // out = 100_000 * 10_000_000 / (1_000_000 + 100_000) = 909_090
+        assert_eq!(route.expected_out, 909_090);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_best_route_panics_when_no_pool_reserves_are_reachable() {
+        // Registered "pools" that are bare generated addresses (no contract
+        // behind them) can never answer get_reserves, so every route must be
+        // skipped and get_best_route has nothing left to return.
+        let (env, contract_id, _) = setup_with_pools(0);
+        let mut pools: Vec<Address> = vec![&env];
+        pools.push_back(Address::generate(&env));
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("POOLS"), &pools);
+        });
+        let client = LpAggregatorClient::new(&env, &contract_id);
+        let ti = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.get_best_route(&ti, &to, &100_000);
+    }
+
+    #[test]
+    fn test_find_paths_skips_unreachable_pools_without_panicking() {
+        // Mix one real pool with one unreachable (bare address, no contract)
+        // pool. find_paths must skip the unreachable one and still return the
+        // route(s) priced off the real pool, rather than panicking or pricing
+        // the unreachable pool with a fabricated fallback.
+        let (env, contract_id, real_pool) = setup_with_pool_reserves(1_000_000, 1_000_000);
+        env.as_contract(&contract_id, || {
+            let mut pools: Vec<Address> = vec![&env, real_pool.clone()];
+            pools.push_back(Address::generate(&env));
+            env.storage()
+                .instance()
+                .set(&symbol_short!("POOLS"), &pools);
+        });
+        let client = LpAggregatorClient::new(&env, &contract_id);
+        let ti = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let routes = client.find_paths(&ti, &to, &100_000, &1);
+        assert_eq!(routes.len(), 1);
+        assert_eq!(
+            routes.get(0).unwrap().hops.get(0).unwrap().pool_address,
+            real_pool
+        );
+    }
+
     // ── legacy ────────────────────────────────────────────────────────────────
 
     #[test]
@@ -468,15 +607,15 @@ mod tests {
     fn test_swap_route_struct() {
         let env = Env::default();
         let pool = Address::generate(&env);
-        let hop  = SwapHop {
+        let hop = SwapHop {
             pool_address: pool.clone(),
-            token_in:     pool.clone(),
-            token_out:    pool.clone(),
-            amount_in:    1_000_000,
+            token_in: pool.clone(),
+            token_out: pool.clone(),
+            amount_in: 1_000_000,
         };
         let route = SwapRoute {
-            hops:             vec![&env, hop],
-            expected_out:     980_000,
+            hops: vec![&env, hop],
+            expected_out: 980_000,
             price_impact_bps: 200,
         };
         assert_eq!(route.hops.len(), 1);


### PR DESCRIPTION
## Summary

Four independent fixes, each with its own commit:

- **Reconciliation pagination** — `BalanceComparator.Reconcile` only fetched the first 500 active vaults and discarded the real total, silently skipping the rest on any deployment past that size. Now loops over every page.
- **KYC identity fields dropped** — `full_name`, `date_of_birth`, and `country` were accepted by the request but never persisted. Added real validation (ISO 3166-1 alpha-2 country codes, real date parsing) and threaded them through service → repository → a new migration.
- **KYC document upload was a no-op** — uploaded files were never actually written anywhere; the handler just built a string key from the client-supplied filename. Added a real `objectstorage.Store` (local-disk implementation, server-generated keys, content-type allowlist, size limits) and wired it in.
- **lp_aggregator priced swaps off a hardcoded 1:1 pair** — `simulate_swap` called `get_reserves` but discarded the result and used `(1_000_000, 1_000_000)` regardless of the pool's real reserves. Now parses and uses the real reserves; an unreachable/invalid pool is skipped rather than faked.

## Testing

- Go: `go build ./...` and `go test ./...` both pass across the whole `apps/api` module (new tests added for all three Go-side fixes).
- Rust: `cargo test -p lp_aggregator` passes (16/16), including new tests for a balanced pool, an imbalanced pool, and an unreachable pool.
- `gofmt`/`go vet` clean on touched files; `cargo fmt` applied.

Closes #1192
Closes #1191
Closes #1190
Closes #1189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - KYC submissions now validate name, date of birth, and country.
  - KYC identity documents are securely stored with file-size and type restrictions.
  - Validated identity details are saved with KYC records.
  - Swap route discovery now uses live pool reserves and skips unavailable pools.

- **Bug Fixes**
  - Reconciliation now checks all vaults across multiple pages and reports progress when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->