### PR TITLE
fix: post-testnet audit backlog — typed auth error, share-price tests, UUID coercion, analytics aggregation

### DIFF
--- a/apps/api/internal/repository/postgres/bank_account_repository.go
+++ b/apps/api/internal/repository/postgres/bank_account_repository.go
@@ -94,8 +94,14 @@ func (r *BankAccountRepository) ListByUser(ctx context.Context, userID uuid.UUID
 		); err != nil {
 			return nil, err
 		}
-		parsedID, _ := uuid.Parse(id)
-		parsedUser, _ := uuid.Parse(uid)
+		parsedID, err := uuid.Parse(id)
+		if err != nil {
+			return nil, fmt.Errorf("bank account repository: parse id %q: %w", id, err)
+		}
+		parsedUser, err := uuid.Parse(uid)
+		if err != nil {
+			return nil, fmt.Errorf("bank account repository: parse user id %q: %w", uid, err)
+		}
 		var verified *time.Time
 		if verifiedAt.Valid {
 			verified = &verifiedAt.Time
@@ -138,7 +144,11 @@ func (r *BankAccountRepository) GetByID(ctx context.Context, id uuid.UUID) (bank
 	if err != nil {
 		return bankaccount.BankAccount{}, nil, "", mapBankAccountError(err)
 	}
-	parsedUser, _ := uuid.Parse(uid)
+	parsedUser, err := uuid.Parse(uid)
+	if err != nil {
+		return bankaccount.BankAccount{}, nil, "", fmt.Errorf(
+			"bank account repository: parse user id %q: %w", uid, err)
+	}
 	var verified *time.Time
 	if verifiedAt.Valid {
 		verified = &verifiedAt.Time

--- a/apps/api/internal/repository/postgres/bank_account_repository_test.go
+++ b/apps/api/internal/repository/postgres/bank_account_repository_test.go
@@ -1,0 +1,132 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+)
+
+// A malformed identifier must surface as an error rather than being coerced to
+// the zero UUID and used as a real identifier (nester#1197). Each affected
+// method is exercised separately: silently returning uuid.Nil in a domain
+// object is what let a bad value reach a WHERE clause or an ownership check.
+
+func TestBankAccountRepository_ListByUser_RejectsMalformedID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	cols := []string{
+		"id", "user_id", "bank_name", "bank_code", "account_last4",
+		"account_name", "currency", "country", "is_default", "verified_at", "created_at",
+	}
+	mock.ExpectQuery("SELECT id, user_id, bank_name").
+		WithArgs(userID.String()).
+		WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			"not-a-uuid", userID.String(), "Kuda", "090267", "1234",
+			"Ada Lovelace", "NGN", "NG", true, nil, time.Now(),
+		))
+
+	repo := NewBankAccountRepository(db)
+	accounts, err := repo.ListByUser(context.Background(), userID)
+	if err == nil {
+		t.Fatalf("ListByUser: expected an error for a malformed id, got accounts=%v", accounts)
+	}
+	if accounts != nil {
+		t.Fatalf("ListByUser: expected no accounts on a parse failure, got %v", accounts)
+	}
+	if !strings.Contains(err.Error(), "parse id") {
+		t.Fatalf("ListByUser: expected a parse error, got %v", err)
+	}
+}
+
+func TestBankAccountRepository_ListByUser_RejectsMalformedUserID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	userID := uuid.New()
+	cols := []string{
+		"id", "user_id", "bank_name", "bank_code", "account_last4",
+		"account_name", "currency", "country", "is_default", "verified_at", "created_at",
+	}
+	mock.ExpectQuery("SELECT id, user_id, bank_name").
+		WithArgs(userID.String()).
+		WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			uuid.New().String(), "", "Kuda", "090267", "1234",
+			"Ada Lovelace", "NGN", "NG", true, nil, time.Now(),
+		))
+
+	repo := NewBankAccountRepository(db)
+	if _, err := repo.ListByUser(context.Background(), userID); err == nil {
+		t.Fatal("ListByUser: expected an error for a malformed user id")
+	} else if !strings.Contains(err.Error(), "parse user id") {
+		t.Fatalf("ListByUser: expected a user id parse error, got %v", err)
+	}
+}
+
+func TestBankAccountRepository_GetByID_RejectsMalformedUserID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	id := uuid.New()
+	cols := []string{
+		"user_id", "bank_name", "bank_code", "account_number_encrypted",
+		"account_name", "currency", "country", "is_default", "verified_at",
+		"created_at", "key_version",
+	}
+	mock.ExpectQuery("SELECT user_id, bank_name").
+		WithArgs(id.String()).
+		WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			"not-a-uuid", "Kuda", "090267", []byte("cipher"),
+			"Ada Lovelace", "NGN", "NG", true, nil, time.Now(), "v1",
+		))
+
+	repo := NewBankAccountRepository(db)
+	account, _, _, err := repo.GetByID(context.Background(), id)
+	if err == nil {
+		t.Fatal("GetByID: expected an error for a malformed user id")
+	}
+	if !strings.Contains(err.Error(), "parse user id") {
+		t.Fatalf("GetByID: expected a user id parse error, got %v", err)
+	}
+	// The caller must not receive an account whose owner is the zero UUID: an
+	// ownership check against uuid.Nil is reachable deterministically.
+	if account.UserID != uuid.Nil || account.ID != uuid.Nil {
+		t.Fatalf("GetByID: expected a zero-valued account on failure, got %+v", account)
+	}
+}
+
+func TestBankAccountRepository_ScanPending_RejectsMalformedID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT id, account_number_encrypted, key_version").
+		WithArgs("v2", 10).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "account_number_encrypted", "key_version"}).
+			AddRow("not-a-uuid", []byte("cipher"), "v1"))
+
+	repo := NewBankAccountRepository(db)
+	rows, err := repo.ScanPending(context.Background(), "v2", 10)
+	if err == nil {
+		t.Fatalf("ScanPending: expected an error for a malformed id, got rows=%v", rows)
+	}
+	if !strings.Contains(err.Error(), "parse id") {
+		t.Fatalf("ScanPending: expected a parse error, got %v", err)
+	}
+}

