### PR TITLE
feat(api): reconcile indexed vault balances against on-chain state on a schedule

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -235,6 +235,22 @@ TX_POLLER_INTERVAL=15s
 # Horizon time to ingest a freshly submitted transaction.
 TX_POLLER_MIN_AGE=30s
 
+# Scheduled vault-balance reconciliation (nester#1082): reads the
+# authoritative total_assets from each active vault's contract and compares
+# it to vaults.current_balance in raw stroops, recording — never correcting —
+# any divergence to the reconciliation audit tables, the log, and the
+# divergence metric. Disabling the money path's safety net is expected to
+# page (BalanceReconciliationMetricsAbsent) rather than pass silently.
+RECONCILE_ENABLED=true
+
+# How often the balance reconciler sweeps the vault book. If raised past 30m,
+# the BalanceReconciliationStalled alert threshold must move with it.
+RECONCILE_INTERVAL=5m
+
+# Dry-run rehearses a full sweep against production data: findings are logged
+# but nothing is written, counted, or alerted. Liveness still emits.
+RECONCILE_DRY_RUN=false
+
 # Payment provider keys for offramp features (bank list, account resolution).
 # At least one must be set in production or staging — the API will refuse to
 # start if both are empty in those environments.

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/notifications"
 	"github.com/suncrestlabs/nester/apps/api/internal/objectstorage"
 	"github.com/suncrestlabs/nester/apps/api/internal/oracle"
+	"github.com/suncrestlabs/nester/apps/api/internal/reconciliation"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository"
 	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
 	"github.com/suncrestlabs/nester/apps/api/internal/retry"
@@ -1532,6 +1533,58 @@ func run() error {
 		submissionReconciler.SetLeaderChecker(schedulerLeadership)
 		go submissionReconciler.Run(shutdownCtx)
 	}
+
+	// Vault-balance reconciliation (nester#1082). The scheduled safety net for
+	// the money path: reads the authoritative balance from each vault contract
+	// and compares it against vaults.current_balance, recording — never
+	// correcting — any divergence to the reconciliation audit tables, the log,
+	// and the divergence metric the ReconciliationDivergence alert pages on.
+	//
+	// The comparison happens in RAW STROOPS, the unit the event indexer stores
+	// (docs/event-indexer-replay.md; migration 103) — see
+	// stellarpkg.ContractReader.TotalAssetsStroops for why rescaling either
+	// side would hide bookkeeping errors.
+	//
+	// Like the submission reconciler above it needs no key material, runs on
+	// the shared leader gate so one instance sweeps, and stops the moment
+	// shutdown begins. RECONCILE_DRY_RUN rehearses a pass against production
+	// data without writing or alerting anything.
+	balanceReconciler := reconciliation.NewRunner(
+		reconciliation.RunnerConfig{
+			Enabled:  cfg.Reconciliation().Enabled(),
+			Interval: cfg.Reconciliation().Interval(),
+			DryRun:   cfg.Reconciliation().DryRun(),
+		},
+		reconciliation.NewPostgresRepository(db),
+		[]reconciliation.Comparator{
+			reconciliation.BalanceComparator{
+				Vaults: vaultRepository,
+				Chain:  stellarpkg.StroopsBalanceReader{Reader: contractReader},
+				// Severity thresholds are stroop-denominated because the
+				// comparison is: warn on any nonzero disagreement (with exact
+				// integer bookkeeping there is no acceptable dust), escalate
+				// to critical at 1 USDC (1e7 stroops). The dust tolerance is
+				// sub-integer so no whole-stroop difference can be waved off.
+				Classifier: reconciliation.Classifier{
+					DustTolerance:     decimal.RequireFromString("0.5"),
+					WarningThreshold:  decimal.NewFromInt(1),
+					CriticalThreshold: decimal.NewFromInt(10_000_000),
+				},
+				Logger: baseLogger.WithGroup("balance-reconciler"),
+			},
+		},
+		reconciliation.NewLogAlerter(baseLogger.WithGroup("balance-reconciler")),
+		baseLogger.WithGroup("balance-reconciler"),
+	)
+	balanceReconciler.SetLeaderChecker(schedulerLeadership)
+	balanceReconciler.SetMetrics(appMetrics)
+	// Liveness is a scrape-time series (freshness-collector pattern): a dead
+	// reconciler's age keeps climbing on the clock, and a non-leader replica
+	// emits nothing rather than a misleading idle age.
+	if err := appMetrics.RegisterBalanceReconcileAge(balanceReconciler.AgeSample); err != nil {
+		baseLogger.Error("failed to register balance reconcile age collector", "error", err)
+	}
+	go balanceReconciler.Run(shutdownCtx)
 
 	// Balance-freshness SLI (nester#1056, nester#1088): the indexer samples
 	// its own position against the network tip on every tick and publishes it

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	bankAccountCipherKey  string
 	accountCipher         AccountCipherConfig
 	transactionPoller     TransactionPollerConfig
+	reconciliation        ReconciliationConfig
 	recurringDeposit      RecurringDepositConfig
 	jobQueue              JobQueueConfig
 	harvest               HarvestConfig
@@ -172,6 +173,16 @@ type TransactionPollerConfig struct {
 	enabled  bool
 	interval time.Duration
 	minAge   time.Duration
+}
+
+// ReconciliationConfig governs the scheduled vault-balance reconciliation job
+// (nester#1082, see internal/reconciliation.Runner): it reads authoritative
+// balances from the vault contract and compares them to the database,
+// recording — never correcting — any divergence.
+type ReconciliationConfig struct {
+	enabled  bool
+	interval time.Duration
+	dryRun   bool
 }
 
 // StartupConfig governs one-shot work performed before the server begins
