### PR TITLE
Launch-readiness gaps: storage safety, per-endpoint SLO, retention, pagination guard, recurring projections, exact decimals, pinned scanners

### DIFF
--- a/apps/api/pkg/listquery/pagination_contract_test.go
+++ b/apps/api/pkg/listquery/pagination_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -54,6 +55,7 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 
 	fset := token.NewFileSet()
 	violations := []string{}
+	matchedKnown := map[string]bool{}
 
 	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -76,6 +78,12 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 		}
 
 		rel, _ := filepath.Rel(root, path)
+		// knownLargeLimits keys are written with forward slashes, but
+		// filepath.Rel returns OS-native separators — on Windows that makes
+		// every allowlist lookup miss and the whole suite fail on entries
+		// that were already reviewed. Normalise so the keys mean the same
+		// thing on every platform CI or a developer runs this on.
+		rel = filepath.ToSlash(rel)
 
 		ast.Inspect(file, func(n ast.Node) bool {
 			kv, ok := n.(*ast.KeyValueExpr)
@@ -99,6 +107,8 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 			key2 := rel + ":" + strconv.Itoa(pos.Line)
 			if _, known := knownLargeLimits[key2]; !known {
 				violations = append(violations, key2+": "+key.Name+": "+lit.Value)
+			} else {
+				matchedKnown[key2] = true
 			}
 			return true
 		})
@@ -109,6 +119,7 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 	}
 
 	if len(violations) > 0 {
+		sort.Strings(violations)
 		t.Errorf(
 			"found %d list-limit literal(s) >= 500 not in the reviewed allowlist "+
 				"(pkg/listquery/pagination_contract_test.go's knownLargeLimits):\n  %s\n\n"+
@@ -124,13 +135,30 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 		)
 	}
 
-	// Sanity check on the test itself: if every known entry stops matching
-	// (e.g. because the underlying code moved and line numbers shifted),
-	// this test would pass vacuously without actually scanning anything
-	// meaningful. Fail loudly instead so the allowlist gets updated rather
-	// than silently going stale.
+	// Sanity check on the test itself: if a known entry stops matching (e.g.
+	// because the underlying code moved and line numbers shifted), this test
+	// would pass vacuously without actually scanning anything meaningful.
+	// Checking only that the map is non-empty does not catch that — the map
+	// is a literal, so it is non-empty by construction even when every entry
+	// has gone stale. Assert each entry actually matched a real call site.
 	if len(knownLargeLimits) == 0 {
 		t.Fatal("knownLargeLimits is empty — this test would no longer verify anything")
+	}
+	stale := []string{}
+	for key := range knownLargeLimits {
+		if !matchedKnown[key] {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf(
+			"%d knownLargeLimits entr(ies) no longer match a large list-limit literal:\n  %s\n\n"+
+				"The referenced code moved, changed, or was fixed. Update the allowlist to the "+
+				"current file:line (or drop the entry if the limit is gone) so this guard keeps "+
+				"covering what it claims to.",
+			len(stale), strings.Join(stale, "\n  "),
+		)
 	}
 }
 

--- a/apps/dapp/frontend/context/NetworkProvider.test.tsx
+++ b/apps/dapp/frontend/context/NetworkProvider.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { NetworkProvider, useNetwork } from "./NetworkProvider";
 import { readNetworkId } from "@/lib/storageKeys";
+import { safeStorage } from "@/lib/storage";
 
 // Issue #1233: NetworkProvider must route through safeStorage rather than
 // raw localStorage, and setNetwork must never leave React state and
@@ -21,7 +22,13 @@ function TestConsumer() {
 
 describe("NetworkProvider (#1233)", () => {
   beforeEach(() => {
-    window.localStorage.clear();
+    // safeStorage.clear(), not window.localStorage.clear(): a test whose
+    // write fell back to the in-memory map (the quota/throwing cases below)
+    // would otherwise leave that value shadowing localStorage for every
+    // later test in this file, since a present memoryStore entry wins over a
+    // native read. Clearing only the native store made the cache-purge test
+    // fail purely on test order.
+    safeStorage.clear();
   });
 
   afterEach(() => {

--- a/apps/dapp/frontend/lib/storage.test.ts
+++ b/apps/dapp/frontend/lib/storage.test.ts
@@ -94,4 +94,39 @@ describe("safeStorage", () => {
       expect(safeStorage.getRaw("missing")).toBeNull();
     });
   });
+
+  describe("clear", () => {
+    it("clears the in-memory fallback, not just localStorage", () => {
+      // A write that hits quota falls back to the in-memory map, and that
+      // entry is authoritative over a native read. Clearing only the native
+      // store would leave it shadowing localStorage for the rest of the
+      // session, so a caller that cleared storage would still read the stale
+      // value back.
+      const setItem = vi
+        .spyOn(window.localStorage.__proto__, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("QuotaExceededError");
+        });
+      safeStorage.set("shadowed", "from-memory");
+      setItem.mockRestore();
+
+      expect(safeStorage.get("shadowed", null)).toBe("from-memory");
+
+      safeStorage.clear();
+      expect(safeStorage.get("shadowed", null)).toBeNull();
+    });
+
+    it("clears values that were written durably to localStorage", () => {
+      safeStorage.set("durable", "v");
+      safeStorage.clear();
+      expect(safeStorage.get("durable", null)).toBeNull();
+    });
+
+    it("does not throw when localStorage.clear itself throws", () => {
+      vi.spyOn(window.localStorage.__proto__, "clear").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+      expect(() => safeStorage.clear()).not.toThrow();
+    });
+  });
 });