--- a/apps/api/internal/service/performance/analytics_test.go
+++ b/apps/api/internal/service/performance/analytics_test.go
@@ -1,0 +1,234 @@
+package performance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	perfdom "github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// analyticsVaultRepo lists a fixed set of vaults for GetUserAnalytics. Only
+// ListUserVaults is exercised; every other method is a hard failure so a change
+// that starts calling one is caught rather than silently stubbed.
+type analyticsVaultRepo struct {
+	vault.Repository
+	vaults []vault.Vault
+	err    error
+}
+
+func (r *analyticsVaultRepo) ListUserVaults(
+	_ context.Context, _ uuid.UUID, _ vault.UserListFilter,
+) ([]vault.Vault, int, error) {
+	if r.err != nil {
+		return nil, 0, r.err
+	}
+	return r.vaults, len(r.vaults), nil
+}
+
+// analyticsSnapshotRepo serves per-vault history from a map.
+type analyticsSnapshotRepo struct {
+	perfdom.SnapshotRepository
+	history map[uuid.UUID][]perfdom.Snapshot
+}
+
+func (r *analyticsSnapshotRepo) HistoryForVault(
+	_ context.Context, vaultID uuid.UUID, _ time.Time,
+) ([]perfdom.Snapshot, error) {
+	snaps, ok := r.history[vaultID]
+	if !ok {
+		return nil, perfdom.ErrSnapshotNotFound
+	}
+	return snaps, nil
+}
+
+func day(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return parsed
+}
+
+func snap(vaultID uuid.UUID, at time.Time, balance, yield int64) perfdom.Snapshot {
+	return perfdom.Snapshot{
+		VaultID:          vaultID,
+		TotalBalance:     decimal.NewFromInt(balance),
+		TotalYieldEarned: decimal.NewFromInt(yield),
+		SnapshotAt:       at,
+	}
+}
+
+// A two-vault user's daily series must reflect both vaults, not just the first
+// one in the list (nester#1195).
+func TestGetUserAnalytics_DailySnapshotsAggregateAllVaults(t *testing.T) {
+	vaultA, vaultB := uuid.New(), uuid.New()
+	d1 := day(t, "2026-03-01T12:00:00Z")
+	d2 := day(t, "2026-03-02T12:00:00Z")
+
+	svc := NewService(
+		&analyticsSnapshotRepo{history: map[uuid.UUID][]perfdom.Snapshot{
+			vaultA: {snap(vaultA, d1, 100, 10), snap(vaultA, d2, 110, 20)},
+			vaultB: {snap(vaultB, d1, 500, 50), snap(vaultB, d2, 520, 70)},
+		}},
+		&analyticsVaultRepo{vaults: []vault.Vault{
+			{ID: vaultA, ContractAddress: "CVAULTA", CurrentBalance: decimal.NewFromInt(110)},
+			{ID: vaultB, ContractAddress: "CVAULTB", CurrentBalance: decimal.NewFromInt(520)},
+		}},
+	)
+
+	resp, err := svc.GetUserAnalytics(context.Background(), uuid.New(), d1.Add(-24*time.Hour), time.Time{})
+	if err != nil {
+		t.Fatalf("GetUserAnalytics: %v", err)
+	}
+
+	if len(resp.DailySnapshots) != 2 {
+		t.Fatalf("expected 2 daily snapshots, got %d: %+v", len(resp.DailySnapshots), resp.DailySnapshots)
+	}
+
+	// Day one: 100 + 500 balance, 10 + 50 yield — not either vault alone.
+	got := resp.DailySnapshots[0]
+	if got.Date != "2026-03-01" || got.TotalBalanceUSD != 600 || got.YieldEarnedUSD != 60 {
+		t.Fatalf("day one must sum both vaults, got %+v", got)
+	}
+	got = resp.DailySnapshots[1]
+	if got.Date != "2026-03-02" || got.TotalBalanceUSD != 630 || got.YieldEarnedUSD != 90 {
+		t.Fatalf("day two must sum both vaults, got %+v", got)
+	}
+}
+
+// A vault with no snapshot on a given day must carry its last known balance
+// forward rather than dropping out of the portfolio total, which would read as
+// a loss the user never took.
+func TestGetUserAnalytics_CarriesVaultForwardAcrossMissingDays(t *testing.T) {
+	vaultA, vaultB := uuid.New(), uuid.New()
+	d1 := day(t, "2026-03-01T12:00:00Z")
+	d2 := day(t, "2026-03-02T12:00:00Z")
+
+	svc := NewService(
+		&analyticsSnapshotRepo{history: map[uuid.UUID][]perfdom.Snapshot{
+			vaultA: {snap(vaultA, d1, 100, 10), snap(vaultA, d2, 110, 20)},
+			// vaultB was snapshotted on day one only.
+			vaultB: {snap(vaultB, d1, 500, 50)},
+		}},
+		&analyticsVaultRepo{vaults: []vault.Vault{
+			{ID: vaultA, ContractAddress: "CVAULTA"},
+			{ID: vaultB, ContractAddress: "CVAULTB"},
+		}},
+	)
+
+	resp, err := svc.GetUserAnalytics(context.Background(), uuid.New(), d1.Add(-24*time.Hour), time.Time{})
+	if err != nil {
+		t.Fatalf("GetUserAnalytics: %v", err)
+	}
+	if len(resp.DailySnapshots) != 2 {
+		t.Fatalf("expected 2 daily snapshots, got %+v", resp.DailySnapshots)
+	}
+	// 110 (day two) + 500 (carried from day one), not 110 alone.
+	if got := resp.DailySnapshots[1]; got.TotalBalanceUSD != 610 {
+		t.Fatalf("expected the un-snapshotted vault to carry forward, got %+v", got)
+	}
+}
+
+// VaultMonthlyYield must be populated rather than empty in every response, and
+// must report yield earned within each month rather than the cumulative total.
+func TestGetUserAnalytics_PopulatesVaultMonthlyYield(t *testing.T) {
+	vaultA := uuid.New()
+	march := day(t, "2026-03-31T12:00:00Z")
+	april := day(t, "2026-04-30T12:00:00Z")
+
+	svc := NewService(
+		&analyticsSnapshotRepo{history: map[uuid.UUID][]perfdom.Snapshot{
+			// TotalYieldEarned is cumulative: 30 by end of March, 80 by end of April.
+			vaultA: {snap(vaultA, march, 1000, 30), snap(vaultA, april, 1100, 80)},
+		}},
+		&analyticsVaultRepo{vaults: []vault.Vault{{ID: vaultA, ContractAddress: "CVAULTA"}}},
+	)
+
+	resp, err := svc.GetUserAnalytics(context.Background(), uuid.New(), march.Add(-24*time.Hour), time.Time{})
+	if err != nil {
+		t.Fatalf("GetUserAnalytics: %v", err)
+	}
+	if len(resp.VaultMonthlyYield) != 2 {
+		t.Fatalf("expected 2 monthly entries, got %+v", resp.VaultMonthlyYield)
+	}
+
+	first := resp.VaultMonthlyYield[0]
+	if first.Month != "2026-03" || first.YieldUSD != 30 || first.VaultID != vaultA.String() {
+		t.Fatalf("March entry wrong: %+v", first)
+	}
+	second := resp.VaultMonthlyYield[1]
+	// 80 cumulative minus 30 already earned = 50 earned in April.
+	if second.Month != "2026-04" || second.YieldUSD != 50 {
+		t.Fatalf("April entry must report the month's growth, not the cumulative total: %+v", second)
+	}
+}
+
+// A user with no vaults gets an empty series, not an error and not a zero-filled
+// one.
+func TestGetUserAnalytics_NoVaultsReturnsEmptySeries(t *testing.T) {
+	svc := NewService(
+		&analyticsSnapshotRepo{history: map[uuid.UUID][]perfdom.Snapshot{}},
+		&analyticsVaultRepo{vaults: nil},
+	)
+
+	resp, err := svc.GetUserAnalytics(context.Background(), uuid.New(), time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetUserAnalytics: %v", err)
+	}
+	if resp.DailySnapshots == nil || len(resp.DailySnapshots) != 0 {
+		t.Fatalf("expected an empty, non-nil daily series, got %+v", resp.DailySnapshots)
+	}
+	if resp.VaultMonthlyYield == nil || len(resp.VaultMonthlyYield) != 0 {
+		t.Fatalf("expected an empty, non-nil monthly yield, got %+v", resp.VaultMonthlyYield)
+	}
+}
+
+// A vault that exists but has never been snapshotted must not error the whole
+// request, and must not contribute a zero-balance day.
+func TestGetUserAnalytics_VaultWithoutSnapshotsIsSkipped(t *testing.T) {
+	withData, without := uuid.New(), uuid.New()
+	d1 := day(t, "2026-03-01T12:00:00Z")
+
+	svc := NewService(
+		&analyticsSnapshotRepo{history: map[uuid.UUID][]perfdom.Snapshot{
+			withData: {snap(withData, d1, 100, 10)},
+		}},
+		&analyticsVaultRepo{vaults: []vault.Vault{
+			{ID: withData, ContractAddress: "CWITH"},
+			{ID: without, ContractAddress: "CWITHOUT"},
+		}},
+	)
+
+	resp, err := svc.GetUserAnalytics(context.Background(), uuid.New(), d1.Add(-24*time.Hour), time.Time{})
+	if err != nil {
+		t.Fatalf("GetUserAnalytics: %v", err)
+	}
+	if len(resp.DailySnapshots) != 1 || resp.DailySnapshots[0].TotalBalanceUSD != 100 {
+		t.Fatalf("expected only the snapshotted vault to contribute, got %+v", resp.DailySnapshots)
+	}
+	for _, entry := range resp.VaultMonthlyYield {
+		if entry.VaultID == without.String() {
+			t.Fatalf("a never-snapshotted vault must not appear in monthly yield: %+v", entry)
+		}
+	}
+}
+
+// A repository failure on any vault's history is surfaced, not swallowed —
+// otherwise a partial portfolio would be presented as the whole one.
+func TestGetUserAnalytics_PropagatesHistoryError(t *testing.T) {
+	svc := NewService(
+		&analyticsSnapshotRepo{history: nil},
+		&analyticsVaultRepo{err: errors.New("boom")},
+	)
+
+	if _, err := svc.GetUserAnalytics(context.Background(), uuid.New(), time.Time{}, time.Time{}); err == nil {
+		t.Fatal("expected the vault listing error to be surfaced")
+	}
+}

