### PR TITLE
fix(api): serialise concurrent operations on the same vault position

### DIFF
--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -439,6 +439,22 @@ func (r *VaultRepository) UpdateHarvestFrequency(ctx context.Context, id uuid.UU
 
 // RecordWithdrawal decrements current_balance atomically and writes a ledger
 // entry. It does NOT touch total_deposited (deposits are never reversed).
+//
+// Serialisation (nester#1084): the position row is locked with
+// SELECT ... FOR UPDATE and the sufficient-funds check re-runs under that
+// lock. Two concurrent withdrawals therefore cannot both read the same
+// pre-withdrawal balance and both pass — the second waits on the row lock and
+// re-checks against the post-withdrawal balance. The service-layer check
+// stays as a fast-fail before any on-chain submit; this one is authoritative.
+//
+// Lock ordering (deadlock safety): every money-path write — RecordDeposit,
+// RecordWithdrawal, RecordHarvest, applyConfirmedBalanceChange — locks
+// exactly one vaults row first (the deposit path's single atomic UPDATE takes
+// the same row lock, an equivalent serialisation) and only then inserts into
+// vault_transactions. No money path locks a second vaults row or takes the
+// two in the other order, so deposit and withdrawal cannot deadlock; they
+// queue on the same row lock. The lock spans only the statements below — no
+// network or chain I/O happens inside the transaction.
 func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
@@ -450,7 +466,27 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, re
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	result, err := tx.ExecContext(
+	var rawBalance string
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT current_balance FROM vaults WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+		id.String(),
+	).Scan(&rawBalance); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return vault.ErrVaultNotFound
+		}
+		return mapRepositoryError(err)
+	}
+
+	balance, err := decimal.NewFromString(rawBalance)
+	if err != nil {
+		return fmt.Errorf("parse current balance: %w", err)
+	}
+	if balance.LessThan(record.Amount) {
+		return vault.ErrWithdrawalExceedsPosition
+	}
+
+	if _, err := tx.ExecContext(
 		ctx,
 		`UPDATE vaults
 		 SET current_balance = current_balance - $2::numeric,
@@ -458,17 +494,8 @@ func (r *VaultRepository) RecordWithdrawal(ctx context.Context, id uuid.UUID, re
 		 WHERE id = $1 AND deleted_at IS NULL`,
 		id.String(),
 		record.Amount.String(),
-	)
-	if err != nil {
+	); err != nil {
 		return mapRepositoryError(err)
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rowsAffected == 0 {
-		return vault.ErrVaultNotFound
 	}
 
 	if _, err := tx.ExecContext(

--- a/apps/api/internal/repository/postgres/vault_repository_integration_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_integration_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -205,6 +206,163 @@ func TestVaultRepositoryIntegrationRecordDepositConcurrent(t *testing.T) {
 	}
 	if !fetched.CurrentBalance.Equal(decimal.RequireFromString("20")) {
 		t.Fatalf("expected current balance 20, got %s", fetched.CurrentBalance)
+	}
+}
+
+// TestVaultRepositoryIntegrationRecordWithdrawalConcurrent is the acceptance
+// test for nester#1084: N concurrent withdrawals of the full balance must
+// yield exactly one success. Without the FOR UPDATE re-check every goroutine
+// reads the same pre-withdrawal balance, all pass, and the position goes
+// negative.
+func TestVaultRepositoryIntegrationRecordWithdrawalConcurrent(t *testing.T) {
+	db := openIntegrationDB(t)
+	applyIntegrationMigrations(t, db)
+	resetIntegrationTables(t, db)
+
+	repository := NewVaultRepository(db)
+	ctx := context.Background()
+	userID := seedIntegrationUser(t, db)
+
+	fullBalance := decimal.RequireFromString("100")
+	created, err := repository.CreateVault(ctx, vault.Vault{
+		ID:              uuid.New(),
+		UserID:          userID,
+		ContractAddress: "CA-INT-WD-RACE",
+		TotalDeposited:  fullBalance,
+		CurrentBalance:  fullBalance,
+		Currency:        "USDC",
+		Status:          vault.StatusActive,
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	const n = 8
+	results := make(chan error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			results <- repository.RecordWithdrawal(ctx, created.ID, vault.TransactionRecord{
+				UserID:               userID,
+				Amount:               fullBalance,
+				SharesMintedOrBurned: fullBalance,
+				SharePriceAtTime:     decimal.NewFromInt(1),
+			})
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var successes, insufficient int
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, vault.ErrWithdrawalExceedsPosition):
+			insufficient++
+		default:
+			t.Errorf("RecordWithdrawal() unexpected error = %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful withdrawal, got %d", successes)
+	}
+	if insufficient != n-1 {
+		t.Fatalf("expected %d ErrWithdrawalExceedsPosition, got %d", n-1, insufficient)
+	}
+
+	fetched, err := repository.GetVault(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetVault() error = %v", err)
+	}
+	if !fetched.CurrentBalance.Equal(decimal.Zero) {
+		t.Fatalf("expected current balance 0, got %s", fetched.CurrentBalance)
+	}
+
+	var ledgerRows int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM vault_transactions WHERE vault_id = $1 AND type = 'withdrawal'`,
+		created.ID.String(),
+	).Scan(&ledgerRows); err != nil {
+		t.Fatalf("count ledger rows: %v", err)
+	}
+	if ledgerRows != 1 {
+		t.Fatalf("expected exactly 1 withdrawal ledger row, got %d", ledgerRows)
+	}
+}
+
+// TestVaultRepositoryIntegrationDepositWithdrawalInterleaved exercises the
+// documented lock ordering (nester#1084): deposits and withdrawals on the
+// same position queue on one row lock in the same order, so an interleaved
+// mix must complete without deadlock and land on the exact expected balance.
+func TestVaultRepositoryIntegrationDepositWithdrawalInterleaved(t *testing.T) {
+	db := openIntegrationDB(t)
+	applyIntegrationMigrations(t, db)
+	resetIntegrationTables(t, db)
+
+	repository := NewVaultRepository(db)
+	ctx := context.Background()
+	userID := seedIntegrationUser(t, db)
+
+	start := decimal.RequireFromString("100")
+	created, err := repository.CreateVault(ctx, vault.Vault{
+		ID:              uuid.New(),
+		UserID:          userID,
+		ContractAddress: "CA-INT-MIXED",
+		TotalDeposited:  start,
+		CurrentBalance:  start,
+		Currency:        "USDC",
+		Status:          vault.StatusActive,
+	})
+	if err != nil {
+		t.Fatalf("CreateVault() error = %v", err)
+	}
+
+	// 5 deposits of 10 and 5 withdrawals of 10. Worst-case ordering (all
+	// withdrawals first) still only draws down 50 of the initial 100, so
+	// every operation must succeed regardless of interleaving.
+	const each = 5
+	amount := decimal.RequireFromString("10")
+	var wg sync.WaitGroup
+	wg.Add(each * 2)
+	errs := make(chan error, each*2)
+	for range each {
+		go func() {
+			defer wg.Done()
+			errs <- repository.RecordDeposit(ctx, created.ID, vault.TransactionRecord{
+				UserID:               userID,
+				Amount:               amount,
+				SharesMintedOrBurned: amount,
+				SharePriceAtTime:     decimal.NewFromInt(1),
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			errs <- repository.RecordWithdrawal(ctx, created.ID, vault.TransactionRecord{
+				UserID:               userID,
+				Amount:               amount,
+				SharesMintedOrBurned: amount,
+				SharePriceAtTime:     decimal.NewFromInt(1),
+			})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent money-path write error = %v", err)
+		}
+	}
+
+	fetched, err := repository.GetVault(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetVault() error = %v", err)
+	}
+	if !fetched.CurrentBalance.Equal(start) {
+		t.Fatalf("expected current balance %s, got %s", start, fetched.CurrentBalance)
 	}
 }
 

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -691,6 +691,12 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 	// made the guard opt-out: any request carrying tx_hash bypassed it, and
 	// when no verifier is configured nothing re-checks afterwards, so a
 	// forged hash drove current_balance negative.
+	//
+	// This read is NOT serialised against concurrent withdrawals — it is a
+	// fast-fail so we never submit a doomed on-chain call. The authoritative
+	// check re-runs inside repository.RecordWithdrawal under a row lock
+	// (SELECT ... FOR UPDATE), which is what makes concurrent withdrawals of
+	// the same position safe (nester#1084).
 	if existing.CurrentBalance.LessThan(input.Amount) {
 		return vault.Vault{}, vault.ErrWithdrawalExceedsPosition
 	}

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -447,6 +447,11 @@ func (r *memoryVaultRepository) RecordWithdrawal(_ context.Context, id uuid.UUID
 			}
 		}
 	}
+	// Mirrors the Postgres repository: the sufficiency check re-runs under
+	// the row lock at write time (nester#1084).
+	if model.CurrentBalance.LessThan(record.Amount) {
+		return vault.ErrWithdrawalExceedsPosition
+	}
 
 	model.CurrentBalance = model.CurrentBalance.Sub(record.Amount)
 	model.UpdatedAt = time.Now().UTC()


### PR DESCRIPTION
Closes #1084

## Problem

Two concurrent withdrawals on the same position could both read the pre-withdrawal balance (service-level `GetVault` is a plain `SELECT`) and both pass the sufficient-funds check. `VaultRepository.RecordWithdrawal` then decremented unconditionally — nothing on the money path took a row lock. The only thing stopping a negative position was the `check_current_balance` constraint, which surfaces as a raw SQLSTATE 23514 error on a nondeterministic subset of the racing requests.

## Fix

- `VaultRepository.RecordWithdrawal` now locks the position row with `SELECT ... FOR UPDATE` and re-runs the sufficiency check **under the lock**, returning `ErrWithdrawalExceedsPosition` to the losers (the handler already maps this to a 400, same as the pre-check).
- The service-level check stays as a fast-fail so a doomed withdrawal is never submitted on-chain; the repository check is authoritative.
- **Minimum lock span:** the transaction contains only the locked `SELECT`, the balance `UPDATE`, and the ledger `INSERT` — no chain or network I/O happens inside it.
- **Lock ordering (documented on `RecordWithdrawal`):** every money-path write locks exactly one `vaults` row first — the deposit path's single atomic `UPDATE` takes the same row lock, an equivalent serialisation — and only then inserts into `vault_transactions`. No path locks a second vaults row or takes the two in the other order, so deposit and withdrawal queue on one lock and cannot deadlock.
- The in-memory test repository mirrors the new contract.

## Acceptance criteria

- [x] Money-path writes take `SELECT ... FOR UPDATE` on the position row (withdrawal), or an equivalent serialisation (deposit's atomic `UPDATE`).
- [x] Integration test: 8 concurrent withdrawals of the full balance → exactly **1 success**, 7 × `ErrWithdrawalExceedsPosition`, final balance 0, exactly 1 ledger row (`TestVaultRepositoryIntegrationRecordWithdrawalConcurrent`).
- [x] Lock held for the minimum span; lock ordering documented; interleaved deposits/withdrawals complete without deadlock (`TestVaultRepositoryIntegrationDepositWithdrawalInterleaved`).

## Verification

- `go build ./...`, `go vet` clean.
- Full `internal/service` + `internal/repository/postgres` suites pass against a real Postgres (`TEST_DATABASE_DSN`), including the two new tests.
- Reverting only the repository change makes the new concurrency test fail (all goroutines race past the check; constraint errors instead of exactly-one-success), confirming the test catches the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal processing under concurrent activity to prevent balances from becoming negative or being withdrawn more than once.
  * Withdrawals now return a clear insufficient-balance error when funds are unavailable.
  * Interleaved deposits and withdrawals reliably preserve the correct final balance.

* **Tests**
  * Added coverage for concurrent withdrawals and mixed deposit-withdrawal activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->