--- a/apps/dapp/frontend/lib/storage.ts
+++ b/apps/dapp/frontend/lib/storage.ts
@@ -192,6 +192,29 @@ export const safeStorage = {
     },
 
     /**
+     * Clears BOTH backing stores.
+     *
+     * `window.localStorage.clear()` alone is not enough, and the difference
+     * is a real bug rather than a test-only concern: since a present
+     * memoryStore entry is authoritative over a native read (see
+     * readNative), any key whose write once fell back to memory (private
+     * browsing, quota exceeded) keeps shadowing localStorage for the rest of
+     * the session. A caller that "cleared storage" and then read the key
+     * back would still get the stale fallback value — e.g. a user who hit a
+     * quota error while switching networks would keep reading the old
+     * network id even after a clear.
+     */
+    clear() {
+        memoryStore.clear();
+        if (!isBrowser()) return;
+        try {
+            window.localStorage.clear();
+        } catch {
+            // ignore — storage may be disabled; the memory fallback is cleared
+        }
+    },
+
+    /**
      * Subscribe to cross-tab updates for a single key. The callback receives
      * the parsed value when another tab writes, or `null` on remove. Returns
      * an unsubscribe function.


### PR DESCRIPTION
## Summary

Integrates #1272 and #1274 and fixes two defects found while verifying them together. Both source PRs were reviewed against their linked issues and merged into `integration/launch-gaps-1272-1274` first; this PR brings that integrated, verified result to `dev`.

### From #1272 (@Xueen-code) — #1233, #1227, #1226, #1225

- Storage safety: network/settings persistence routed through the `safeStorage` wrapper rather than the raw API, `setNetwork` persists before updating React state, and a real pre-existing bug is fixed where a value that fell back to the in-memory map on a failed write was invisible to later reads.
- Per-endpoint error budgets: a per-route recording group bounded by the existing `route` label, plus one absolute-threshold `EndpointErrorRateHigh` alert. Includes a correct fix for a PromQL bug — the aggregate's `- (X or vector(0))` pattern breaks under `by (route)` grouping.
- Retention/deletion policy: `docs/data-retention.md` plus a wired, tested `DataRetentionJob` enforcing two categories, with deletion itself audit-logged.
- Pagination: `TestNoNewUnboundedListLimits`, an AST-walking guard against new hardcoded large page sizes.

### From #1274 (@Kinkytech) — #1224, #1223, #1221

- Projections resolve the vault's linked savings goal and active schedule instead of hardcoding `MonthlyContribution` to zero, and responses now state the assumptions behind the numbers.
- Activity amounts stay `decimal.Decimal` end to end, serialising as an exact JSON string; the frontend `Transaction.amount` contract moves to `string` to match.
- `govulncheck` and `gosec` pinned from one shared `.github/security-scanner-versions.env` rather than `@latest`.

## Two defects fixed here

Both were only reachable by building and running the combined tree, which is why neither source PR caught them.

**`TestNoNewUnboundedListLimits` was platform-dependent.** It built allowlist keys with `filepath.Rel` (OS-native separators) and compared them against a forward-slash-keyed map. Linux CI agreed and passed; on Windows every lookup missed and all four already-reviewed call sites reported as violations. Fixed with `filepath.ToSlash`. Its own staleness check had the inverse problem — it asserted only that the map literal was non-empty, which it is by construction, so an entry whose line number drifted would silently stop matching. It now tracks which entries actually matched and fails on the ones that did not.

**The in-memory storage fallback could shadow `localStorage` permanently.** `readNative` treats a present `memoryStore` entry as authoritative, which is what makes a memory-fallback write visible to a later read — but nothing ever cleared that map, and `window.localStorage.clear()` does not touch it. A user who hit a quota error while switching networks would keep reading the stale network id back even after clearing storage. Added `safeStorage.clear()`, which clears both stores and never throws.

That second one surfaced as one of #1272's own new tests failing only in sequence: the quota case left `nester_network_id` shadowed as `"mainnet"`, so the next test mounted already on mainnet, `setNetwork("mainnet")` hit its no-op guard, and the portfolio cache was never purged. The test was right and the storage layer was wrong, so the layer is fixed and `beforeEach` clears through it rather than papering over the order dependence.

## Verification

```
cd apps/api && go build ./...   # clean
go vet ./...                    # clean
go test ./...                   # all packages pass

cd apps/dapp/frontend
npx vitest run                  # 33 files, 279 tests pass (276 + 3 new clear() tests)
npx next build                  # succeeds
```

The pagination guard was verified to still catch a real violation by injecting one and confirming the failure, then confirming it goes green again on removal.

Pre-existing counts move in the right direction and neither is a regression: `gofmt -l` 77 on `dev` to 76 here, and `tsc --noEmit` 16 errors on `dev` to 13 here.

Closes #1233
Closes #1227
Closes #1226
Closes #1225
Closes #1224
Closes #1223
Closes #1221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recurring-contribution support for vault projections, including transparent assumptions about contribution amount, cadence, timeline, and APY.
  - Added per-route API availability monitoring for sustained elevated error rates.

- **Bug Fixes**
  - Preserved exact transaction amounts in activity history and exports, preventing precision loss.
  - Improved network, theme, currency, and insight settings persistence when browser storage is unavailable.

- **Chores**
  - Added automatic cleanup of expired activity and notification history while preserving audit records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->