--- a/apps/api/internal/service/performance/service.go
+++ b/apps/api/internal/service/performance/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -227,6 +228,160 @@ type BalanceProvider interface {
 // vault.CurrentBalance across the page below into totalBalance for display,
 // so if vault creation ever becomes bulk/programmatic this reasoning stops
 // holding and needs real pagination, same as that fix.
+// aggregateDailySnapshots folds every vault's snapshot history into one daily
+// portfolio series.
+//
+// Snapshots are written per vault and are not aligned to a common schedule, so
+// a day where one vault happened not to be snapshotted must not drop that
+// vault's balance out of the portfolio total — that would read as a sudden
+// loss. Each vault therefore carries its most recent snapshot forward across
+// days it has none, which is the same reading a user gets from the vault's own
+// performance view.
+//
+// The series runs from the first day any vault has a snapshot through the last
+// such day, bounded by toTime when that is set (a zero toTime means no upper
+// bound). Days before a vault's first snapshot contribute nothing: that vault
+// did not exist yet as far as the data is concerned.
+func aggregateDailySnapshots(
+	vaults []vault.Vault,
+	histories map[uuid.UUID][]perfdom.Snapshot,
+	toTime time.Time,
+) []analytics.DailySnapshot {
+	// Latest snapshot per vault per day, in UTC calendar days.
+	perVaultDay := make(map[uuid.UUID]map[string]perfdom.Snapshot, len(vaults))
+	days := make(map[string]struct{})
+
+	for _, v := range vaults {
+		byDay := make(map[string]perfdom.Snapshot)
+		for _, snap := range histories[v.ID] {
+			if !toTime.IsZero() && snap.SnapshotAt.After(toTime) {
+				continue
+			}
+			day := snap.SnapshotAt.UTC().Format("2006-01-02")
+			// Keep the last snapshot of the day: it is the day's closing state.
+			if prev, ok := byDay[day]; ok && prev.SnapshotAt.After(snap.SnapshotAt) {
+				continue
+			}
+			byDay[day] = snap
+			days[day] = struct{}{}
+		}
+		perVaultDay[v.ID] = byDay
+	}
+
+	if len(days) == 0 {
+		return []analytics.DailySnapshot{}
+	}
+
+	ordered := make([]string, 0, len(days))
+	for day := range days {
+		ordered = append(ordered, day)
+	}
+	sort.Strings(ordered)
+
+	// Walk every calendar day in the covered range so gaps are filled by the
+	// carry-forward below rather than collapsing the series.
+	first, err := time.Parse("2006-01-02", ordered[0])
+	if err != nil {
+		return []analytics.DailySnapshot{}
+	}
+	last, err := time.Parse("2006-01-02", ordered[len(ordered)-1])
+	if err != nil {
+		return []analytics.DailySnapshot{}
+	}
+
+	carried := make(map[uuid.UUID]perfdom.Snapshot, len(vaults))
+	out := make([]analytics.DailySnapshot, 0, int(last.Sub(first).Hours()/24)+1)
+
+	for day := first; !day.After(last); day = day.AddDate(0, 0, 1) {
+		key := day.Format("2006-01-02")
+		var balance, yield decimal.Decimal
+		var seen bool
+
+		for _, v := range vaults {
+			if snap, ok := perVaultDay[v.ID][key]; ok {
+				carried[v.ID] = snap
+			}
+			snap, ok := carried[v.ID]
+			if !ok {
+				// This vault has no snapshot on or before this day.
+				continue
+			}
+			seen = true
+			balance = balance.Add(snap.TotalBalance)
+			yield = yield.Add(snap.TotalYieldEarned)
+		}
+
+		if !seen {
+			continue
+		}
+		out = append(out, analytics.DailySnapshot{
+			Date:            key,
+			TotalBalanceUSD: balance.InexactFloat64(),
+			YieldEarnedUSD:  yield.InexactFloat64(),
+		})
+	}
+
+	return out
+}
+
+// buildVaultMonthlyYield reports each vault's yield earned within each calendar
+// month, rather than leaving the field empty in every response.
+//
+// TotalYieldEarned on a snapshot is cumulative since the vault opened, so a
+// month's yield is the growth over that month: the last snapshot of the month
+// minus the last snapshot of the previous month. The first month a vault
+// appears in has no prior snapshot to subtract, so its cumulative total to date
+// is what was earned within the window being reported.
+func buildVaultMonthlyYield(
+	vaults []vault.Vault,
+	histories map[uuid.UUID][]perfdom.Snapshot,
+	toTime time.Time,
+) []analytics.VaultMonthlyYield {
+	out := []analytics.VaultMonthlyYield{}
+
+	for _, v := range vaults {
+		lastOfMonth := make(map[string]perfdom.Snapshot)
+		for _, snap := range histories[v.ID] {
+			if !toTime.IsZero() && snap.SnapshotAt.After(toTime) {
+				continue
+			}
+			month := snap.SnapshotAt.UTC().Format("2006-01")
+			if prev, ok := lastOfMonth[month]; ok && prev.SnapshotAt.After(snap.SnapshotAt) {
+				continue
+			}
+			lastOfMonth[month] = snap
+		}
+		if len(lastOfMonth) == 0 {
+			continue
+		}
+
+		months := make([]string, 0, len(lastOfMonth))
+		for month := range lastOfMonth {
+			months = append(months, month)
+		}
+		sort.Strings(months)
+
+		name := v.ContractAddress
+		if name == "" {
+			name = v.ID.String()
+		}
+
+		var prevCumulative decimal.Decimal
+		for _, month := range months {
+			cumulative := lastOfMonth[month].TotalYieldEarned
+			out = append(out, analytics.VaultMonthlyYield{
+				VaultID:   v.ID.String(),
+				VaultName: name,
+				Month:     month,
+				YieldUSD:  cumulative.Sub(prevCumulative).InexactFloat64(),
+			})
+			prevCumulative = cumulative
+		}
+	}
+
+	return out
+}
+
 func (s *Service) GetUserAnalytics(ctx context.Context, userID uuid.UUID, fromTime, toTime time.Time) (*analytics.AnalyticsResponse, error) {
 	// Get user's vaults
 	userVaults, _, err := s.vaultRepo.ListUserVaults(ctx, userID, vault.UserListFilter{Page: 1, PerPage: 1000})
@@ -245,32 +400,20 @@ func (s *Service) GetUserAnalytics(ctx context.Context, userID uuid.UUID, fromTi
 	}, nil
 	}
 
-	// Get daily snapshots for the user (aggregated across all vaults)
-	// For now, we'll use the latest snapshot as a placeholder
-	// In a real implementation, this would query a user-level analytics table or aggregate vault snapshots
-	var dailySnapshots []analytics.DailySnapshot
-	if len(userVaults) > 0 {
-		// For simplicity, we're generating a simple time series based on the first vault's history
-		// In production, this should come from a dedicated analytics table or service
-		firstVaultID := userVaults[0].ID
-		snapshots, err := s.repo.HistoryForVault(ctx, firstVaultID, fromTime)
+	// Read every vault's history once. Both the daily series and the monthly
+	// per-vault yield below are built from this, so a multi-vault user is
+	// never shown one vault's numbers labelled as their portfolio (#1195).
+	histories := make(map[uuid.UUID][]perfdom.Snapshot, len(userVaults))
+	for _, v := range userVaults {
+		snapshots, err := s.repo.HistoryForVault(ctx, v.ID, fromTime)
 		if err != nil && !errors.Is(err, perfdom.ErrSnapshotNotFound) {
 			return &analytics.AnalyticsResponse{}, fmt.Errorf("failed to get vault history: %w", err)
 		}
-
-		for _, snap := range snapshots {
-			dailySnapshots = append(dailySnapshots, analytics.DailySnapshot{
-				Date:          snap.SnapshotAt.Format("2006-01-02"),
-				TotalBalanceUSD: snap.TotalBalance.InexactFloat64(),
-				YieldEarnedUSD:  snap.TotalYieldEarned.InexactFloat64(),
-			})
-		}
+		histories[v.ID] = snapshots
 	}
 
-	// Get vault monthly yield (aggregated yield per vault per month)
-	var vaultMonthlyYield []analytics.VaultMonthlyYield
-	// This would typically come from a separate aggregation table
-	// For now, we'll leave it empty and let the frontend handle empty state
+	dailySnapshots := aggregateDailySnapshots(userVaults, histories, toTime)
+	vaultMonthlyYield := buildVaultMonthlyYield(userVaults, histories, toTime)
 
 	// Get current allocation across all vaults
 	var currentAllocation []analytics.CurrentAllocation

--- a/packages/contracts/contracts/allocation_strategy/src/lib.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/lib.rs
@@ -316,7 +316,7 @@ impl AllocationStrategyContract {
         operator.require_auth();
 
         if !AccessControl::has_role(&env, &operator, Role::Operator) {
-            panic!("Caller is not an authorized operator");
+            panic_with_error!(&env, ContractError::Unauthorized);
         }
 
         // Call the inner compute directly to avoid a second require_auth for the same address.

--- a/packages/contracts/contracts/allocation_strategy/src/test.rs
+++ b/packages/contracts/contracts/allocation_strategy/src/test.rs
@@ -1198,9 +1198,12 @@ fn set_allocations_role_lifecycle() {
     let apys = valid_apys(&env);
 
     // Admin is intentionally not an implicit Operator for this entrypoint.
-    assert!(client
-        .try_set_allocations(&admin, &1_000_i128, &apys)
-        .is_err());
+    assert_eq!(
+        client.try_set_allocations(&admin, &1_000_i128, &apys),
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            nester_common::ContractError::Unauthorized as u32,
+        ))),
+    );
 
     client.grant_role(&admin, &operator, &Role::Operator);
     client.set_allocations(&operator, &1_000_i128, &apys);
@@ -1210,9 +1213,12 @@ fn set_allocations_role_lifecycle() {
     assert_eq!(allocated, 1_000);
 
     client.revoke_role(&admin, &operator, &Role::Operator);
-    assert!(client
-        .try_set_allocations(&operator, &1_000_i128, &apys)
-        .is_err());
+    assert_eq!(
+        client.try_set_allocations(&operator, &1_000_i128, &apys),
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            nester_common::ContractError::Unauthorized as u32,
+        ))),
+    );
 }
 
 // AllocationStrategy.set_allocations requires operator role — unauthorized callers are rejected.