@@ -419,6 +430,12 @@ func Load() (*Config, error) {
 			enabled:  loader.boolDefault("TX_POLLER_ENABLED", true),
 			interval: loader.durationDefault("TX_POLLER_INTERVAL", 15*time.Second),
 			minAge:   loader.durationDefault("TX_POLLER_MIN_AGE", 30*time.Second),
+		},
+		reconciliation: ReconciliationConfig{
+			enabled: loader.boolDefault("RECONCILE_ENABLED", true),
+			// Default matches reconciliation.DefaultCadenceConfig().Balance.
+			interval: loader.durationDefault("RECONCILE_INTERVAL", 5*time.Minute),
+			dryRun:   loader.boolDefault("RECONCILE_DRY_RUN", false),
 		},
 		recurringDeposit: RecurringDepositConfig{
 			enabled:    loader.boolDefault("RECURRING_DEPOSIT_ENABLED", true),
@@ -739,6 +756,22 @@ func (c Config) AccountCipher() AccountCipherConfig {
 
 func (c Config) TransactionPoller() TransactionPollerConfig {
 	return c.transactionPoller
+}
+
+func (c Config) Reconciliation() ReconciliationConfig {
+	return c.reconciliation
+}
+
+func (r ReconciliationConfig) Enabled() bool {
+	return r.enabled
+}
+
+func (r ReconciliationConfig) Interval() time.Duration {
+	return r.interval
+}
+
+func (r ReconciliationConfig) DryRun() bool {
+	return r.dryRun
 }
 
 func (t TransactionPollerConfig) Enabled() bool {

--- a/apps/api/internal/metrics/balance_reconcile.go
+++ b/apps/api/internal/metrics/balance_reconcile.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// BalanceReconcileAgeSource reports how long ago the vault-balance reconciler
+// finished a pass, and whether the series should be emitted at all. It returns
+// false on a replica that is not the elected leader (only the instance doing
+// the work reports an age) and on a runner that was never started.
+type BalanceReconcileAgeSource func() (age time.Duration, emit bool)
+
+// balanceReconcileCollector exposes the vault-balance reconciler's liveness
+// (nester#1082) as a scrape-time series, following FreshnessCollector: a
+// pushed gauge would freeze at its last healthy value when the reconciler
+// dies, which is exactly the failure mode a liveness metric exists to expose.
+// Deriving the age at scrape time from the runner's last-pass timestamp means
+// the number keeps climbing on the clock even when nothing of ours runs.
+//
+// When the source declines to emit — non-leader replica, runner never started
+// — the series is absent rather than zero. Absent is safe: emitting zero
+// would claim "just reconciled", the one value that always looks perfect, and
+// the BalanceReconciliationMetricsAbsent alert covers the dark case.
+type balanceReconcileCollector struct {
+	source BalanceReconcileAgeSource
+	age    *prometheus.Desc
+}
+
+func newBalanceReconcileCollector(source BalanceReconcileAgeSource) *balanceReconcileCollector {
+	return &balanceReconcileCollector{
+		source: source,
+		age: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "reconcile", "balance_last_run_age_seconds"),
+			"Seconds since the vault-balance reconciler finished a pass, derived at scrape time. Absent on non-leader replicas and when the reconciler is not running.",
+			nil, nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *balanceReconcileCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.age
+}
+
+// Collect implements prometheus.Collector.
+func (c *balanceReconcileCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.source == nil {
+		return
+	}
+	age, emit := c.source()
+	if !emit {
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.age, prometheus.GaugeValue, age.Seconds())
+}
+
+// RegisterBalanceReconcileAge attaches the vault-balance reconciler liveness
+// collector to the registry. A nil source is a no-op so callers do not need
+// to branch when the reconciler is not constructed.
+func (m *Metrics) RegisterBalanceReconcileAge(source BalanceReconcileAgeSource) error {
+	if m == nil || source == nil {
+		return nil
+	}
+	return m.registry.Register(newBalanceReconcileCollector(source))
+}

--- a/apps/api/internal/metrics/balance_reconcile_test.go
+++ b/apps/api/internal/metrics/balance_reconcile_test.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+// The balance reconciler shares the runs counter but must NOT touch the
+// transaction poller's age gauge: each loop's liveness stands alone, or a
+// dead poller could hide behind a healthy balance reconciler (nester#1082).
+func TestBalanceReconcileRunDoesNotResetPollerAge(t *testing.T) {
+	m := New()
+
+	m.SetReconcileLastRunAge(900 * time.Second)
+	m.RecordBalanceReconcileRun(ReconcileCompleted)
+	m.RecordBalanceReconcileRun(ReconcileFailed)
+
+	if got := counterValue(t, m.Registry(), "nester_reconcile_runs_total", map[string]string{"outcome": "completed"}); got != 1 {
+		t.Fatalf("completed runs = %v, want 1", got)
+	}
+	if got := counterValue(t, m.Registry(), "nester_reconcile_runs_total", map[string]string{"outcome": "failed"}); got != 1 {
+		t.Fatalf("failed runs = %v, want 1", got)
+	}
+	if got := gaugeValue(t, m.Registry(), "nester_reconcile_last_run_age_seconds"); got != 900 {
+		t.Fatalf("poller age after balance run = %v, want 900 (untouched)", got)
+	}
+}
+
+// balanceSeriesValue gathers the balance age series, reporting whether it was
+// present at all — its absence is load-bearing (see the collector doc).
+func balanceSeriesValue(t *testing.T, m *Metrics) (float64, bool) {
+	t.Helper()
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "nester_reconcile_balance_last_run_age_seconds" {
+			continue
+		}
+		metricsInFamily := family.GetMetric()
+		if len(metricsInFamily) != 1 {
+			t.Fatalf("expected 1 series, got %d", len(metricsInFamily))
+		}
+		return metricsInFamily[0].GetGauge().GetValue(), true
+	}
+	return 0, false
+}
+
+func TestBalanceReconcileAgeIsDerivedAtScrapeTime(t *testing.T) {
+	m := New()
+
+	age := 90 * time.Second
+	emit := true
+	if err := m.RegisterBalanceReconcileAge(func() (time.Duration, bool) {
+		return age, emit
+	}); err != nil {
+		t.Fatalf("RegisterBalanceReconcileAge() error = %v", err)
+	}
+
+	got, present := balanceSeriesValue(t, m)
+	if !present {
+		t.Fatal("expected the balance age series to be present")
+	}
+	if got != 90 {
+		t.Fatalf("balance age = %v, want 90", got)
+	}
+
+	// The value moves per scrape — nothing of ours has to run for it to
+	// change, which is the point of the pull collector.
+	age = 2000 * time.Second
+	got, _ = balanceSeriesValue(t, m)
+	if got != 2000 {
+		t.Fatalf("balance age after source change = %v, want 2000", got)
+	}
+
+	// A source that declines to emit (non-leader, never started) removes the
+	// series rather than publishing zero — zero is the one value that always
+	// looks perfect.
+	emit = false
+	if _, present := balanceSeriesValue(t, m); present {
+		t.Fatal("expected the series to be absent when the source declines to emit")
+	}
+}
+
+func TestRegisterBalanceReconcileAgeNilSourceIsNoop(t *testing.T) {
+	m := New()
+	if err := m.RegisterBalanceReconcileAge(nil); err != nil {
+		t.Fatalf("nil source should be a no-op, got %v", err)
+	}
+	if _, present := balanceSeriesValue(t, m); present {
+		t.Fatal("no source registered but series present")
+	}
+}

--- a/apps/api/internal/metrics/slo.go
+++ b/apps/api/internal/metrics/slo.go
@@ -290,6 +290,23 @@ func (m *Metrics) RecordReconcileRun(outcome ReconcileOutcome) {
 	m.slo.reconcileLastRunAge.Set(0)
 }
 
+// RecordBalanceReconcileRun records one pass of the vault-balance reconciler
+// (nester#1082) on the shared runs counter.
+//
+// It deliberately does NOT reset nester_reconcile_last_run_age_seconds: that
+// gauge is the transaction poller's liveness signal, and a balance pass
+// resetting it would let a dead poller hide behind a healthy balance
+// reconciler (and vice versa). The balance reconciler's liveness is a
+// separate scrape-time series — see RegisterBalanceReconcileAge — so each
+// loop's death is visible on its own.
+func (m *Metrics) RecordBalanceReconcileRun(outcome ReconcileOutcome) {
+	if m == nil {
+		return
+	}
+
+	m.slo.reconcileRunsTotal.WithLabelValues(string(outcome)).Inc()
+}
+
 // RecordReconcileDivergence counts one finding where our record and the chain
 // disagree. Call it once per finding, not once per pass, so the counter
 // reflects how much disagreement exists rather than how often any was seen.

--- a/apps/api/internal/reconciliation/comparators.go
+++ b/apps/api/internal/reconciliation/comparators.go
@@ -2,6 +2,8 @@ package reconciliation
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,6 +26,11 @@ type BalanceComparator struct {
 	Chain      VaultBalanceReader
 	Classifier Classifier
 	Clock      func() time.Time
+	// Logger records per-vault chain-read failures (nil falls back to
+	// slog.Default). Those are logged and skipped rather than failing the
+	// run — see Reconcile — so the log line is the only trace of a vault
+	// that could not be compared.
+	Logger *slog.Logger
 }
 
 func (c BalanceComparator) Name() string { return "vault_balance" }
@@ -40,11 +47,26 @@ const vaultReconcilePageSize = 500
 
 func (c BalanceComparator) Reconcile(ctx context.Context, scope Scope) (ComparisonResult, error) {
 	now := clock(c.Clock)
+	logger := c.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 
 	var findings []Finding
 	classifier := NewClassifier(c.Classifier)
 	checked := 0
 	offset := 0
+	// Per-vault chain-read failures are logged and skipped rather than
+	// failing the run (nester#1082): contract addresses are caller-supplied
+	// at vault creation, so a single unreadable contract — uninitialized,
+	// malformed, or holding an i128 balance past the reader's int64 range —
+	// must not become a standing denial of the whole safety net, dropping
+	// every finding already collected each pass. The false-clean trap is
+	// guarded below: if every attempted read failed the run still fails,
+	// so an RPC outage or open circuit breaker cannot read as "all clear".
+	readFailures := 0
+	firstReadErr := error(nil)
+	attemptedReads := 0
 	for {
 		filter := vault.ListFilter{Status: string(vault.StatusActive), Limit: vaultReconcilePageSize, Offset: offset}
 		vaults, total, err := c.Vaults.ListVaults(ctx, filter)
@@ -59,14 +81,31 @@ func (c BalanceComparator) Reconcile(ctx context.Context, scope Scope) (Comparis
 			if scope.VaultID != uuid.Nil && v.ID != scope.VaultID {
 				continue
 			}
-			checked++
 			if v.ContractAddress == "" {
+				checked++
 				continue
 			}
+			attemptedReads++
 			onChain, err := c.Chain.TotalAssets(ctx, v.ContractAddress)
 			if err != nil {
-				return ComparisonResult{Checked: checked}, err
+				// Shutdown is not a per-vault condition: propagate so the
+				// engine records the aborted run instead of a sweep that
+				// skips every remaining vault and completes.
+				if ctx.Err() != nil {
+					return ComparisonResult{Checked: checked}, err
+				}
+				readFailures++
+				if firstReadErr == nil {
+					firstReadErr = err
+				}
+				logger.Warn("reconciliation: chain read failed; vault skipped this pass",
+					"vault_id", v.ID.String(),
+					"contract_address", v.ContractAddress,
+					"error", err,
+				)
+				continue
 			}
+			checked++
 			if !v.CurrentBalance.Equal(onChain) {
 				recorded := v.CurrentBalance
 				chain := onChain
@@ -92,6 +131,24 @@ func (c BalanceComparator) Reconcile(ctx context.Context, scope Scope) (Comparis
 		if offset >= total || len(vaults) == 0 {
 			break
 		}
+	}
+
+	// Every attempted read failing is not a set of per-vault problems — it is
+	// the chain-read path being down (RPC outage, open breaker, bad config).
+	// Completing the run would report zero divergences because nothing was
+	// compared, the exact false-clean reading this system must never produce.
+	if attemptedReads > 0 && readFailures == attemptedReads {
+		return ComparisonResult{Checked: checked},
+			fmt.Errorf("all %d chain reads failed; first error: %w", readFailures, firstReadErr)
+	}
+	if readFailures > 0 {
+		// checked_count on the run row reflects only vaults actually
+		// compared (or empty-address rows with nothing to compare), so a
+		// partial sweep is visible as checked < active vault count.
+		logger.Warn("reconciliation: pass completed with partial coverage",
+			"checked", checked,
+			"read_failures", readFailures,
+		)
 	}
 
 	return ComparisonResult{Checked: checked, Findings: findings}, nil

--- a/apps/api/internal/reconciliation/comparators_skip_test.go
+++ b/apps/api/internal/reconciliation/comparators_skip_test.go
@@ -1,0 +1,84 @@
+package reconciliation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// One unreadable contract must not kill the sweep (nester#1082): contract
+// addresses are caller-supplied at vault creation, so a run that dies on the
+// first bad one is a standing denial of the whole safety net — and it drops
+// every finding already collected.
+func TestBalanceComparator_SkipsVaultWithFailingChainRead(t *testing.T) {
+	healthy := makeVault("addr-ok", decimal.NewFromInt(100))
+	poisoned := makeVault("addr-poisoned", decimal.NewFromInt(200))
+	drifted := makeVault("addr-drifted", decimal.NewFromInt(300))
+
+	lister := &fakeVaultLister{vaults: []vault.Vault{healthy, poisoned, drifted}}
+	chain := &fakeChainReader{
+		balances: map[string]decimal.Decimal{
+			"addr-ok":      decimal.NewFromInt(100),
+			"addr-drifted": decimal.NewFromInt(299),
+		},
+		errFor: map[string]error{"addr-poisoned": errors.New("simulate failed: contract not initialized")},
+	}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	result, err := comparator.Reconcile(context.Background(), Scope{})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v — a single bad contract must not fail the run", err)
+	}
+	// The poisoned vault is not counted as checked: checked_count reflects
+	// only vaults actually compared, so partial coverage is visible.
+	if result.Checked != 2 {
+		t.Fatalf("Checked = %d, want 2 (the unreadable vault must not count as compared)", result.Checked)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("findings = %d, want 1 — the drifted vault's finding must survive the earlier read failure", len(result.Findings))
+	}
+	if result.Findings[0].EntityID != drifted.ID.String() {
+		t.Fatalf("finding entity = %s, want the drifted vault %s", result.Findings[0].EntityID, drifted.ID)
+	}
+}
+
+// Every read failing is not N vault problems — it is the chain-read path
+// being down. Completing the run would report zero divergences because
+// nothing was compared: the false-clean reading this system must never
+// produce, so the run fails.
+func TestBalanceComparator_AllReadsFailingFailsRun(t *testing.T) {
+	a := makeVault("addr-a", decimal.NewFromInt(1))
+	b := makeVault("addr-b", decimal.NewFromInt(2))
+
+	lister := &fakeVaultLister{vaults: []vault.Vault{a, b}}
+	chain := &fakeChainReader{errFor: map[string]error{
+		"addr-a": errors.New("rpc unreachable"),
+		"addr-b": errors.New("rpc unreachable"),
+	}}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	if _, err := comparator.Reconcile(context.Background(), Scope{}); err == nil {
+		t.Fatal("expected the run to fail when every chain read failed")
+	}
+}
+
+// Shutdown is not a per-vault condition: a cancelled context propagates so
+// the engine records the aborted run instead of a sweep that "completes"
+// after skipping every remaining vault.
+func TestBalanceComparator_CancellationPropagates(t *testing.T) {
+	v := makeVault("addr-x", decimal.NewFromInt(1))
+	lister := &fakeVaultLister{vaults: []vault.Vault{v}}
+	chain := &fakeChainReader{errFor: map[string]error{"addr-x": context.Canceled}}
+	comparator := BalanceComparator{Vaults: lister, Chain: chain, Clock: func() time.Time { return time.Unix(0, 0) }}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := comparator.Reconcile(ctx, Scope{}); err == nil {
+		t.Fatal("expected the cancelled sweep to propagate an error")
+	}
+}

--- a/apps/api/internal/reconciliation/comparators_test.go
+++ b/apps/api/internal/reconciliation/comparators_test.go
@@ -48,9 +48,15 @@ func (f *fakeVaultLister) ListVaults(_ context.Context, filter vault.ListFilter)
 // test set, i.e. no finding.
 type fakeChainReader struct {
 	balances map[string]decimal.Decimal
+	// errFor makes reads for these addresses fail, simulating an
+	// uninitialized contract or an i128 past the reader's int64 range.
+	errFor map[string]error
 }
 
 func (f *fakeChainReader) TotalAssets(_ context.Context, contractAddress string) (decimal.Decimal, error) {
+	if err, ok := f.errFor[contractAddress]; ok {
+		return decimal.Zero, err
+	}
 	if bal, ok := f.balances[contractAddress]; ok {
 		return bal, nil
 	}

--- a/apps/api/internal/reconciliation/engine.go
+++ b/apps/api/internal/reconciliation/engine.go
@@ -123,7 +123,13 @@ func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope
 		}
 	}
 
-	if err := e.repo.CompleteRun(ctx, run.ID, stats); err != nil {
+	// Bookkeeping writes survive cancellation (nester#1082): a SIGTERM
+	// mid-pass cancels the comparator's context, and issuing the final
+	// status write on that same context would strand the run row in
+	// status 'running' forever — indistinguishable from a killed process.
+	// The database pool outlives the signal during graceful drain, so the
+	// detached write almost always lands.
+	if err := e.repo.CompleteRun(context.WithoutCancel(ctx), run.ID, stats); err != nil {
 		return stats, fmt.Errorf("reconciliation: complete run: %w", err)
 	}
 	return stats, nil
@@ -136,7 +142,11 @@ func (e *Engine) runComparator(ctx context.Context, comparator Comparator, scope
 // from one that was simply killed, and runErr is lost. Logging it here means
 // the cause survives even when the write does not (nester#1194).
 func (e *Engine) recordFailedRun(ctx context.Context, runID uuid.UUID, runErr error) {
-	if failErr := e.repo.FailRun(ctx, runID, runErr.Error()); failErr != nil {
+	// Detached from cancellation for the same reason as CompleteRun: when the
+	// failure IS the cancellation (shutdown mid-pass), writing the failure on
+	// the cancelled context would itself fail and strand the run row in
+	// status 'running' (nester#1082).
+	if failErr := e.repo.FailRun(context.WithoutCancel(ctx), runID, runErr.Error()); failErr != nil {
 		e.logger.Error("reconciliation: failed to record run failure",
 			"run_id", runID,
 			"original_error", runErr,

--- a/apps/api/internal/reconciliation/log_alerter.go
+++ b/apps/api/internal/reconciliation/log_alerter.go
@@ -1,0 +1,67 @@
+package reconciliation
+
+import (
+	"context"
+	"log/slog"
+)
+
+// LogAlerter dispatches findings to structured logs. It is the production
+// Alerter (nester#1082): the pager itself rides the Prometheus divergence
+// counter (ReconciliationDivergence fires on any recorded finding), so what
+// the alert path owes the operator is not another delivery channel but the
+// JOIN KEY — the divergence metric is deliberately unlabelled by vault or
+// user (cardinality policy, docs/observability/slo.md), and the runbook sends
+// whoever was paged to the logs to find which records are affected.
+type LogAlerter struct {
+	logger *slog.Logger
+}
+
+// NewLogAlerter builds an alerter over the given logger. A nil logger falls
+// back to slog.Default, matching the Engine's own convention.
+func NewLogAlerter(logger *slog.Logger) *LogAlerter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &LogAlerter{logger: logger}
+}
+
+// CriticalFinding logs at Error level — a critical divergence is the most
+// serious signal this system produces.
+func (a *LogAlerter) CriticalFinding(ctx context.Context, finding Finding) error {
+	a.logger.ErrorContext(ctx, "reconciliation divergence", a.attrs(finding)...)
+	return nil
+}
+
+// WarningFinding logs at Warn level.
+func (a *LogAlerter) WarningFinding(ctx context.Context, finding Finding) error {
+	a.logger.WarnContext(ctx, "reconciliation divergence", a.attrs(finding)...)
+	return nil
+}
+
+// attrs renders the finding fields the runbook's triage procedure needs:
+// enough to locate the exact record and see both sides of the disagreement
+// without a database query.
+func (a *LogAlerter) attrs(finding Finding) []any {
+	attrs := []any{
+		"finding_id", finding.ID.String(),
+		"run_id", finding.RunID.String(),
+		"level", string(finding.Level),
+		"type", string(finding.Type),
+		"severity", string(finding.Severity),
+		"entity_type", finding.EntityType,
+		"entity_id", finding.EntityID,
+	}
+	if finding.RecordedValue != nil {
+		attrs = append(attrs, "recorded_value", finding.RecordedValue.String())
+	}
+	if finding.OnChainValue != nil {
+		attrs = append(attrs, "on_chain_value", finding.OnChainValue.String())
+	}
+	if finding.Difference != nil {
+		attrs = append(attrs, "difference", finding.Difference.String())
+	}
+	for key, value := range finding.Details {
+		attrs = append(attrs, "detail_"+key, value)
+	}
+	return attrs
+}

--- a/apps/api/internal/reconciliation/log_alerter_test.go
+++ b/apps/api/internal/reconciliation/log_alerter_test.go
@@ -1,0 +1,68 @@
+package reconciliation
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// levelCaptureHandler records message, level, and attrs so the test can
+// assert both the severity mapping and the presence of the join-key fields.
+type levelCaptureHandler struct {
+	records *[]string
+}
+
+func (h levelCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h levelCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.WriteString(r.Level.String() + " " + r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteString(" " + a.Key + "=" + a.Value.String())
+		return true
+	})
+	*h.records = append(*h.records, sb.String())
+	return nil
+}
+func (h levelCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h levelCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestLogAlerterLevelsAndFields(t *testing.T) {
+	finding := mismatchFinding(t, "250", "100")
+	finding.Details = map[string]string{"contract_address": "CVAULT1"}
+	finding.ObservedAt = time.Now()
+
+	var logs []string
+	alerter := NewLogAlerter(slog.New(levelCaptureHandler{records: &logs}))
+
+	if err := alerter.CriticalFinding(context.Background(), finding); err != nil {
+		t.Fatalf("CriticalFinding() error = %v", err)
+	}
+	if err := alerter.WarningFinding(context.Background(), finding); err != nil {
+		t.Fatalf("WarningFinding() error = %v", err)
+	}
+
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 log records, got %d: %v", len(logs), logs)
+	}
+	if !strings.HasPrefix(logs[0], "ERROR ") {
+		t.Fatalf("critical finding logged at %q, want ERROR", logs[0])
+	}
+	if !strings.HasPrefix(logs[1], "WARN ") {
+		t.Fatalf("warning finding logged at %q, want WARN", logs[1])
+	}
+	for _, want := range []string{
+		"type=mismatch",
+		"entity_type=vault",
+		"entity_id=vault-1",
+		"recorded_value=250",
+		"on_chain_value=100",
+		"difference=150",
+		"detail_contract_address=CVAULT1",
+	} {
+		if !strings.Contains(logs[0], want) {
+			t.Fatalf("critical log missing %q: %q", want, logs[0])
+		}
+	}
+}

--- a/apps/api/internal/reconciliation/runner.go
+++ b/apps/api/internal/reconciliation/runner.go
@@ -1,0 +1,389 @@
+package reconciliation
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
+)
+
+// Runner drives the reconciliation Engine on a schedule (nester#1082). The
+// engine, comparators, and audit tables all predate it (nester#887) but had
+// no production caller: nothing constructed them, so the database could
+// silently diverge from the chain and nothing would notice. Construct with
+// NewRunner, then call Run from a goroutine; Run returns when the context is
+// cancelled.
+type Runner struct {
+	cfg     RunnerConfig
+	engine  *Engine
+	logger  *slog.Logger
+	metrics RunnerMetricsRecorder
+	leader  LeaderChecker
+	now     func() time.Time
+
+	// startedAt and lastPassEnd feed the liveness metric (AgeSample). Unix
+	// nanos, zero until set — matching the transaction poller's lastTickEnd.
+	// lastPassEnd advances only on SUCCESSFUL passes: a reconciler failing
+	// every pass must read as stalled (age climbing), not alive — one
+	// failed-run increment per interval is too sparse for the rate-window
+	// ReconciliationFailing alert to hold at balance cadence, so the age
+	// series is what pages when nothing is actually being compared.
+	startedAt   atomic.Int64
+	lastPassEnd atomic.Int64
+	// wasLeader tracks the last observed leadership state so the liveness
+	// anchor can be reset when leadership is GAINED. Without that, a
+	// follower promoted after days of idling would emit age = now - boot
+	// until its next pass — a multi-day spike that falsely pages
+	// BalanceReconciliationStalled on every failover at intervals past ~10m.
+	wasLeader atomic.Bool
+}
+
+// RunnerConfig is populated from RECONCILE_* environment configuration.
+type RunnerConfig struct {
+	// Enabled gates the loop; when false Run returns immediately so main.go
+	// can call it unconditionally (transaction-poller convention).
+	Enabled bool
+	// Interval between passes. Defaults to the balance cadence in
+	// DefaultCadenceConfig when non-positive.
+	Interval time.Duration
+	// DryRun performs the full read-and-compare pass but writes nothing:
+	// findings go to the log instead of the audit tables, and no divergence
+	// metric is emitted (a dry run must never page an operator). Liveness and
+	// run-outcome metrics are still recorded — a dry-running reconciler is
+	// alive, and its death must not read as clean silence.
+	DryRun bool
+}
+
+// LeaderChecker gates passes to the elected leader. Declared locally rather
+// than importing the scheduler package, following SubmissionReconciler's
+// convention; a nil checker means "always leader" (single instance, tests).
+type LeaderChecker interface {
+	IsLeader() bool
+}
+
+// RunnerMetricsRecorder is the slice of metrics recording this runner needs.
+// Declared here as an interface, matching the transaction poller's approach,
+// so this package does not depend on Prometheus and tests can record calls
+// without a registry.
+type RunnerMetricsRecorder interface {
+	RecordBalanceReconcileRun(outcome metrics.ReconcileOutcome)
+	RecordReconcileDivergence(kind metrics.DivergenceKind)
+}
+
+type noopRunnerMetrics struct{}
+
+func (noopRunnerMetrics) RecordBalanceReconcileRun(metrics.ReconcileOutcome) {}
+func (noopRunnerMetrics) RecordReconcileDivergence(metrics.DivergenceKind)   {}
+
+// NewRunner builds a scheduled reconciliation runner over the given audit
+// repository, comparators, and alerter.
+//
+// In dry-run mode the repository is replaced with a log-only decorator and no
+// divergence metrics are emitted; otherwise the repository is wrapped so every
+// successfully recorded finding also increments the divergence counter — the
+// metric and the audit row cannot disagree about what was found.
+func NewRunner(cfg RunnerConfig, repo Repository, comparators []Comparator, alerter Alerter, logger *slog.Logger) *Runner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultCadenceConfig().Balance
+	}
+
+	r := &Runner{
+		cfg:     cfg,
+		logger:  logger,
+		metrics: noopRunnerMetrics{},
+		now:     func() time.Time { return time.Now().UTC() },
+	}
+
+	engineRepo := repo
+	if cfg.DryRun {
+		engineRepo = &dryRunRepository{logger: logger}
+		// The dry-run repository already logs every finding with the fields
+		// an alert would carry; dispatching to the alerter as well would log
+		// each finding twice, and a rehearsal must not alert.
+		alerter = nil
+	} else {
+		engineRepo = &meteredRepository{inner: repo, runner: r}
+	}
+	r.engine = NewEngine(engineRepo, comparators, alerter).WithLogger(logger)
+
+	return r
+}
+
+// SetLeaderChecker installs the leadership gate. Call before Run.
+func (r *Runner) SetLeaderChecker(leader LeaderChecker) {
+	r.leader = leader
+}
+
+// SetMetrics wires metrics recording. Call before Run. A nil recorder leaves
+// the runner unmetered rather than panicking.
+func (r *Runner) SetMetrics(rec RunnerMetricsRecorder) {
+	if rec == nil {
+		return
+	}
+	r.metrics = rec
+}
+
+// SetClock overrides the time source for tests.
+func (r *Runner) SetClock(now func() time.Time) {
+	r.now = now
+	r.engine.SetClock(now)
+}
+
+// Run drives the loop until ctx is cancelled. When Config.Enabled is false,
+// Run returns immediately so main.go can call it unconditionally.
+func (r *Runner) Run(ctx context.Context) {
+	if !r.cfg.Enabled {
+		r.logger.Info("balance reconciliation disabled; not starting")
+		return
+	}
+	r.startedAt.Store(r.now().UnixNano())
+	r.logger.Info("balance reconciliation starting",
+		"interval", r.cfg.Interval,
+		"dry_run", r.cfg.DryRun,
+	)
+
+	// Run once immediately so a restart re-establishes the integrity signal
+	// without waiting a full interval.
+	r.Tick(ctx)
+
+	ticker := time.NewTicker(r.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Info("balance reconciliation stopping")
+			return
+		case <-ticker.C:
+			r.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single reconciliation pass. Exported for tests.
+//
+// A non-leader replica skips the pass without touching lastPassEnd: its
+// liveness series is suppressed entirely (see AgeSample), so only the replica
+// actually doing the work reports an age.
+//
+// Leadership is checked once per pass, matching the submission reconciler.
+// The narrow overlap on a handover mid-pass can at worst duplicate audit
+// rows and finding counts for one pass — reconciliation moves no money, so
+// the leadership doc's re-check-before-money-moving rule does not bite here.
+func (r *Runner) Tick(ctx context.Context) {
+	if !r.observeLeadership() {
+		return
+	}
+
+	stats, err := r.engine.Run(ctx, Scope{FullSweep: true, StartedAt: r.now()})
+	if err != nil {
+		// A pass aborted by shutdown is not a failing reconciler: recording
+		// it as failed would tick the ReconciliationFailing series on every
+		// deploy. The engine has already recorded the aborted run row.
+		if ctx.Err() != nil {
+			r.logger.Info("balance reconciliation pass cancelled by shutdown")
+			return
+		}
+		// Recorded as a failed run rather than left silent: a pass that
+		// aborted found no divergences because it stopped checking, which
+		// must not read as a clean result (nester#1108 doctrine). The
+		// liveness anchor deliberately does NOT advance — persistent
+		// failure reads as a climbing age and pages via
+		// BalanceReconciliationStalled.
+		r.logger.Error("balance reconciliation pass failed", "error", err)
+		r.metrics.RecordBalanceReconcileRun(metrics.ReconcileFailed)
+		return
+	}
+
+	r.lastPassEnd.Store(r.now().UnixNano())
+	r.metrics.RecordBalanceReconcileRun(metrics.ReconcileCompleted)
+	r.logger.Info("balance reconciliation pass completed",
+		"checked", stats.Checked,
+		"findings", stats.Findings,
+		"critical", stats.Critical,
+		"dry_run", r.cfg.DryRun,
+	)
+}
+
+// observeLeadership reports whether this replica currently leads, resetting
+// the liveness anchor on the moment leadership is GAINED. Both Tick and
+// AgeSample observe through here, so a freshly promoted follower re-anchors
+// on its first scrape or tick — whichever comes first — and never emits the
+// stale boot-time age it accumulated while following. The atomics make the
+// worst concurrent interleaving a harmless double re-anchor.
+func (r *Runner) observeLeadership() bool {
+	if r.leader == nil {
+		return true
+	}
+	isLeader := r.leader.IsLeader()
+	if isLeader && !r.wasLeader.Swap(true) {
+		// Anchor only a runner that is actually running: a disabled runner
+		// must stay absent from the liveness series, not emit a fresh age
+		// because a scrape observed it holding leadership.
+		if r.startedAt.Load() != 0 {
+			r.lastPassEnd.Store(r.now().UnixNano())
+		}
+	}
+	if !isLeader {
+		r.wasLeader.Store(false)
+	}
+	return isLeader
+}
+
+// AgeSample reports how long ago this runner last completed a successful
+// pass, for the scrape-time liveness collector
+// (metrics.RegisterBalanceReconcileAge).
+//
+// The boolean gates emission:
+//   - a runner that never started (disabled) emits nothing, so the series is
+//     absent and the absent() alert — not a frozen healthy value — covers it;
+//   - a non-leader replica emits nothing, so a healthy follower's climbing
+//     idle time cannot page while the leader is reconciling on schedule. If
+//     no replica holds leadership the series disappears cluster-wide, which
+//     the absent() alert reports — leaderless is exactly as dark as stopped.
+//
+// The anchor is reset when leadership is gained (see observeLeadership) and
+// otherwise advances only on successful passes, so both a hanging first pass
+// and a permanently failing loop read as a climbing age.
+func (r *Runner) AgeSample() (time.Duration, bool) {
+	if !r.observeLeadership() {
+		return 0, false
+	}
+	anchor := r.lastPassEnd.Load()
+	if anchor == 0 {
+		anchor = r.startedAt.Load()
+	}
+	if anchor == 0 {
+		return 0, false
+	}
+	return r.now().Sub(time.Unix(0, anchor)), true
+}
+
+// LastPassEnd returns the wall-clock time the last successful pass finished
+// (or leadership was gained), or zero if neither has happened yet.
+func (r *Runner) LastPassEnd() time.Time {
+	v := r.lastPassEnd.Load()
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v)
+}
+
+// ── repository decorators ────────────────────────────────────────────────────
+
+// meteredRepository counts every successfully recorded finding on the
+// divergence metric. Wrapping the repository rather than walking engine stats
+// means the counter and the audit table are fed by the same event: a finding
+// that failed to persist is not counted, and one that persisted cannot be
+// missed.
+type meteredRepository struct {
+	inner  Repository
+	runner *Runner
+}
+
+func (m *meteredRepository) CreateRun(ctx context.Context, run Run) (Run, error) {
+	return m.inner.CreateRun(ctx, run)
+}
+
+func (m *meteredRepository) AddFinding(ctx context.Context, finding Finding) (Finding, error) {
+	stored, err := m.inner.AddFinding(ctx, finding)
+	if err != nil {
+		return stored, err
+	}
+	// DiscrepancyType and metrics.DivergenceKind are deliberately the same
+	// closed vocabulary (see metrics/slo.go), so the conversion is a cast.
+	m.runner.metrics.RecordReconcileDivergence(metrics.DivergenceKind(stored.Type))
+	return stored, nil
+}
+
+func (m *meteredRepository) CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats) error {
+	return m.inner.CompleteRun(ctx, runID, stats)
+}
+
+func (m *meteredRepository) FailRun(ctx context.Context, runID uuid.UUID, errText string) error {
+	return m.inner.FailRun(ctx, runID, errText)
+}
+
+func (m *meteredRepository) GetCheckpoint(ctx context.Context, key string) (string, bool, error) {
+	return m.inner.GetCheckpoint(ctx, key)
+}
+
+func (m *meteredRepository) SetCheckpoint(ctx context.Context, key, value string) error {
+	return m.inner.SetCheckpoint(ctx, key, value)
+}
+
+func (m *meteredRepository) RecordCorrection(ctx context.Context, findingID uuid.UUID, reason string) error {
+	return m.inner.RecordCorrection(ctx, findingID, reason)
+}
+
+// dryRunRepository satisfies Repository without writing anything. Findings
+// are logged at Warn with the same fields the audit row would carry, so an
+// operator can rehearse a reconciliation pass against production data and
+// read exactly what a live run would have recorded — with no rows written, no
+// metrics emitted, and no page fired.
+type dryRunRepository struct {
+	logger *slog.Logger
+}
+
+func (d *dryRunRepository) CreateRun(ctx context.Context, run Run) (Run, error) {
+	d.logger.InfoContext(ctx, "dry-run: reconciliation run started (not recorded)",
+		"run_id", run.ID.String(),
+		"level", string(run.Level),
+		"comparator", run.Comparator,
+	)
+	return run, nil
+}
+
+func (d *dryRunRepository) AddFinding(ctx context.Context, finding Finding) (Finding, error) {
+	attrs := []any{
+		"run_id", finding.RunID.String(),
+		"level", string(finding.Level),
+		"type", string(finding.Type),
+		"severity", string(finding.Severity),
+		"entity_type", finding.EntityType,
+		"entity_id", finding.EntityID,
+	}
+	if finding.RecordedValue != nil {
+		attrs = append(attrs, "recorded_value", finding.RecordedValue.String())
+	}
+	if finding.OnChainValue != nil {
+		attrs = append(attrs, "on_chain_value", finding.OnChainValue.String())
+	}
+	if finding.Difference != nil {
+		attrs = append(attrs, "difference", finding.Difference.String())
+	}
+	d.logger.WarnContext(ctx, "dry-run: divergence found (not recorded)", attrs...)
+	return finding, nil
+}
+
+func (d *dryRunRepository) CompleteRun(ctx context.Context, runID uuid.UUID, stats Stats) error {
+	d.logger.InfoContext(ctx, "dry-run: reconciliation run completed (not recorded)",
+		"run_id", runID.String(),
+		"checked", stats.Checked,
+		"findings", stats.Findings,
+		"critical", stats.Critical,
+	)
+	return nil
+}
+
+func (d *dryRunRepository) FailRun(ctx context.Context, runID uuid.UUID, errText string) error {
+	d.logger.WarnContext(ctx, "dry-run: reconciliation run failed (not recorded)",
+		"run_id", runID.String(),
+		"error", errText,
+	)
+	return nil
+}
+
+func (d *dryRunRepository) GetCheckpoint(context.Context, string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (d *dryRunRepository) SetCheckpoint(context.Context, string, string) error { return nil }
+
+func (d *dryRunRepository) RecordCorrection(context.Context, uuid.UUID, string) error { return nil }

--- a/apps/api/internal/reconciliation/runner_integration_test.go
+++ b/apps/api/internal/reconciliation/runner_integration_test.go
@@ -1,0 +1,267 @@
+package reconciliation
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
+)
+
+// Acceptance test for nester#1082, criterion 4: a deliberately corrupted
+// vault row must be detected as a divergence — recorded in the audit tables
+// with both values, alerted, counted on the metric — and NEVER corrected.
+//
+// The helpers are package-local copies of the repository/postgres harness
+// (that package's helpers are unexported; precedent for the copy is
+// internal/scheduler/leadership_integration_test.go).
+
+func openReconciliationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if strings.TrimSpace(dsn) == "" {
+		t.Skip("TEST_DATABASE_DSN is not set")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func resetReconciliationTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if _, err := db.Exec(`TRUNCATE TABLE reconciliation_findings, reconciliation_runs, reconciliation_checkpoints, settlements, allocations, vault_transactions, yield_harvests, vaults, users RESTART IDENTITY CASCADE`); err != nil {
+		t.Fatalf("TRUNCATE failed: %v", err)
+	}
+}
+
+func seedReconciliationUser(t *testing.T, db *sql.DB) uuid.UUID {
+	t.Helper()
+
+	userID := uuid.New()
+	if _, err := db.Exec(
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
+		userID.String(),
+		"G"+userID.String(), // final schema: wallet_address NOT NULL UNIQUE
+		"Reconciliation User",
+	); err != nil {
+		t.Fatalf("seed user failed: %v", err)
+	}
+	return userID
+}
+
+// seedActiveVault inserts an active vault holding balance (raw stroops, the
+// unit the event indexer stores — migration 103).
+func seedActiveVault(t *testing.T, db *sql.DB, userID uuid.UUID, contractAddress, balance string) uuid.UUID {
+	t.Helper()
+
+	vaultID := uuid.New()
+	if _, err := db.Exec(
+		`INSERT INTO vaults (id, user_id, contract_address, currency, status, total_deposited, current_balance)
+		 VALUES ($1, $2, $3, 'USDC', 'active', $4::numeric, $4::numeric)`,
+		vaultID.String(), userID.String(), contractAddress, balance,
+	); err != nil {
+		t.Fatalf("seed vault failed: %v", err)
+	}
+	return vaultID
+}
+
+// stubChain returns fixed authoritative balances per contract address,
+// standing in for ContractReader.TotalAssetsStroops.
+type stubChain struct {
+	balances map[string]decimal.Decimal
+}
+
+func (s stubChain) TotalAssets(_ context.Context, contractAddress string) (decimal.Decimal, error) {
+	return s.balances[contractAddress], nil
+}
+
+// newIntegrationRunner wires the runner exactly as main.go does: real audit
+// repository, real vault lister, stroop-denominated classifier thresholds.
+func newIntegrationRunner(db *sql.DB, chain VaultBalanceReader, dryRun bool, logger *slog.Logger) *Runner {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	comparator := BalanceComparator{
+		Vaults: postgres.NewVaultRepository(db),
+		Chain:  chain,
+		Classifier: Classifier{
+			DustTolerance:     decimal.RequireFromString("0.5"),
+			WarningThreshold:  decimal.NewFromInt(1),
+			CriticalThreshold: decimal.NewFromInt(10_000_000),
+		},
+		Logger: logger,
+	}
+	return NewRunner(
+		RunnerConfig{Enabled: true, DryRun: dryRun},
+		NewPostgresRepository(db),
+		[]Comparator{comparator},
+		NewLogAlerter(logger),
+		logger,
+	)
+}
+
+func TestReconciliationIntegrationDetectsCorruptedRow(t *testing.T) {
+	db := openReconciliationTestDB(t)
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
+	resetReconciliationTables(t, db)
+
+	userID := seedReconciliationUser(t, db)
+
+	// A healthy vault: database and chain agree exactly.
+	seedActiveVault(t, db, userID, "CRECON-OK", "38250000000")
+	// The corrupted row: the database claims 1e7 stroops (1 USDC) more than
+	// the chain holds — as if the indexer misapplied a withdrawal.
+	corruptedID := seedActiveVault(t, db, userID, "CRECON-BAD", "38250000000")
+
+	chain := stubChain{balances: map[string]decimal.Decimal{
+		"CRECON-OK":  decimal.RequireFromString("38250000000"),
+		"CRECON-BAD": decimal.RequireFromString("38240000000"),
+	}}
+
+	rec := &fakeRunnerMetrics{}
+	runner := newIntegrationRunner(db, chain, false, nil)
+	runner.SetMetrics(rec)
+
+	runner.Tick(context.Background())
+
+	// The run row: completed, checked both vaults, found exactly one
+	// critical divergence.
+	var status string
+	var checked, findings, critical int
+	if err := db.QueryRow(
+		`SELECT status, checked_count, finding_count, critical_count
+		 FROM reconciliation_runs WHERE comparator = 'vault_balance'`,
+	).Scan(&status, &checked, &findings, &critical); err != nil {
+		t.Fatalf("read run row: %v", err)
+	}
+	if status != "completed" || checked != 2 || findings != 1 || critical != 1 {
+		t.Fatalf("run = status %q checked %d findings %d critical %d, want completed/2/1/1",
+			status, checked, findings, critical)
+	}
+
+	// The finding row: the corrupted vault, both values, the exact
+	// difference, open for review.
+	var entityID, findingType, severity, resolution string
+	var recorded, onChain, difference string
+	if err := db.QueryRow(
+		`SELECT entity_id, type, severity, resolution_state,
+		        recorded_value::text, on_chain_value::text, difference::text
+		 FROM reconciliation_findings`,
+	).Scan(&entityID, &findingType, &severity, &resolution, &recorded, &onChain, &difference); err != nil {
+		t.Fatalf("read finding row: %v", err)
+	}
+	if entityID != corruptedID.String() {
+		t.Fatalf("finding entity = %s, want the corrupted vault %s", entityID, corruptedID)
+	}
+	if findingType != "mismatch" || severity != "critical" || resolution != "open" {
+		t.Fatalf("finding = type %q severity %q resolution %q, want mismatch/critical/open",
+			findingType, severity, resolution)
+	}
+	if !decimal.RequireFromString(recorded).Equal(decimal.RequireFromString("38250000000")) {
+		t.Fatalf("recorded_value = %s, want 38250000000", recorded)
+	}
+	if !decimal.RequireFromString(onChain).Equal(decimal.RequireFromString("38240000000")) {
+		t.Fatalf("on_chain_value = %s, want 38240000000", onChain)
+	}
+	if !decimal.RequireFromString(difference).Equal(decimal.RequireFromString("10000000")) {
+		t.Fatalf("difference = %s, want 10000000", difference)
+	}
+
+	// Never silently auto-corrected: the corrupted balance is untouched.
+	var balanceAfter string
+	if err := db.QueryRow(
+		`SELECT current_balance::text FROM vaults WHERE id = $1`, corruptedID.String(),
+	).Scan(&balanceAfter); err != nil {
+		t.Fatalf("re-read corrupted vault: %v", err)
+	}
+	if !decimal.RequireFromString(balanceAfter).Equal(decimal.RequireFromString("38250000000")) {
+		t.Fatalf("corrupted balance was modified to %s — reconciliation must never correct", balanceAfter)
+	}
+
+	// The divergence reached the metric exactly once, and the pass completed.
+	if len(rec.divergences) != 1 || rec.divergences[0] != "mismatch" {
+		t.Fatalf("divergence metrics = %v, want [mismatch]", rec.divergences)
+	}
+	if len(rec.runs) != 1 || string(rec.runs[0]) != "completed" {
+		t.Fatalf("run metrics = %v, want [completed]", rec.runs)
+	}
+}
+
+func TestReconciliationIntegrationDryRunWritesNothing(t *testing.T) {
+	db := openReconciliationTestDB(t)
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
+	resetReconciliationTables(t, db)
+
+	userID := seedReconciliationUser(t, db)
+	corruptedID := seedActiveVault(t, db, userID, "CRECON-DRY", "5000000000")
+
+	chain := stubChain{balances: map[string]decimal.Decimal{
+		"CRECON-DRY": decimal.RequireFromString("4000000000"),
+	}}
+
+	rec := &fakeRunnerMetrics{}
+	var logs []string
+	runner := newIntegrationRunner(db, chain, true, slog.New(captureHandler{records: &logs}))
+	runner.SetMetrics(rec)
+
+	runner.Tick(context.Background())
+
+	// Positive evidence first: the dry run must have actually compared and
+	// found the corruption — otherwise "wrote nothing" would also pass for a
+	// dry-run mode that silently stopped comparing at all.
+	var foundDivergenceLog bool
+	for _, entry := range logs {
+		if strings.Contains(entry, "dry-run: divergence found") &&
+			strings.Contains(entry, "recorded_value=5000000000") &&
+			strings.Contains(entry, "on_chain_value=4000000000") {
+			foundDivergenceLog = true
+		}
+	}
+	if !foundDivergenceLog {
+		t.Fatalf("dry run did not log the divergence with both values; logs: %v", logs)
+	}
+
+	var runRows, findingRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM reconciliation_runs`).Scan(&runRows); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM reconciliation_findings`).Scan(&findingRows); err != nil {
+		t.Fatalf("count findings: %v", err)
+	}
+	if runRows != 0 || findingRows != 0 {
+		t.Fatalf("dry run wrote runs=%d findings=%d, want 0/0", runRows, findingRows)
+	}
+
+	var balanceAfter string
+	if err := db.QueryRow(
+		`SELECT current_balance::text FROM vaults WHERE id = $1`, corruptedID.String(),
+	).Scan(&balanceAfter); err != nil {
+		t.Fatalf("re-read vault: %v", err)
+	}
+	if !decimal.RequireFromString(balanceAfter).Equal(decimal.RequireFromString("5000000000")) {
+		t.Fatalf("dry run modified the balance to %s", balanceAfter)
+	}
+
+	if len(rec.divergences) != 0 {
+		t.Fatalf("dry run emitted divergence metrics: %v", rec.divergences)
+	}
+	// Liveness still counts: a dry-running reconciler is alive.
+	if len(rec.runs) != 1 || string(rec.runs[0]) != "completed" {
+		t.Fatalf("run metrics = %v, want [completed]", rec.runs)
+	}
+}

--- a/apps/api/internal/reconciliation/runner_test.go
+++ b/apps/api/internal/reconciliation/runner_test.go
@@ -1,0 +1,336 @@
+package reconciliation
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
+)
+
+type fakeRunnerMetrics struct {
+	runs        []metrics.ReconcileOutcome
+	divergences []metrics.DivergenceKind
+}
+
+func (f *fakeRunnerMetrics) RecordBalanceReconcileRun(outcome metrics.ReconcileOutcome) {
+	f.runs = append(f.runs, outcome)
+}
+
+func (f *fakeRunnerMetrics) RecordReconcileDivergence(kind metrics.DivergenceKind) {
+	f.divergences = append(f.divergences, kind)
+}
+
+type fakeLeader struct{ leader bool }
+
+func (f fakeLeader) IsLeader() bool { return f.leader }
+
+// mismatchFinding builds a classified vault-balance mismatch for tests.
+func mismatchFinding(t *testing.T, recorded, onChain string) Finding {
+	t.Helper()
+	rec := decimal.RequireFromString(recorded)
+	chain := decimal.RequireFromString(onChain)
+	return NewClassifier(Classifier{}).Classify(FindingInput{
+		Level:         LevelBalance,
+		Type:          TypeMismatch,
+		EntityType:    "vault",
+		EntityID:      "vault-1",
+		RecordedValue: &rec,
+		OnChainValue:  &chain,
+	}, time.Now())
+}
+
+func TestRunnerDisabledDoesNotStart(t *testing.T) {
+	repo := &fakeRepo{}
+	runner := NewRunner(RunnerConfig{Enabled: false}, repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 1},
+	}}, nil, slog.New(slog.DiscardHandler))
+
+	// Run must return immediately rather than block on the ticker.
+	runner.Run(context.Background())
+
+	if len(repo.runs) != 0 {
+		t.Fatalf("disabled runner created %d runs, want 0", len(repo.runs))
+	}
+	if _, emit := runner.AgeSample(); emit {
+		t.Fatal("disabled runner must not emit a liveness sample")
+	}
+}
+
+func TestRunnerTickRecordsFindingsAndMetrics(t *testing.T) {
+	finding := mismatchFinding(t, "250", "100")
+	repo := &fakeRepo{}
+	rec := &fakeRunnerMetrics{}
+
+	runner := NewRunner(RunnerConfig{Enabled: true}, repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 3, Findings: []Finding{finding}},
+	}}, nil, slog.New(slog.DiscardHandler))
+	runner.SetMetrics(rec)
+
+	runner.Tick(context.Background())
+
+	if len(repo.findings) != 1 {
+		t.Fatalf("findings persisted = %d, want 1", len(repo.findings))
+	}
+	if len(rec.runs) != 1 || rec.runs[0] != metrics.ReconcileCompleted {
+		t.Fatalf("run outcomes = %v, want [completed]", rec.runs)
+	}
+	if len(rec.divergences) != 1 || rec.divergences[0] != metrics.DivergenceMismatch {
+		t.Fatalf("divergence kinds = %v, want [mismatch]", rec.divergences)
+	}
+	age, emit := runner.AgeSample()
+	if !emit {
+		t.Fatal("expected a liveness sample after a completed pass")
+	}
+	if age < 0 || age > time.Minute {
+		t.Fatalf("age = %v, want a small positive duration", age)
+	}
+}
+
+func TestRunnerTickComparatorErrorRecordsFailedRun(t *testing.T) {
+	repo := &fakeRepo{}
+	rec := &fakeRunnerMetrics{}
+
+	runner := NewRunner(RunnerConfig{Enabled: true}, repo, []Comparator{fakeComparator{
+		err: errors.New("chain read failed"),
+	}}, nil, slog.New(slog.DiscardHandler))
+	runner.SetMetrics(rec)
+
+	runner.Tick(context.Background())
+
+	if len(rec.runs) != 1 || rec.runs[0] != metrics.ReconcileFailed {
+		t.Fatalf("run outcomes = %v, want [failed]", rec.runs)
+	}
+	if len(rec.divergences) != 0 {
+		t.Fatalf("divergences = %v, want none", rec.divergences)
+	}
+	// The liveness anchor advances only on SUCCESS: a reconciler failing
+	// every pass must read as a climbing age (and page via
+	// BalanceReconciliationStalled), because one failed-run increment per
+	// interval is too sparse for the rate-window ReconciliationFailing
+	// alert to hold at balance cadence. With no prior success and Run never
+	// started, there is no anchor at all.
+	if _, emit := runner.AgeSample(); emit {
+		t.Fatal("a failed pass must not advance the liveness anchor")
+	}
+}
+
+func TestRunnerSkipsWhenNotLeader(t *testing.T) {
+	repo := &fakeRepo{}
+	rec := &fakeRunnerMetrics{}
+
+	runner := NewRunner(RunnerConfig{Enabled: true}, repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 1},
+	}}, nil, slog.New(slog.DiscardHandler))
+	runner.SetMetrics(rec)
+	runner.SetLeaderChecker(fakeLeader{leader: false})
+
+	runner.Tick(context.Background())
+
+	if len(repo.runs) != 0 {
+		t.Fatalf("non-leader created %d runs, want 0", len(repo.runs))
+	}
+	if len(rec.runs) != 0 {
+		t.Fatalf("non-leader recorded %d run outcomes, want 0", len(rec.runs))
+	}
+	// A follower must not emit a liveness age: its climbing idle time would
+	// page while the leader is reconciling on schedule.
+	if _, emit := runner.AgeSample(); emit {
+		t.Fatal("non-leader must not emit a liveness sample")
+	}
+}
+
+func TestRunnerDryRunWritesAndAlertsNothing(t *testing.T) {
+	finding := mismatchFinding(t, "250", "100")
+	repo := &fakeRepo{}
+	rec := &fakeRunnerMetrics{}
+	alerter := &fakeAlerter{}
+	var logs []string
+	logger := slog.New(captureHandler{records: &logs})
+
+	runner := NewRunner(RunnerConfig{Enabled: true, DryRun: true}, repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 1, Findings: []Finding{finding}},
+	}}, alerter, logger)
+	runner.SetMetrics(rec)
+
+	runner.Tick(context.Background())
+
+	if len(repo.runs) != 0 || len(repo.findings) != 0 {
+		t.Fatalf("dry run wrote runs=%d findings=%d, want 0/0", len(repo.runs), len(repo.findings))
+	}
+	if alerter.critical != 0 || alerter.warning != 0 {
+		t.Fatalf("dry run dispatched alerts: critical=%d warning=%d", alerter.critical, alerter.warning)
+	}
+	if len(rec.divergences) != 0 {
+		t.Fatalf("dry run emitted divergence metrics: %v", rec.divergences)
+	}
+	// The pass itself still counts — a dry-running reconciler is alive and
+	// its death must not read as clean silence.
+	if len(rec.runs) != 1 || rec.runs[0] != metrics.ReconcileCompleted {
+		t.Fatalf("run outcomes = %v, want [completed]", rec.runs)
+	}
+	if _, emit := runner.AgeSample(); !emit {
+		t.Fatal("expected a liveness sample from a dry run")
+	}
+
+	var foundDivergenceLog bool
+	for _, entry := range logs {
+		if strings.Contains(entry, "dry-run: divergence found") &&
+			strings.Contains(entry, "recorded_value=250") &&
+			strings.Contains(entry, "on_chain_value=100") {
+			foundDivergenceLog = true
+		}
+	}
+	if !foundDivergenceLog {
+		t.Fatalf("dry run did not log the divergence with both values; logs: %v", logs)
+	}
+}
+
+// mutableLeader lets a test flip leadership mid-flight.
+type mutableLeader struct{ leader bool }
+
+func (m *mutableLeader) IsLeader() bool { return m.leader }
+
+// A follower promoted to leader must not emit the stale age it accumulated
+// while following — without re-anchoring, a replica up for two days would
+// report a two-day "last pass age" on its first post-promotion scrape and
+// falsely page BalanceReconciliationStalled on every failover.
+func TestRunnerReanchorsOnLeadershipGain(t *testing.T) {
+	current := time.Unix(1_000_000, 0)
+	runner := NewRunner(RunnerConfig{Enabled: true}, &fakeRepo{}, nil, nil, slog.New(slog.DiscardHandler))
+	runner.SetClock(func() time.Time { return current })
+
+	leader := &mutableLeader{leader: false}
+	runner.SetLeaderChecker(leader)
+
+	// Simulate a replica that started Run() two days ago and has been a
+	// follower ever since.
+	runner.startedAt.Store(current.Add(-48 * time.Hour).UnixNano())
+
+	if _, emit := runner.AgeSample(); emit {
+		t.Fatal("a follower must not emit a liveness sample")
+	}
+
+	// Promotion: the first observation after gaining leadership re-anchors,
+	// so the emitted age is measured from promotion, not from boot.
+	leader.leader = true
+	age, emit := runner.AgeSample()
+	if !emit {
+		t.Fatal("expected a liveness sample after gaining leadership")
+	}
+	if age != 0 {
+		t.Fatalf("age at promotion = %v, want 0 (re-anchored), not the 48h since boot", age)
+	}
+
+	// Losing and regaining leadership later re-anchors again.
+	leader.leader = false
+	if _, emit := runner.AgeSample(); emit {
+		t.Fatal("a demoted replica must stop emitting")
+	}
+	current = current.Add(3 * time.Hour)
+	leader.leader = true
+	age, emit = runner.AgeSample()
+	if !emit || age != 0 {
+		t.Fatalf("age after regaining leadership = %v emit=%v, want 0/true", age, emit)
+	}
+}
+
+// A pass aborted by shutdown is not a failing reconciler: recording it as
+// failed would tick ReconciliationFailing on every deploy.
+func TestRunnerShutdownCancellationIsNotAFailedRun(t *testing.T) {
+	rec := &fakeRunnerMetrics{}
+	runner := NewRunner(RunnerConfig{Enabled: true}, &fakeRepo{}, []Comparator{fakeComparator{
+		err: context.Canceled,
+	}}, nil, slog.New(slog.DiscardHandler))
+	runner.SetMetrics(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner.Tick(ctx)
+
+	if len(rec.runs) != 0 {
+		t.Fatalf("run outcomes = %v, want none for a shutdown-cancelled pass", rec.runs)
+	}
+}
+
+// countingComparator counts passes with an atomic so a test can observe the
+// ticker loop from another goroutine without racing the fake repository.
+type countingComparator struct{ passes *atomic.Int32 }
+
+func (c countingComparator) Name() string { return "counting" }
+func (c countingComparator) Level() Level { return LevelBalance }
+func (c countingComparator) Reconcile(context.Context, Scope) (ComparisonResult, error) {
+	c.passes.Add(1)
+	return ComparisonResult{}, nil
+}
+
+// The "on a schedule" half of criterion 1: Run must keep re-running passes on
+// the configured interval, not just fire the immediate first tick.
+func TestRunnerRunRecursOnInterval(t *testing.T) {
+	var passes atomic.Int32
+	runner := NewRunner(
+		RunnerConfig{Enabled: true, Interval: 5 * time.Millisecond},
+		&fakeRepo{},
+		[]Comparator{countingComparator{passes: &passes}},
+		nil,
+		slog.New(slog.DiscardHandler),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runner.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(10 * time.Second)
+	for passes.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d passes within the deadline — the ticker is not recurring", passes.Load())
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestRunnerDefaultsIntervalToBalanceCadence(t *testing.T) {
+	runner := NewRunner(RunnerConfig{Enabled: true}, &fakeRepo{}, nil, nil, nil)
+	if runner.cfg.Interval != DefaultCadenceConfig().Balance {
+		t.Fatalf("interval = %v, want %v", runner.cfg.Interval, DefaultCadenceConfig().Balance)
+	}
+}
+
+func TestRunnerRunStopsOnContextCancel(t *testing.T) {
+	repo := &fakeRepo{}
+	runner := NewRunner(RunnerConfig{Enabled: true, Interval: time.Hour}, repo, []Comparator{fakeComparator{
+		result: ComparisonResult{Checked: 1},
+	}}, nil, slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runner.Run(ctx)
+		close(done)
+	}()
+
+	// The immediate first tick happens before the ticker wait; cancel and the
+	// loop must exit promptly.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+	if len(repo.runs) != 1 {
+		t.Fatalf("expected exactly the immediate first pass, got %d runs", len(repo.runs))
+	}
+}

--- a/apps/api/internal/stellar/reader.go
+++ b/apps/api/internal/stellar/reader.go
@@ -68,6 +68,12 @@ func (r *ContractReader) rebuildRPC() {
 
 // TotalAssets calls the vault_token total_assets() view and converts the i128
 // return value (7-decimal stroops) to a decimal USDC amount.
+//
+// NOT for reconciliation: this method returns DISPLAY units, and *ContractReader
+// therefore satisfies reconciliation.VaultBalanceReader with the wrong unit.
+// Reconciliation compares against vaults.current_balance, which stores raw
+// stroops — wire StroopsBalanceReader there, never this reader directly, or
+// every vault diverges by a factor of 1e7.
 func (r *ContractReader) TotalAssets(ctx context.Context, contractAddress string) (decimal.Decimal, error) {
 	return r.VaultBalance(ctx, contractAddress)
 }
@@ -80,6 +86,42 @@ func (r *ContractReader) VaultBalance(ctx context.Context, contractAddress strin
 	}
 	// Soroban vault amounts are stored in 7-decimal stroops (Stellar standard).
 	return decimal.NewFromInt(raw).Shift(-7), nil
+}
+
+// TotalAssetsStroops calls the vault_token total_assets() view and returns the
+// i128 value as raw stroops, without the display rescale TotalAssets applies.
+//
+// This is the reconciliation read (nester#1082). The event indexer stores
+// vault balances "as emitted" — raw stroop integers, not display USDC (see
+// docs/event-indexer-replay.md fixture rule 7 and migration 103, which widened
+// vaults.current_balance specifically so i128 stroop amounts round-trip
+// exactly). Comparing that column against the chain therefore has to happen in
+// stroops: rescaling either side would turn an exact integer comparison into a
+// decimal one and hide single-stroop bookkeeping errors — the exact class of
+// divergence reconciliation exists to catch.
+//
+// Known bound: simulateI128 rejects values outside int64 (~9.2e18 stroops,
+// ~922 billion USDC). A vault past that errors here rather than reporting a
+// truncated balance; the balance comparator logs and skips it each pass, so
+// the bound is visible in the logs, never silently wrong.
+func (r *ContractReader) TotalAssetsStroops(ctx context.Context, contractAddress string) (decimal.Decimal, error) {
+	raw, err := r.simulateI128(ctx, contractAddress, "total_assets", nil)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return decimal.NewFromInt(raw), nil
+}
+
+// StroopsBalanceReader adapts ContractReader to the reconciliation package's
+// VaultBalanceReader interface (TotalAssets) while keeping the raw-stroops
+// unit contract documented on TotalAssetsStroops. The reconciliation engine
+// asks for "total assets" and must receive the same unit the database stores.
+type StroopsBalanceReader struct {
+	Reader *ContractReader
+}
+
+func (s StroopsBalanceReader) TotalAssets(ctx context.Context, contractAddress string) (decimal.Decimal, error) {
+	return s.Reader.TotalAssetsStroops(ctx, contractAddress)
 }
 
 // SourceAPYBPS calls yield_registry get_source_performance(id) and returns

--- a/apps/api/internal/stellar/reader_test.go
+++ b/apps/api/internal/stellar/reader_test.go
@@ -1,0 +1,89 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+)
+
+// testContractAddress is a syntactically valid contract strkey used across
+// existing fixtures.
+const testContractAddress = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+
+// newSimulateServer serves simulateTransaction responses whose returnValue is
+// the given i128, encoded exactly as Soroban RPC returns it.
+func newSimulateServer(t *testing.T, hi int64, lo uint64) *httptest.Server {
+	t.Helper()
+
+	val := xdr.ScVal{
+		Type: xdr.ScValTypeScvI128,
+		I128: &xdr.Int128Parts{Hi: xdr.Int64(hi), Lo: xdr.Uint64(lo)},
+	}
+	encoded, err := xdr.MarshalBase64(val)
+	if err != nil {
+		t.Fatalf("encode i128 ScVal: %v", err)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  map[string]any{"returnValue": encoded},
+		})
+	}))
+}
+
+// The unit contract the whole balance reconciliation rests on (nester#1082):
+// TotalAssetsStroops returns the i128 raw, TotalAssets rescales by 1e7, and
+// the StroopsBalanceReader adapter exposes the RAW value through the
+// TotalAssets method name the reconciliation interface expects. If the
+// adapter ever delegated to the display method instead, every vault would
+// diverge by a factor of 1e7 — this test is what pins that apart.
+func TestTotalAssetsStroopsAndDisplayUnits(t *testing.T) {
+	// 38_250_000_000 stroops = 3825 USDC.
+	server := newSimulateServer(t, 0, 38_250_000_000)
+	defer server.Close()
+
+	reader := NewContractReader(server.URL, "Test SDF Network ; September 2015", "")
+
+	stroops, err := reader.TotalAssetsStroops(context.Background(), testContractAddress)
+	if err != nil {
+		t.Fatalf("TotalAssetsStroops() error = %v", err)
+	}
+	if stroops.String() != "38250000000" {
+		t.Fatalf("TotalAssetsStroops() = %s, want 38250000000 (raw, unshifted)", stroops)
+	}
+
+	display, err := reader.TotalAssets(context.Background(), testContractAddress)
+	if err != nil {
+		t.Fatalf("TotalAssets() error = %v", err)
+	}
+	if display.String() != "3825" {
+		t.Fatalf("TotalAssets() = %s, want 3825 (display USDC)", display)
+	}
+
+	adapted, err := StroopsBalanceReader{Reader: reader}.TotalAssets(context.Background(), testContractAddress)
+	if err != nil {
+		t.Fatalf("StroopsBalanceReader.TotalAssets() error = %v", err)
+	}
+	if !adapted.Equal(stroops) {
+		t.Fatalf("StroopsBalanceReader.TotalAssets() = %s, want the raw stroops %s", adapted, stroops)
+	}
+}
+
+// An i128 balance past int64 must error loudly, never return a truncated or
+// wrapped value the comparator would then record as a divergence.
+func TestTotalAssetsStroopsOverflowErrors(t *testing.T) {
+	server := newSimulateServer(t, 1, 0) // hi=1 → 2^64, outside int64
+	defer server.Close()
+
+	reader := NewContractReader(server.URL, "Test SDF Network ; September 2015", "")
+
+	if _, err := reader.TotalAssetsStroops(context.Background(), testContractAddress); err == nil {
+		t.Fatal("expected an overflow error for an i128 past int64, got nil")
+	}
+}