@@ -1226,9 +1232,15 @@ fn test_set_allocations_unauthorized_is_rejected() {
     assert!(!env.as_contract(&strategy_id, || {
         nester_access_control::AccessControl::has_role(&env, &attacker, Role::Operator)
     }));
-    assert!(client
-        .try_set_allocations(&attacker, &1_000_i128, &apys)
-        .is_err());
+    // The refusal must be the typed Unauthorized contract error, not a bare
+    // host panic (issue #1200): a caller has to be able to tell "you are not
+    // an operator" apart from "the contract broke".
+    assert_eq!(
+        client.try_set_allocations(&attacker, &1_000_i128, &apys),
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            nester_common::ContractError::Unauthorized as u32,
+        ))),
+    );
 }
 
 #[test]

--- a/packages/contracts/tests/integration/src/integration/share_price_tests.rs
+++ b/packages/contracts/tests/integration/src/integration/share_price_tests.rs
@@ -1,27 +1,239 @@
 //! Integration tests for share price edge cases.
 #![cfg(test)]
 
-use nester_common::ContractError;
+extern crate std;
+
+use soroban_sdk::{testutils::Ledger as _, token};
+
+use nester_access_control::Role;
+use nester_common::{ContractError, MIN_DEPOSIT_AMOUNT};
+use nester_test_utils::NesterHarness;
 use vault_contract::conversion::{
     assets_to_shares_down, assets_to_shares_up, shares_to_assets_down, shares_to_assets_up,
 };
+use vault_contract::{CircuitBreakerConfig, FeeConfig};
 
-/// Deposit after yield reported results in share price > 1:1.
+/// 1 unit at 7 decimals -- the protocol minimum deposit.
+const DEPOSIT: i128 = MIN_DEPOSIT_AMOUNT;
+
+/// Zero every fee so the assertions below isolate share-price arithmetic
+/// rather than fee arithmetic. Fee behaviour is covered by fee_tests.rs.
+fn zero_fees(h: &NesterHarness) {
+    h.vault().set_fee_config(
+        &h.admin,
+        &FeeConfig {
+            performance_fee_bps: 0,
+            management_fee_bps: 0,
+            early_withdrawal_fee_bps: 0,
+            treasury_address: h.treasury_id.clone(),
+        },
+    );
+}
+
+/// Disable the 20% rolling-window circuit breaker so a full withdrawal is not
+/// rejected for reasons unrelated to share price.
+fn disable_circuit_breaker(h: &NesterHarness) {
+    h.vault().set_circuit_breaker_config(
+        &h.admin,
+        &CircuitBreakerConfig {
+            threshold_bps: 10_000, // 100% -- effectively off
+            window_seconds: 7_200,
+        },
+    );
+}
+
+/// Mint `amount` to the vault and report it as yield, which is what raises
+/// total_assets above total_supply and so pushes share price above 1:1.
+fn accrue_yield(h: &NesterHarness, amount: i128) {
+    h.mint_deposit_tokens(&h.vault_id, amount);
+    h.vault().grant_role(&h.admin, &h.admin, &Role::Manager);
+    h.vault().report_yield(&h.admin, &amount);
+}
+
+/// Deposit after yield is reported buys shares at a price above 1:1, so the
+/// same asset amount buys strictly fewer shares than the first deposit did.
 #[test]
 fn test_deposit_after_yield_share_price_above_one() {
-    assert!(true, "placeholder: share price > 1 after yield");
+    let h = NesterHarness::setup();
+    zero_fees(&h);
+    disable_circuit_breaker(&h);
+
+    let first = h.create_user();
+    h.mint_deposit_tokens(&first, DEPOSIT);
+    let first_shares = h.vault().deposit(&first, &DEPOSIT, &0);
+    assert_eq!(first_shares, DEPOSIT, "first deposit mints shares 1:1");
+
+    // 10% yield: total_assets becomes 11 units against 10 units of supply,
+    // so share price is exactly 1.1.
+    let yield_amount = DEPOSIT / 10;
+    accrue_yield(&h, yield_amount);
+
+    let total_assets = h.token().total_assets();
+    let total_supply = h.token().total_supply();
+    assert_eq!(total_assets, DEPOSIT + yield_amount);
+    assert_eq!(total_supply, DEPOSIT);
+    assert!(
+        total_assets > total_supply,
+        "share price must exceed 1:1 once yield has accrued"
+    );
+
+    // The concrete expectation, not just the inequality: at a 1.1 share price
+    // a DEPOSIT-sized deposit buys DEPOSIT * supply / assets shares, floored.
+    let second = h.create_user();
+    h.mint_deposit_tokens(&second, DEPOSIT);
+    let second_shares = h.vault().deposit(&second, &DEPOSIT, &0);
+    let expected = DEPOSIT * total_supply / total_assets;
+    assert_eq!(
+        expected, 9_090_909,
+        "10 units at a 1.1 share price is 9.090909 shares, floored"
+    );
+    assert_eq!(
+        second_shares, expected,
+        "deposit after yield must buy shares at the raised price"
+    );
+    assert!(
+        second_shares < first_shares,
+        "the same assets must buy fewer shares once share price is above one"
+    );
+
+    // The first depositor still owns their share of the yield: their shares
+    // are now worth more than they paid.
+    let first_value = shares_to_assets_down(
+        first_shares,
+        h.token().total_assets(),
+        h.token().total_supply(),
+    )
+    .unwrap();
+    assert!(
+        first_value > DEPOSIT,
+        "the pre-yield depositor's shares must be worth more than their cost basis"
+    );
 }
 