--- a/docker/grafana/dashboards/slo-money-path-integrity.json
+++ b/docker/grafana/dashboards/slo-money-path-integrity.json
@@ -362,7 +362,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "completed vs failed. A healthy reconciler shows a flat completed line and no failed line. failed means passes are running but inspecting nothing \u2014 usually a database error on the list-pending query.",
+      "description": "completed vs failed, summed across both loops (the tx poller and the balance reconciler, nester#1082). A healthy system shows a flat completed line and no failed line. failed means passes are running but completing nothing \u2014 a database error on the list-pending query, or the balance sweep unable to list vaults or reach the chain.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -512,7 +512,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Should sawtooth near zero, resetting every pass. A monotonic climb means the poller stopped, and every integrity signal on this board froze with it.",
+      "description": "Both loops should sawtooth near zero, resetting every pass. A monotonic climb means that loop stopped, and its integrity signals on this board froze with it. The tx poller pages above 600 (15s interval); the balance reconciler (nester#1082) pages above 1800 (5m interval). The series are separate deliberately: one loop's health must not vouch for the other's.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -572,9 +572,21 @@
           "editorMode": "code",
           "expr": "reconcile:health:last_run_age_seconds",
           "instant": false,
-          "legendFormat": "last run age",
+          "legendFormat": "tx poller age",
           "range": true,