-/// Multiple deposits at different share prices, then withdrawal -- proportional returns.
+/// Two deposits made at different share prices withdraw in proportion to the
+/// shares each holds, not in proportion to the assets each paid in.
 #[test]
 fn test_multiple_deposits_different_share_prices() {
-    assert!(true, "placeholder: multiple deposits at different share prices");
+    let h = NesterHarness::setup();
+    zero_fees(&h);
+    disable_circuit_breaker(&h);
+
+    // Deposit 1 at a 1.0 share price.
+    let early = h.create_user();
+    h.mint_deposit_tokens(&early, DEPOSIT);
+    let early_shares = h.vault().deposit(&early, &DEPOSIT, &0);
+    assert_eq!(early_shares, DEPOSIT);
+
+    // Yield lifts the price to 1.1 before the second deposit.
+    let yield_amount = DEPOSIT / 10;
+    accrue_yield(&h, yield_amount);
+
+    // Deposit 2 at the raised price -- same assets in, fewer shares out.
+    let late = h.create_user();
+    h.mint_deposit_tokens(&late, DEPOSIT);
+    let late_shares = h.vault().deposit(&late, &DEPOSIT, &0);
+    assert_eq!(late_shares, 9_090_909);
+    assert!(late_shares < early_shares);
+
+    let total_assets = h.token().total_assets();
+    let total_supply = h.token().total_supply();
+    assert_eq!(total_assets, DEPOSIT * 2 + yield_amount);
+    assert_eq!(total_supply, early_shares + late_shares);
+
+    // Past the lock period so no early-withdrawal fee distorts the payouts.
+    h.env.ledger().with_mut(|l| l.timestamp = 86_401);
+
+    let early_expected = shares_to_assets_down(early_shares, total_assets, total_supply).unwrap();
+
+    let usdc = token::Client::new(&h.env, &h.deposit_token_id);
+
+    assert_eq!(h.vault().withdraw(&early, &early_shares, &0), 0);
+    assert_eq!(
+        usdc.balance(&early),
+        early_expected,
+        "the early depositor withdraws their share of the pool"
+    );
+
+    // Re-read the pool after the first withdrawal: the late depositor's payout
+    // is priced against what is actually left, not against the pre-withdrawal
+    // snapshot.
+    let late_expected = shares_to_assets_down(
+        late_shares,
+        h.token().total_assets(),
+        h.token().total_supply(),
+    )
+    .unwrap();
+    assert_eq!(h.vault().withdraw(&late, &late_shares, &0), 0);
+    assert_eq!(
+        usdc.balance(&late),
+        late_expected,
+        "the late depositor withdraws their share of the pool"
+    );
+
+    // Proportionality: the early depositor bought at 1.0 and so leaves with
+    // the yield accrued before the late deposit; the late depositor bought at
+    // 1.1 and so leaves with substantially what they paid in -- they must not
+    // capture yield that accrued before they arrived.
+    assert!(
+        usdc.balance(&early) > DEPOSIT,
+        "the early depositor keeps the yield accrued before the second deposit"
+    );
+    assert!(
+        usdc.balance(&late) <= DEPOSIT,
+        "the late depositor must not be paid yield that accrued before they deposited"
+    );
+
+    // Rounding is in the protocol's favour, never the depositors': the pool
+    // cannot pay out more than it holds.
+    assert!(
+        usdc.balance(&early) + usdc.balance(&late) <= DEPOSIT * 2 + yield_amount,
+        "total paid out must not exceed total assets held"
+    );
+    assert_eq!(h.token().total_supply(), 0, "all shares burned");
 }
 