-          "refId": "last run"
+          "refId": "tx polle"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reconcile:balance:last_run_age_seconds",
+          "instant": false,
+          "legendFormat": "balance reconciler age",
+          "range": true,
+          "refId": "balance "
         }
       ],
       "title": "Reconciler age over time",

--- a/docker/prometheus/rules/slo_alerts.yml
+++ b/docker/prometheus/rules/slo_alerts.yml
@@ -596,8 +596,9 @@ groups:
             Reconciliation found {{ $value | printf "%.0f" }} divergence(s)
             between our records and the chain in the last hour
           description: >-
-            The reconciler compared our transaction records against the chain
-            and they disagree. Breakdown by kind:
+            Reconciliation compared our records — transaction statuses and
+            vault balances — against the chain and they disagree. Breakdown
+            by kind:
             {{ with query "reconcile:divergence:rate30m" }}
             {{ range . }}{{ .Labels.kind }}={{ .Value | printf "%.4f" }}/s
             {{ end }}{{ end }}
@@ -638,9 +639,11 @@ groups:
           runbook: docs/observability/runbooks/money-path-integrity.md
 
       - alert: ReconciliationFailing
-        # A pass that cannot list its work. Distinct from the stall above: the
-        # loop is alive and ticking, but every pass aborts before inspecting
-        # anything, which also produces a false-clean divergence count.
+        # A pass that cannot complete its work. Distinct from the stalls: the
+        # loop is alive and ticking, but every pass aborts before finishing,
+        # which also produces a false-clean divergence count. Both loops feed
+        # this series — the transaction poller and the vault-balance
+        # reconciler (nester#1082).
         expr: reconcile:health:failed_run_rate5m > 0
         for: 15m
         labels:
@@ -651,12 +654,70 @@ groups:
           summary: >-
             Reconciliation passes are failing before inspecting anything
           description: >-
-            The poller is running but its passes abort while listing pending
-            transactions, so nothing is being reconciled and the divergence
-            count is falsely clean. Usually a database error on the
-            list-pending query. Ticketing rather than paging because
-            ReconciliationStalled pages if the loop stops entirely; this is
+            A reconciliation loop is running but its passes abort before
+            completing, so nothing is being verified and the divergence count
+            is falsely clean. Both loops feed this series: the transaction
+            poller (usually a database error on the list-pending query) and
+            the vault-balance reconciler (a database error listing vaults, or
+            the chain read failing every pass). Ticketing rather than paging
+            because the stall alerts page if a loop stops entirely; this is
             the narrower case where it keeps ticking without doing work.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: BalanceReconciliationStalled
+        # Same doctrine as ReconciliationStalled, for the vault-balance job
+        # (nester#1082): zero balance divergences is only good news if the
+        # comparison actually ran. The balance reconciler has its own age
+        # series because the shared gauge above is reset every 15s by the
+        # transaction poller, which would mask this job's death entirely.
+        # Threshold is six times the 5m default interval so a slow sweep or a
+        # leadership handover does not page.
+        expr: reconcile:balance:last_run_age_seconds > 1800
+        for: 10m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Vault-balance reconciliation has not completed a pass for
+            {{ $value | humanizeDuration }}
+          description: >-
+            The vault-balance reconciler has not finished a pass in over 30
+            minutes, against a 5m default interval. While this is firing,
+            balance divergence silence is unknown, not clean: nothing is
+            comparing vaults.current_balance against the chain. Check the
+            balance-reconciler goroutine, scheduler leadership, and
+            nester_reconcile_runs_total{outcome="failed"}. If
+            RECONCILE_INTERVAL was raised past 30 minutes this threshold must
+            move with it.
+          dashboard: /d/nester-slo-money-path/money-path-integrity
+          runbook: docs/observability/runbooks/money-path-integrity.md
+
+      - alert: BalanceReconciliationMetricsAbsent
+        # The balance age series is emitted only while the reconciler runs and
+        # only by the elected leader, so cluster-wide absence means the money
+        # path's balance safety net is off: RECONCILE_ENABLED=false, no
+        # replica holds leadership, or the process never registered the
+        # collector. Dry-run mode still emits — a rehearsal is alive.
+        expr: absent(nester_reconcile_balance_last_run_age_seconds)
+        for: 10m
+        labels:
+          severity: page
+          slo: money_path_integrity
+          service: api
+        annotations:
+          summary: >-
+            Vault-balance reconciliation metrics are absent
+          description: >-
+            nester_reconcile_balance_last_run_age_seconds has not been
+            reported for 10 minutes, so nothing is confirming that vault
+            balances still agree with the chain — the safety net the rest of
+            the money path relies on is dark. Either the API is down (other
+            alerts are firing), no replica holds scheduler leadership, or the
+            reconciler was disabled via RECONCILE_ENABLED=false — disabling
+            the safety net is expected to page rather than pass silently.
           dashboard: /d/nester-slo-money-path/money-path-integrity
           runbook: docs/observability/runbooks/money-path-integrity.md
 
@@ -700,11 +761,12 @@ groups:
             Money-path integrity metrics are absent
           description: >-
             nester_reconcile_last_run_age_seconds has not been reported for 10
-            minutes. Every alert in this group evaluates against it, so
-            reconciliation and pending-submission monitoring are both dark.
-            Either the API is down (in which case other alerts are firing) or
-            the transaction poller was never started — TX_POLLER_ENABLED unset
-            disables it silently at boot.
+            minutes. The transaction poller's reconciliation and
+            pending-submission alerts evaluate against it, so both are dark
+            (the vault-balance reconciler has its own series and absence
+            alert). Either the API is down (in which case other alerts are
+            firing) or the transaction poller was never started —
+            TX_POLLER_ENABLED unset disables it silently at boot.
           dashboard: /d/nester-slo-money-path/money-path-integrity
           runbook: docs/observability/runbooks/money-path-integrity.md
 

--- a/docker/prometheus/rules/slo_money_path_alerts_test.yml
+++ b/docker/prometheus/rules/slo_money_path_alerts_test.yml
@@ -21,6 +21,11 @@
 #      queue depth — a deep queue that drains is healthy, a shallow one that
 #      never drains is not.
 #   5. Absent metrics page rather than silently disabling the group.
+#
+#   6. The vault-balance reconciler (nester#1082) has its own liveness and
+#      absence alerts, because the shared reconcile age gauge is reset every
+#      15s by the transaction poller and would mask the balance job's death —
+#      one loop's health must not vouch for the other's.
 
 rule_files:
   - slo_recording.yml