-/// Minimum deposit of 1 unit calculates shares without panic.
+/// A deposit of exactly one unit -- the protocol minimum -- mints shares
+/// without panicking, and at a share price above one it rounds down, in the
+/// protocol's favour rather than the depositor's.
 #[test]
 fn test_minimum_deposit_one_unit() {
-    assert!(true, "placeholder: minimum deposit 1 unit");
+    let h = NesterHarness::setup();
+    zero_fees(&h);
+    disable_circuit_breaker(&h);
+
+    // Seed the pool and raise the share price to a value that does not divide
+    // evenly, so the rounding direction is observable.
+    let seed = h.create_user();
+    h.mint_deposit_tokens(&seed, DEPOSIT);
+    h.vault().deposit(&seed, &DEPOSIT, &0);
+    accrue_yield(&h, DEPOSIT / 3); // share price = 1.333..., not exact
+
+    let total_assets = h.token().total_assets();
+    let total_supply = h.token().total_supply();
+
+    let user = h.create_user();
+    h.mint_deposit_tokens(&user, MIN_DEPOSIT_AMOUNT);
+    let shares = h.vault().deposit(&user, &MIN_DEPOSIT_AMOUNT, &0);
+
+    // Does not panic, and mints a positive number of shares.
+    assert!(shares > 0, "a one-unit deposit must mint non-zero shares");
+
+    let floor = assets_to_shares_down(MIN_DEPOSIT_AMOUNT, total_assets, total_supply).unwrap();
+    let ceil = assets_to_shares_up(MIN_DEPOSIT_AMOUNT, total_assets, total_supply).unwrap();
+    assert!(ceil > floor, "the chosen share price must not divide evenly");
+    assert_eq!(
+        shares, floor,
+        "a deposit must round shares down, in the protocol's favour"
+    );
+
+    // The depositor cannot immediately withdraw more than they paid in: the
+    // rounding loss stays with the pool.
+    let redeemable =
+        shares_to_assets_down(shares, h.token().total_assets(), h.token().total_supply()).unwrap();
+    assert!(
+        redeemable <= MIN_DEPOSIT_AMOUNT,
+        "rounding must not let a minimum deposit withdraw more than it paid in"
+    );
 }
 
 /// Zero-share edge case: calculated shares round to zero should revert.


### PR DESCRIPTION
Four independent findings from the post-testnet codebase audit. One commit per issue — see each commit message for the full reasoning.

- `set_allocations` refused unauthorized callers with a bare `panic!`, so a client could not tell an auth refusal from an internal failure. Now `panic_with_error!(ContractError::Unauthorized)`, with the three auth tests tightened from `.is_err()` to typed assertions. Closes #1200
- Three share-price tests were `assert!(true)` stubs, reporting the share-price arithmetic as covered when nothing exercised it. All three now run against real contract state via `NesterHarness`. Closes #1199
- The bank account repository discarded `uuid.Parse` errors, so a malformed id became the zero UUID and was used as a real identifier. Now rejected with a wrapped error on every affected method. Closes #1197
- `GetUserAnalytics` built a multi-vault user's entire daily series from `userVaults[0]`. Now aggregates across all vaults with carry-forward across un-snapshotted days, and populates the previously always-empty `VaultMonthlyYield`. Closes #1195

Verified locally: `go build ./...` and `go vet` clean; Go tests pass in performance, postgres, and handler; `cargo test` passes 52 integration + 74 allocation_strategy tests.

Out of scope, flagged for follow-up: the same discarded-`uuid.Parse` pattern exists in `savings_goal_repository.go`, `savings_schedule_repository.go`, `savings_streak_repository.go`, and `protocol_tvl_repository.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics now aggregate daily balances across all vaults, carry balances across missing snapshot days, and calculate monthly yield per vault.
  - Share-price behavior now supports accurate deposits, withdrawals, yield accrual, and minimum deposits with appropriate rounding.

- **Bug Fixes**
  - Invalid bank account and user identifiers now return clear parsing errors instead of being silently accepted.
  - Unauthorized allocation changes now return a specific authorization error.

- **Tests**
  - Added coverage for analytics aggregation, share-price scenarios, identifier validation, and authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->