@@ -38,6 +43,10 @@ tests:
       # Reconciler completing passes: age resets, so it stays low.
       - series: 'nester_reconcile_last_run_age_seconds'
         values: '0+0x60'
+      # Balance reconciler (nester#1082) sweeping on its 5m cadence: the age
+      # sawtooths but never nears the 1800s threshold.
+      - series: 'nester_reconcile_balance_last_run_age_seconds'
+        values: '0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0+60x4 0'
       - series: 'nester_reconcile_runs_total{outcome="completed"}'
         values: '0+4x60'
       - series: 'nester_reconcile_runs_total{outcome="failed"}'
@@ -65,6 +74,12 @@ tests:
         exp_alerts: []
       - eval_time: 45m
         alertname: MoneyPathMetricsAbsent
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: BalanceReconciliationStalled
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: BalanceReconciliationMetricsAbsent
         exp_alerts: []
 
   # ---------------------------------------------------------------------
@@ -100,7 +115,7 @@ tests:
               summary: >-
                 Reconciliation found 1 divergence(s) between our records and the chain in the last hour
               description: >-
-                The reconciler compared our transaction records against the chain and they disagree. Breakdown by kind:  mismatch=0.0006/s  A "mismatch" is the most serious — both sides have the record and the values differ, which means a displayed balance is wrong. "missing" and "extra" mean a record exists on one side only. "stuck" means a submission has not reached a terminal state. Paging rather than ticketing because a savings product whose balance disagrees with the chain cannot be allowed to keep taking deposits while someone reads a ticket queue.
+                Reconciliation compared our records — transaction statuses and vault balances — against the chain and they disagree. Breakdown by kind:  mismatch=0.0006/s  A "mismatch" is the most serious — both sides have the record and the values differ, which means a displayed balance is wrong. "missing" and "extra" mean a record exists on one side only. "stuck" means a submission has not reached a terminal state. Paging rather than ticketing because a savings product whose balance disagrees with the chain cannot be allowed to keep taking deposits while someone reads a ticket queue.
               dashboard: /d/nester-slo-money-path/money-path-integrity
               runbook: docs/observability/runbooks/money-path-integrity.md
 
@@ -196,7 +211,7 @@ tests:
               summary: >-
                 Reconciliation passes are failing before inspecting anything
               description: >-
-                The poller is running but its passes abort while listing pending transactions, so nothing is being reconciled and the divergence count is falsely clean. Usually a database error on the list-pending query. Ticketing rather than paging because ReconciliationStalled pages if the loop stops entirely; this is the narrower case where it keeps ticking without doing work.
+                A reconciliation loop is running but its passes abort before completing, so nothing is being verified and the divergence count is falsely clean. Both loops feed this series: the transaction poller (usually a database error on the list-pending query) and the vault-balance reconciler (a database error listing vaults, or the chain read failing every pass). Ticketing rather than paging because the stall alerts page if a loop stops entirely; this is the narrower case where it keeps ticking without doing work.
               dashboard: /d/nester-slo-money-path/money-path-integrity
               runbook: docs/observability/runbooks/money-path-integrity.md
       # A ticking loop is not a stalled one.
@@ -297,6 +312,95 @@ tests:
               summary: >-
                 Money-path integrity metrics are absent
               description: >-
-                nester_reconcile_last_run_age_seconds has not been reported for 10 minutes. Every alert in this group evaluates against it, so reconciliation and pending-submission monitoring are both dark. Either the API is down (in which case other alerts are firing) or the transaction poller was never started — TX_POLLER_ENABLED unset disables it silently at boot.
+                nester_reconcile_last_run_age_seconds has not been reported for 10 minutes. The transaction poller's reconciliation and pending-submission alerts evaluate against it, so both are dark (the vault-balance reconciler has its own series and absence alert). Either the API is down (in which case other alerts are firing) or the transaction poller was never started — TX_POLLER_ENABLED unset disables it silently at boot.
               dashboard: /d/nester-slo-money-path/money-path-integrity
               runbook: docs/observability/runbooks/money-path-integrity.md
+
+  # ---------------------------------------------------------------------
+  # 6. Balance reconciler (nester#1082)
+  # ---------------------------------------------------------------------
+  # The balance job's version of the stall case: the transaction poller keeps
+  # ticking — its gauge reads healthy — while the balance reconciler is dead.
+  # This is exactly the masking the separate age series exists to defeat: on
+  # the shared gauge this scenario is invisible.
+  - interval: 1m
+    name: a stalled balance reconciler pages while the transaction poller looks healthy
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      # Constant past the threshold rather than a ramp — the summary
+      # humanizes this value, and a ramp makes the rendered figure depend on
+      # scrape alignment at the evaluation boundary (same reasoning as the
+      # stalled-reconciler case above).
+      - series: 'nester_reconcile_balance_last_run_age_seconds'
+        values: '2700x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '10x60'
+      - series: 'nester_reconcile_runs_total{outcome="failed"}'
+        values: '0x60'
+      - series: 'nester_reconcile_divergences_total{kind="mismatch"}'
+        values: '0x60'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BalanceReconciliationStalled
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Vault-balance reconciliation has not completed a pass for 45m 0s
+              description: >-
+                The vault-balance reconciler has not finished a pass in over 30 minutes, against a 5m default interval. While this is firing, balance divergence silence is unknown, not clean: nothing is comparing vaults.current_balance against the chain. Check the balance-reconciler goroutine, scheduler leadership, and nester_reconcile_runs_total{outcome="failed"}. If RECONCILE_INTERVAL was raised past 30 minutes this threshold must move with it.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+      # The transaction poller's own stall alert correctly stays quiet — its
+      # loop is fine. One loop's health must not vouch for the other's.
+      - eval_time: 20m
+        alertname: ReconciliationStalled
+        exp_alerts: []
+
+  # Boundary: just under the threshold stays quiet.
+  - interval: 1m
+    name: a balance reconciler just under the threshold does not page
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_reconcile_balance_last_run_age_seconds'
+        values: '1700x60'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: BalanceReconciliationStalled
+        exp_alerts: []
+
+  # The dark case: the series is gone entirely. The age series is emitted
+  # only by a running leader, so absence means the balance safety net is off
+  # — disabled, leaderless, or never wired. The transaction poller's series
+  # being present must not cover for it: MoneyPathMetricsAbsent stays quiet
+  # here and the balance-specific absence alert is what fires.
+  - interval: 1m
+    name: an absent balance reconciler series pages on its own alert
+    input_series:
+      - series: 'nester_reconcile_last_run_age_seconds'
+        values: '0+0x60'
+      - series: 'nester_reconcile_runs_total{outcome="completed"}'
+        values: '0+4x60'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: BalanceReconciliationMetricsAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              slo: money_path_integrity
+              service: api
+            exp_annotations:
+              summary: >-
+                Vault-balance reconciliation metrics are absent
+              description: >-
+                nester_reconcile_balance_last_run_age_seconds has not been reported for 10 minutes, so nothing is confirming that vault balances still agree with the chain — the safety net the rest of the money path relies on is dark. Either the API is down (other alerts are firing), no replica holds scheduler leadership, or the reconciler was disabled via RECONCILE_ENABLED=false — disabling the safety net is expected to page rather than pass silently.
+              dashboard: /d/nester-slo-money-path/money-path-integrity
+              runbook: docs/observability/runbooks/money-path-integrity.md
+      - eval_time: 15m
+        alertname: MoneyPathMetricsAbsent
+        exp_alerts: []

--- a/docker/prometheus/rules/slo_recording.yml
+++ b/docker/prometheus/rules/slo_recording.yml
@@ -662,6 +662,15 @@ groups:
       - record: reconcile:health:failed_run_rate5m
         expr: sum(rate(nester_reconcile_runs_total{outcome="failed"}[5m]))
 
+      # Balance-reconciler liveness (nester#1082). The age gauge above belongs
+      # to the transaction poller and is reset every 15 seconds by its passes,
+      # so a dead vault-balance reconciler would hide behind it forever. The
+      # balance job publishes its own scrape-time age series — emitted only by
+      # the replica actually doing the work — recorded here for the same
+      # dashboard/pager symmetry as the rest of the group.
+      - record: reconcile:balance:last_run_age_seconds
+        expr: max(nester_reconcile_balance_last_run_age_seconds)
+
       # Pending submissions. Depth alone is ambiguous — a large queue that
       # drains is healthy — so the age of the oldest entry is the series the
       # alert is written against.

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -379,6 +379,30 @@ nester_indexer_lag_seconds <= nester_indexer_staleness_budget_seconds
 nester_indexer_lag_last_sample_age_seconds
 ```
 
+### Reconciliation
+
+Emitted by the two loops that compare our record of the money path against
+the chain: the transaction poller (#1108, `internal/service/transaction_poller.go`)
+and the vault-balance reconciler (#1082, `internal/reconciliation/runner.go`).
+Alerted on by the money-path integrity group
+(`docs/observability/runbooks/money-path-integrity.md`).
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `nester_reconcile_runs_total` | Counter | `outcome` (`completed`/`failed`) | Reconciliation passes, both loops. `failed` means a pass aborted before completing — a false-clean divergence count. |
+| `nester_reconcile_divergences_total` | Counter | `kind` (`missing`/`extra`/`mismatch`/`stuck`) | Findings where our record and the chain disagree. One increment per finding. The kind vocabulary mirrors `reconciliation.DiscrepancyType`. |
+| `nester_reconcile_last_run_age_seconds` | Gauge | none | Seconds since the transaction poller completed a pass. Aged by a ticker in `main.go`; reset on each pass. |
+| `nester_reconcile_balance_last_run_age_seconds` | Gauge | none | Seconds since the vault-balance reconciler finished a sweep, derived at scrape time (pull collector, same reasoning as indexer freshness). **Absent** on non-leader replicas and when the reconciler is not running — absence pages via `BalanceReconciliationMetricsAbsent`. |
+
+**Cardinality:** every label is a closed compile-time set. Divergences are
+deliberately unlabelled by vault, user, or hash — the structured logs and the
+`reconciliation_findings` table are the join key from a firing alert to the
+affected records.
+
+**Why two age series.** `RecordReconcileRun` resets the poller's gauge every
+15 seconds, so a vault-balance reconciler sharing it could die invisibly
+behind a healthy poller (and vice versa). Each loop's liveness stands alone.
+
 ### Runtime
 
 The standard Go and process collectors are registered: `go_goroutines`,

--- a/docs/observability/runbooks/money-path-integrity.md
+++ b/docs/observability/runbooks/money-path-integrity.md
@@ -16,10 +16,33 @@ anything stuck in flight.**
 | Alert | Meaning |
 |---|---|
 | `ReconciliationDivergence` | Our records and the chain disagree. A balance somewhere is wrong. |
-| `ReconciliationStalled` | The reconciler has not completed a pass. **A zero divergence count right now means nothing.** |
-| `ReconciliationFailing` | The loop is ticking but every pass aborts before inspecting anything. Same trap as above, narrower cause. |
+| `ReconciliationStalled` | The transaction poller has not completed a pass. **A zero divergence count right now means nothing.** |
+| `ReconciliationFailing` | A reconciliation loop is ticking but every pass aborts before completing. Same trap as above, narrower cause. |
+| `BalanceReconciliationStalled` | The vault-balance reconciler (#1082) has not completed a sweep. Balance divergence silence is unknown, not clean. |
+| `BalanceReconciliationMetricsAbsent` | The balance reconciler's liveness series is gone — disabled, leaderless, or dead. The balance safety net is off. |
 | `PendingSubmissionsBacklogged` | A submission has been in flight far too long. Someone's money is in limbo. |
 | `MoneyPathMetricsAbsent` | The series these alerts read are gone. Money-path monitoring is dark. |
+
+Two loops feed this group. The **transaction poller** (#1108) reconciles
+pending transaction *statuses* against Horizon every 15s. The **vault-balance
+reconciler** (#1082) sweeps every active vault every 5 minutes
+(`RECONCILE_INTERVAL`), reads the authoritative `total_assets` from the vault
+contract, and compares it against `vaults.current_balance` **in raw stroops**
+— the unit the event indexer stores (migration 103). Each divergence is
+written to `reconciliation_findings`, logged, and counted on the shared
+divergence metric; it is **never auto-corrected**. Each loop has its own
+liveness alert because the shared age gauge is reset every 15s by the poller —
+one loop's health must not vouch for the other's.
+`RECONCILE_DRY_RUN=true` rehearses a sweep against production data: findings
+go to the log only, nothing is written or counted, and liveness still emits.
+
+**First rollout warning:** the balance comparison is exact and in stroops. A
+deployment whose vault balances were ever written by the pre-#1082 service
+paths (which store display USDC rather than stroops) will diverge on its
+first live sweep — those ARE real record-vs-chain disagreements, but they
+will page all at once. Run the first sweep on an existing deployment with
+`RECONCILE_DRY_RUN=true`, triage the logged findings, reconcile the rows, and
+only then go live.
 
 **The trap, and it is the important part of this runbook:** three of these
 alerts exist only because "no divergences reported" is ambiguous. It means
@@ -95,13 +118,21 @@ The reconciler ran and found real disagreement.
 **Do not restart anything.** A restart clears no divergence and destroys the
 in-memory context of what was mid-flight.
 
-1. Identify the affected transactions from the poller logs — the divergence
-   metric is deliberately unlabelled by user or hash (cardinality policy in
+1. Identify the affected records from the logs — the divergence metric is
+   deliberately unlabelled by user, vault, or hash (cardinality policy in
    `docs/observability/metrics.md`), so the logs are the join key:
 
    ```
+   # stuck transactions (poller):
    grep "transaction poller" <api logs> | grep -v "status reconciled"
+   # balance mismatches (balance reconciler) — carries vault id, both values,
+   # and the difference:
+   grep "reconciliation divergence" <api logs>
    ```
+
+   Balance findings are also durable rows: query `reconciliation_findings`
+   (joined to `reconciliation_runs`) for entity ids, recorded vs on-chain
+   values, severity, and resolution state.
 
 2. For each affected transaction, treat **the chain as authoritative**. Confirm
    the on-chain state via Horizon before changing any record.
@@ -147,18 +178,28 @@ against a 15s interval.
 
 ## Cause C — passes failing
 
-`ReconciliationFailing`: the loop ticks, but each pass aborts while listing
-pending transactions and inspects nothing.
+`ReconciliationFailing`: a loop ticks, but its passes abort before completing.
+Both loops feed this series — the transaction poller (a pass that cannot list
+pending transactions) and the balance reconciler (a pass that cannot list
+vaults, or whose chain reads all failed).
 
-Almost always a database error on the list-pending query. Check:
+Usually a database error. Check:
 
 - Connection pool exhaustion (`nester_db_pool_acquired_connections` against
   `nester_db_pool_max_connections`).
-- Statement timeouts on the pending-transaction query as the table grows.
+- Statement timeouts on the pending-transaction or vault listing queries as
+  the tables grow.
 - Replica lag if the query is routed to a read replica.
+- For the balance loop: the Soroban RPC circuit breaker — every chain read
+  failing fails the pass by design, so an RPC outage cannot read as "all
+  vaults agree".
 
-This tickets rather than pages because `ReconciliationStalled` pages if the
-loop stops entirely. The divergence count is equally false-clean in both cases.
+This tickets rather than pages because the stall alerts page if a loop stops
+entirely — and the balance reconciler's liveness anchor only advances on
+*successful* passes, so its persistent failure also climbs
+`reconcile:balance:last_run_age_seconds` and pages via
+`BalanceReconciliationStalled`. The divergence count is equally false-clean
+in every one of these cases.
 
 ---
 
@@ -173,6 +214,32 @@ reconciliation and pending-submission monitoring are both dark.
 2. Is the scrape working? Check the `nester-api` target in Prometheus.
 3. Did the poller ever start? `TX_POLLER_ENABLED` unset means these series are
    never produced and this alert is the only thing that will tell you.
+
+---
+
+## Cause E — balance reconciler stalled or absent
+
+`BalanceReconciliationStalled` (`reconcile:balance:last_run_age_seconds >
+1800`) or `BalanceReconciliationMetricsAbsent` (the series is gone). Either
+way, nothing is confirming vault balances against the chain.
+
+1. **Absent:** the age series is emitted only by the elected leader while the
+   reconciler runs. Check, in order: `RECONCILE_ENABLED=false` (disabling the
+   safety net pages by design), scheduler leadership (no replica holding the
+   advisory lock means no replica emits), and whether the API booted at all.
+2. **Stalled:** the leader holds the series but passes are not completing
+   successfully — the age anchor advances only on success, so a hanging
+   sweep and a persistently failing one both land here. A full sweep reads
+   `total_assets` once per active vault; check
+   `nester_reconcile_runs_total{outcome="failed"}` (failing, not hanging →
+   see [Cause C](#cause-c--passes-failing)), the Soroban RPC circuit
+   breaker, and whether the vault count has outgrown the interval. A vault
+   whose individual chain read fails is logged and skipped, never fatal —
+   only every read failing fails the pass. `RECONCILE_INTERVAL` raises the
+   cadence; the 1800s alert threshold must move with it if it exceeds 30
+   minutes.
+3. Once it recovers, the first completed pass is the first honest reading of
+   balance divergence — same recovery rule as Cause B.
 
 ---
 

--- a/scripts/build_slo_dashboards.py
+++ b/scripts/build_slo_dashboards.py
@@ -978,10 +978,12 @@ def build_money_path_dashboard() -> dict[str, Any]:
             "none",
             {"h": 9, "w": 12, "x": 12, "y": 11},
             description=(
-                "completed vs failed. A healthy reconciler shows a flat "
-                "completed line and no failed line. failed means passes are "
-                "running but inspecting nothing — usually a database error on "
-                "the list-pending query."
+                "completed vs failed, summed across both loops (the tx "
+                "poller and the balance reconciler, nester#1082). A healthy "
+                "system shows a flat completed line and no failed line. "
+                "failed means passes are running but completing nothing — a "
+                "database error on the list-pending query, or the balance "
+                "sweep unable to list vaults or reach the chain."
             ),
         ),
         _timeseries(
@@ -1001,13 +1003,20 @@ def build_money_path_dashboard() -> dict[str, Any]:
         ),
         _timeseries(
             "Reconciler age over time",
-            [("reconcile:health:last_run_age_seconds", "last run age")],
+            [
+                ("reconcile:health:last_run_age_seconds", "tx poller age"),
+                ("reconcile:balance:last_run_age_seconds", "balance reconciler age"),
+            ],
             "s",
             {"h": 9, "w": 12, "x": 12, "y": 20},
             description=(
-                "Should sawtooth near zero, resetting every pass. A monotonic "
-                "climb means the poller stopped, and every integrity signal on "
-                "this board froze with it."
+                "Both loops should sawtooth near zero, resetting every pass. "
+                "A monotonic climb means that loop stopped, and its integrity "
+                "signals on this board froze with it. The tx poller pages "
+                "above 600 (15s interval); the balance reconciler "
+                "(nester#1082) pages above 1800 (5m interval). The series are "
+                "separate deliberately: one loop's health must not vouch for "
+                "the other's."
             ),
             thresholds=[
                 {"color": "green", "value": None},


### PR DESCRIPTION
Closes #1082

## What this does

The reconciliation engine, comparators, classifier, and audit tables (#887, migration 085) were complete but **entirely orphaned** — nothing constructed them, no scheduler ran them, no alerter existed, and no metrics were emitted. This PR wires the money path's safety net end to end. No new migration is needed; the audit schema from 085 is used as-is.

### The scheduled job (criterion 1)
- New `reconciliation.Runner` drives the existing `Engine` + `BalanceComparator` on a leader-gated loop (advisory-lock leadership, same gate as the submission reconciler): immediate first pass, then every `RECONCILE_INTERVAL` (default **5m**, matching the package's own balance cadence). `RECONCILE_ENABLED` defaults **on**.
- The authoritative read is `total_assets()` via Soroban simulation — no key material, shared `contractReader` with breaker + retry instrumentation.

### The unit contract (please review this decision)
The comparison happens in **raw stroops** via a new `ContractReader.TotalAssetsStroops` + `StroopsBalanceReader` adapter. The event indexer stores vault balances *as emitted* (migration 103 widened the columns for exactly this; `docs/event-indexer-replay.md` fixture rule 7), so exact-integer vs exact-integer is the only comparison that can't hide single-stroop bookkeeping errors. **Heads-up:** the pre-#1082 service-layer write paths store display USDC into the same column — that live incoherence is upstream of this PR, and the reconciler will surface it as real record-vs-chain divergences. The runbook gains a **First rollout** section: run `RECONCILE_DRY_RUN=true` on an existing deployment first, triage, then go live. `TotalAssets` (display) now carries a doc warning against wiring it into reconciliation.

### Recorded, alerted, metered — never corrected (criterion 2)
- Findings persist to `reconciliation_findings` through the existing repository; a decorator increments `nester_reconcile_divergences_total{kind}` **per persisted finding**, so the metric and the audit row cannot disagree. The existing `ReconciliationDivergence` page alert fires on any of them.
- `LogAlerter` logs critical/warning findings with the join-key fields (vault id, both values, difference) that the cardinality policy deliberately keeps off the metric.
- Nothing writes to `vaults` — the integration test asserts the corrupted balance is untouched.

### Liveness that can't lie
- New scrape-time pull collector `nester_reconcile_balance_last_run_age_seconds` (freshness-collector pattern): the tx poller resets the shared gauge every 15s, so sharing it would let either loop die invisibly behind the other.
- Emitted **only by the elected leader**; the anchor advances **only on successful passes** and re-anchors on leadership gain — a hanging first pass, a permanently failing loop, and a leaderless cluster all read as stalled/absent, never clean, and a failover cannot emit a follower's stale boot-age (no false page).
- New alerts **BalanceReconciliationStalled** (>1800s, page) and **BalanceReconciliationMetricsAbsent** (page — disabling the safety net is loud by design), with recording rule, promtool unit tests (healthy / stalled-while-poller-healthy / boundary / absent), dashboard line, runbook Cause E, and metrics.md docs. `ReconciliationFailing` + `MoneyPathMetricsAbsent` + `ReconciliationDivergence` texts updated for two loops, promtool expectations in lockstep.

### Production safety + dry-run (criterion 3)
- Per-vault chain-read failures (uninitialized contract, i128 past the reader's documented int64 bound) are **logged and skipped** — one bad caller-supplied contract address cannot become a standing denial of the sweep, and findings already collected survive. If **every** read fails, the run fails: an RPC outage or open breaker can never read as all-clear.
- `RECONCILE_DRY_RUN=true` runs the full read-and-compare against production data, logs each would-be finding with both values, writes nothing, counts nothing, alerts nothing; liveness still emits.
- `CompleteRun`/`FailRun` are detached from cancellation (`context.WithoutCancel`) so SIGTERM mid-sweep cannot strand run rows in status `running`; a shutdown-cancelled pass is not recorded as a failed run (no `ReconciliationFailing` tick on every deploy).

### Corrupted-row proof (criterion 4)
`TestReconciliationIntegrationDetectsCorruptedRow` (real Postgres + full migration chain) seeds a healthy vault and a vault whose DB balance is 1e7 stroops above the stubbed chain: exactly one **critical mismatch** finding with exact recorded/on-chain/difference values, run row completed with checked=2/findings=1/critical=1, divergence metric incremented once, and the corrupted balance **unchanged**. The dry-run variant proves the same detection from the logs with zero rows written.

## Verification
- `go build ./...`, `go vet` clean; full `./internal/...` suite passes against real Postgres (`TEST_DATABASE_DSN`), including new unit tests for the runner (leadership re-anchoring, success-only liveness, shutdown cancellation, ticker recurrence), comparator skip semantics, the stroops-vs-display unit contract (httptest Soroban RPC stub, incl. int64 overflow), the metrics collector, and the log alerter.
- `promtool test rules` passes for all three suites (run via `prom/prometheus` docker image, same as CI).
- Dashboards regenerated via `scripts/build_slo_dashboards.py`; only the money-path dashboard changed.

## Known scope notes
- Findings are re-recorded per run for a persisting divergence (one row per run per divergent vault) — this mirrors the tx poller re-counting stuck transactions each pass and keeps `ReconciliationDivergence` firing while disagreement persists; resolution workflow is the existing `resolution_state` column.
- Only `status='active'` vaults are swept (the comparator's pre-existing contract). Paused vaults whose balances the indexer still mutates are a possible follow-up.
- The reader's i128-to-int64 bound (~9.2e18 stroops) is documented at `TotalAssetsStroops`; a vault past it is skipped loudly each pass, never reported truncated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled vault-balance reconciliation against authoritative on-chain balances.
  * Added configurable intervals, enablement, and dry-run mode.
  * Divergences are recorded and surfaced through logs and metrics without automatic correction.
* **Bug Fixes**
  * Individual chain-read failures no longer abort otherwise successful reconciliation passes.
  * Shutdown and cancellation now preserve reconciliation status updates.
* **Observability**
  * Added dedicated liveness metrics, dashboard panels, and alerts for balance reconciliation.
* **Documentation**
  * Updated metrics references and operational runbooks with reconciliation behavior and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->