### PR TITLE
fix(api): close the cross-user WebSocket hole and repair the build (#1228, #1229, #1230, #1231)

### DIFF
--- a/.github/workflows/api-property-nightly.yml
+++ b/.github/workflows/api-property-nightly.yml
@@ -1,0 +1,32 @@
+name: Nightly API property tests
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  share-accounting:
+    name: Randomized share accounting
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/api/go.mod
+          cache: true
+
+      # Deliberately omit RAPID_SEED: each nightly run explores a new set of
+      # sequences, while ci.yml supplies the reproducible merge gate.
+      - name: Run randomized share-accounting properties
+        env:
+          RAPID_CHECKS: "256"
+        run: go test -timeout 120s -run PropertyBased -v ./internal/domain/vault

--- a/.github/workflows/api-property-nightly.yml
+++ b/.github/workflows/api-property-nightly.yml
@@ -17,9 +17,9 @@ jobs:
       run:
         working-directory: apps/api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0a12ed9d6470b8847fe87a30f6be17367a786d20 # v5.0.1
         with:
           go-version-file: apps/api/go.mod
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Lint website
         run: pnpm --filter @nester/website lint
 
-
   intelligence:
     name: Intelligence (Python)
     needs: changes
@@ -116,7 +115,6 @@ jobs:
 
       - name: Test
         run: pytest
-
 
   dapp-frontend:
     name: Dapp Frontend (Next.js)
@@ -216,7 +214,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install promtool and amtool
         run: |
@@ -490,6 +488,11 @@ jobs:
           TEST_DATABASE_DSN: postgres://nester:nester@localhost:5432/nester_test?sslmode=disable
         run: go test -race -timeout 900s -count=1 -p 1 ./...
 
+      - name: Test (property-based vault arithmetic)
+        env:
+          RAPID_CHECKS: "32"
+          RAPID_SEED: "29062026"
+        run: go test -timeout 60s -run PropertyBased -v ./internal/domain/vault
 
   contracts:
     name: Contracts (Rust)
@@ -508,7 +511,6 @@ jobs:
 
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown
-
 
       - name: Build yield_registry WASM
         run: cargo build --release --target wasm32-unknown-unknown -p yield-registry-contract
@@ -556,4 +558,3 @@ jobs:
             echo "ERROR: No vault-contract tests ran — possible missing WASM artifact"
             exit 1
           fi
-

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/sync v0.22.0
+	pgregory.net/rapid v1.1.0
 )
 
 require (

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -218,3 +218,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/apps/api/internal/domain/vault/property_test.go
+++ b/apps/api/internal/domain/vault/property_test.go
@@ -1,0 +1,415 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"pgregory.net/rapid"
+)
+
+// Property-based invariant tests for vault share-price and accounting.
+//
+// These tests generate adversarial sequences of deposits, yields, and
+// withdrawals, asserting the accounting invariants after every operation.
+//
+// Run with:
+//   go test -v ./... -run PropertyBased
+//
+// Override case count for deep runs:
+//   RAPID_CHECKS=10000 go test -v ./...
+//
+// The tests mirror the contract-side property tests in
+// packages/contracts/tests/integration/src/integration/property_tests.rs
+
+// Generators for property testing
+
+func genAmount() *rapid.Generator[decimal.Decimal] {
+	return rapid.Custom(func(t *rapid.T) decimal.Decimal {
+		// Generate amounts in stroops (1 USDC = 1,000,000 stroops).
+		// Include boundary magnitudes: single stroop, min deposit, realistic ranges.
+		choice := rapid.IntRange(0, 5).Draw(t, "choice")
+		switch choice {
+		case 0:
+			// Single stroop
+			return decimal.NewFromInt(1)
+		case 1:
+			// Minimum deposit (10 USDC)
+			return decimal.NewFromInt(10_000_000)
+		case 2:
+			// Medium (100 USDC)
+			return decimal.NewFromInt(100_000_000)
+		case 3:
+			// Large (1000 USDC)
+			return decimal.NewFromInt(1_000_000_000)
+		case 4:
+			// Very large (10000 USDC)
+			return decimal.NewFromInt(10_000_000_000)
+		default:
+			// Random range 1-1000 USDC
+			val := rapid.Int64Range(1_000_000, 1_000_000_000).Draw(t, "val")
+			return decimal.NewFromInt(val)
+		}
+	})
+}
+
+func genYieldBps() *rapid.Generator[int32] {
+	// Yield as basis points (100 bps = 1%). Range 1-2000 bps (1-20% yield).
+	return rapid.Int32Range(1, 2000)
+}
+
+func genLossBps() *rapid.Generator[int32] {
+	// Loss as basis points. Range 1-1000 bps (1-10% loss).
+	return rapid.Int32Range(1, 1000)
+}
+
+func genWithdrawBps() *rapid.Generator[int32] {
+	// Withdrawal percentage of held shares. Range 1-10000 bps (1-100% of held).
+	return rapid.Int32Range(1, 10000)
+}
+
+// ReferenceModel simulates the Go-side share accounting locally.
+type ReferenceModel struct {
+	TotalDeposited decimal.Decimal
+	CurrentBalance decimal.Decimal
+	TotalShares    decimal.Decimal
+	UserShares     map[int]decimal.Decimal
+	UserPrincipal  map[int]decimal.Decimal
+	AccruedFees    decimal.Decimal
+}
+
+func NewReferenceModel() *ReferenceModel {
+	return &ReferenceModel{
+		TotalDeposited: decimal.Zero,
+		CurrentBalance: decimal.Zero,
+		TotalShares:    decimal.Zero,
+		UserShares:     make(map[int]decimal.Decimal),
+		UserPrincipal:  make(map[int]decimal.Decimal),
+		AccruedFees:    decimal.Zero,
+	}
+}
+
+// Deposit adds assets and mints shares using the same formula as ComputeSharePrice.
+func (m *ReferenceModel) Deposit(userIdx int, amount decimal.Decimal) decimal.Decimal {
+	if amount.Sign() <= 0 {
+		return decimal.Zero
+	}
+
+	var shares decimal.Decimal
+	if m.TotalShares.IsZero() || m.TotalDeposited.Sign() <= 0 {
+		// First deposit is 1:1
+		shares = amount
+	} else {
+		// shares = amount * total_shares / total_deposited
+		shares = amount.Mul(m.TotalShares).Div(m.TotalDeposited)
+	}
+
+	if shares.Sign() <= 0 {
+		return decimal.Zero
+	}
+
+	m.TotalDeposited = m.TotalDeposited.Add(amount)
+	m.CurrentBalance = m.CurrentBalance.Add(amount)
+	m.TotalShares = m.TotalShares.Add(shares)
+
+	m.UserShares[userIdx] = m.UserShares[userIdx].Add(shares)
+	m.UserPrincipal[userIdx] = m.UserPrincipal[userIdx].Add(amount)
+
+	return shares
+}
+
+// Withdraw removes shares and assets, accruing fees on yield portion.
+func (m *ReferenceModel) Withdraw(userIdx int, shares decimal.Decimal, performanceFeeBps int32) decimal.Decimal {
+	if shares.Sign() <= 0 || m.TotalShares.Sign() <= 0 {
+		return decimal.Zero
+	}
+
+	userShares := m.UserShares[userIdx]
+	actualShares := shares
+	if actualShares.GreaterThan(userShares) {
+		actualShares = userShares
+	}
+
+	if actualShares.Sign() <= 0 {
+		return decimal.Zero
+	}
+
+	// assets = shares * current_balance / total_shares
+	assets := actualShares.Mul(m.CurrentBalance).Div(m.TotalShares)
+
+	// Principal portion of withdrawal
+	var principalPortion decimal.Decimal
+	if userShares.Sign() > 0 {
+		principalPortion = m.UserPrincipal[userIdx].Mul(actualShares).Div(userShares)
+	}
+
+	// Yield portion (gain on this withdrawal)
+	yieldPart := assets.Sub(principalPortion)
+	if yieldPart.Sign() < 0 {
+		yieldPart = decimal.Zero
+	}
+
+	// Performance fee = yield_part * (feeBps / 10000)
+	feeBps := decimal.NewFromInt32(performanceFeeBps)
+	performanceFee := yieldPart.Mul(feeBps).Div(decimal.NewFromInt(10000))
+
+	netAssets := assets.Sub(performanceFee)
+
+	m.TotalShares = m.TotalShares.Sub(actualShares)
+	m.TotalDeposited = m.TotalDeposited.Sub(principalPortion)
+	m.CurrentBalance = m.CurrentBalance.Sub(netAssets).Sub(performanceFee)
+
+	m.UserShares[userIdx] = m.UserShares[userIdx].Sub(actualShares)
+	m.UserPrincipal[userIdx] = m.UserPrincipal[userIdx].Sub(principalPortion)
+	m.AccruedFees = m.AccruedFees.Add(performanceFee)
+
+	return netAssets
+}
+
+// ReportYield adds yield to the vault (increases CurrentBalance, keeps shares constant).
+func (m *ReferenceModel) ReportYield(amount decimal.Decimal) {
+	if amount.Sign() > 0 {
+		m.CurrentBalance = m.CurrentBalance.Add(amount)
+	}
+}
+
+// ReportLoss removes assets from the vault (decreases CurrentBalance).
+func (m *ReferenceModel) ReportLoss(amount decimal.Decimal) {
+	if amount.Sign() > 0 && amount.LessThan(m.CurrentBalance) {
+		m.CurrentBalance = m.CurrentBalance.Sub(amount)
+	}
+}
+
+// SharePrice returns the live NAV per share.
+func (m *ReferenceModel) SharePrice() decimal.Decimal {
+	if m.TotalDeposited.IsZero() || m.TotalDeposited.Sign() <= 0 {
+		return decimal.NewFromInt(1)
+	}
+	return m.CurrentBalance.Div(m.TotalDeposited)
+}
+
+// CheckConservation verifies that user shares sum to total shares.
+func (m *ReferenceModel) CheckConservation() bool {
+	sum := decimal.Zero
+	for _, userShares := range m.UserShares {
+		sum = sum.Add(userShares)
+	}
+	return sum.Equal(m.TotalShares)
+}
+
+// SumUserShares returns the total shares held by all users.
+func (m *ReferenceModel) SumUserShares() decimal.Decimal {
+	sum := decimal.Zero
+	for _, userShares := range m.UserShares {
+		sum = sum.Add(userShares)
+	}
+	return sum
+}
+
+// Invariant 1: Conservation - user shares must sum to total shares
+func TestPropConservation(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+		numUsers := rapid.IntRange(1, 10).Draw(t, "num_users")
+		numOps := rapid.IntRange(5, 50).Draw(t, "num_ops")
+
+		for i := 0; i < numOps; i++ {
+			opType := rapid.IntRange(0, 3).Draw(t, "op_type")
+			userIdx := rapid.IntRange(0, numUsers).Draw(t, "user_idx")
+
+			switch opType {
+			case 0: // Deposit
+				amount := genAmount().Draw(t, "deposit_amount")
+				model.Deposit(userIdx, amount)
+
+			case 1: // Withdraw
+				if model.TotalShares.Sign() > 0 {
+					shareBps := genWithdrawBps().Draw(t, "withdraw_bps")
+					model.Withdraw(userIdx, model.UserShares[userIdx].Mul(decimal.NewFromInt32(shareBps)).Div(decimal.NewFromInt(10000)), 1000)
+				}
+
+			case 2: // Report yield
+				if model.TotalDeposited.Sign() > 0 {
+					yieldBps := genYieldBps().Draw(t, "yield_bps")
+					yieldAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(yieldBps)).Div(decimal.NewFromInt(10000))
+					model.ReportYield(yieldAmount)
+				}
+
+			case 3: // Report loss
+				if model.TotalDeposited.Sign() > 0 {
+					lossBps := genLossBps().Draw(t, "loss_bps")
+					lossAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(lossBps)).Div(decimal.NewFromInt(10000))
+					model.ReportLoss(lossAmount)
+				}
+			}
+
+			// Assert conservation after each operation
+			if !model.CheckConservation() {
+				t.Fatalf("conservation violated: user shares sum %s != total shares %s",
+					model.SumUserShares(), model.TotalShares)
+			}
+		}
+	})
+}
+
+// Invariant 2: Round-trip safety - deposit + immediate withdraw <= deposit
+func TestPropRoundTripSafety(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+		userIdx := 0
+
+		// First deposit
+		amount := rapid.Int64Range(10_000_000, 1_000_000_000).Draw(t, "amount")
+		depositAmount := decimal.NewFromInt(amount)
+		model.Deposit(userIdx, depositAmount)
+
+		// Immediate withdrawal of all shares
+		shares := model.UserShares[userIdx]
+		withdrawn := model.Withdraw(userIdx, shares, 1000)
+
+		// Assert we didn't get more back than we put in
+		if withdrawn.GreaterThan(depositAmount) {
+			t.Fatalf("round trip returned more: deposited %s, withdrew %s",
+				depositAmount, withdrawn)
+		}
+	})
+}
+
+// Invariant 3: Share price monotonicity - price only increases on yield, not deposits/losses
+func TestPropSharePriceMonotonicity(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+		userIdx := 0
+
+		// Initial deposit
+		amount := rapid.Int64Range(10_000_000, 1_000_000_000).Draw(t, "amount")
+		model.Deposit(userIdx, decimal.NewFromInt(amount))
+
+		previousPrice := model.SharePrice()
+		numOps := rapid.IntRange(3, 30).Draw(t, "num_ops")
+
+		for i := 0; i < numOps; i++ {
+			opType := rapid.IntRange(0, 2).Draw(t, "op_type")
+
+			switch opType {
+			case 0: // Yield increases price
+				if model.TotalDeposited.Sign() > 0 {
+					yieldBps := rapid.Int32Range(1, 500).Draw(t, "yield_bps")
+					yieldAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(yieldBps)).Div(decimal.NewFromInt(10000))
+					model.ReportYield(yieldAmount)
+
+					currentPrice := model.SharePrice()
+					if currentPrice.LessThan(previousPrice) {
+						t.Fatalf("share price decreased after yield: %s -> %s",
+							previousPrice, currentPrice)
+					}
+					previousPrice = currentPrice
+				}
+
+			case 1: // Loss - price can decrease
+				if model.TotalDeposited.Sign() > 0 && model.CurrentBalance.GreaterThan(decimal.NewFromInt(1000000)) {
+					lossBps := rapid.Int32Range(1, 500).Draw(t, "loss_bps")
+					lossAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(lossBps)).Div(decimal.NewFromInt(10000))
+					model.ReportLoss(lossAmount)
+					// Loss can decrease price; no assertion here
+					previousPrice = model.SharePrice()
+				}
+			}
+		}
+	})
+}
+
+// Invariant 4: No mint from nothing - total shares never exceed assets divided by share price
+func TestPropNoMintFromNothing(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+		numUsers := rapid.IntRange(1, 5).Draw(t, "num_users")
+		numOps := rapid.IntRange(5, 50).Draw(t, "num_ops")
+
+		for i := 0; i < numOps; i++ {
+			opType := rapid.IntRange(0, 3).Draw(t, "op_type")
+			userIdx := rapid.IntRange(0, numUsers).Draw(t, "user_idx")
+
+			switch opType {
+			case 0: // Deposit
+				amount := genAmount().Draw(t, "deposit_amount")
+				model.Deposit(userIdx, amount)
+
+			case 1: // Withdraw
+				if model.TotalShares.Sign() > 0 {
+					shareBps := genWithdrawBps().Draw(t, "withdraw_bps")
+					model.Withdraw(userIdx, model.UserShares[userIdx].Mul(decimal.NewFromInt32(shareBps)).Div(decimal.NewFromInt(10000)), 1000)
+				}
+
+			case 2: // Report yield or loss
+				if model.TotalDeposited.Sign() > 0 {
+					if rapid.Bool().Draw(t, "yield_vs_loss") {
+						yieldBps := rapid.Int32Range(1, 1000).Draw(t, "yield_bps")
+						yieldAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(yieldBps)).Div(decimal.NewFromInt(10000))
+						model.ReportYield(yieldAmount)
+					} else {
+						lossBps := rapid.Int32Range(1, 500).Draw(t, "loss_bps")
+						lossAmount := model.TotalDeposited.Mul(decimal.NewFromInt32(lossBps)).Div(decimal.NewFromInt(10000))
+						model.ReportLoss(lossAmount)
+					}
+				}
+			}
+
+			// Invariant: total deposited must never be negative
+			if model.TotalDeposited.Sign() < 0 {
+				t.Fatalf("total deposited went negative: %s", model.TotalDeposited)
+			}
+
+			// Invariant: total shares must never be negative
+			if model.TotalShares.Sign() < 0 {
+				t.Fatalf("total shares went negative: %s", model.TotalShares)
+			}
+
+			// Invariant: current balance must never be negative
+			if model.CurrentBalance.Sign() < 0 {
+				t.Fatalf("current balance went negative: %s", model.CurrentBalance)
+			}
+
+			// Invariant: conservation
+			if !model.CheckConservation() {
+				t.Fatalf("conservation violated after op %d", i)
+			}
+		}
+	})
+}
+
+// Regression test: empty vault first deposit should be 1:1
+func TestPropEmptyVaultFirstDeposit(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+		amount := rapid.Int64Range(10_000_000, 1_000_000_000).Draw(t, "amount")
+		shares := model.Deposit(0, decimal.NewFromInt(amount))
+
+		if !shares.Equal(decimal.NewFromInt(amount)) {
+			t.Fatalf("first deposit should be 1:1: deposited %s, minted %s", amount, shares)
+		}
+	})
+}
+
+// Regression test: tiny amounts should not create zero-share situations
+func TestPropTinyAmountHandling(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		model := NewReferenceModel()
+
+		// Large initial deposit
+		model.Deposit(0, decimal.NewFromInt(1_000_000_000))
+
+		// Many tiny deposits should all mint at least 1 share if rounding is fair
+		for i := 0; i < 100; i++ {
+			shares := model.Deposit(1, decimal.NewFromInt(1_000_001)) // 1 USDC + 1 stroop
+			// Shares might round to zero for very small amounts, but this is acceptable
+			// The invariant is that our accounting remains consistent, not that every
+			// amount mints shares.
+			if shares.Sign() > 0 {
+				if !model.CheckConservation() {
+					t.Fatalf("conservation violated after tiny deposit %d", i)
+				}
+			}
+		}
+	})
+}

--- a/apps/api/internal/domain/vault/property_test.go
+++ b/apps/api/internal/domain/vault/property_test.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"pgregory.net/rapid"
 )
@@ -31,23 +30,23 @@ func genAmount() *rapid.Generator[decimal.Decimal] {
 		choice := rapid.IntRange(0, 5).Draw(t, "choice")
 		switch choice {
 		case 0:
-			// Single stroop
-			return decimal.NewFromInt(1)
+			// Single stroop (1e-7 USDC)
+			return decimal.New(1, -7)
 		case 1:
 			// Minimum deposit (10 USDC)
-			return decimal.NewFromInt(10_000_000)
+			return decimal.NewFromInt(10)
 		case 2:
 			// Medium (100 USDC)
-			return decimal.NewFromInt(100_000_000)
+			return decimal.NewFromInt(100)
 		case 3:
 			// Large (1000 USDC)
-			return decimal.NewFromInt(1_000_000_000)
+			return decimal.NewFromInt(1000)
 		case 4:
 			// Very large (10000 USDC)
-			return decimal.NewFromInt(10_000_000_000)
+			return decimal.NewFromInt(10000)
 		default:
 			// Random range 1-1000 USDC
-			val := rapid.Int64Range(1_000_000, 1_000_000_000).Draw(t, "val")
+			val := rapid.Int64Range(1, 1000).Draw(t, "val")
 			return decimal.NewFromInt(val)
 		}
 	})
@@ -100,8 +99,10 @@ func (m *ReferenceModel) Deposit(userIdx int, amount decimal.Decimal) decimal.De
 		// First deposit is 1:1
 		shares = amount
 	} else {
-		// shares = amount * total_shares / total_deposited
-		shares = amount.Mul(m.TotalShares).Div(m.TotalDeposited)
+		// shares = amount / sharePrice, rounded to 6 decimals (matching production)
+		// where sharePrice = CurrentBalance / TotalDeposited
+		sharePrice := m.CurrentBalance.Div(m.TotalDeposited)
+		shares = amount.Div(sharePrice).Round(6)
 	}
 
 	if shares.Sign() <= 0 {
@@ -207,7 +208,7 @@ func (m *ReferenceModel) SumUserShares() decimal.Decimal {
 }
 
 // Invariant 1: Conservation - user shares must sum to total shares
-func TestPropConservation(t *testing.T) {
+func TestPropertyBasedConservation(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 		numUsers := rapid.IntRange(1, 10).Draw(t, "num_users")
@@ -253,7 +254,7 @@ func TestPropConservation(t *testing.T) {
 }
 
 // Invariant 2: Round-trip safety - deposit + immediate withdraw <= deposit
-func TestPropRoundTripSafety(t *testing.T) {
+func TestPropertyBasedRoundTripSafety(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 		userIdx := 0
@@ -276,7 +277,7 @@ func TestPropRoundTripSafety(t *testing.T) {
 }
 
 // Invariant 3: Share price monotonicity - price only increases on yield, not deposits/losses
-func TestPropSharePriceMonotonicity(t *testing.T) {
+func TestPropertyBasedSharePriceMonotonicity(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 		userIdx := 0
@@ -320,7 +321,7 @@ func TestPropSharePriceMonotonicity(t *testing.T) {
 }
 
 // Invariant 4: No mint from nothing - total shares never exceed assets divided by share price
-func TestPropNoMintFromNothing(t *testing.T) {
+func TestPropertyBasedNoMintFromNothing(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 		numUsers := rapid.IntRange(1, 5).Draw(t, "num_users")
@@ -379,7 +380,7 @@ func TestPropNoMintFromNothing(t *testing.T) {
 }
 
 // Regression test: empty vault first deposit should be 1:1
-func TestPropEmptyVaultFirstDeposit(t *testing.T) {
+func TestPropertyBasedEmptyVaultFirstDeposit(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 		amount := rapid.Int64Range(10_000_000, 1_000_000_000).Draw(t, "amount")
@@ -392,7 +393,7 @@ func TestPropEmptyVaultFirstDeposit(t *testing.T) {
 }
 
 // Regression test: tiny amounts should not create zero-share situations
-func TestPropTinyAmountHandling(t *testing.T) {
+func TestPropertyBasedTinyAmountHandling(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		model := NewReferenceModel()
 

--- a/apps/api/internal/domain/vault/property_test.go
+++ b/apps/api/internal/domain/vault/property_test.go
@@ -387,7 +387,7 @@ func TestPropertyBasedEmptyVaultFirstDeposit(t *testing.T) {
 		shares := model.Deposit(0, decimal.NewFromInt(amount))
 
 		if !shares.Equal(decimal.NewFromInt(amount)) {
-			t.Fatalf("first deposit should be 1:1: deposited %s, minted %s", amount, shares)
+			t.Fatalf("first deposit should be 1:1: deposited %d, minted %s", amount, shares)
 		}
 	})
 }

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -457,3 +457,70 @@ func TestSettlementHandler_ListUserSettlementsWithStatus(t *testing.T) {
 		t.Fatalf("want 1 settlement, got %d", len(list))
 	}
 }
+
+// TestSettlementHandler_PostRejectsOverWithdrawal tests that settlement
+// initiation rejects amounts exceeding the user's available balance.
+// This is a critical server-side check that cannot rely on client-side validation.
+func TestSettlementHandler_PostRejectsOverWithdrawal(t *testing.T) {
+	userID := uuid.New()
+	vaultID := uuid.New()
+
+	// Create a settlement service with a vault repository that tracks balance
+	vaultRepo := &settlementVaultRepoMock{
+		balance: decimal.NewFromInt(100), // User has 100 USDC
+	}
+	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
+	// Note: In a real scenario, we'd need to wire the vault repo to check balance.
+	// For now, this test documents the expected behavior.
+
+	h := newSettlementHandler(svc, userID)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	handler := injectAuthUser(auth.User{ID: userID.String()}, mux)
+	server := httptest.NewServer(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(handler))
+	defer server.Close()
+
+	// Attempt to withdraw 150 USDC when only 100 is available
+	overWithdrawalBody := `{
+		"user_id": "` + userID.String() + `",
+		"vault_id": "` + vaultID.String() + `",
+		"amount": "150",
+		"currency": "USDC",
+		"fiat_currency": "NGN",
+		"fiat_amount": "226500",
+		"exchange_rate": "1512.45",
+		"destination": {
+			"type": "bank_transfer",
+			"provider": "bank",
+			"account_number": "1234567890",
+			"account_name": "Test User",
+			"bank_code": "029"
+		}
+	}`
+
+	resp, err := http.Post(
+		server.URL+"/api/v1/settlements",
+		"application/json",
+		bytes.NewBufferString(overWithdrawalBody),
+	)
+	if err != nil {
+		t.Fatalf("POST settlements: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Server must reject over-withdrawals with 400 Bad Request or 422 Unprocessable Entity
+	// (whichever is more semantically appropriate for the domain error)
+	// For now, document that this should be validated.
+	// Once vault balance checking is wired into settlement service, this test should
+	// verify the rejection.
+	_ = vaultRepo // Currently unused; will be used when balance validation is added
+}
+
+// settlementVaultRepoMock is a test helper that mocks vault balance for over-withdrawal testing.
+type settlementVaultRepoMock struct {
+	balance decimal.Decimal
+}
+
+func (m *settlementVaultRepoMock) GetBalance(_ context.Context, _ uuid.UUID) (decimal.Decimal, error) {
+	return m.balance, nil
+}

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -470,8 +470,7 @@ func TestSettlementHandler_PostRejectsOverWithdrawal(t *testing.T) {
 		balance: decimal.NewFromInt(100), // User has 100 USDC
 	}
 	svc := service.NewSettlementService(newSettlementStubRepo(), nil)
-	// Note: In a real scenario, we'd need to wire the vault repo to check balance.
-	// For now, this test documents the expected behavior.
+	svc.SetVaultRepository(vaultRepo)
 
 	h := newSettlementHandler(svc, userID)
 	mux := http.NewServeMux()
@@ -509,11 +508,15 @@ func TestSettlementHandler_PostRejectsOverWithdrawal(t *testing.T) {
 	defer resp.Body.Close()
 
 	// Server must reject over-withdrawals with 400 Bad Request or 422 Unprocessable Entity
-	// (whichever is more semantically appropriate for the domain error)
-	// For now, document that this should be validated.
-	// Once vault balance checking is wired into settlement service, this test should
-	// verify the rejection.
-	_ = vaultRepo // Currently unused; will be used when balance validation is added
+	if resp.StatusCode != http.StatusBadRequest && resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("Expected 400 or 422 for over-withdrawal, got %d", resp.StatusCode)
+	}
+
+	// Verify no settlement was created by checking the response body
+	body := io.ReadAll(resp.Body)
+	if len(body) > 0 {
+		t.Logf("Response body: %s", string(body))
+	}
 }
 
 // settlementVaultRepoMock is a test helper that mocks vault balance for over-withdrawal testing.
@@ -521,6 +524,6 @@ type settlementVaultRepoMock struct {
 	balance decimal.Decimal
 }
 
-func (m *settlementVaultRepoMock) GetBalance(_ context.Context, _ uuid.UUID) (decimal.Decimal, error) {
+func (m *settlementVaultRepoMock) GetUserVaultBalance(_ context.Context, _ uuid.UUID) (decimal.Decimal, error) {
 	return m.balance, nil
 }

--- a/apps/api/internal/handler/settlement_handler_test.go
+++ b/apps/api/internal/handler/settlement_handler_test.go
@@ -513,7 +513,10 @@ func TestSettlementHandler_PostRejectsOverWithdrawal(t *testing.T) {
 	}
 
 	// Verify no settlement was created by checking the response body
-	body := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if len(body) > 0 {
 		t.Logf("Response body: %s", string(body))
 	}

--- a/apps/api/internal/handler/user_handler.go
+++ b/apps/api/internal/handler/user_handler.go
@@ -45,6 +45,8 @@ func (h *UserHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/users/wallet/{address}", h.getUserByWallet)
 	mux.HandleFunc("POST /api/v1/users/kyc/{id}", h.submitKYC)
 	mux.HandleFunc("GET /api/v1/users/kyc/{id}", h.getKYCStatus)
+	mux.HandleFunc("POST /api/v1/users/me/kyc", h.submitKYCMe)
+	mux.HandleFunc("GET /api/v1/users/me/kyc", h.getKYCStatusMe)
 	mux.HandleFunc("GET /api/v1/users/profile", h.getProfile)
 	mux.HandleFunc("PATCH /api/v1/users/profile", h.updateProfile)
 	mux.HandleFunc("GET /api/v1/user-vaults/{id}", h.listUserVaultsForIntelligence)
@@ -281,6 +283,89 @@ func (h *UserHandler) getKYCStatus(w http.ResponseWriter, r *http.Request) {
 	userID, err := uuid.Parse(idStr)
 	if err != nil {
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("invalid user ID"))
+		return
+	}
+
+	model, err := h.service.GetUser(r.Context(), userID)
+	if err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	resp := map[string]any{
+		"status": model.KYCStatus,
+	}
+	if model.KYCSubmittedAt != nil {
+		resp["submitted_at"] = model.KYCSubmittedAt
+	}
+	if model.KYCReviewedAt != nil {
+		resp["reviewed_at"] = model.KYCReviewedAt
+	}
+	if model.KYCRejectionReason != nil {
+		resp["rejection_reason"] = model.KYCRejectionReason
+	}
+
+	response.WriteJSON(w, http.StatusOK, response.OK(resp))
+}
+
+// submitKYCMe submits KYC data for the authenticated user (no user ID param needed).
+func (h *UserHandler) submitKYCMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
+		return
+	}
+
+	// Reuse the same submitKYC logic
+	r.Body = http.MaxBytesReader(w, r.Body, maxKYCUploadBytes)
+	if err := r.ParseMultipartForm(kycInMemoryBytes); err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("could not parse multipart form"))
+		return
+	}
+
+	fullName := r.FormValue("full_name")
+	dateOfBirth := r.FormValue("date_of_birth")
+	country := r.FormValue("country")
+	idType := r.FormValue("id_type")
+	idNumber := r.FormValue("id_number")
+
+	if idType == "" || idNumber == "" {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("id_type and id_number are required"))
+		return
+	}
+
+	idFrontFile, idFrontHeader, err := r.FormFile("id_front")
+	if err != nil {
+		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("id_front is required"))
+		return
+	}
+	defer idFrontFile.Close()
+
+	frontKey := "s3://mock-bucket/" + idFrontHeader.Filename
+
+	var backKey *string
+	idBackFile, idBackHeader, err := r.FormFile("id_back")
+	if err == nil {
+		defer idBackFile.Close()
+		bk := "s3://mock-bucket/" + idBackHeader.Filename
+		backKey = &bk
+	}
+
+	_ = fullName
+	_ = dateOfBirth
+	_ = country
+
+	if err := h.service.SubmitKYC(r.Context(), userID, idType, idNumber, frontKey, backKey); err != nil {
+		h.writeDomainError(w, r, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusAccepted, response.OK(map[string]string{"status": "pending"}))
+}
+
+// getKYCStatusMe retrieves KYC status for the authenticated user.
+func (h *UserHandler) getKYCStatusMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.authenticatedUserID(w, r)
+	if !ok {
 		return
 	}
 

--- a/apps/api/internal/handler/user_handler.go
+++ b/apps/api/internal/handler/user_handler.go
@@ -248,6 +248,16 @@ func (h *UserHandler) submitKYC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.submitKYCFor(w, r, userID)
+}
+
+// submitKYCFor runs the KYC submission for an already-resolved user id.
+// Shared by submitKYC (id from the path) and submitKYCMe (id from the
+// session) so the two routes cannot drift — an earlier copy of this logic
+// on the /users/me/ route still discarded the identity fields and wrote a
+// mock storage key, reintroducing nester#1190 and nester#1191.
+func (h *UserHandler) submitKYCFor(w http.ResponseWriter, r *http.Request, userID uuid.UUID) {
+
 	if h.kycStore == nil {
 		// Storage is not ready in this environment — reject the upload
 		// rather than accept and discard it (nester#1191's explicit
@@ -388,57 +398,21 @@ func (h *UserHandler) getKYCStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // submitKYCMe submits KYC data for the authenticated user (no user ID param needed).
+// submitKYCMe submits KYC for the authenticated user.
+//
+// Delegates to submitKYCFor rather than repeating the parsing and storage
+// logic. The copy that used to live here discarded full_name, date_of_birth
+// and country with `_ =`, and built its storage key by concatenating the
+// client-supplied filename onto "s3://mock-bucket/" — reintroducing both
+// nester#1190 and nester#1191 on a second route after they were fixed on the
+// first.
 func (h *UserHandler) submitKYCMe(w http.ResponseWriter, r *http.Request) {
 	userID, ok := h.authenticatedUserID(w, r)
 	if !ok {
 		return
 	}
 
-	// Reuse the same submitKYC logic
-	r.Body = http.MaxBytesReader(w, r.Body, maxKYCUploadBytes)
-	if err := r.ParseMultipartForm(kycInMemoryBytes); err != nil {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("could not parse multipart form"))
-		return
-	}
-
-	fullName := r.FormValue("full_name")
-	dateOfBirth := r.FormValue("date_of_birth")
-	country := r.FormValue("country")
-	idType := r.FormValue("id_type")
-	idNumber := r.FormValue("id_number")
-
-	if idType == "" || idNumber == "" {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("id_type and id_number are required"))
-		return
-	}
-
-	idFrontFile, idFrontHeader, err := r.FormFile("id_front")
-	if err != nil {
-		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr("id_front is required"))
-		return
-	}
-	defer idFrontFile.Close()
-
-	frontKey := "s3://mock-bucket/" + idFrontHeader.Filename
-
-	var backKey *string
-	idBackFile, idBackHeader, err := r.FormFile("id_back")
-	if err == nil {
-		defer idBackFile.Close()
-		bk := "s3://mock-bucket/" + idBackHeader.Filename
-		backKey = &bk
-	}
-
-	_ = fullName
-	_ = dateOfBirth
-	_ = country
-
-	if err := h.service.SubmitKYC(r.Context(), userID, idType, idNumber, frontKey, backKey); err != nil {
-		h.writeDomainError(w, r, err)
-		return
-	}
-
-	response.WriteJSON(w, http.StatusAccepted, response.OK(map[string]string{"status": "pending"}))
+	h.submitKYCFor(w, r, userID)
 }
 
 // getKYCStatusMe retrieves KYC status for the authenticated user.

--- a/apps/api/internal/handler/user_handler_test.go
+++ b/apps/api/internal/handler/user_handler_test.go
@@ -183,3 +183,87 @@ func TestUserHandler_GetEndpoints(t *testing.T) {
 		t.Errorf("expected 200 OK, got %d", resp3.StatusCode)
 	}
 }
+
+// TestUserHandler_KYCSubmissionAndRetrieval verifies that KYC submission
+// reaches the API endpoint and persists status for retrieval.
+func TestUserHandler_KYCSubmissionAndRetrieval(t *testing.T) {
+	repo := newMockUserRepository()
+	svc := service.NewUserService(repo)
+	handler := NewUserHandler(svc)
+
+	mux := http.NewServeMux()
+	handler.Register(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Create a user
+	u, _ := svc.RegisterUser(context.Background(), "G-KYC-TEST", "Bob")
+
+	// Submit KYC with multipart form
+	body := new(bytes.Buffer)
+	writer := io.MultiWriter(body)
+
+	// Create a minimal multipart form manually
+	formBody := `--boundary
+Content-Disposition: form-data; name="full_name"
+
+Bob Smith
+--boundary
+Content-Disposition: form-data; name="date_of_birth"
+
+1990-01-15
+--boundary
+Content-Disposition: form-data; name="country"
+
+US
+--boundary
+Content-Disposition: form-data; name="id_type"
+
+passport
+--boundary
+Content-Disposition: form-data; name="id_number"
+
+12345678
+--boundary
+Content-Disposition: form-data; name="id_front"; filename="passport_front.jpg"
+Content-Type: image/jpeg
+
+[fake image data]
+--boundary--`
+
+	// Submit KYC
+	req, err := http.NewRequest("POST", server.URL+"/api/v1/users/kyc/"+u.ID.String(), bytes.NewBufferString(formBody))
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=boundary")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST KYC submission failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("expected 202 Accepted, got %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		t.Logf("response body: %s", body)
+	}
+
+	// Retrieve KYC status
+	getResp, err := http.Get(server.URL + "/api/v1/users/kyc/" + u.ID.String())
+	if err != nil {
+		t.Fatalf("GET KYC status failed: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 OK, got %d", getResp.StatusCode)
+	}
+
+	// Parse response and verify status is pending
+	respBody, _ := io.ReadAll(getResp.Body)
+	if !bytes.Contains(respBody, []byte("pending")) {
+		t.Errorf("expected 'pending' status in response, got: %s", respBody)
+	}
+}

--- a/apps/api/internal/handler/user_handler_test.go
+++ b/apps/api/internal/handler/user_handler_test.go
@@ -201,7 +201,6 @@ func TestUserHandler_KYCSubmissionAndRetrieval(t *testing.T) {
 
 	// Submit KYC with multipart form
 	body := new(bytes.Buffer)
-	writer := io.MultiWriter(body)
 
 	// Create a minimal multipart form manually
 	formBody := `--boundary

--- a/apps/api/internal/handler/user_handler_test.go
+++ b/apps/api/internal/handler/user_handler_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/suncrestlabs/nester/apps/api/internal/crypto"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/user"
 	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/objectstorage"
 	"github.com/suncrestlabs/nester/apps/api/internal/service"
 )
 
@@ -188,8 +190,26 @@ func TestUserHandler_GetEndpoints(t *testing.T) {
 // reaches the API endpoint and persists status for retrieval.
 func TestUserHandler_KYCSubmissionAndRetrieval(t *testing.T) {
 	repo := newMockUserRepository()
-	svc := service.NewUserService(repo)
+
+	// The KYC path encrypts the id number before persisting it, so the
+	// service needs a cipher — without one the submission fails with a 500.
+	cipher, err := crypto.NewAccountCipher(testCipherKey(7))
+	if err != nil {
+		t.Fatalf("NewAccountCipher() error = %v", err)
+	}
+	svc := service.NewUserService(repo).WithCipher(cipher)
 	handler := NewUserHandler(svc)
+
+	// A document store is required: the handler rejects an upload with 503
+	// rather than accepting a KYC record that points at nothing (#1191).
+	// Without this the route answers STORAGE_UNAVAILABLE and the submission
+	// never reaches the service, which is correct behaviour, not a bug in
+	// the endpoint.
+	store, err := objectstorage.NewLocalDiskStore(t.TempDir(), 8<<20, KYCAllowedContentTypes)
+	if err != nil {
+		t.Fatalf("NewLocalDiskStore() error = %v", err)
+	}
+	handler.SetKYCStore(store)
 
 	mux := http.NewServeMux()
 	handler.Register(mux)
@@ -199,10 +219,9 @@ func TestUserHandler_KYCSubmissionAndRetrieval(t *testing.T) {
 	// Create a user
 	u, _ := svc.RegisterUser(context.Background(), "G-KYC-TEST", "Bob")
 
-	// Submit KYC with multipart form
-	body := new(bytes.Buffer)
-
-	// Create a minimal multipart form manually
+	// Submit KYC with a hand-built multipart form. formBody below carries
+	// the payload; the bytes.Buffer this used to allocate was never written
+	// to or read, which is what the compiler was objecting to.
 	formBody := `--boundary
 Content-Disposition: form-data; name="full_name"
 

--- a/apps/api/internal/middleware/authz_matrix_test.go
+++ b/apps/api/internal/middleware/authz_matrix_test.go
@@ -120,6 +120,10 @@ var authzMatrix = []AuthzRoute{
 	{Method: "GET", Path: "/api/v1/yields/", Public: true},
 	{Method: "GET", Path: "/api/v1/yields/00000000-0000-0000-0000-000000000000", Public: true},
 
+	// ── KYC for the authenticated user (#1231) ─────────────────────────
+	{Method: "POST", Path: "/api/v1/users/me/kyc"},
+	{Method: "GET", Path: "/api/v1/users/me/kyc"},
+
 	// ── Money-path pause switches (#1120) ──────────────────────────────
 	{Method: "GET", Path: "/api/v1/admin/money-path/switches", RequireRole: "admin"},
 	{Method: "PUT", Path: "/api/v1/admin/money-path/switches/deposit", RequireRole: "admin"},

--- a/apps/api/internal/service/settlement_service.go
+++ b/apps/api/internal/service/settlement_service.go
@@ -25,14 +25,25 @@ type SavedBankAccountResolver interface {
 	ResolveForSettlement(ctx context.Context, userID, accountID uuid.UUID) (bankaccount.BankAccount, error)
 }
 
+// VaultRepository checks user vault balances for settlement validation.
+type VaultRepository interface {
+	GetUserVaultBalance(ctx context.Context, vaultID uuid.UUID) (decimal.Decimal, error)
+}
+
 type SettlementService struct {
 	repository   offramp.Repository
 	bankAccounts SavedBankAccountResolver
+	vaultRepo    VaultRepository
 	sep24        *Sep24Resolver // POC: SEP-24 integration
 }
 
 func NewSettlementService(repository offramp.Repository, bankAccounts SavedBankAccountResolver) *SettlementService {
 	return &SettlementService{repository: repository, bankAccounts: bankAccounts}
+}
+
+// SetVaultRepository injects the vault repository for balance validation.
+func (s *SettlementService) SetVaultRepository(vaultRepo VaultRepository) {
+	s.vaultRepo = vaultRepo
 }
 
 // SetSep24Resolver injects the SEP-24 resolver for POC testing.
@@ -133,6 +144,17 @@ func (s *SettlementService) InitiateSettlement(ctx context.Context, input Initia
 
 	if err := validateDestination(input.Destination); err != nil {
 		return offramp.Settlement{}, err
+	}
+
+	// Check vault balance if vaultRepo is configured
+	if s.vaultRepo != nil {
+		balance, err := s.vaultRepo.GetUserVaultBalance(ctx, input.VaultID)
+		if err != nil {
+			return offramp.Settlement{}, fmt.Errorf("vault balance check failed: %w", err)
+		}
+		if input.Amount.GreaterThan(balance) {
+			return offramp.Settlement{}, offramp.ErrInvalidAmount
+		}
 	}
 
 	model := offramp.Settlement{

--- a/apps/api/internal/ws/client.go
+++ b/apps/api/internal/ws/client.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,6 +59,11 @@ func (c *Client) readPump() {
 			case ActionSubscribe:
 				c.mu.Lock()
 				for _, ch := range msg.Channels {
+					if !c.maySubscribe(ch) {
+						c.hub.logger.Warn("websocket subscription rejected",
+							"channel", ch, "user_id", c.userID)
+						continue
+					}
 					c.subs[ch] = true
 					c.hub.subscribe(c, ch)
 				}
@@ -112,4 +118,31 @@ func (c *Client) writePump() {
 			}
 		}
 	}
+}
+
+// userScopedChannelPrefixes are the channel namespaces whose second segment is
+// a user id. A client may only subscribe to its own.
+var userScopedChannelPrefixes = []string{"notifications/"}
+
+// maySubscribe reports whether this client is allowed to subscribe to ch.
+//
+// Channels outside the user-scoped namespaces are shared and open to any
+// authenticated client. Within them the second segment is a user id, and the
+// hub previously honoured whatever the client asked for — so one user could
+// name another's channel and receive their private events. The client's own
+// id comes from the authenticated session, not from the message, so it cannot
+// be spoofed by the subscribe frame (nester#1230).
+func (c *Client) maySubscribe(ch string) bool {
+	for _, prefix := range userScopedChannelPrefixes {
+		if !strings.HasPrefix(ch, prefix) {
+			continue
+		}
+		owner := strings.TrimPrefix(ch, prefix)
+		if i := strings.IndexByte(owner, '/'); i >= 0 {
+			owner = owner[:i]
+		}
+		// An unauthenticated client has no id and so owns no user channel.
+		return c.userID != "" && owner == c.userID
+	}
+	return true
 }

--- a/apps/api/internal/ws/hub_test.go
+++ b/apps/api/internal/ws/hub_test.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -287,4 +288,94 @@ func TestHub_gracefulShutdown_allClientsDisconnected(t *testing.T) {
 	}
 	checkClosed(c1, "c1")
 	checkClosed(c2, "c2")
+}
+
+// TestHub_CrossUserSubscriptionRejection verifies that a user cannot subscribe
+// to another user's private channels. This is a critical authorization check:
+// channel names like "user:alice" or "notifications/alice" are user-scoped,
+// and a forged token or session-fixation attack must not grant one user access
+// to another's real-time data.
+func TestHub_CrossUserSubscriptionRejection(t *testing.T) {
+	hub := newTestHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(hub.ServeWs))
+	defer server.Close()
+
+	// Authenticator: token "user-alice" authenticates as user ID "user-alice"
+	// token "user-bob" authenticates as user ID "user-bob"
+	hub.authenticator = func(token string) (userID, sessionID string, err error) {
+		if token == "invalid" {
+			return "", "", fmt.Errorf("invalid token")
+		}
+		// Simple mock: token becomes the userID
+		return token, token + "-session", nil
+	}
+
+	// Alice connects
+	aliceURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?token=user-alice"
+	aliceConn, resp, err := websocket.DefaultDialer.Dial(aliceURL, nil)
+	if err != nil {
+		t.Fatalf("Alice failed to connect: %v, Response: %v", err, resp)
+	}
+	defer aliceConn.Close()
+
+	// Bob connects
+	bobURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?token=user-bob"
+	bobConn, resp, err := websocket.DefaultDialer.Dial(bobURL, nil)
+	if err != nil {
+		t.Fatalf("Bob failed to connect: %v, Response: %v", err, resp)
+	}
+	defer bobConn.Close()
+
+	// Alice subscribes to her own private channel (valid)
+	alicePrivate := ClientMessage{
+		Action:   "subscribe",
+		Channels: []string{"notifications/user-alice"},
+	}
+	if err := aliceConn.WriteJSON(alicePrivate); err != nil {
+		t.Fatalf("Alice subscription write failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Bob attempts to subscribe to Alice's private channel (must be rejected)
+	// In a real implementation, the server must validate that Bob (userID: user-bob)
+	// is not attempting to subscribe to channels he doesn't own.
+	alicePrivateAsBob := ClientMessage{
+		Action:   "subscribe",
+		Channels: []string{"notifications/user-alice"},
+	}
+	if err := bobConn.WriteJSON(alicePrivateAsBob); err != nil {
+		t.Fatalf("Bob subscription write failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Broadcast to Alice's private channel
+	aliceEvent := Event{
+		Channel: "notifications/user-alice",
+		Type:    EventType("test_event"),
+		Data:    map[string]interface{}{"data": "alice-sensitive"},
+	}
+	hub.BroadcastEvent(aliceEvent)
+
+	// Alice should receive the event
+	aliceConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	var aliceRecv Event
+	if err := aliceConn.ReadJSON(&aliceRecv); err != nil {
+		t.Fatalf("Alice failed to receive event: %v", err)
+	}
+	if aliceRecv.Channel != "notifications/user-alice" {
+		t.Errorf("Alice: expected channel notifications/user-alice, got %s", aliceRecv.Channel)
+	}
+
+	// Bob must NOT receive the event (authorization rejection)
+	bobConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	var bobRecv Event
+	if err := bobConn.ReadJSON(&bobRecv); err == nil {
+		// If we got here, Bob received the event he shouldn't have
+		t.Errorf("Bob received Alice's private event (authorization failure): %+v", bobRecv)
+	}
+	// Expected: read timeout or close frame (authorization denied)
 }

--- a/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
+++ b/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
@@ -179,14 +179,47 @@ describe("getJitteredReconnectDelay", () => {
 describe("useWebSocket wire protocol", () => {
     const baseOpts = {
         url: WS_URL,
-        token: "jwt-123",
+        getToken: () => "jwt-123",
         channels: ["user:abc", "vaults:global"],
         onEvent: () => {},
     };
 
-    it("authenticates via the upgrade URL query string", () => {
+    it("authenticates via the upgrade URL query string using the token getter", () => {
         renderHook(() => useWebSocket(baseOpts));
         expect(MockWebSocket.last().url).toBe(`${WS_URL}?token=jwt-123`);
+    });
+
+    it("calls the token getter before each connection attempt", () => {
+        const getToken = vi.fn().mockReturnValue("jwt-initial");
+        renderHook(() => useWebSocket({ ...baseOpts, getToken }));
+        expect(getToken).toHaveBeenCalled();
+        const initialCalls = getToken.mock.calls.length;
+
+        act(() => MockWebSocket.last().close());
+        act(() => vi.advanceTimersByTime(1000));
+        expect(getToken.mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+
+    it("reconnects when the token getter returns a different token", () => {
+        let currentToken = "jwt-initial";
+        const getToken = () => currentToken;
+        const { rerender } = renderHook(() => useWebSocket({ ...baseOpts, getToken }));
+        act(() => MockWebSocket.last().open());
+        const before = MockWebSocket.instances.length;
+
+        // Simulate token refresh by changing what the getter returns
+        currentToken = "jwt-refreshed";
+        rerender();
+
+        // Should reconnect with the new token
+        expect(MockWebSocket.instances.length).toBeGreaterThan(before);
+        expect(MockWebSocket.last().url).toBe(`${WS_URL}?token=jwt-refreshed`);
+    });
+
+    it("uses stale token on offline without socket", () => {
+        renderHook(() => useWebSocket({ ...baseOpts, url: "" }));
+        // No socket should be created when url is empty
+        expect(MockWebSocket.instances.length).toBe(0);
     });
 
     it("subscribes with the hub's {action, channels} frame", () => {
@@ -248,21 +281,6 @@ describe("useWebSocket wire protocol", () => {
         expect(unsubs[0].channels).toEqual(["vaults:global"]);
     });
 
-    it("reconnects when the token changes, since it is part of the URL", () => {
-        const { rerender } = renderHook(
-            ({ token }) => useWebSocket({ ...baseOpts, token }),
-            { initialProps: { token: "" } }
-        );
-        act(() => MockWebSocket.last().open());
-        const before = MockWebSocket.instances.length;
-
-        act(() => rerender({ token: "jwt-new" }));
-
-        expect(MockWebSocket.instances.length).toBe(before + 1);
-        expect(MockWebSocket.last().url).toBe(`${WS_URL}?token=jwt-new`);
-    });
-});
-
 // ---------------------------------------------------------------------------
 // State transitions
 // ---------------------------------------------------------------------------
@@ -270,7 +288,7 @@ describe("useWebSocket wire protocol", () => {
 describe("useWebSocket state transitions", () => {
     const baseOpts = {
         url: WS_URL,
-        token: "jwt",
+        getToken: () => "jwt",
         channels: ["user:abc", "vaults:global"],
         onEvent: () => {},
     };
@@ -370,7 +388,7 @@ describe("useWebSocket state transitions", () => {
 describe("useWebSocket heartbeat", () => {
     const baseOpts = {
         url: WS_URL,
-        token: "jwt",
+        getToken: () => "jwt",
         channels: ["user:abc"],
         onEvent: () => {},
     };
@@ -437,7 +455,7 @@ describe("useWebSocket heartbeat", () => {
 describe("useWebSocket reconciliation", () => {
     const baseOpts = {
         url: WS_URL,
-        token: "jwt",
+        getToken: () => "jwt",
         channels: ["user:abc"],
         onEvent: () => {},
     };
@@ -502,7 +520,7 @@ describe("useWebSocket reconciliation", () => {
 describe("useWebSocket in a hidden tab", () => {
     const baseOpts = {
         url: WS_URL,
-        token: "jwt",
+        getToken: () => "jwt",
         channels: ["user:abc"],
         onEvent: () => {},
     };

--- a/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
+++ b/apps/dapp/frontend/__tests__/useWebSocket.test.tsx
@@ -280,6 +280,7 @@ describe("useWebSocket wire protocol", () => {
         expect(unsubs).toHaveLength(1);
         expect(unsubs[0].channels).toEqual(["vaults:global"]);
     });
+});
 
 // ---------------------------------------------------------------------------
 // State transitions

--- a/apps/dapp/frontend/app/layout.tsx
+++ b/apps/dapp/frontend/app/layout.tsx
@@ -17,6 +17,7 @@ import { NetworkBanner } from "@/components/network/NetworkSelector";
 import { ServiceWorkerRegister } from "@/components/service-worker-register";
 import {
     E2E_HARNESS_CHANNELS,
+    E2E_HARNESS_TOKEN,
     E2E_HARNESS_ENABLED,
     E2E_HARNESS_HEARTBEAT_INTERVAL_MS,
     E2E_HARNESS_HEARTBEAT_TIMEOUT_MS,
@@ -99,6 +100,11 @@ export default function RootLayout({
                                                             channelsOverride={
                                                                 E2E_HARNESS_ENABLED
                                                                     ? E2E_HARNESS_CHANNELS
+                                                                    : undefined
+                                                            }
+                                                            tokenOverride={
+                                                                E2E_HARNESS_ENABLED
+                                                                    ? E2E_HARNESS_TOKEN
                                                                     : undefined
                                                             }
                                                             heartbeatInterval={

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -158,6 +158,7 @@ export default function OfframpPage() {
   const [userBalance, setUserBalance] = useState<number | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(true);
   const [balanceError, setBalanceError] = useState<string | null>(null);
+  const [selectedVaultId, setSelectedVaultId] = useState<string | null>(null);
 
   // Dynamic form schema based on loaded balance
   const formSchema = createFormSchema(userBalance ?? 0);
@@ -170,6 +171,12 @@ export default function OfframpPage() {
         const portfolio =
           await apiRequest<PortfolioSummary>("/portfolio/summary");
         setUserBalance(portfolio.total_balance_usd);
+
+        // Fetch vaults to get the first vault ID for settlement
+        const vaults = await apiRequest<Array<{ id: string }>>("/vaults");
+        if (vaults && vaults.length > 0) {
+          setSelectedVaultId(vaults[0].id);
+        }
       } catch (err) {
         setBalanceError(
           err instanceof Error ? err.message : "Failed to load balance",
@@ -379,25 +386,40 @@ export default function OfframpPage() {
 
     // Call real settlement API
     try {
+      // Build destination from payoutMode
+      let destination: any;
+      if (payoutMode.type === "saved") {
+        destination = {
+          type: "bank_transfer",
+          provider: "bank",
+          account_number: payoutMode.account.account_number,
+          account_name: payoutMode.account.account_name,
+          bank_code: payoutMode.account.bank_code,
+        };
+      } else {
+        // Manual mode - use form data
+        destination = {
+          type: "bank_transfer",
+          provider: "bank",
+          account_number: data.accountNumber,
+          account_name: resolvedName || data.accountName,
+          bank_code: data.bankCode,
+        };
+      }
+
       const settlement = await apiRequest<{
         id: string;
       }>("/settlements", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          vault_id: "placeholder", // In real usage, this would be the actual vault ID
+          vault_id: selectedVaultId || "", // Use the real vault ID from user's vaults
           amount: numericAmount.toString(),
           currency: sendAsset.symbol,
           fiat_currency: receiveCurrency.symbol,
           fiat_amount: displayReceive.toString(),
           exchange_rate: receiveCurrency.rate.toString(),
-          destination: {
-            type: "bank_transfer",
-            provider: "bank",
-            account_number: data.accountNumber,
-            account_name: resolvedName,
-            bank_code: data.bankCode,
-          },
+          destination,
         }),
       });
 
@@ -408,10 +430,8 @@ export default function OfframpPage() {
           title: "Withdrawal Submitted",
           message: `Withdrew ${numericAmount.toLocaleString("en-US", {
             maximumFractionDigits: 2,
-          })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? selectedBankCode} ending in ${data.accountNumber.slice(-4)}.`,
-          actionUrl: settlement.id
-            ? getExplorerTxUrl(settlement.id)
-            : undefined,
+          })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? effectiveBankCode} ending in ${destination.account_number.slice(-4)}.`,
+          // TODO: Add explorer link once settlement returns on-chain transaction hash
           actionLabel: "View Transaction",
         },
         { showToast: true },

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -15,19 +15,20 @@ import { cn } from "@/lib/utils";
 import { KYCStatusBadge, type KYCStatus } from "@/components/kyc/KYCSection";
 import Link from "next/link";
 import {
-    ChevronDown,
-    ArrowDownUp,
-    ShieldCheck,
-    Clock,
-    Info,
-    Zap,
-    Tag,
-    Building2,
-    Loader2,
-    CheckCircle2,
-    ArrowRight,
-    AlertCircle,
+  ChevronDown,
+  ArrowDownUp,
+  ShieldCheck,
+  Clock,
+  Info,
+  Zap,
+  Tag,
+  Building2,
+  Loader2,
+  CheckCircle2,
+  ArrowRight,
+  AlertCircle,
 } from "lucide-react";
+import { apiRequest } from "@/lib/api/client";
 
 import { type LPNode, LP_NODES } from "@/lib/settlement-data";
 import { getExplorerTxUrl } from "@/utils/explorer";
@@ -35,8 +36,8 @@ import { BankCombobox } from "@/components/offramp/BankCombobox";
 import { AccountNameField } from "@/components/offramp/AccountNameField";
 import { SuggestedBankChips } from "@/components/offramp/SuggestedBankChips";
 import {
-    SavedBankAccountPicker,
-    type PayoutMode,
+  SavedBankAccountPicker,
+  type PayoutMode,
 } from "@/components/offramp/SavedBankAccountPicker";
 import { SaveAccountPrompt } from "@/components/offramp/SaveAccountPrompt";
 import { useBankResolver } from "@/hooks/useBankResolver";
@@ -45,939 +46,1095 @@ import { useOfflineStatus } from "@/hooks/useOfflineStatus";
 import { useTranslations } from "@/context/locale-context";
 
 const SEND_ASSETS = [
-    { symbol: "USDC", name: "USD Coin", image: "/usdc.png" },
-    { symbol: "USDT", name: "Tether", image: "/usdc.png" },
-    { symbol: "XLM", name: "Stellar Lumens", image: "/logo.png" },
+  { symbol: "USDC", name: "USD Coin", image: "/usdc.png" },
+  { symbol: "USDT", name: "Tether", image: "/usdc.png" },
+  { symbol: "XLM", name: "Stellar Lumens", image: "/logo.png" },
 ];
 
 const RECEIVE_CURRENCIES = [
-    { symbol: "NGN", name: "Nigerian Naira", image: "/naira.webp", rate: 1512.45 },
-    { symbol: "GHS", name: "Ghanaian Cedi", image: "/naira.webp", rate: 15.80 },
-    { symbol: "KES", name: "Kenyan Shilling", image: "/naira.webp", rate: 129.50 },
+  {
+    symbol: "NGN",
+    name: "Nigerian Naira",
+    image: "/naira.webp",
+    rate: 1512.45,
+  },
+  { symbol: "GHS", name: "Ghanaian Cedi", image: "/naira.webp", rate: 15.8 },
+  { symbol: "KES", name: "Kenyan Shilling", image: "/naira.webp", rate: 129.5 },
 ];
 
-
-
 interface QuoteResult {
-    node: LPNode;
-    effectiveRate: number;
-    receiveAmount: number;
-    fee: number;
-    isSameBank: boolean;
-    estimatedTime: string;
-    isBest: boolean;
-    rateOffset: number;
+  node: LPNode;
+  effectiveRate: number;
+  receiveAmount: number;
+  fee: number;
+  isSameBank: boolean;
+  estimatedTime: string;
+  isBest: boolean;
+  rateOffset: number;
+}
+
+interface PortfolioSummary {
+  total_balance_usd: number;
+  total_deposited_usd: number;
+  total_yield_usd: number;
 }
 
 type QuotePhase = "idle" | "scanning" | "comparing" | "ranking" | "done";
 
 function jitterOffset(base: number): number {
-    return base + (Math.random() - 0.5) * 3;
+  return base + (Math.random() - 0.5) * 3;
 }
 
 function buildQuotes(
-    amount: number,
-    bankCode: string,
-    currency: typeof RECEIVE_CURRENCIES[0]
+  amount: number,
+  bankCode: string,
+  currency: (typeof RECEIVE_CURRENCIES)[0],
 ): QuoteResult[] {
-    const results: QuoteResult[] = LP_NODES.map((node) => {
-        const rateOffset = jitterOffset(node.baseRateOffset);
-        const effectiveRate = currency.rate + rateOffset;
-        const nodeFee = amount * (node.fee / 100);
-        const netAmount = amount - nodeFee;
-        const receiveAmount = netAmount * effectiveRate;
-        const isSameBank = node.bank === bankCode;
-        const estimatedTime = isSameBank
-            ? `~${Math.max(3, node.avgSettleTime - 8)}s`
-            : `${Math.ceil(node.avgSettleTime / 60) || 1}-${Math.ceil(node.avgSettleTime / 60) + 4} min`;
+  const results: QuoteResult[] = LP_NODES.map((node) => {
+    const rateOffset = jitterOffset(node.baseRateOffset);
+    const effectiveRate = currency.rate + rateOffset;
+    const nodeFee = amount * (node.fee / 100);
+    const netAmount = amount - nodeFee;
+    const receiveAmount = netAmount * effectiveRate;
+    const isSameBank = node.bank === bankCode;
+    const estimatedTime = isSameBank
+      ? `~${Math.max(3, node.avgSettleTime - 8)}s`
+      : `${Math.ceil(node.avgSettleTime / 60) || 1}-${Math.ceil(node.avgSettleTime / 60) + 4} min`;
 
-        return { node, effectiveRate, receiveAmount, fee: nodeFee, isSameBank, estimatedTime, isBest: false, rateOffset };
-    });
+    return {
+      node,
+      effectiveRate,
+      receiveAmount,
+      fee: nodeFee,
+      isSameBank,
+      estimatedTime,
+      isBest: false,
+      rateOffset,
+    };
+  });
 
-    results.sort((a, b) => {
-        const diff = Math.abs(a.receiveAmount - b.receiveAmount) / Math.max(a.receiveAmount, b.receiveAmount);
-        if (diff < 0.005 && a.isSameBank !== b.isSameBank) {
-            return a.isSameBank ? -1 : 1;
-        }
-        return b.receiveAmount - a.receiveAmount;
-    });
+  results.sort((a, b) => {
+    const diff =
+      Math.abs(a.receiveAmount - b.receiveAmount) /
+      Math.max(a.receiveAmount, b.receiveAmount);
+    if (diff < 0.005 && a.isSameBank !== b.isSameBank) {
+      return a.isSameBank ? -1 : 1;
+    }
+    return b.receiveAmount - a.receiveAmount;
+  });
 
-    results[0].isBest = true;
-    return results;
+  results[0].isBest = true;
+  return results;
 }
 
-const MOCK_BALANCE = 5000;
-
-const formSchema = z.object({
+const createFormSchema = (userBalance: number) =>
+  z.object({
     amount: validateAmount({
-        min: 1,
-        balance: MOCK_BALANCE,
-        maxDecimals: 6,
-        minMessage: "Minimum amount is 1 USDC",
-        balanceMessage: `Amount exceeds your balance of ${MOCK_BALANCE.toLocaleString()} USDC`
+      min: 1,
+      balance: userBalance,
+      maxDecimals: 6,
+      minMessage: "Minimum amount is 1 USDC",
+      balanceMessage: `Amount exceeds your balance of ${userBalance.toLocaleString()} USDC`,
     }),
     accountNumber: validateBankAccount(),
-    bankCode: z.string({ message: "Please select a bank" }).min(1, "Please select a bank"),
-});
+    bankCode: z
+      .string({ message: "Please select a bank" })
+      .min(1, "Please select a bank"),
+  });
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof createFormSchema>>;
 
 export default function OfframpPage() {
-    const { isConnected } = useWallet();
-    const { addNotification } = useNotifications();
-    const router = useRouter();
-    const { isOffline } = useOfflineStatus();
-    const t = useTranslations();
+  const { isConnected } = useWallet();
+  const { addNotification } = useNotifications();
+  const router = useRouter();
+  const { isOffline } = useOfflineStatus();
+  const t = useTranslations();
 
-    // In a real app, this would come from the user's KYC state loaded via API
-    const [kycStatus] = useState<KYCStatus>("unverified");
+  // In a real app, this would come from the user's KYC state loaded via API
+  const [kycStatus] = useState<KYCStatus>("unverified");
 
-    const {
-        handleSubmit,
-        watch,
-        control,
-        setValue,
-        formState: { errors, isValid, isDirty },
-        trigger,
-    } = useForm<FormValues>({
-        resolver: zodResolver(formSchema),
-        mode: "onBlur",
-        defaultValues: {
-            amount: "",
-            accountNumber: "",
-            bankCode: "",
-        },
-    });
+  // Fetch real user balance
+  const [userBalance, setUserBalance] = useState<number | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(true);
+  const [balanceError, setBalanceError] = useState<string | null>(null);
 
-    const sendAmount = watch("amount");
-    const accountNumber = watch("accountNumber");
-    const selectedBankCode = watch("bankCode");
+  // Dynamic form schema based on loaded balance
+  const formSchema = createFormSchema(userBalance ?? 0);
 
-    const [sendAsset, setSendAsset] = useState(SEND_ASSETS[0]);
-    const [receiveCurrency, setReceiveCurrency] = useState(RECEIVE_CURRENCIES[0]);
-    const [manualName, setManualName] = useState("");
-    const [payoutMode, setPayoutMode] = useState<PayoutMode>({ type: "manual" });
-    const [savePromptOpen, setSavePromptOpen] = useState(false);
-    const [lastManualPayout, setLastManualPayout] = useState<{
-        bankName: string;
-        bankCode: string;
-        accountNumber: string;
-        accountName: string;
-    } | null>(null);
-
-    const { resolveState, accountInfo } = useBankResolver(accountNumber, selectedBankCode);
-    const resolvedName = resolveState === "success" ? (accountInfo?.account_name ?? null) : null;
-    const [showSendDropdown, setShowSendDropdown] = useState(false);
-    const [showReceiveDropdown, setShowReceiveDropdown] = useState(false);
-
-    const [quotePhase, setQuotePhase] = useState<QuotePhase>("idle");
-    const [scannedCount, setScannedCount] = useState(0);
-    const [quotes, setQuotes] = useState<QuoteResult[]>([]);
-    const [selectedQuote, setSelectedQuote] = useState<QuoteResult | null>(null);
-    const [showLargeWarning, setShowLargeWarning] = useState(false);
-    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const refreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-    useEffect(() => {
-        if (!isConnected) {
-            router.push("/");
-        }
-    }, [isConnected, router]);
-
-    const numericAmount = parseFloat(sendAmount) || 0;
-    const effectiveBankCode =
-        payoutMode.type === "saved"
-            ? payoutMode.account.bank_code ?? ""
-            : selectedBankCode;
-    const allFieldsFilled =
-        payoutMode.type === "saved"
-            ? numericAmount > 0 && Boolean(effectiveBankCode)
-            : isValid;
-
-    const runQuoteScan = useCallback(
-        (amount: number, bankCode: string, currency: typeof RECEIVE_CURRENCIES[0]) => {
-            setQuotePhase("scanning");
-            setScannedCount(0);
-            setQuotes([]);
-            setSelectedQuote(null);
-
-            let count = 0;
-            const scanInterval = setInterval(() => {
-                count++;
-                setScannedCount(count);
-                if (count >= LP_NODES.length) {
-                    clearInterval(scanInterval);
-                    setQuotePhase("comparing");
-                    setTimeout(() => {
-                        setQuotePhase("ranking");
-                        setTimeout(() => {
-                            const results = buildQuotes(amount, bankCode, currency);
-                            setQuotes(results);
-                            setSelectedQuote(results[0]);
-                            setQuotePhase("done");
-                        }, 400);
-                    }, 600);
-                }
-            }, 120);
-        },
-        []
-    );
-
-    const silentRefresh = useCallback(
-        (amount: number, bankCode: string, currency: typeof RECEIVE_CURRENCIES[0]) => {
-            const results = buildQuotes(amount, bankCode, currency);
-            setQuotes(results);
-            setSelectedQuote((prev) => {
-                if (!prev) return results[0];
-                const same = results.find((q) => q.node.id === prev.node.id);
-                return same || results[0];
-            });
-        },
-        []
-    );
-
-    useEffect(() => {
-        if (refreshRef.current) {
-            clearInterval(refreshRef.current);
-            refreshRef.current = null;
-        }
-
-        if (!allFieldsFilled) {
-            setQuotePhase("idle");
-            setQuotes([]);
-            setSelectedQuote(null);
-            return;
-        }
-
-        if (debounceRef.current) clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(() => {
-            runQuoteScan(numericAmount, effectiveBankCode, receiveCurrency);
-
-            refreshRef.current = setInterval(() => {
-                silentRefresh(numericAmount, effectiveBankCode, receiveCurrency);
-            }, 8000);
-        }, 500);
-
-        return () => {
-            if (debounceRef.current) clearTimeout(debounceRef.current);
-            if (refreshRef.current) clearInterval(refreshRef.current);
-        };
-    }, [allFieldsFilled, numericAmount, effectiveBankCode, receiveCurrency, runQuoteScan, silentRefresh]);
-
-    if (!isConnected) return null;
-
-    const displayReceive = selectedQuote
-        ? selectedQuote.receiveAmount
-        : numericAmount > 0
-            ? numericAmount * receiveCurrency.rate * 0.995
-            : 0;
-
-    const handleWithdraw = handleSubmit((data) => {
-        if (isOffline) {
-            return;
-        }
-        const quote = selectedQuote;
-        const canSubmit =
-            payoutMode.type === "saved"
-                ? numericAmount > 0 && quotePhase === "done" && quote
-                : isValid && quotePhase === "done" && quote;
-        if (!canSubmit || !quote) {
-            return;
-        }
-
-        if (numericAmount > 10000 && !showLargeWarning) {
-            setShowLargeWarning(true);
-            return;
-        }
-
-        setShowLargeWarning(false);
-
-        if (payoutMode.type === "manual" && resolvedName) {
-            void fetchBankList("NG").then((banks) => {
-                const bank = banks.find((b) => b.code === data.bankCode);
-                setLastManualPayout({
-                    bankName: bank?.name ?? data.bankCode,
-                    bankCode: data.bankCode,
-                    accountNumber: data.accountNumber,
-                    accountName: resolvedName,
-                });
-                setSavePromptOpen(true);
-            });
-        }
-
-        addNotification(
-            {
-                type: "withdrawal_processed",
-                title: "Withdrawal Submitted",
-                message: `Withdrew ${numericAmount.toLocaleString("en-US", {
-                    maximumFractionDigits: 2,
-                })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? selectedBankCode} ending in ${data.accountNumber.slice(-4)}.`,
-                actionUrl: getExplorerTxUrl(`mock-settlement-${quote.node.id}`),
-                actionLabel: "View Transaction",
-            },
-            { showToast: true }
+  useEffect(() => {
+    const fetchUserBalance = async () => {
+      try {
+        setBalanceLoading(true);
+        setBalanceError(null);
+        const portfolio =
+          await apiRequest<PortfolioSummary>("/portfolio/summary");
+        setUserBalance(portfolio.total_balance_usd);
+      } catch (err) {
+        setBalanceError(
+          err instanceof Error ? err.message : "Failed to load balance",
         );
-    });
+        setUserBalance(0); // Fail safely
+      } finally {
+        setBalanceLoading(false);
+      }
+    };
 
-    return (
-        <AppShell>
-            <div className="mx-auto max-w-xl">
-                {/* KYC Banner for unverified users */}
-                {kycStatus === "unverified" && (
-                    <motion.div
-                        initial={{ opacity: 0, y: -8 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 flex items-start gap-3"
-                    >
-                        <AlertCircle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
-                        <div className="flex-1 min-w-0">
-                            <p className="text-sm text-amber-800">
-                                Identity verification required for offramp
-                            </p>
-                            <p className="text-xs text-amber-600/80 mt-0.5">
-                                Complete KYC to unlock fiat withdrawals.
-                            </p>
-                        </div>
-                        <div className="flex items-center gap-2 shrink-0">
-                            <KYCStatusBadge status={kycStatus} />
-                            <Link
-                                href="/settings?tab=verification"
-                                className="text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900"
-                            >
-                                Verify now
-                            </Link>
-                        </div>
-                    </motion.div>
+    if (isConnected) {
+      fetchUserBalance();
+    }
+  }, [isConnected]);
+
+  const {
+    handleSubmit,
+    watch,
+    control,
+    setValue,
+    formState: { errors, isValid, isDirty },
+    trigger,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onBlur",
+    defaultValues: {
+      amount: "",
+      accountNumber: "",
+      bankCode: "",
+    },
+  });
+
+  const sendAmount = watch("amount");
+  const accountNumber = watch("accountNumber");
+  const selectedBankCode = watch("bankCode");
+
+  const [sendAsset, setSendAsset] = useState(SEND_ASSETS[0]);
+  const [receiveCurrency, setReceiveCurrency] = useState(RECEIVE_CURRENCIES[0]);
+  const [manualName, setManualName] = useState("");
+  const [payoutMode, setPayoutMode] = useState<PayoutMode>({ type: "manual" });
+  const [savePromptOpen, setSavePromptOpen] = useState(false);
+  const [lastManualPayout, setLastManualPayout] = useState<{
+    bankName: string;
+    bankCode: string;
+    accountNumber: string;
+    accountName: string;
+  } | null>(null);
+
+  const { resolveState, accountInfo } = useBankResolver(
+    accountNumber,
+    selectedBankCode,
+  );
+  const resolvedName =
+    resolveState === "success" ? (accountInfo?.account_name ?? null) : null;
+  const [showSendDropdown, setShowSendDropdown] = useState(false);
+  const [showReceiveDropdown, setShowReceiveDropdown] = useState(false);
+
+  const [quotePhase, setQuotePhase] = useState<QuotePhase>("idle");
+  const [scannedCount, setScannedCount] = useState(0);
+  const [quotes, setQuotes] = useState<QuoteResult[]>([]);
+  const [selectedQuote, setSelectedQuote] = useState<QuoteResult | null>(null);
+  const [showLargeWarning, setShowLargeWarning] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!isConnected) {
+      router.push("/");
+    }
+  }, [isConnected, router]);
+
+  const numericAmount = parseFloat(sendAmount) || 0;
+  const effectiveBankCode =
+    payoutMode.type === "saved"
+      ? (payoutMode.account.bank_code ?? "")
+      : selectedBankCode;
+  const allFieldsFilled =
+    payoutMode.type === "saved"
+      ? numericAmount > 0 && Boolean(effectiveBankCode)
+      : isValid;
+
+  const runQuoteScan = useCallback(
+    (
+      amount: number,
+      bankCode: string,
+      currency: (typeof RECEIVE_CURRENCIES)[0],
+    ) => {
+      setQuotePhase("scanning");
+      setScannedCount(0);
+      setQuotes([]);
+      setSelectedQuote(null);
+
+      let count = 0;
+      const scanInterval = setInterval(() => {
+        count++;
+        setScannedCount(count);
+        if (count >= LP_NODES.length) {
+          clearInterval(scanInterval);
+          setQuotePhase("comparing");
+          setTimeout(() => {
+            setQuotePhase("ranking");
+            setTimeout(() => {
+              const results = buildQuotes(amount, bankCode, currency);
+              setQuotes(results);
+              setSelectedQuote(results[0]);
+              setQuotePhase("done");
+            }, 400);
+          }, 600);
+        }
+      }, 120);
+    },
+    [],
+  );
+
+  const silentRefresh = useCallback(
+    (
+      amount: number,
+      bankCode: string,
+      currency: (typeof RECEIVE_CURRENCIES)[0],
+    ) => {
+      const results = buildQuotes(amount, bankCode, currency);
+      setQuotes(results);
+      setSelectedQuote((prev) => {
+        if (!prev) return results[0];
+        const same = results.find((q) => q.node.id === prev.node.id);
+        return same || results[0];
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (refreshRef.current) {
+      clearInterval(refreshRef.current);
+      refreshRef.current = null;
+    }
+
+    if (!allFieldsFilled) {
+      setQuotePhase("idle");
+      setQuotes([]);
+      setSelectedQuote(null);
+      return;
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      runQuoteScan(numericAmount, effectiveBankCode, receiveCurrency);
+
+      refreshRef.current = setInterval(() => {
+        silentRefresh(numericAmount, effectiveBankCode, receiveCurrency);
+      }, 8000);
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (refreshRef.current) clearInterval(refreshRef.current);
+    };
+  }, [
+    allFieldsFilled,
+    numericAmount,
+    effectiveBankCode,
+    receiveCurrency,
+    runQuoteScan,
+    silentRefresh,
+  ]);
+
+  if (!isConnected) return null;
+
+  const displayReceive = selectedQuote
+    ? selectedQuote.receiveAmount
+    : numericAmount > 0
+      ? numericAmount * receiveCurrency.rate * 0.995
+      : 0;
+
+  const handleWithdraw = handleSubmit(async (data) => {
+    if (isOffline) {
+      return;
+    }
+    const quote = selectedQuote;
+    const canSubmit =
+      payoutMode.type === "saved"
+        ? numericAmount > 0 && quotePhase === "done" && quote
+        : isValid && quotePhase === "done" && quote;
+    if (!canSubmit || !quote) {
+      return;
+    }
+
+    if (numericAmount > 10000 && !showLargeWarning) {
+      setShowLargeWarning(true);
+      return;
+    }
+
+    setShowLargeWarning(false);
+
+    if (payoutMode.type === "manual" && resolvedName) {
+      void fetchBankList("NG").then((banks) => {
+        const bank = banks.find((b) => b.code === data.bankCode);
+        setLastManualPayout({
+          bankName: bank?.name ?? data.bankCode,
+          bankCode: data.bankCode,
+          accountNumber: data.accountNumber,
+          accountName: resolvedName,
+        });
+        setSavePromptOpen(true);
+      });
+    }
+
+    // Call real settlement API
+    try {
+      const settlement = await apiRequest<{
+        id: string;
+      }>("/settlements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          vault_id: "placeholder", // In real usage, this would be the actual vault ID
+          amount: numericAmount.toString(),
+          currency: sendAsset.symbol,
+          fiat_currency: receiveCurrency.symbol,
+          fiat_amount: displayReceive.toString(),
+          exchange_rate: receiveCurrency.rate.toString(),
+          destination: {
+            type: "bank_transfer",
+            provider: "bank",
+            account_number: data.accountNumber,
+            account_name: resolvedName,
+            bank_code: data.bankCode,
+          },
+        }),
+      });
+
+      // Use the real settlement ID in the explorer link
+      addNotification(
+        {
+          type: "withdrawal_processed",
+          title: "Withdrawal Submitted",
+          message: `Withdrew ${numericAmount.toLocaleString("en-US", {
+            maximumFractionDigits: 2,
+          })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? selectedBankCode} ending in ${data.accountNumber.slice(-4)}.`,
+          actionUrl: settlement.id
+            ? getExplorerTxUrl(settlement.id)
+            : undefined,
+          actionLabel: "View Transaction",
+        },
+        { showToast: true },
+      );
+    } catch (error) {
+      addNotification(
+        {
+          type: "error",
+          title: "Withdrawal Failed",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to process withdrawal",
+        },
+        { showToast: true },
+      );
+    }
+  });
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-xl">
+        {/* KYC Banner for unverified users */}
+        {kycStatus === "unverified" && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 flex items-start gap-3"
+          >
+            <AlertCircle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-amber-800">
+                Identity verification required for offramp
+              </p>
+              <p className="text-xs text-amber-600/80 mt-0.5">
+                Complete KYC to unlock fiat withdrawals.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <KYCStatusBadge status={kycStatus} />
+              <Link
+                href="/settings?tab=verification"
+                className="text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900"
+              >
+                Verify now
+              </Link>
+            </div>
+          </motion.div>
+        )}
+
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="text-center mb-6 sm:mb-8"
+        >
+          <h1 className="font-heading text-xl sm:text-2xl font-semibold text-foreground">
+            {t("offramp.title")}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("offramp.subtitle")}
+          </p>
+        </motion.div>
+
+        {/* Main Card */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="rounded-2xl border border-border bg-white dark:bg-[#100F0F] shadow-sm overflow-hidden"
+        >
+          <div className="p-4 sm:p-5">
+            <label className="text-xs text-muted-foreground font-medium mb-2 block">
+              You&apos;ll send
+            </label>
+            <div className="flex flex-col gap-1">
+              <div
+                className={cn(
+                  "flex items-center gap-3 rounded-2xl border px-3 py-2 transition-colors",
+                  errors.amount
+                    ? "border-red-500 bg-red-50/30"
+                    : "border-transparent bg-transparent hover:border-border",
                 )}
-
-                {/* Header */}
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.4 }}
-                    className="text-center mb-6 sm:mb-8"
-                >
-                    <h1 className="font-heading text-xl sm:text-2xl font-semibold text-foreground">
-                        {t("offramp.title")}
-                    </h1>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                        {t("offramp.subtitle")}
-                    </p>
-                </motion.div>
-
-                {/* Main Card */}
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.4, delay: 0.1 }}
-                    className="rounded-2xl border border-border bg-white dark:bg-[#100F0F] shadow-sm overflow-hidden"
-                >
-                    <div className="p-4 sm:p-5">
-                        <label className="text-xs text-muted-foreground font-medium mb-2 block">
-                            You&apos;ll send
-                        </label>
-                        <div className="flex flex-col gap-1">
-                            <div className={cn(
-                                "flex items-center gap-3 rounded-2xl border px-3 py-2 transition-colors",
-                                errors.amount ? "border-red-500 bg-red-50/30" : "border-transparent bg-transparent hover:border-border"
-                            )}>
-                                <Controller
-                                    name="amount"
-                                    control={control}
-                                    render={({ field: { onChange, onBlur, value } }) => (
-                                        <input
-                                            type="text"
-                                            inputMode="decimal"
-                                            placeholder="0.00"
-                                            value={value}
-                                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                                const val = e.target.value;
-                                                if (/^\d*\.?\d*$/.test(val)) {
-                                                    onChange(val);
-                                                    if (isDirty) trigger("amount");
-                                                }
-                                            }}
-                                            onBlur={onBlur}
-                                            onPaste={() => {
-                                                setTimeout(() => { trigger("amount"); }, 0);
-                                            }}
-                                            className={cn(
-                                                "flex-1 text-2xl sm:text-3xl font-heading font-light text-foreground bg-transparent outline-none placeholder:text-muted-foreground/40 min-w-0 min-h-[44px]",
-                                                errors.amount && "text-red-500"
-                                            )}
-                                        />
-                                    )}
-                                />
-                                <div className="relative">
-                                    <button
-                                        onClick={() => setShowSendDropdown(!showSendDropdown)}
-                                        className="flex items-center gap-2 px-3 py-2 rounded-full bg-secondary hover:bg-secondary/80 transition-colors min-h-[44px]"
-                                    >
-                                    <Image
-                                        src={sendAsset.image}
-                                        alt={sendAsset.symbol}
-                                        width={20}
-                                        height={20}
-                                        className="rounded-full"
-                                    />
-                                    <span className="text-sm font-medium text-foreground">
-                                        {sendAsset.symbol}
-                                    </span>
-                                    <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                                </button>
-                                {showSendDropdown && (
-                                    <div className="absolute right-0 top-full mt-1 w-48 rounded-xl border border-border bg-white dark:bg-[#100F0F] shadow-lg py-1 z-10">
-                                        {SEND_ASSETS.map((asset) => (
-                                            <button
-                                                key={asset.symbol}
-                                                onClick={() => {
-                                                    setSendAsset(asset);
-                                                    setShowSendDropdown(false);
-                                                }}
-                                                className="w-full flex items-center gap-2.5 px-3 py-3 text-sm hover:bg-secondary/50 transition-colors min-h-[44px]"
-                                            >
-                                                <Image
-                                                    src={asset.image}
-                                                    alt={asset.symbol}
-                                                    width={18}
-                                                    height={18}
-                                                    className="rounded-full"
-                                                />
-                                                <span className="font-medium">{asset.symbol}</span>
-                                                <span className="text-muted-foreground text-xs ml-auto">
-                                                    {asset.name}
-                                                </span>
-                                            </button>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                        <div className="flex justify-between mt-2 px-1">
-                            {errors.amount ? (
-                                <span className="text-xs text-red-500 font-medium">{errors.amount.message}</span>
-                            ) : (
-                                <span></span>
-                            )}
-                            <div className="text-xs text-muted-foreground">
-                                Balance: {MOCK_BALANCE.toLocaleString()} {sendAsset.symbol}
-                            </div>
-                        </div>
+              >
+                <Controller
+                  name="amount"
+                  control={control}
+                  render={({ field: { onChange, onBlur, value } }) => (
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="0.00"
+                      value={value}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        const val = e.target.value;
+                        if (/^\d*\.?\d*$/.test(val)) {
+                          onChange(val);
+                          if (isDirty) trigger("amount");
+                        }
+                      }}
+                      onBlur={onBlur}
+                      onPaste={() => {
+                        setTimeout(() => {
+                          trigger("amount");
+                        }, 0);
+                      }}
+                      className={cn(
+                        "flex-1 text-2xl sm:text-3xl font-heading font-light text-foreground bg-transparent outline-none placeholder:text-muted-foreground/40 min-w-0 min-h-[44px]",
+                        errors.amount && "text-red-500",
+                      )}
+                    />
+                  )}
+                />
+                <div className="relative">
+                  <button
+                    onClick={() => setShowSendDropdown(!showSendDropdown)}
+                    className="flex items-center gap-2 px-3 py-2 rounded-full bg-secondary hover:bg-secondary/80 transition-colors min-h-[44px]"
+                  >
+                    <Image
+                      src={sendAsset.image}
+                      alt={sendAsset.symbol}
+                      width={20}
+                      height={20}
+                      className="rounded-full"
+                    />
+                    <span className="text-sm font-medium text-foreground">
+                      {sendAsset.symbol}
+                    </span>
+                    <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                  </button>
+                  {showSendDropdown && (
+                    <div className="absolute right-0 top-full mt-1 w-48 rounded-xl border border-border bg-white dark:bg-[#100F0F] shadow-lg py-1 z-10">
+                      {SEND_ASSETS.map((asset) => (
+                        <button
+                          key={asset.symbol}
+                          onClick={() => {
+                            setSendAsset(asset);
+                            setShowSendDropdown(false);
+                          }}
+                          className="w-full flex items-center gap-2.5 px-3 py-3 text-sm hover:bg-secondary/50 transition-colors min-h-[44px]"
+                        >
+                          <Image
+                            src={asset.image}
+                            alt={asset.symbol}
+                            width={18}
+                            height={18}
+                            className="rounded-full"
+                          />
+                          <span className="font-medium">{asset.symbol}</span>
+                          <span className="text-muted-foreground text-xs ml-auto">
+                            {asset.name}
+                          </span>
+                        </button>
+                      ))}
                     </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex justify-between mt-2 px-1">
+                {errors.amount ? (
+                  <span className="text-xs text-red-500 font-medium">
+                    {errors.amount.message}
+                  </span>
+                ) : (
+                  <span></span>
+                )}
+                <div className="text-xs text-muted-foreground">
+                  {balanceLoading ? (
+                    <span className="flex items-center gap-1">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Loading balance...
+                    </span>
+                  ) : balanceError ? (
+                    <span className="text-red-500">Unable to load balance</span>
+                  ) : (
+                    <>
+                      Balance: {(userBalance ?? 0).toLocaleString()}{" "}
+                      {sendAsset.symbol}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Swap Divider */}
+          <div className="relative px-4 sm:px-5">
+            <div className="border-t border-border" />
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+              <div className="h-9 w-9 rounded-full border border-border bg-white dark:bg-[#100F0F] flex items-center justify-center shadow-sm">
+                <ArrowDownUp className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </div>
+          </div>
+
+          <div className="p-4 sm:p-5">
+            <label className="text-xs text-muted-foreground font-medium mb-2 block">
+              You&apos;ll receive
+            </label>
+            <div className="flex items-center gap-3">
+              <div className="flex-1 text-2xl sm:text-3xl font-heading font-light text-foreground min-w-0 truncate min-h-[44px] flex items-center">
+                {allFieldsFilled && selectedQuote ? (
+                  displayReceive.toLocaleString("en-US", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })
+                ) : numericAmount > 0 ? (
+                  <span className="text-muted-foreground/60">
+                    ≈{" "}
+                    {(
+                      numericAmount *
+                      receiveCurrency.rate *
+                      0.995
+                    ).toLocaleString("en-US", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground/40">0.00</span>
+                )}
+              </div>
+              <div className="relative">
+                <button
+                  onClick={() => setShowReceiveDropdown(!showReceiveDropdown)}
+                  className="flex items-center gap-2 px-3 py-2 rounded-full bg-secondary hover:bg-secondary/80 transition-colors min-h-[44px]"
+                >
+                  <Image
+                    src={receiveCurrency.image}
+                    alt={receiveCurrency.symbol}
+                    width={20}
+                    height={20}
+                    className="rounded-full"
+                  />
+                  <span className="text-sm font-medium text-foreground">
+                    {receiveCurrency.symbol}
+                  </span>
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                </button>
+                {showReceiveDropdown && (
+                  <div className="absolute right-0 top-full mt-1 w-48 rounded-xl border border-border bg-white dark:bg-[#100F0F] shadow-lg py-1 z-10">
+                    {RECEIVE_CURRENCIES.map((currency) => (
+                      <button
+                        key={currency.symbol}
+                        onClick={() => {
+                          setReceiveCurrency(currency);
+                          setShowReceiveDropdown(false);
+                        }}
+                        className="w-full flex items-center gap-2.5 px-3 py-3 text-sm hover:bg-secondary/50 transition-colors min-h-[44px]"
+                      >
+                        <Image
+                          src={currency.image}
+                          alt={currency.symbol}
+                          width={18}
+                          height={18}
+                          className="rounded-full"
+                        />
+                        <span className="font-medium">{currency.symbol}</span>
+                        <span className="text-muted-foreground text-xs ml-auto">
+                          {currency.name}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Bank Details Section */}
+          <div className="border-t border-border p-4 sm:p-5 space-y-4">
+            <SavedBankAccountPicker
+              currency={receiveCurrency.symbol}
+              value={payoutMode}
+              onChange={setPayoutMode}
+            />
+
+            {savePromptOpen && lastManualPayout && (
+              <SaveAccountPrompt
+                {...lastManualPayout}
+                currency={receiveCurrency.symbol}
+                country="NG"
+                onDismiss={() => setSavePromptOpen(false)}
+                onSaved={() => setSavePromptOpen(false)}
+              />
+            )}
+
+            {payoutMode.type === "saved" ? (
+              <div className="rounded-xl border border-border bg-secondary/20 px-4 py-3 text-sm">
+                <p className="font-medium text-foreground">
+                  {payoutMode.account.bank_name}
+                </p>
+                <p className="text-muted-foreground text-xs mt-1">
+                  {payoutMode.account.account_name} · ••••
+                  {payoutMode.account.account_last4}
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Step 1 — Account number */}
+                <div>
+                  <label className="text-xs text-muted-foreground font-medium mb-2 block">
+                    Account number
+                  </label>
+                  <Controller
+                    name="accountNumber"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <>
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          maxLength={10}
+                          placeholder="Enter 10-digit NUBAN"
+                          value={value}
+                          onChange={(
+                            e: React.ChangeEvent<HTMLInputElement>,
+                          ) => {
+                            const val = e.target.value.replace(/\D/g, "");
+                            onChange(val);
+                            // Clear bank selection when account number changes
+                            if (selectedBankCode) {
+                              setValue("bankCode", "", { shouldDirty: true });
+                            }
+                            if (isDirty) trigger("accountNumber");
+                          }}
+                          onBlur={onBlur}
+                          onPaste={() => {
+                            setTimeout(() => {
+                              trigger("accountNumber");
+                            }, 0);
+                          }}
+                          className={cn(
+                            "w-full px-4 py-3 rounded-xl border border-border bg-white dark:bg-[#100F0F] text-sm text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-foreground/20 transition-colors min-h-[52px]",
+                            errors.accountNumber &&
+                              "border-red-500 focus:border-red-500",
+                          )}
+                        />
+                        {errors.accountNumber && (
+                          <span className="text-xs text-red-500 font-medium mt-1 block">
+                            {errors.accountNumber.message}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  />
                 </div>
 
-                {/* Swap Divider */}
-                    <div className="relative px-4 sm:px-5">
-                        <div className="border-t border-border" />
-                        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-                            <div className="h-9 w-9 rounded-full border border-border bg-white dark:bg-[#100F0F] flex items-center justify-center shadow-sm">
-                                <ArrowDownUp className="h-4 w-4 text-muted-foreground" />
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="p-4 sm:p-5">
-                        <label className="text-xs text-muted-foreground font-medium mb-2 block">
-                            You&apos;ll receive
-                        </label>
-                        <div className="flex items-center gap-3">
-                            <div className="flex-1 text-2xl sm:text-3xl font-heading font-light text-foreground min-w-0 truncate min-h-[44px] flex items-center">
-                                {allFieldsFilled && selectedQuote ? (
-                                    displayReceive.toLocaleString("en-US", {
-                                        minimumFractionDigits: 2,
-                                        maximumFractionDigits: 2,
-                                    })
-                                ) : numericAmount > 0 ? (
-                                    <span className="text-muted-foreground/60">
-                                        ≈{" "}
-                                        {(numericAmount * receiveCurrency.rate * 0.995).toLocaleString("en-US", {
-                                            minimumFractionDigits: 2,
-                                            maximumFractionDigits: 2,
-                                        })}
-                                    </span>
-                                ) : (
-                                    <span className="text-muted-foreground/40">0.00</span>
-                                )}
-                            </div>
-                            <div className="relative">
-                                <button
-                                    onClick={() => setShowReceiveDropdown(!showReceiveDropdown)}
-                                    className="flex items-center gap-2 px-3 py-2 rounded-full bg-secondary hover:bg-secondary/80 transition-colors min-h-[44px]"
-                                >
-                                    <Image
-                                        src={receiveCurrency.image}
-                                        alt={receiveCurrency.symbol}
-                                        width={20}
-                                        height={20}
-                                        className="rounded-full"
-                                    />
-                                    <span className="text-sm font-medium text-foreground">
-                                        {receiveCurrency.symbol}
-                                    </span>
-                                    <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                                </button>
-                                {showReceiveDropdown && (
-                                    <div className="absolute right-0 top-full mt-1 w-48 rounded-xl border border-border bg-white dark:bg-[#100F0F] shadow-lg py-1 z-10">
-                                        {RECEIVE_CURRENCIES.map((currency) => (
-                                            <button
-                                                key={currency.symbol}
-                                                onClick={() => {
-                                                    setReceiveCurrency(currency);
-                                                    setShowReceiveDropdown(false);
-                                                }}
-                                                className="w-full flex items-center gap-2.5 px-3 py-3 text-sm hover:bg-secondary/50 transition-colors min-h-[44px]"
-                                            >
-                                                <Image
-                                                    src={currency.image}
-                                                    alt={currency.symbol}
-                                                    width={18}
-                                                    height={18}
-                                                    className="rounded-full"
-                                                />
-                                                <span className="font-medium">{currency.symbol}</span>
-                                                <span className="text-muted-foreground text-xs ml-auto">
-                                                    {currency.name}
-                                                </span>
-                                            </button>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Bank Details Section */}
-                    <div className="border-t border-border p-4 sm:p-5 space-y-4">
-                        <SavedBankAccountPicker
-                            currency={receiveCurrency.symbol}
-                            value={payoutMode}
-                            onChange={setPayoutMode}
-                        />
-
-                        {savePromptOpen && lastManualPayout && (
-                            <SaveAccountPrompt
-                                {...lastManualPayout}
-                                currency={receiveCurrency.symbol}
-                                country="NG"
-                                onDismiss={() => setSavePromptOpen(false)}
-                                onSaved={() => setSavePromptOpen(false)}
-                            />
-                        )}
-
-                        {payoutMode.type === "saved" ? (
-                            <div className="rounded-xl border border-border bg-secondary/20 px-4 py-3 text-sm">
-                                <p className="font-medium text-foreground">
-                                    {payoutMode.account.bank_name}
-                                </p>
-                                <p className="text-muted-foreground text-xs mt-1">
-                                    {payoutMode.account.account_name} · ••••
-                                    {payoutMode.account.account_last4}
-                                </p>
-                            </div>
-                        ) : (
-                        <>
-                        {/* Step 1 — Account number */}
-                        <div>
-                            <label className="text-xs text-muted-foreground font-medium mb-2 block">
-                                Account number
-                            </label>
-                            <Controller
-                                name="accountNumber"
-                                control={control}
-                                render={({ field: { onChange, onBlur, value } }) => (
-                                    <>
-                                        <input
-                                            type="text"
-                                            inputMode="numeric"
-                                            maxLength={10}
-                                            placeholder="Enter 10-digit NUBAN"
-                                            value={value}
-                                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                                const val = e.target.value.replace(/\D/g, "");
-                                                onChange(val);
-                                                // Clear bank selection when account number changes
-                                                if (selectedBankCode) {
-                                                    setValue("bankCode", "", { shouldDirty: true });
-                                                }
-                                                if (isDirty) trigger("accountNumber");
-                                            }}
-                                            onBlur={onBlur}
-                                            onPaste={() => {
-                                                setTimeout(() => { trigger("accountNumber"); }, 0);
-                                            }}
-                                            className={cn(
-                                                "w-full px-4 py-3 rounded-xl border border-border bg-white dark:bg-[#100F0F] text-sm text-foreground placeholder:text-muted-foreground/60 outline-none focus:border-foreground/20 transition-colors min-h-[52px]",
-                                                errors.accountNumber && "border-red-500 focus:border-red-500"
-                                            )}
-                                        />
-                                        {errors.accountNumber && (
-                                            <span className="text-xs text-red-500 font-medium mt-1 block">
-                                                {errors.accountNumber.message}
-                                            </span>
-                                        )}
-                                    </>
-                                )}
-                            />
-                        </div>
-
-                        {/* Step 2 — Bank selection (chips + combobox) */}
-                        <AnimatePresence>
-                            {accountNumber?.length === 10 && (
-                                <motion.div
-                                    key="bank-picker"
-                                    initial={{ opacity: 0, height: 0 }}
-                                    animate={{ opacity: 1, height: "auto" }}
-                                    exit={{ opacity: 0, height: 0 }}
-                                    transition={{ duration: 0.2 }}
-                                    className="space-y-3 overflow-hidden"
-                                >
-                                    {/* Popular bank quick-picks */}
-                                    <Controller
-                                        name="bankCode"
-                                        control={control}
-                                        render={({ field: { value } }) => (
-                                            <SuggestedBankChips
-                                                selectedCode={value}
-                                                onSelect={(code) => {
-                                                    setValue("bankCode", code, { shouldDirty: true, shouldValidate: true });
-                                                    trigger("bankCode");
-                                                }}
-                                            />
-                                        )}
-                                    />
-
-                                    {/* Full searchable combobox */}
-                                    <div>
-                                        <p className="text-[11px] text-muted-foreground mb-1.5">
-                                            Don&apos;t see your bank?
-                                        </p>
-                                        <Controller
-                                            name="bankCode"
-                                            control={control}
-                                            render={({ field: { onChange, value } }) => (
-                                                <BankCombobox
-                                                    value={value}
-                                                    onChange={(code) => {
-                                                        onChange(code);
-                                                        trigger("bankCode");
-                                                    }}
-                                                    error={errors.bankCode?.message}
-                                                />
-                                            )}
-                                        />
-                                    </div>
-                                </motion.div>
-                            )}
-                        </AnimatePresence>
-
-                        {/* Step 3 — Account name resolution */}
-                        <AccountNameField
-                            resolveState={resolveState}
-                            accountName={resolvedName}
-                            onManualName={setManualName}
-                            manualName={manualName}
-                        />
-                        </>
-                        )}
-                    </div>
-
-                    {/* Rate info */}
-                    {selectedQuote && allFieldsFilled && (
-                        <div className="border-t border-border px-4 sm:px-5 py-4 space-y-2">
-                            <div className="flex items-center justify-between text-xs gap-2">
-                                <span className="text-muted-foreground flex items-center gap-1 shrink-0">
-                                    Rate via {selectedQuote.node.name}
-                                    <Info className="h-3 w-3" />
-                                </span>
-                                <span className="text-foreground font-medium text-right">
-                                    1 {sendAsset.symbol} ≈{" "}
-                                    {selectedQuote.effectiveRate.toLocaleString(undefined, {
-                                        minimumFractionDigits: 2,
-                                        maximumFractionDigits: 2,
-                                    })}{" "}
-                                    {receiveCurrency.symbol}
-                                </span>
-                            </div>
-                            <div className="flex items-center justify-between text-xs">
-                                <span className="text-muted-foreground">
-                                    Node fee ({selectedQuote.node.fee}%)
-                                </span>
-                                <span className="text-foreground font-medium">
-                                    {selectedQuote.fee.toFixed(4)} {sendAsset.symbol}
-                                </span>
-                            </div>
-                            <div className="flex items-center justify-between text-xs">
-                                <span className="text-muted-foreground">Estimated time</span>
-                                <span className="text-foreground font-medium flex items-center gap-1">
-                                    <Clock className="h-3 w-3" />
-                                    {selectedQuote.estimatedTime}
-                                    {selectedQuote.isSameBank && (
-                                        <span className="text-emerald-600 font-medium ml-1">
-                                            Same bank
-                                        </span>
-                                    )}
-                                </span>
-                            </div>
-                        </div>
-                    )}
-
-                    {/* Large amount warning */}
-                    {showLargeWarning && (
-                        <div className="mx-4 sm:mx-5 mb-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-                            <div className="flex items-start gap-2">
-                                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                                <span>
-                                    You&apos;re about to withdraw ${numericAmount.toLocaleString("en-US", { maximumFractionDigits: 2 })} — are you sure?
-                                </span>
-                            </div>
-                        </div>
-                    )}
-
-                    {/* CTA Button */}
-                    <div className="p-4 sm:p-5 pt-0">
-                        <button
-                            disabled={
-                                isOffline ||
-                                !isValid ||
-                                quotePhase !== "done" ||
-                                resolveState === "loading" ||
-                                resolveState === "not_found" ||
-                                resolveState === "idle" ||
-                                (resolveState === "provider_error" && !manualName.trim())
-                            }
-                            onClick={handleWithdraw}
-                            className="w-full rounded-xl bg-foreground text-background py-4 text-sm font-medium transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-                        >
-                            {isOffline
-                                ? t("offramp.offlineMessage")
-                                : !numericAmount
-                                ? t("offramp.enterAmount")
-                                : !selectedBankCode
-                                    ? t("offramp.selectBank")
-                                    : (accountNumber?.length || 0) !== 10
-                                        ? "Enter account number"
-                                        : resolveState === "loading"
-                                            ? "Verifying account..."
-                                            : resolveState === "not_found"
-                                                ? "Account not found"
-                                                : resolveState === "idle"
-                                                    ? "Waiting for account verification..."
-                                                    : quotePhase !== "done"
-                                                        ? "Finding best rate..."
-                                                        : showLargeWarning
-                                                            ? "Yes, confirm withdrawal"
-                                                            : `Withdraw ${displayReceive.toLocaleString("en-US", { minimumFractionDigits: 2 })} ${receiveCurrency.symbol}`}
-                        </button>
-                    </div>
-                </motion.div>
-
-                {/* LP Node Quotes */}
+                {/* Step 2 — Bank selection (chips + combobox) */}
                 <AnimatePresence>
-                    {allFieldsFilled && quotePhase !== "idle" && (
-                        <motion.div
-                            initial={{ opacity: 0, y: 16 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: 8 }}
-                            transition={{ duration: 0.35, delay: 0.05 }}
-                            className="mt-4 rounded-2xl border border-border bg-white dark:bg-[#100F0F] shadow-sm overflow-hidden"
-                        >
-                            {/* Quotes Header */}
-                            <div className="px-4 sm:px-5 py-3.5 flex items-center justify-between border-b border-border gap-2">
-                                <div className="flex items-center gap-2 shrink-0">
-                                    <Tag className="h-3.5 w-3.5 text-muted-foreground" />
-                                    <span className="text-sm font-medium text-foreground">Quotes</span>
-                                </div>
-                                <div className="flex items-center gap-1.5 text-xs text-muted-foreground overflow-hidden">
-                                    {quotePhase === "done" ? (
-                                        <span className="flex items-center gap-1 flex-wrap justify-end">
-                                            <span className="flex items-center gap-1">
-                                                <span className="relative flex h-1.5 w-1.5 shrink-0">
-                                                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                                                    <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
-                                                </span>
-                                                Live
-                                            </span>
-                                            <span className="text-muted-foreground/40">·</span>
-                                            <span>{quotes.length} nodes</span>
-                                            <span className="hidden sm:inline text-muted-foreground/40">·</span>
-                                            <span className="hidden sm:inline">Nester LP Network</span>
-                                        </span>
-                                    ) : (
-                                        <span className="flex items-center gap-1.5">
-                                            <Loader2 className="h-3 w-3 animate-spin shrink-0" />
-                                            <span className="truncate">
-                                                {quotePhase === "scanning" &&
-                                                    `Scanning (${scannedCount}/${LP_NODES.length})`}
-                                                {quotePhase === "comparing" && "Comparing rates..."}
-                                                {quotePhase === "ranking" && "Ranking..."}
-                                            </span>
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
+                  {accountNumber?.length === 10 && (
+                    <motion.div
+                      key="bank-picker"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="space-y-3 overflow-hidden"
+                    >
+                      {/* Popular bank quick-picks */}
+                      <Controller
+                        name="bankCode"
+                        control={control}
+                        render={({ field: { value } }) => (
+                          <SuggestedBankChips
+                            selectedCode={value}
+                            onSelect={(code) => {
+                              setValue("bankCode", code, {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              });
+                              trigger("bankCode");
+                            }}
+                          />
+                        )}
+                      />
 
-                            {/* Progress bar */}
-                            {quotePhase !== "done" && (
-                                <div className="h-0.5 bg-secondary overflow-hidden">
-                                    <motion.div
-                                        className="h-full bg-foreground/70"
-                                        initial={{ width: "0%" }}
-                                        animate={{
-                                            width:
-                                                quotePhase === "scanning"
-                                                    ? `${(scannedCount / LP_NODES.length) * 60}%`
-                                                    : quotePhase === "comparing"
-                                                        ? "80%"
-                                                        : "95%",
-                                        }}
-                                        transition={{ duration: 0.2, ease: "easeOut" }}
-                                    />
-                                </div>
-                            )}
-
-                            {quotePhase === "done" && quotes.length > 0 && (
-                                <div className="divide-y divide-border">
-                                    {quotes.slice(0, 5).map((quote, i) => (
-                                        <motion.button
-                                            key={quote.node.id}
-                                            initial={{ opacity: 0, x: -8 }}
-                                            animate={{ opacity: 1, x: 0 }}
-                                            transition={{ duration: 0.25, delay: i * 0.06 }}
-                                            onClick={() => setSelectedQuote(quote)}
-                                            className={cn(
-                                                "w-full flex items-center gap-3 px-4 sm:px-5 py-3 text-left transition-colors min-h-[56px]",
-                                                selectedQuote?.node.id === quote.node.id
-                                                    ? "bg-secondary/60"
-                                                    : "hover:bg-secondary/30"
-                                            )}
-                                        >
-                                            <div
-                                                className={cn(
-                                                    "h-7 w-7 rounded-full flex items-center justify-center shrink-0",
-                                                    quote.isBest
-                                                        ? "bg-emerald-100 text-emerald-700"
-                                                        : "bg-secondary text-muted-foreground"
-                                                )}
-                                            >
-                                                {quote.isBest ? (
-                                                    <Zap className="h-3.5 w-3.5" />
-                                                ) : (
-                                                    <Building2 className="h-3.5 w-3.5" />
-                                                )}
-                                            </div>
-
-                                            <div className="flex-1 min-w-0">
-                                                <div className="flex items-center gap-1.5 flex-wrap">
-                                                    <span className="text-sm font-medium text-foreground truncate">
-                                                        {quote.node.name}
-                                                    </span>
-                                                    {quote.isBest && (
-                                                        <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 text-emerald-700">
-                                                            Best
-                                                        </span>
-                                                    )}
-                                                    {quote.isSameBank && (
-                                                        <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-50 text-blue-600">
-                                                            Same Bank
-                                                        </span>
-                                                    )}
-                                                </div>
-                                                <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground flex-wrap">
-                                                    <span>{quote.node.fee}% fee</span>
-                                                    <span className="text-muted-foreground/30">·</span>
-                                                    <span>{quote.estimatedTime}</span>
-                                                    <span className="hidden sm:inline text-muted-foreground/30">·</span>
-                                                    <span className="hidden sm:inline">
-                                                        {quote.node.reliability}% reliable
-                                                    </span>
-                                                </div>
-                                            </div>
-
-                                            <div className="text-right shrink-0">
-                                                {quote.isBest && quotes.length > 1 && (
-                                                    <div className="text-[10px] font-medium text-emerald-600 mb-0.5">
-                                                        +
-                                                        {(
-                                                            quote.receiveAmount -
-                                                            quotes[quotes.length - 1].receiveAmount
-                                                        ).toLocaleString("en-US", {
-                                                            minimumFractionDigits: 2,
-                                                            maximumFractionDigits: 2,
-                                                        })}
-                                                    </div>
-                                                )}
-                                                <div className="text-sm font-medium text-foreground tabular-nums">
-                                                    {quote.receiveAmount.toLocaleString("en-US", {
-                                                        minimumFractionDigits: 2,
-                                                        maximumFractionDigits: 2,
-                                                    })}
-                                                </div>
-                                                <div className="text-[10px] text-muted-foreground">
-                                                    {receiveCurrency.symbol}
-                                                </div>
-                                            </div>
-
-                                            {selectedQuote?.node.id === quote.node.id && (
-                                                <CheckCircle2 className="h-4 w-4 text-foreground shrink-0" />
-                                            )}
-                                        </motion.button>
-                                    ))}
-
-                                    {quotes.length > 5 && (
-                                        <div className="px-5 py-2.5 text-center">
-                                            <span className="text-xs text-muted-foreground">
-                                                +{quotes.length - 5} more nodes available
-                                            </span>
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-
-                            {quotePhase === "done" && selectedQuote && (
-                                <div className="px-4 sm:px-5 py-3 bg-secondary/30 flex items-center gap-2 text-[11px] text-muted-foreground">
-                                    <ArrowRight className="h-3 w-3 shrink-0" />
-                                    <span>
-                                        Routing through{" "}
-                                        <strong className="text-foreground font-medium">
-                                            {selectedQuote.node.name}
-                                        </strong>
-                                        {selectedQuote.isSameBank && (
-                                            <> — same-bank transfer for instant settlement</>
-                                        )}
-                                    </span>
-                                </div>
-                            )}
-                        </motion.div>
-                    )}
+                      {/* Full searchable combobox */}
+                      <div>
+                        <p className="text-[11px] text-muted-foreground mb-1.5">
+                          Don&apos;t see your bank?
+                        </p>
+                        <Controller
+                          name="bankCode"
+                          control={control}
+                          render={({ field: { onChange, value } }) => (
+                            <BankCombobox
+                              value={value}
+                              onChange={(code) => {
+                                onChange(code);
+                                trigger("bankCode");
+                              }}
+                              error={errors.bankCode?.message}
+                            />
+                          )}
+                        />
+                      </div>
+                    </motion.div>
+                  )}
                 </AnimatePresence>
 
-                <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ duration: 0.4, delay: 0.3 }}
-                    className="mt-4 flex items-center justify-center gap-2"
-                >
-                    <ShieldCheck className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                    <span className="text-[11px] text-muted-foreground text-center">
-                        Secured by Soroban smart contract escrow — auto-refund if settlement fails
-                    </span>
-                </motion.div>
+                {/* Step 3 — Account name resolution */}
+                <AccountNameField
+                  resolveState={resolveState}
+                  accountName={resolvedName}
+                  onManualName={setManualName}
+                  manualName={manualName}
+                />
+              </>
+            )}
+          </div>
 
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.4, delay: 0.4 }}
-                    className="mt-8 rounded-2xl border border-border bg-white dark:bg-[#100F0F] p-5"
-                >
-                    <h3 className="font-heading text-sm font-medium text-foreground mb-3">
-                        Recent Offramps
-                    </h3>
-                    <div className="flex flex-col items-center justify-center py-6 text-center">
-                        <Clock className="h-5 w-5 text-muted-foreground/30 mb-2" />
-                        <p className="text-xs text-muted-foreground">No offramps yet</p>
-                    </div>
-                </motion.div>
+          {/* Rate info */}
+          {selectedQuote && allFieldsFilled && (
+            <div className="border-t border-border px-4 sm:px-5 py-4 space-y-2">
+              <div className="flex items-center justify-between text-xs gap-2">
+                <span className="text-muted-foreground flex items-center gap-1 shrink-0">
+                  Rate via {selectedQuote.node.name}
+                  <Info className="h-3 w-3" />
+                </span>
+                <span className="text-foreground font-medium text-right">
+                  1 {sendAsset.symbol} ≈{" "}
+                  {selectedQuote.effectiveRate.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  {receiveCurrency.symbol}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">
+                  Node fee ({selectedQuote.node.fee}%)
+                </span>
+                <span className="text-foreground font-medium">
+                  {selectedQuote.fee.toFixed(4)} {sendAsset.symbol}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">Estimated time</span>
+                <span className="text-foreground font-medium flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {selectedQuote.estimatedTime}
+                  {selectedQuote.isSameBank && (
+                    <span className="text-emerald-600 font-medium ml-1">
+                      Same bank
+                    </span>
+                  )}
+                </span>
+              </div>
             </div>
-        </AppShell>
-    );
+          )}
+
+          {/* Large amount warning */}
+          {showLargeWarning && (
+            <div className="mx-4 sm:mx-5 mb-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>
+                  You&apos;re about to withdraw $
+                  {numericAmount.toLocaleString("en-US", {
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  — are you sure?
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* CTA Button */}
+          <div className="p-4 sm:p-5 pt-0">
+            <button
+              disabled={
+                isOffline ||
+                !isValid ||
+                quotePhase !== "done" ||
+                resolveState === "loading" ||
+                resolveState === "not_found" ||
+                resolveState === "idle" ||
+                (resolveState === "provider_error" && !manualName.trim())
+              }
+              onClick={handleWithdraw}
+              className="w-full rounded-xl bg-foreground text-background py-4 text-sm font-medium transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {isOffline
+                ? t("offramp.offlineMessage")
+                : !numericAmount
+                  ? t("offramp.enterAmount")
+                  : !selectedBankCode
+                    ? t("offramp.selectBank")
+                    : (accountNumber?.length || 0) !== 10
+                      ? "Enter account number"
+                      : resolveState === "loading"
+                        ? "Verifying account..."
+                        : resolveState === "not_found"
+                          ? "Account not found"
+                          : resolveState === "idle"
+                            ? "Waiting for account verification..."
+                            : quotePhase !== "done"
+                              ? "Finding best rate..."
+                              : showLargeWarning
+                                ? "Yes, confirm withdrawal"
+                                : `Withdraw ${displayReceive.toLocaleString("en-US", { minimumFractionDigits: 2 })} ${receiveCurrency.symbol}`}
+            </button>
+          </div>
+        </motion.div>
+
+        {/* LP Node Quotes */}
+        <AnimatePresence>
+          {allFieldsFilled && quotePhase !== "idle" && (
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 8 }}
+              transition={{ duration: 0.35, delay: 0.05 }}
+              className="mt-4 rounded-2xl border border-border bg-white dark:bg-[#100F0F] shadow-sm overflow-hidden"
+            >
+              {/* Quotes Header */}
+              <div className="px-4 sm:px-5 py-3.5 flex items-center justify-between border-b border-border gap-2">
+                <div className="flex items-center gap-2 shrink-0">
+                  <Tag className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm font-medium text-foreground">
+                    Quotes
+                  </span>
+                </div>
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground overflow-hidden">
+                  {quotePhase === "done" ? (
+                    <span className="flex items-center gap-1 flex-wrap justify-end">
+                      <span className="flex items-center gap-1">
+                        <span className="relative flex h-1.5 w-1.5 shrink-0">
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                          <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
+                        </span>
+                        Live
+                      </span>
+                      <span className="text-muted-foreground/40">·</span>
+                      <span>{quotes.length} nodes</span>
+                      <span className="hidden sm:inline text-muted-foreground/40">
+                        ·
+                      </span>
+                      <span className="hidden sm:inline">
+                        Nester LP Network
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1.5">
+                      <Loader2 className="h-3 w-3 animate-spin shrink-0" />
+                      <span className="truncate">
+                        {quotePhase === "scanning" &&
+                          `Scanning (${scannedCount}/${LP_NODES.length})`}
+                        {quotePhase === "comparing" && "Comparing rates..."}
+                        {quotePhase === "ranking" && "Ranking..."}
+                      </span>
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Progress bar */}
+              {quotePhase !== "done" && (
+                <div className="h-0.5 bg-secondary overflow-hidden">
+                  <motion.div
+                    className="h-full bg-foreground/70"
+                    initial={{ width: "0%" }}
+                    animate={{
+                      width:
+                        quotePhase === "scanning"
+                          ? `${(scannedCount / LP_NODES.length) * 60}%`
+                          : quotePhase === "comparing"
+                            ? "80%"
+                            : "95%",
+                    }}
+                    transition={{ duration: 0.2, ease: "easeOut" }}
+                  />
+                </div>
+              )}
+
+              {quotePhase === "done" && quotes.length > 0 && (
+                <div className="divide-y divide-border">
+                  {quotes.slice(0, 5).map((quote, i) => (
+                    <motion.button
+                      key={quote.node.id}
+                      initial={{ opacity: 0, x: -8 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ duration: 0.25, delay: i * 0.06 }}
+                      onClick={() => setSelectedQuote(quote)}
+                      className={cn(
+                        "w-full flex items-center gap-3 px-4 sm:px-5 py-3 text-left transition-colors min-h-[56px]",
+                        selectedQuote?.node.id === quote.node.id
+                          ? "bg-secondary/60"
+                          : "hover:bg-secondary/30",
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "h-7 w-7 rounded-full flex items-center justify-center shrink-0",
+                          quote.isBest
+                            ? "bg-emerald-100 text-emerald-700"
+                            : "bg-secondary text-muted-foreground",
+                        )}
+                      >
+                        {quote.isBest ? (
+                          <Zap className="h-3.5 w-3.5" />
+                        ) : (
+                          <Building2 className="h-3.5 w-3.5" />
+                        )}
+                      </div>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <span className="text-sm font-medium text-foreground truncate">
+                            {quote.node.name}
+                          </span>
+                          {quote.isBest && (
+                            <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 text-emerald-700">
+                              Best
+                            </span>
+                          )}
+                          {quote.isSameBank && (
+                            <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-50 text-blue-600">
+                              Same Bank
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground flex-wrap">
+                          <span>{quote.node.fee}% fee</span>
+                          <span className="text-muted-foreground/30">·</span>
+                          <span>{quote.estimatedTime}</span>
+                          <span className="hidden sm:inline text-muted-foreground/30">
+                            ·
+                          </span>
+                          <span className="hidden sm:inline">
+                            {quote.node.reliability}% reliable
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="text-right shrink-0">
+                        {quote.isBest && quotes.length > 1 && (
+                          <div className="text-[10px] font-medium text-emerald-600 mb-0.5">
+                            +
+                            {(
+                              quote.receiveAmount -
+                              quotes[quotes.length - 1].receiveAmount
+                            ).toLocaleString("en-US", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </div>
+                        )}
+                        <div className="text-sm font-medium text-foreground tabular-nums">
+                          {quote.receiveAmount.toLocaleString("en-US", {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </div>
+                        <div className="text-[10px] text-muted-foreground">
+                          {receiveCurrency.symbol}
+                        </div>
+                      </div>
+
+                      {selectedQuote?.node.id === quote.node.id && (
+                        <CheckCircle2 className="h-4 w-4 text-foreground shrink-0" />
+                      )}
+                    </motion.button>
+                  ))}
+
+                  {quotes.length > 5 && (
+                    <div className="px-5 py-2.5 text-center">
+                      <span className="text-xs text-muted-foreground">
+                        +{quotes.length - 5} more nodes available
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {quotePhase === "done" && selectedQuote && (
+                <div className="px-4 sm:px-5 py-3 bg-secondary/30 flex items-center gap-2 text-[11px] text-muted-foreground">
+                  <ArrowRight className="h-3 w-3 shrink-0" />
+                  <span>
+                    Routing through{" "}
+                    <strong className="text-foreground font-medium">
+                      {selectedQuote.node.name}
+                    </strong>
+                    {selectedQuote.isSameBank && (
+                      <> — same-bank transfer for instant settlement</>
+                    )}
+                  </span>
+                </div>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4, delay: 0.3 }}
+          className="mt-4 flex items-center justify-center gap-2"
+        >
+          <ShieldCheck className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+          <span className="text-[11px] text-muted-foreground text-center">
+            Secured by Soroban smart contract escrow — auto-refund if settlement
+            fails
+          </span>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.4 }}
+          className="mt-8 rounded-2xl border border-border bg-white dark:bg-[#100F0F] p-5"
+        >
+          <h3 className="font-heading text-sm font-medium text-foreground mb-3">
+            Recent Offramps
+          </h3>
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <Clock className="h-5 w-5 text-muted-foreground/30 mb-2" />
+            <p className="text-xs text-muted-foreground">No offramps yet</p>
+          </div>
+        </motion.div>
+      </div>
+    </AppShell>
+  );
 }

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -407,7 +407,12 @@ export default function OfframpPage() {
           type: "bank_transfer",
           provider: "bank",
           account_number: data.accountNumber,
-          account_name: resolvedName || data.accountName,
+          // The form has no accountName field — the schema is amount,
+          // accountNumber and bankCode. The account name is resolved from
+          // the bank lookup, so `|| data.accountName` referenced something
+          // that does not exist and failed the type check. resolvedName is
+          // null until the lookup succeeds; the server validates the field.
+          account_name: resolvedName ?? "",
           bank_code: data.bankCode,
         };
       }

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -450,7 +450,10 @@ export default function OfframpPage() {
     } catch (error) {
       addNotification(
         {
-          type: "error",
+          // "error" is not a NotificationType. offramp_status is the member
+          // for an off-ramp outcome, and this is the failure end of the same
+          // flow whose success path above uses withdrawal_processed.
+          type: "offramp_status",
           title: "Withdrawal Failed",
           message:
             error instanceof Error

--- a/apps/dapp/frontend/app/offramp/page.tsx
+++ b/apps/dapp/frontend/app/offramp/page.tsx
@@ -388,11 +388,16 @@ export default function OfframpPage() {
     try {
       // Build destination from payoutMode
       let destination: any;
+      let bankAccountID: string | undefined;
       if (payoutMode.type === "saved") {
+        // SavedBankAccount deliberately carries only account_last4 — the API
+        // never returns a full account number to the client, so one cannot be
+        // sent back. POST /settlements accepts bank_account_id for exactly
+        // this case and resolves the account server-side.
+        bankAccountID = payoutMode.account.id;
         destination = {
           type: "bank_transfer",
           provider: "bank",
-          account_number: payoutMode.account.account_number,
           account_name: payoutMode.account.account_name,
           bank_code: payoutMode.account.bank_code,
         };
@@ -420,6 +425,7 @@ export default function OfframpPage() {
           fiat_amount: displayReceive.toString(),
           exchange_rate: receiveCurrency.rate.toString(),
           destination,
+          ...(bankAccountID ? { bank_account_id: bankAccountID } : {}),
         }),
       });
 
@@ -430,7 +436,7 @@ export default function OfframpPage() {
           title: "Withdrawal Submitted",
           message: `Withdrew ${numericAmount.toLocaleString("en-US", {
             maximumFractionDigits: 2,
-          })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? effectiveBankCode} ending in ${destination.account_number.slice(-4)}.`,
+          })} ${sendAsset.symbol} to ${accountInfo?.bank_name ?? effectiveBankCode} ending in ${payoutMode.type === "saved" ? payoutMode.account.account_last4 : String(destination.account_number ?? "").slice(-4)}.`,
           // TODO: Add explorer link once settlement returns on-chain transaction hash
           actionLabel: "View Transaction",
         },

--- a/apps/dapp/frontend/app/settings/page.tsx
+++ b/apps/dapp/frontend/app/settings/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ShieldCheck, User, Bell, Globe, Monitor } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
@@ -12,7 +10,11 @@ import { BankAccountsSection } from "@/components/settings/bank-accounts-section
 import { SessionsSection } from "@/components/settings/sessions-section";
 import { cn } from "@/lib/utils";
 import { useLocale, useTranslations } from "@/context/locale-context";
-import { SUPPORTED_LOCALES, LOCALE_LABELS, type Locale } from "@/lib/i18n/config";
+import {
+  SUPPORTED_LOCALES,
+  LOCALE_LABELS,
+  type Locale,
+} from "@/lib/i18n/config";
 
 // --- Savings goal notification settings (#740) ---
 
@@ -20,348 +22,476 @@ type Channel = "push" | "email" | "in_app";
 type Milestone = "25" | "50" | "75" | "100" | "deadline";
 
 const CHANNELS: { id: Channel; label: string }[] = [
-    { id: "push", label: "Push" },
-    { id: "email", label: "Email" },
-    { id: "in_app", label: "In-App" },
+  { id: "push", label: "Push" },
+  { id: "email", label: "Email" },
+  { id: "in_app", label: "In-App" },
 ];
 
 const MILESTONES: { id: Milestone; label: string }[] = [
-    { id: "25", label: "25% reached" },
-    { id: "50", label: "50% reached" },
-    { id: "75", label: "75% reached" },
-    { id: "100", label: "Goal completed" },
-    { id: "deadline", label: "Deadline breach" },
+  { id: "25", label: "25% reached" },
+  { id: "50", label: "50% reached" },
+  { id: "75", label: "75% reached" },
+  { id: "100", label: "Goal completed" },
+  { id: "deadline", label: "Deadline breach" },
 ];
 
 type SavingsNotifPrefs = Record<Milestone, Record<Channel, boolean>>;
 
 function defaultSavingsPrefs(): SavingsNotifPrefs {
-    const prefs = {} as SavingsNotifPrefs;
-    for (const m of MILESTONES) {
-        prefs[m.id] = { push: true, email: true, in_app: true };
-    }
-    return prefs;
+  const prefs = {} as SavingsNotifPrefs;
+  for (const m of MILESTONES) {
+    prefs[m.id] = { push: true, email: true, in_app: true };
+  }
+  return prefs;
 }
 
-function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
-    return (
-        <label className="relative inline-flex cursor-pointer items-center">
-            <input type="checkbox" checked={checked} onChange={onChange} className="peer sr-only" />
-            <div className="h-5 w-9 rounded-full bg-black/10 dark:bg-white/10 peer-checked:bg-black dark:peer-checked:bg-blue-600 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4" />
-        </label>
-    );
+function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <label className="relative inline-flex cursor-pointer items-center">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="peer sr-only"
+      />
+      <div className="h-5 w-9 rounded-full bg-black/10 dark:bg-white/10 peer-checked:bg-black dark:peer-checked:bg-blue-600 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4" />
+    </label>
+  );
 }
 
 function SavingsNotificationsSection() {
-    const [prefs, setPrefs] = useState<SavingsNotifPrefs>(defaultSavingsPrefs);
-    const [saving, setSaving] = useState(false);
-    const [saved, setSaved] = useState(false);
+  const [prefs, setPrefs] = useState<SavingsNotifPrefs>(defaultSavingsPrefs);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
 
-    const toggle = useCallback((milestone: Milestone, channel: Channel) => {
-        setPrefs((prev) => ({
-            ...prev,
-            [milestone]: { ...prev[milestone], [channel]: !prev[milestone][channel] },
-        }));
-        setSaved(false);
-    }, []);
+  const toggle = useCallback((milestone: Milestone, channel: Channel) => {
+    setPrefs((prev) => ({
+      ...prev,
+      [milestone]: { ...prev[milestone], [channel]: !prev[milestone][channel] },
+    }));
+    setSaved(false);
+  }, []);
 
-    const save = useCallback(async () => {
-        setSaving(true);
-        try {
-            await fetch("/api/v1/notifications/preferences", {
-                method: "PATCH",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ savings_milestones: prefs }),
-            });
-            setSaved(true);
-        } finally {
-            setSaving(false);
-        }
-    }, [prefs]);
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      await fetch("/api/v1/notifications/preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ savings_milestones: prefs }),
+      });
+      setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }, [prefs]);
 
-    return (
-        <div className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6">
-            <h2 className="mb-1 text-sm font-medium text-black dark:text-white">Savings Goal Milestones</h2>
-            <p className="mb-5 text-xs text-black/40 dark:text-white/40">Choose which channels receive alerts at each milestone</p>
+  return (
+    <div className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6">
+      <h2 className="mb-1 text-sm font-medium text-black dark:text-white">
+        Savings Goal Milestones
+      </h2>
+      <p className="mb-5 text-xs text-black/40 dark:text-white/40">
+        Choose which channels receive alerts at each milestone
+      </p>
 
-            <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                    <thead>
-                        <tr>
-                            <th className="pb-3 text-left text-xs font-medium text-black/40 dark:text-white/40 w-40">Milestone</th>
-                            {CHANNELS.map((c) => (
-                                <th key={c.id} className="pb-3 text-center text-xs font-medium text-black/40 dark:text-white/40 w-20">
-                                    {c.label}
-                                </th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-black/4 dark:divide-white/4">
-                        {MILESTONES.map((m) => (
-                            <tr key={m.id}>
-                                <td className="py-3 text-sm text-black dark:text-white">{m.label}</td>
-                                {CHANNELS.map((c) => (
-                                    <td key={c.id} className="py-3 text-center">
-                                        <div className="flex justify-center">
-                                            <Toggle
-                                                checked={prefs[m.id][c.id]}
-                                                onChange={() => toggle(m.id, c.id)}
-                                            />
-                                        </div>
-                                    </td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-
-            <div className="mt-5 flex items-center gap-3">
-                <button
-                    onClick={save}
-                    disabled={saving}
-                    className="rounded-xl bg-black dark:bg-blue-600 px-5 py-2.5 text-sm text-white transition-opacity hover:opacity-75 disabled:opacity-40"
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="pb-3 text-left text-xs font-medium text-black/40 dark:text-white/40 w-40">
+                Milestone
+              </th>
+              {CHANNELS.map((c) => (
+                <th
+                  key={c.id}
+                  className="pb-3 text-center text-xs font-medium text-black/40 dark:text-white/40 w-20"
                 >
-                    {saving ? "Saving…" : "Save"}
-                </button>
-                {saved && <span className="text-xs text-black/40 dark:text-white/40">Saved</span>}
-            </div>
-        </div>
-    );
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-black/4 dark:divide-white/4">
+            {MILESTONES.map((m) => (
+              <tr key={m.id}>
+                <td className="py-3 text-sm text-black dark:text-white">
+                  {m.label}
+                </td>
+                {CHANNELS.map((c) => (
+                  <td key={c.id} className="py-3 text-center">
+                    <div className="flex justify-center">
+                      <Toggle
+                        checked={prefs[m.id][c.id]}
+                        onChange={() => toggle(m.id, c.id)}
+                      />
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-5 flex items-center gap-3">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="rounded-xl bg-black dark:bg-blue-600 px-5 py-2.5 text-sm text-white transition-opacity hover:opacity-75 disabled:opacity-40"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {saved && (
+          <span className="text-xs text-black/40 dark:text-white/40">
+            Saved
+          </span>
+        )}
+      </div>
+    </div>
+  );
 }
 
-type Tab = "profile" | "verification" | "security" | "notifications" | "preferences";
+type Tab =
+  | "profile"
+  | "verification"
+  | "security"
+  | "notifications"
+  | "preferences";
 
 const TABS: { id: Tab; label: string; icon: React.ElementType }[] = [
-    { id: "profile", label: "Profile", icon: User },
-    { id: "verification", label: "Verification", icon: ShieldCheck },
-    { id: "security", label: "Security", icon: Monitor },
-    { id: "notifications", label: "Notifications", icon: Bell },
-    { id: "preferences", label: "Preferences", icon: Globe },
+  { id: "profile", label: "Profile", icon: User },
+  { id: "verification", label: "Verification", icon: ShieldCheck },
+  { id: "security", label: "Security", icon: Monitor },
+  { id: "notifications", label: "Notifications", icon: Bell },
+  { id: "preferences", label: "Preferences", icon: Globe },
 ];
 
-// Mocked KYC state — in a real app this would come from an API call
-function useKYCState() {
-    const [status, setStatus] = useState<KYCStatus>("unverified");
-    const [submittedAt, setSubmittedAt] = useState<string | null>(null);
-    const [reviewedAt] = useState<string | null>(null);
-    const [rejectionReason] = useState<string | null>(null);
-    const [isSubmitting, setIsSubmitting] = useState(false);
+interface KYCStatusResponse {
+  status: KYCStatus;
+  submitted_at?: string;
+  reviewed_at?: string;
+  rejection_reason?: string;
+}
 
-    const submitKYC = async (formData: FormData) => {
-        setIsSubmitting(true);
-        try {
-            // In a real app, POST /api/v1/users/{userId}/kyc
-            await new Promise((r) => setTimeout(r, 1200));
-            setStatus("pending");
-            setSubmittedAt(new Date().toISOString());
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
+function useKYCState(userId: string | undefined) {
+  const [status, setStatus] = useState<KYCStatus>("unverified");
+  const [submittedAt, setSubmittedAt] = useState<string | null>(null);
+  const [reviewedAt, setReviewedAt] = useState<string | null>(null);
+  const [rejectionReason, setRejectionReason] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    return { status, submittedAt, reviewedAt, rejectionReason, isSubmitting, submitKYC };
+  // Fetch KYC status from server
+  const fetchStatus = useCallback(async () => {
+    if (!userId) return;
+    try {
+      const resp = await fetch(`/api/v1/users/kyc/${userId}`);
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch KYC status: ${resp.statusText}`);
+      }
+      const data = await resp.json();
+      const kyc = data.data as KYCStatusResponse;
+      setStatus(kyc.status);
+      setSubmittedAt(kyc.submitted_at || null);
+      setReviewedAt(kyc.reviewed_at || null);
+      setRejectionReason(kyc.rejection_reason || null);
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load KYC status",
+      );
+    }
+  }, [userId]);
+
+  // Load status on mount and when userId changes
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const submitKYC = async (formData: FormData) => {
+    if (!userId) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const resp = await fetch(`/api/v1/users/kyc/${userId}`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!resp.ok) {
+        const errorData = await resp.json();
+        throw new Error(
+          errorData.message || `KYC submission failed: ${resp.statusText}`,
+        );
+      }
+      // Refresh status after successful submission
+      await fetchStatus();
+    } catch (err) {
+      const errorMsg =
+        err instanceof Error ? err.message : "Failed to submit KYC";
+      setError(errorMsg);
+      setStatus("rejected"); // Show failed state
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    status,
+    submittedAt,
+    reviewedAt,
+    rejectionReason,
+    isSubmitting,
+    submitKYC,
+    error,
+  };
 }
 
 export default function SettingsPage() {
-    const { isConnected, address } = useWallet();
-    const router = useRouter();
-    const [activeTab, setActiveTab] = useState<Tab>("profile");
-    const { locale, setLocale } = useLocale();
-    const t = useTranslations();
+  const { isConnected, address } = useWallet();
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<Tab>("profile");
+  const { locale, setLocale } = useLocale();
+  const t = useTranslations();
 
-    const kyc = useKYCState();
+  const kyc = useKYCState(address);
 
-    useEffect(() => {
-        if (!isConnected) router.push("/");
-    }, [isConnected, router]);
+  useEffect(() => {
+    if (!isConnected) router.push("/");
+  }, [isConnected, router]);
 
-    if (!isConnected) return null;
+  if (!isConnected) return null;
 
-    return (
-        <AppShell>
-            <motion.div
-                initial={{ opacity: 0, y: -8 }}
+  return (
+    <AppShell>
+      <motion.div
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mb-8"
+      >
+        <h1 className="text-2xl text-black dark:text-white sm:text-3xl">
+          Settings
+        </h1>
+        <p className="mt-1 text-sm text-black/40 dark:text-white/40">
+          Manage your account and preferences
+        </p>
+      </motion.div>
+
+      <div className="flex flex-col gap-8 lg:flex-row lg:gap-10">
+        {/* Sidebar tabs */}
+        <aside className="lg:w-52 shrink-0">
+          <nav className="space-y-0.5">
+            {TABS.map((tab) => {
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors text-left",
+                    activeTab === tab.id
+                      ? "bg-black/[0.04] dark:bg-white/[0.04] text-black dark:text-white font-medium"
+                      : "text-black/40 dark:text-white/40 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] hover:text-black/60 dark:hover:text-white/60",
+                  )}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* Tab content */}
+        <div className="flex-1 min-w-0">
+          <AnimatePresence mode="wait">
+            {activeTab === "profile" && (
+              <motion.div
+                key="profile"
+                initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="mb-8"
-            >
-                <h1 className="text-2xl text-black dark:text-white sm:text-3xl">Settings</h1>
-                <p className="mt-1 text-sm text-black/40 dark:text-white/40">Manage your account and preferences</p>
-            </motion.div>
-
-            <div className="flex flex-col gap-8 lg:flex-row lg:gap-10">
-                {/* Sidebar tabs */}
-                <aside className="lg:w-52 shrink-0">
-                    <nav className="space-y-0.5">
-                        {TABS.map((tab) => {
-                            const Icon = tab.icon;
-                            return (
-                                <button
-                                    key={tab.id}
-                                    onClick={() => setActiveTab(tab.id)}
-                                    className={cn(
-                                        "flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors text-left",
-                                        activeTab === tab.id
-                                            ? "bg-black/[0.04] dark:bg-white/[0.04] text-black dark:text-white font-medium"
-                                            : "text-black/40 dark:text-white/40 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] hover:text-black/60 dark:hover:text-white/60"
-                                    )}
-                                >
-                                    <Icon className="h-4 w-4 shrink-0" />
-                                    {tab.label}
-                                </button>
-                            );
-                        })}
-                    </nav>
-                </aside>
-
-                {/* Tab content */}
-                <div className="flex-1 min-w-0">
-                    <AnimatePresence mode="wait">
-                        {activeTab === "profile" && (
-                            <motion.div
-                                key="profile"
-                                initial={{ opacity: 0, y: 8 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: 8 }}
-                                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
-                            >
-                                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">Profile</h2>
-                                <div className="space-y-4">
-                                    <div>
-                                        <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">Wallet Address</label>
-                                        <div className="h-11 rounded-xl border border-black/8 dark:border-white/8 bg-black/[0.02] dark:bg-white/[0.02] px-4 flex items-center">
-                                            <span className="font-mono text-sm text-black/50 dark:text-white/50 truncate">{address}</span>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">Display Name</label>
-                                        <input
-                                            type="text"
-                                            placeholder="Enter a display name"
-                                            className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none transition-colors focus:border-black/25 dark:focus:border-white/25 focus:bg-white dark:focus:bg-[#100F0F]"
-                                        />
-                                    </div>
-                                    <button className="rounded-xl bg-black dark:bg-blue-600 px-5 py-2.5 text-sm text-white transition-opacity hover:opacity-75">
-                                        Save Changes
-                                    </button>
-                                </div>
-                            </motion.div>
-                        )}
-
-                        {activeTab === "verification" && (
-                            <motion.div
-                                key="verification"
-                                initial={{ opacity: 0, y: 8 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: 8 }}
-                                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
-                            >
-                                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">Identity Verification</h2>
-                                <KYCSection
-                                    status={kyc.status}
-                                    submittedAt={kyc.submittedAt}
-                                    reviewedAt={kyc.reviewedAt}
-                                    rejectionReason={kyc.rejectionReason}
-                                    onSubmit={kyc.submitKYC}
-                                    isSubmitting={kyc.isSubmitting}
-                                />
-                            </motion.div>
-                        )}
-
-                        {activeTab === "security" && (
-                            <motion.div
-                                key="security"
-                                initial={{ opacity: 0, y: 8 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: 8 }}
-                            >
-                                <SessionsSection />
-                            </motion.div>
-                        )}
-
-                        {activeTab === "notifications" && (
-                            <motion.div
-                                key="notifications"
-                                initial={{ opacity: 0, y: 8 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: 8 }}
-                                className="space-y-6"
-                            >
-                                <div className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6">
-                                    <h2 className="mb-5 text-sm font-medium text-black dark:text-white">Notification Preferences</h2>
-                                    <div className="space-y-4">
-                                        {[
-                                            { label: "Deposit confirmed", desc: "When a deposit is confirmed on-chain" },
-                                            { label: "Withdrawal processed", desc: "When a fiat withdrawal is settled" },
-                                            { label: "KYC status update", desc: "When your verification status changes" },
-                                            { label: "Yield accrual", desc: "Daily yield summary" },
-                                        ].map((item) => (
-                                            <div key={item.label} className="flex items-center justify-between gap-4">
-                                                <div>
-                                                    <p className="text-sm text-black dark:text-white">{item.label}</p>
-                                                    <p className="text-xs text-black/40 dark:text-white/40">{item.desc}</p>
-                                                </div>
-                                                <label className="relative inline-flex cursor-pointer items-center">
-                                                    <input type="checkbox" defaultChecked className="peer sr-only" />
-                                                    <div className="h-5 w-9 rounded-full bg-black/10 dark:bg-white/10 peer-checked:bg-black dark:peer-checked:bg-blue-600 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4" />
-                                                </label>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                                <SavingsNotificationsSection />
-                            </motion.div>
-                        )}
-
-                        {activeTab === "preferences" && (
-                            <motion.div
-                                key="preferences"
-                                initial={{ opacity: 0, y: 8 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: 8 }}
-                                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
-                            >
-                                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">Preferences</h2>
-                                <div className="space-y-4">
-                                    <div>
-                                        <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">Currency Display</label>
-                                        <select className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none appearance-none focus:border-black/25 dark:focus:border-white/25">
-                                            <option value="USD">USD ($)</option>
-                                            <option value="EUR">EUR (€)</option>
-                                            <option value="GBP">GBP (£)</option>
-                                            <option value="NGN">NGN (₦)</option>
-                                        </select>
-                                    </div>
-                                    <div>
-                                        <label
-                                            htmlFor="locale-select"
-                                            className="mb-1.5 block text-xs text-black/45 dark:text-white/45"
-                                        >
-                                            {t("settings.language")}
-                                        </label>
-                                        <select
-                                            id="locale-select"
-                                            value={locale}
-                                            onChange={(e) => setLocale(e.target.value as Locale)}
-                                            className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none appearance-none focus:border-black/25 dark:focus:border-white/25"
-                                        >
-                                            {SUPPORTED_LOCALES.map((l) => (
-                                                <option key={l} value={l}>
-                                                    {LOCALE_LABELS[l]}
-                                                </option>
-                                            ))}
-                                        </select>
-                                        <p className="mt-1.5 text-xs text-black/40 dark:text-white/40">
-                                            {t("settings.languageDescription")}
-                                        </p>
-                                    </div>
-                                    <BankAccountsSection />
-                                </div>
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
+                exit={{ opacity: 0, y: 8 }}
+                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
+              >
+                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">
+                  Profile
+                </h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">
+                      Wallet Address
+                    </label>
+                    <div className="h-11 rounded-xl border border-black/8 dark:border-white/8 bg-black/[0.02] dark:bg-white/[0.02] px-4 flex items-center">
+                      <span className="font-mono text-sm text-black/50 dark:text-white/50 truncate">
+                        {address}
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">
+                      Display Name
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="Enter a display name"
+                      className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none transition-colors focus:border-black/25 dark:focus:border-white/25 focus:bg-white dark:focus:bg-[#100F0F]"
+                    />
+                  </div>
+                  <button className="rounded-xl bg-black dark:bg-blue-600 px-5 py-2.5 text-sm text-white transition-opacity hover:opacity-75">
+                    Save Changes
+                  </button>
                 </div>
-            </div>
-        </AppShell>
-    );
+              </motion.div>
+            )}
+
+            {activeTab === "verification" && (
+              <motion.div
+                key="verification"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
+              >
+                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">
+                  Identity Verification
+                </h2>
+                <KYCSection
+                  status={kyc.status}
+                  submittedAt={kyc.submittedAt}
+                  reviewedAt={kyc.reviewedAt}
+                  rejectionReason={kyc.rejectionReason}
+                  onSubmit={kyc.submitKYC}
+                  isSubmitting={kyc.isSubmitting}
+                />
+              </motion.div>
+            )}
+
+            {activeTab === "security" && (
+              <motion.div
+                key="security"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+              >
+                <SessionsSection />
+              </motion.div>
+            )}
+
+            {activeTab === "notifications" && (
+              <motion.div
+                key="notifications"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+                className="space-y-6"
+              >
+                <div className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6">
+                  <h2 className="mb-5 text-sm font-medium text-black dark:text-white">
+                    Notification Preferences
+                  </h2>
+                  <div className="space-y-4">
+                    {[
+                      {
+                        label: "Deposit confirmed",
+                        desc: "When a deposit is confirmed on-chain",
+                      },
+                      {
+                        label: "Withdrawal processed",
+                        desc: "When a fiat withdrawal is settled",
+                      },
+                      {
+                        label: "KYC status update",
+                        desc: "When your verification status changes",
+                      },
+                      { label: "Yield accrual", desc: "Daily yield summary" },
+                    ].map((item) => (
+                      <div
+                        key={item.label}
+                        className="flex items-center justify-between gap-4"
+                      >
+                        <div>
+                          <p className="text-sm text-black dark:text-white">
+                            {item.label}
+                          </p>
+                          <p className="text-xs text-black/40 dark:text-white/40">
+                            {item.desc}
+                          </p>
+                        </div>
+                        <label className="relative inline-flex cursor-pointer items-center">
+                          <input
+                            type="checkbox"
+                            defaultChecked
+                            className="peer sr-only"
+                          />
+                          <div className="h-5 w-9 rounded-full bg-black/10 dark:bg-white/10 peer-checked:bg-black dark:peer-checked:bg-blue-600 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4" />
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <SavingsNotificationsSection />
+              </motion.div>
+            )}
+
+            {activeTab === "preferences" && (
+              <motion.div
+                key="preferences"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+                className="rounded-2xl border border-black/8 dark:border-white/8 bg-white dark:bg-[#100F0F] p-6"
+              >
+                <h2 className="mb-5 text-sm font-medium text-black dark:text-white">
+                  Preferences
+                </h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="mb-1.5 block text-xs text-black/45 dark:text-white/45">
+                      Currency Display
+                    </label>
+                    <select className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none appearance-none focus:border-black/25 dark:focus:border-white/25">
+                      <option value="USD">USD ($)</option>
+                      <option value="EUR">EUR (€)</option>
+                      <option value="GBP">GBP (£)</option>
+                      <option value="NGN">NGN (₦)</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="locale-select"
+                      className="mb-1.5 block text-xs text-black/45 dark:text-white/45"
+                    >
+                      {t("settings.language")}
+                    </label>
+                    <select
+                      id="locale-select"
+                      value={locale}
+                      onChange={(e) => setLocale(e.target.value as Locale)}
+                      className="h-11 w-full rounded-xl border border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] px-4 text-sm outline-none appearance-none focus:border-black/25 dark:focus:border-white/25"
+                    >
+                      {SUPPORTED_LOCALES.map((l) => (
+                        <option key={l} value={l}>
+                          {LOCALE_LABELS[l]}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1.5 text-xs text-black/40 dark:text-white/40">
+                      {t("settings.languageDescription")}
+                    </p>
+                  </div>
+                  <BankAccountsSection />
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </AppShell>
+  );
 }

--- a/apps/dapp/frontend/app/settings/page.tsx
+++ b/apps/dapp/frontend/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { ShieldCheck, User, Bell, Globe, Monitor } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
@@ -188,11 +189,10 @@ function useKYCState(userId: string | undefined) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch KYC status from server
+  // Fetch KYC status from server (authenticated endpoint that uses session user ID)
   const fetchStatus = useCallback(async () => {
-    if (!userId) return;
     try {
-      const resp = await fetch(`/api/v1/users/kyc/${userId}`);
+      const resp = await fetch(`/api/v1/users/me/kyc`);
       if (!resp.ok) {
         throw new Error(`Failed to fetch KYC status: ${resp.statusText}`);
       }
@@ -208,19 +208,18 @@ function useKYCState(userId: string | undefined) {
         err instanceof Error ? err.message : "Failed to load KYC status",
       );
     }
-  }, [userId]);
+  }, []);
 
-  // Load status on mount and when userId changes
+  // Load status on mount
   useEffect(() => {
     fetchStatus();
   }, [fetchStatus]);
 
   const submitKYC = async (formData: FormData) => {
-    if (!userId) return;
     setIsSubmitting(true);
     setError(null);
     try {
-      const resp = await fetch(`/api/v1/users/kyc/${userId}`, {
+      const resp = await fetch(`/api/v1/users/me/kyc`, {
         method: "POST",
         body: formData,
       });
@@ -260,7 +259,7 @@ export default function SettingsPage() {
   const { locale, setLocale } = useLocale();
   const t = useTranslations();
 
-  const kyc = useKYCState(address);
+  const kyc = useKYCState();
 
   useEffect(() => {
     if (!isConnected) router.push("/");

--- a/apps/dapp/frontend/app/settings/page.tsx
+++ b/apps/dapp/frontend/app/settings/page.tsx
@@ -181,7 +181,11 @@ interface KYCStatusResponse {
   rejection_reason?: string;
 }
 
-function useKYCState(userId: string | undefined) {
+// No userId parameter: every call inside goes to /api/v1/users/me/kyc,
+// which resolves the user from the session. The parameter was declared
+// and never read, and the call site passed nothing, so the build failed
+// with "Expected 1 arguments, but got 0".
+function useKYCState() {
   const [status, setStatus] = useState<KYCStatus>("unverified");
   const [submittedAt, setSubmittedAt] = useState<string | null>(null);
   const [reviewedAt, setReviewedAt] = useState<string | null>(null);

--- a/apps/dapp/frontend/components/websocket-provider.tsx
+++ b/apps/dapp/frontend/components/websocket-provider.tsx
@@ -1,33 +1,34 @@
 "use client";
 
 import {
-    createContext,
-    useCallback,
-    useContext,
-    useEffect,
-    useMemo,
-    useRef,
-    type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
 } from "react";
 import { useWallet } from "@/components/wallet-provider";
 import { usePortfolio } from "@/components/portfolio-provider";
 import { useNotifications } from "@/components/notifications-provider";
 import { useWebSocket, type UseWebSocketReturn } from "@/hooks/useWebSocket";
+import { getAccessToken } from "@/lib/auth/token-store";
 import {
-    type WSConnectionStatus,
-    type WSEvent,
-    type BalanceUpdatedPayload,
-    type DepositConfirmedPayload,
-    type WithdrawalConfirmedPayload,
-    type YieldAccruedPayload,
-    type SettlementStatusChangedPayload,
-    type VaultPausedPayload,
-    type VaultUnpausedPayload,
-    type EmergencyQueueFillPayload,
-    type SecurityEventPayload,
-    type BreakerTripPayload,
-    type GoalMilestonePayload,
-    type NudgeAlertPayload,
+  type WSConnectionStatus,
+  type WSEvent,
+  type BalanceUpdatedPayload,
+  type DepositConfirmedPayload,
+  type WithdrawalConfirmedPayload,
+  type YieldAccruedPayload,
+  type SettlementStatusChangedPayload,
+  type VaultPausedPayload,
+  type VaultUnpausedPayload,
+  type EmergencyQueueFillPayload,
+  type SecurityEventPayload,
+  type BreakerTripPayload,
+  type GoalMilestonePayload,
+  type NudgeAlertPayload,
 } from "@/lib/ws-events";
 import { getExplorerTxUrl } from "@/utils/explorer";
 
@@ -36,40 +37,40 @@ import { getExplorerTxUrl } from "@/utils/explorer";
 // ---------------------------------------------------------------------------
 
 interface WebSocketContextValue {
-    /** Friendly connection state for UI indicators */
-    status: WSConnectionStatus;
-    /** True only when the socket is fully open */
-    isConnected: boolean;
-    /**
-     * True when displayed values may no longer reflect the chain — i.e. the
-     * socket is not live. Components rendering a balance must use this to
-     * visually distinguish the value from a live one.
-     */
-    isStale: boolean;
-    /** Epoch ms of the last confirmed sync (event or HTTP reconcile) */
-    lastUpdatedAt: number | null;
-    /** The most recent raw event received */
-    lastEvent: WSEvent | null;
-    /** Imperatively subscribe to an additional channel */
-    subscribe: UseWebSocketReturn["subscribe"];
-    /** Imperatively unsubscribe from a channel */
-    unsubscribe: UseWebSocketReturn["unsubscribe"];
-    /** Force-close the socket and stop reconnects */
-    disconnect: UseWebSocketReturn["disconnect"];
-    /** Reset attempt counter and reconnect immediately */
-    manualReconnect: UseWebSocketReturn["manualReconnect"];
+  /** Friendly connection state for UI indicators */
+  status: WSConnectionStatus;
+  /** True only when the socket is fully open */
+  isConnected: boolean;
+  /**
+   * True when displayed values may no longer reflect the chain — i.e. the
+   * socket is not live. Components rendering a balance must use this to
+   * visually distinguish the value from a live one.
+   */
+  isStale: boolean;
+  /** Epoch ms of the last confirmed sync (event or HTTP reconcile) */
+  lastUpdatedAt: number | null;
+  /** The most recent raw event received */
+  lastEvent: WSEvent | null;
+  /** Imperatively subscribe to an additional channel */
+  subscribe: UseWebSocketReturn["subscribe"];
+  /** Imperatively unsubscribe from a channel */
+  unsubscribe: UseWebSocketReturn["unsubscribe"];
+  /** Force-close the socket and stop reconnects */
+  disconnect: UseWebSocketReturn["disconnect"];
+  /** Reset attempt counter and reconnect immediately */
+  manualReconnect: UseWebSocketReturn["manualReconnect"];
 }
 
 const WebSocketContext = createContext<WebSocketContextValue>({
-    status: "offline",
-    isConnected: false,
-    isStale: true,
-    lastUpdatedAt: null,
-    lastEvent: null,
-    subscribe: () => {},
-    unsubscribe: () => {},
-    disconnect: () => {},
-    manualReconnect: () => {},
+  status: "offline",
+  isConnected: false,
+  isStale: true,
+  lastUpdatedAt: null,
+  lastEvent: null,
+  subscribe: () => {},
+  unsubscribe: () => {},
+  disconnect: () => {},
+  manualReconnect: () => {},
 });
 
 // ---------------------------------------------------------------------------
@@ -85,310 +86,322 @@ const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "";
  * so it can call usePortfolio() / useNotifications() to dispatch live updates.
  */
 interface WebSocketProviderProps {
-    children: ReactNode;
-    /**
-     * Channels to subscribe to instead of the wallet-derived set.
-     *
-     * Only the E2E harness passes this. The production tree subscribes on
-     * behalf of a connected wallet, which a browser-driven test cannot
-     * produce; without an override the harness would subscribe to nothing and
-     * the re-subscribe-on-reconnect behaviour would be untestable.
-     */
-    channelsOverride?: string[];
-    /** Heartbeat ping interval in ms. Harness-only; see channelsOverride. */
-    heartbeatInterval?: number;
-    /** Pong grace period in ms. Harness-only; see channelsOverride. */
-    heartbeatTimeout?: number;
+  children: ReactNode;
+  /**
+   * Channels to subscribe to instead of the wallet-derived set.
+   *
+   * Only the E2E harness passes this. The production tree subscribes on
+   * behalf of a connected wallet, which a browser-driven test cannot
+   * produce; without an override the harness would subscribe to nothing and
+   * the re-subscribe-on-reconnect behaviour would be untestable.
+   */
+  channelsOverride?: string[];
+  /** Heartbeat ping interval in ms. Harness-only; see channelsOverride. */
+  heartbeatInterval?: number;
+  /** Pong grace period in ms. Harness-only; see channelsOverride. */
+  heartbeatTimeout?: number;
 }
 
 export function WebSocketProvider({
-    children,
-    channelsOverride,
+  children,
+  channelsOverride,
+  heartbeatInterval,
+  heartbeatTimeout,
+}: WebSocketProviderProps) {
+  const { address } = useWallet();
+  const { applyBalanceUpdate, applyYieldAccrual, refreshBalances } =
+    usePortfolio();
+  const { addNotification, setConnectionState } = useNotifications();
+
+  // Get current token from token store. Real session token, not a forged one.
+  // Pass a token getter function to useWebSocket so it always uses the current token.
+  const getToken = useCallback(() => getAccessToken(), []);
+
+  const walletChannels = useMemo<string[]>(() => {
+    if (!address) return [];
+    return [
+      `user:${address}`,
+      "vaults:global",
+      "settlements:global",
+      "notifications:safety",
+    ];
+  }, [address]);
+
+  const channels = channelsOverride ?? walletChannels;
+
+  const handleEvent = useCallback(
+    (event: WSEvent) => {
+      switch (event.type) {
+        case "balance_updated": {
+          const p = event.payload as unknown as BalanceUpdatedPayload;
+          applyBalanceUpdate(p.asset, p.newBalance);
+          break;
+        }
+
+        case "deposit_confirmed": {
+          const p = event.payload as unknown as DepositConfirmedPayload;
+          addNotification(
+            {
+              type: "deposit_confirmed",
+              title: "Deposit Confirmed",
+              message: `Deposited ${p.amount.toFixed(2)} ${p.asset} into ${p.vaultName}`,
+              actionUrl: getExplorerTxUrl(p.txHash),
+              actionLabel: "View on Explorer",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "withdrawal_confirmed": {
+          const p = event.payload as unknown as WithdrawalConfirmedPayload;
+          addNotification(
+            {
+              type: "withdrawal_processed",
+              title: "Withdrawal Confirmed",
+              message: `Received ${p.netAmount.toFixed(2)} ${p.asset} from ${p.vaultName}`,
+              actionUrl: getExplorerTxUrl(p.txHash),
+              actionLabel: "View on Explorer",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "yield_accrued": {
+          const p = event.payload as unknown as YieldAccruedPayload;
+          applyYieldAccrual(p.positionId, p.deltaYield);
+          break;
+        }
+
+        case "settlement_status_changed": {
+          const p = event.payload as unknown as SettlementStatusChangedPayload;
+          addNotification(
+            {
+              type: "offramp_status",
+              title: "Settlement Updated",
+              message:
+                p.message ?? `Settlement ${p.settlementId} is now ${p.status}`,
+              actionUrl: "/offramp",
+              actionLabel: "View Off-ramp",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "vault_paused": {
+          const p = event.payload as unknown as VaultPausedPayload;
+          addNotification(
+            {
+              type: "breaker_trip",
+              category: "safety",
+              priority: "safety",
+              title: "Vault Paused / Circuit Breaker",
+              message: p.reason
+                ? `Vault paused: ${p.reason}`
+                : `Vault ${p.vaultId} has been paused by the safety circuit breaker.`,
+              actionUrl: "/vaults",
+              actionLabel: "View Vault Status",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "vault_unpaused": {
+          const p = event.payload as unknown as VaultUnpausedPayload;
+          addNotification(
+            {
+              type: "rebalance_event",
+              category: "transactional",
+              priority: "transactional",
+              title: "Vault Resumed",
+              message: `Vault ${p.vaultId || "operations"} has been resumed. Deposits and withdrawals are active.`,
+              actionUrl: "/vaults",
+              actionLabel: "View Vault",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "emergency_queue_fill": {
+          const p = event.payload as unknown as EmergencyQueueFillPayload;
+          addNotification(
+            {
+              type: "emergency_queue_fill",
+              category: "safety",
+              priority: "safety",
+              title: "Emergency Queue Warning",
+              message:
+                p.message ||
+                `Emergency queue ${p.queueId} (${p.asset}) fill level reached ${p.fillPercentage}%.`,
+              actionUrl: "/vaults",
+              actionLabel: "Manage Emergency Queue",
+              coalesceKey: `emergency_queue_fill_${p.asset}`,
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "security_event": {
+          const p = event.payload as unknown as SecurityEventPayload;
+          addNotification(
+            {
+              type: "security_event",
+              category: "safety",
+              priority: "safety",
+              title: "Security Event Detected",
+              message:
+                p.details ||
+                `Security event ${p.eventType} flagged on account.`,
+              actionUrl: "/settings",
+              actionLabel: "Security Settings",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "breaker_trip": {
+          const p = event.payload as unknown as BreakerTripPayload;
+          addNotification(
+            {
+              type: "breaker_trip",
+              category: "safety",
+              priority: "safety",
+              title: "Circuit Breaker Tripped",
+              message:
+                p.reason ||
+                `Circuit breaker ${p.breakerId} tripped for ${p.asset || "vault"}.`,
+              actionUrl: "/vaults",
+              actionLabel: "Review Circuit Breaker",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "goal_milestone": {
+          const p = event.payload as unknown as GoalMilestonePayload;
+          addNotification(
+            {
+              type: "goal_milestone",
+              title: "Goal Milestone Reached!",
+              message:
+                p.message ||
+                `Congratulations! You reached ${p.progress}% of your ${p.goalTitle} goal.`,
+              actionUrl: "/savings",
+              actionLabel: "View Savings Goal",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        case "nudge_alert": {
+          const p = event.payload as unknown as NudgeAlertPayload;
+          addNotification(
+            {
+              type: "nudge_recommendation",
+              title: p.title || "New Nudge",
+              message: p.message,
+              actionUrl: p.actionUrl || "/savings",
+              actionLabel: p.actionLabel || "Learn More",
+            },
+            { showToast: true },
+          );
+          break;
+        }
+
+        default:
+          break;
+      }
+    },
+    [applyBalanceUpdate, applyYieldAccrual, addNotification],
+  );
+
+  // Pull the authoritative balances over HTTP after every (re)connect.
+  // The hub replays a bounded per-channel history on subscribe, which is
+  // not the same as a snapshot — reconciling is what makes a reconnected
+  // client's numbers trustworthy rather than merely recent.
+  //
+  // Notifications reconcile on their own via setConnectionState below;
+  // duplicating that call here would double-fetch on every reconnect.
+  const reconcile = useCallback(async () => {
+    await refreshBalances();
+  }, [refreshBalances]);
+
+  const {
+    isConnected,
+    status,
+    lastEvent,
+    lastUpdatedAt,
+    subscribe,
+    unsubscribe,
+    disconnect,
+    manualReconnect,
+  } = useWebSocket({
+    url: WS_URL,
+    token: getToken(),
+    channels,
+    onEvent: handleEvent,
+    onPoll: refreshBalances,
+    onReconcile: reconcile,
     heartbeatInterval,
     heartbeatTimeout,
-}: WebSocketProviderProps) {
-    const { address } = useWallet();
-    const { applyBalanceUpdate, applyYieldAccrual, refreshBalances } = usePortfolio();
-    const { addNotification, setConnectionState } = useNotifications();
+  });
 
-    const token = address ? `mock_jwt_${address}` : "";
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    // Skip the initial invocation on mount so that merely mounting the
+    // provider (or a wallet-address change) does not trigger a redundant
+    // reconciliation fetch.  Only actual connection-state transitions
+    // (true→false or false→true) should be reported.
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    setConnectionState(WS_URL ? isConnected : false);
+  }, [isConnected, setConnectionState]);
 
-    const walletChannels = useMemo<string[]>(() => {
-        if (!address) return [];
-        return [
-            `user:${address}`,
-            "vaults:global",
-            "settlements:global",
-            "notifications:safety",
-        ];
-    }, [address]);
+  const value = useMemo<WebSocketContextValue>(() => {
+    const effectiveStatus: WSConnectionStatus = WS_URL ? status : "offline";
+    return {
+      status: effectiveStatus,
+      isConnected: WS_URL ? isConnected : false,
+      isStale: effectiveStatus !== "connected",
+      lastUpdatedAt,
+      lastEvent,
+      subscribe,
+      unsubscribe,
+      disconnect,
+      manualReconnect,
+    };
+  }, [
+    status,
+    isConnected,
+    lastUpdatedAt,
+    lastEvent,
+    subscribe,
+    unsubscribe,
+    disconnect,
+    manualReconnect,
+  ]);
 
-    const channels = channelsOverride ?? walletChannels;
-
-    const handleEvent = useCallback(
-        (event: WSEvent) => {
-            switch (event.type) {
-                case "balance_updated": {
-                    const p = event.payload as unknown as BalanceUpdatedPayload;
-                    applyBalanceUpdate(p.asset, p.newBalance);
-                    break;
-                }
-
-                case "deposit_confirmed": {
-                    const p = event.payload as unknown as DepositConfirmedPayload;
-                    addNotification(
-                        {
-                            type: "deposit_confirmed",
-                            title: "Deposit Confirmed",
-                            message: `Deposited ${p.amount.toFixed(2)} ${p.asset} into ${p.vaultName}`,
-                            actionUrl: getExplorerTxUrl(p.txHash),
-                            actionLabel: "View on Explorer",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "withdrawal_confirmed": {
-                    const p = event.payload as unknown as WithdrawalConfirmedPayload;
-                    addNotification(
-                        {
-                            type: "withdrawal_processed",
-                            title: "Withdrawal Confirmed",
-                            message: `Received ${p.netAmount.toFixed(2)} ${p.asset} from ${p.vaultName}`,
-                            actionUrl: getExplorerTxUrl(p.txHash),
-                            actionLabel: "View on Explorer",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "yield_accrued": {
-                    const p = event.payload as unknown as YieldAccruedPayload;
-                    applyYieldAccrual(p.positionId, p.deltaYield);
-                    break;
-                }
-
-                case "settlement_status_changed": {
-                    const p = event.payload as unknown as SettlementStatusChangedPayload;
-                    addNotification(
-                        {
-                            type: "offramp_status",
-                            title: "Settlement Updated",
-                            message:
-                                p.message ??
-                                `Settlement ${p.settlementId} is now ${p.status}`,
-                            actionUrl: "/offramp",
-                            actionLabel: "View Off-ramp",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "vault_paused": {
-                    const p = event.payload as unknown as VaultPausedPayload;
-                    addNotification(
-                        {
-                            type: "breaker_trip",
-                            category: "safety",
-                            priority: "safety",
-                            title: "Vault Paused / Circuit Breaker",
-                            message: p.reason
-                                ? `Vault paused: ${p.reason}`
-                                : `Vault ${p.vaultId} has been paused by the safety circuit breaker.`,
-                            actionUrl: "/vaults",
-                            actionLabel: "View Vault Status",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "vault_unpaused": {
-                    const p = event.payload as unknown as VaultUnpausedPayload;
-                    addNotification(
-                        {
-                            type: "rebalance_event",
-                            category: "transactional",
-                            priority: "transactional",
-                            title: "Vault Resumed",
-                            message: `Vault ${p.vaultId || "operations"} has been resumed. Deposits and withdrawals are active.`,
-                            actionUrl: "/vaults",
-                            actionLabel: "View Vault",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "emergency_queue_fill": {
-                    const p = event.payload as unknown as EmergencyQueueFillPayload;
-                    addNotification(
-                        {
-                            type: "emergency_queue_fill",
-                            category: "safety",
-                            priority: "safety",
-                            title: "Emergency Queue Warning",
-                            message:
-                                p.message ||
-                                `Emergency queue ${p.queueId} (${p.asset}) fill level reached ${p.fillPercentage}%.`,
-                            actionUrl: "/vaults",
-                            actionLabel: "Manage Emergency Queue",
-                            coalesceKey: `emergency_queue_fill_${p.asset}`,
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "security_event": {
-                    const p = event.payload as unknown as SecurityEventPayload;
-                    addNotification(
-                        {
-                            type: "security_event",
-                            category: "safety",
-                            priority: "safety",
-                            title: "Security Event Detected",
-                            message:
-                                p.details || `Security event ${p.eventType} flagged on account.`,
-                            actionUrl: "/settings",
-                            actionLabel: "Security Settings",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "breaker_trip": {
-                    const p = event.payload as unknown as BreakerTripPayload;
-                    addNotification(
-                        {
-                            type: "breaker_trip",
-                            category: "safety",
-                            priority: "safety",
-                            title: "Circuit Breaker Tripped",
-                            message:
-                                p.reason ||
-                                `Circuit breaker ${p.breakerId} tripped for ${p.asset || "vault"}.`,
-                            actionUrl: "/vaults",
-                            actionLabel: "Review Circuit Breaker",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "goal_milestone": {
-                    const p = event.payload as unknown as GoalMilestonePayload;
-                    addNotification(
-                        {
-                            type: "goal_milestone",
-                            title: "Goal Milestone Reached!",
-                            message:
-                                p.message ||
-                                `Congratulations! You reached ${p.progress}% of your ${p.goalTitle} goal.`,
-                            actionUrl: "/savings",
-                            actionLabel: "View Savings Goal",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                case "nudge_alert": {
-                    const p = event.payload as unknown as NudgeAlertPayload;
-                    addNotification(
-                        {
-                            type: "nudge_recommendation",
-                            title: p.title || "New Nudge",
-                            message: p.message,
-                            actionUrl: p.actionUrl || "/savings",
-                            actionLabel: p.actionLabel || "Learn More",
-                        },
-                        { showToast: true }
-                    );
-                    break;
-                }
-
-                default:
-                    break;
-            }
-        },
-        [applyBalanceUpdate, applyYieldAccrual, addNotification]
-    );
-
-    // Pull the authoritative balances over HTTP after every (re)connect.
-    // The hub replays a bounded per-channel history on subscribe, which is
-    // not the same as a snapshot — reconciling is what makes a reconnected
-    // client's numbers trustworthy rather than merely recent.
-    //
-    // Notifications reconcile on their own via setConnectionState below;
-    // duplicating that call here would double-fetch on every reconnect.
-    const reconcile = useCallback(async () => {
-        await refreshBalances();
-    }, [refreshBalances]);
-
-    const {
-        isConnected,
-        status,
-        lastEvent,
-        lastUpdatedAt,
-        subscribe,
-        unsubscribe,
-        disconnect,
-        manualReconnect,
-    } = useWebSocket({
-        url: WS_URL,
-        token,
-        channels,
-        onEvent: handleEvent,
-        onPoll: refreshBalances,
-        onReconcile: reconcile,
-        heartbeatInterval,
-        heartbeatTimeout,
-    });
-
-    const hasMountedRef = useRef(false);
-    useEffect(() => {
-        // Skip the initial invocation on mount so that merely mounting the
-        // provider (or a wallet-address change) does not trigger a redundant
-        // reconciliation fetch.  Only actual connection-state transitions
-        // (true→false or false→true) should be reported.
-        if (!hasMountedRef.current) {
-            hasMountedRef.current = true;
-            return;
-        }
-        setConnectionState(WS_URL ? isConnected : false);
-    }, [isConnected, setConnectionState]);
-
-    const value = useMemo<WebSocketContextValue>(() => {
-        const effectiveStatus: WSConnectionStatus = WS_URL ? status : "offline";
-        return {
-            status: effectiveStatus,
-            isConnected: WS_URL ? isConnected : false,
-            isStale: effectiveStatus !== "connected",
-            lastUpdatedAt,
-            lastEvent,
-            subscribe,
-            unsubscribe,
-            disconnect,
-            manualReconnect,
-        };
-    }, [status, isConnected, lastUpdatedAt, lastEvent, subscribe, unsubscribe, disconnect, manualReconnect]);
-
-    return (
-        <WebSocketContext.Provider value={value}>
-            {children}
-        </WebSocketContext.Provider>
-    );
+  return (
+    <WebSocketContext.Provider value={value}>
+      {children}
+    </WebSocketContext.Provider>
+  );
 }
 
 export function useWebSocketContext() {
-    return useContext(WebSocketContext);
+  return useContext(WebSocketContext);
 }
 
 export function useWebSocketEvents() {
-    return useContext(WebSocketContext);
+  return useContext(WebSocketContext);
 }

--- a/apps/dapp/frontend/components/websocket-provider.tsx
+++ b/apps/dapp/frontend/components/websocket-provider.tsx
@@ -114,7 +114,8 @@ export function WebSocketProvider({
   const { addNotification, setConnectionState } = useNotifications();
 
   // Get current token from token store. Real session token, not a forged one.
-  // Pass a token getter function to useWebSocket so it always uses the current token.
+  // Pass a token getter function to useWebSocket so it always uses the current token
+  // before each connection attempt (not just at render time).
   const getToken = useCallback(() => getAccessToken(), []);
 
   const walletChannels = useMemo<string[]>(() => {
@@ -345,7 +346,7 @@ export function WebSocketProvider({
     manualReconnect,
   } = useWebSocket({
     url: WS_URL,
-    token: getToken(),
+    getToken,
     channels,
     onEvent: handleEvent,
     onPoll: refreshBalances,

--- a/apps/dapp/frontend/components/websocket-provider.tsx
+++ b/apps/dapp/frontend/components/websocket-provider.tsx
@@ -96,6 +96,17 @@ interface WebSocketProviderProps {
    * the re-subscribe-on-reconnect behaviour would be untestable.
    */
   channelsOverride?: string[];
+  /**
+   * Token to authenticate the socket with instead of the stored session one.
+   *
+   * Only the E2E harness passes this, for the same reason as
+   * channelsOverride. The real token is minted by a wallet signature, and
+   * AuthProvider clears the stored session whenever no wallet is connected,
+   * so a browser-driven test cannot hold one: the socket would be refused
+   * for want of a credential and every reconnection assertion would observe
+   * "offline" rather than the behaviour under test.
+   */
+  tokenOverride?: string;
   /** Heartbeat ping interval in ms. Harness-only; see channelsOverride. */
   heartbeatInterval?: number;
   /** Pong grace period in ms. Harness-only; see channelsOverride. */
@@ -105,6 +116,7 @@ interface WebSocketProviderProps {
 export function WebSocketProvider({
   children,
   channelsOverride,
+  tokenOverride,
   heartbeatInterval,
   heartbeatTimeout,
 }: WebSocketProviderProps) {
@@ -116,7 +128,10 @@ export function WebSocketProvider({
   // Get current token from token store. Real session token, not a forged one.
   // Pass a token getter function to useWebSocket so it always uses the current token
   // before each connection attempt (not just at render time).
-  const getToken = useCallback(() => getAccessToken(), []);
+  const getToken = useCallback(
+    () => tokenOverride ?? getAccessToken(),
+    [tokenOverride],
+  );
 
   const walletChannels = useMemo<string[]>(() => {
     if (!address) return [];

--- a/apps/dapp/frontend/hooks/useWebSocket.ts
+++ b/apps/dapp/frontend/hooks/useWebSocket.ts
@@ -1,64 +1,59 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
-    useCallback,
-    useEffect,
-    useRef,
-    useState,
-} from "react";
-import {
-    buildSocketUrl,
-    isPongFrame,
-    normalizeServerEvent,
-    type ClientWireMessage,
-    type WSConnectionStatus,
-    type WSEvent,
+  buildSocketUrl,
+  isPongFrame,
+  normalizeServerEvent,
+  type ClientWireMessage,
+  type WSConnectionStatus,
+  type WSEvent,
 } from "@/lib/ws-events";
 
 interface UseWebSocketOptions {
-    /** WebSocket server URL, e.g. wss://api.nester.fi/ws */
-    url: string;
-    /** JWT for authenticating the session on connect */
-    token: string;
-    /** Channels to subscribe to on connect, then again after reconnection */
-    channels: string[];
-    /** Called for every event message received */
-    onEvent: (event: WSEvent) => void;
-    /** How many reconnect attempts before giving up (default: 5) */
-    reconnectAttempts?: number;
-    /** Base interval for exponential back-off in ms (default: 1000) */
-    reconnectInterval?: number;
-    /** Interval in ms for REST polling fallback (default: 30 000) */
-    pollInterval?: number;
-    /** Optional: called to fetch latest snapshot via REST when polling */
-    onPoll?: () => Promise<void>;
-    /**
-     * Called after every successful (re)connect to reconcile state over HTTP.
-     * The hub replays buffered history on subscribe, but that buffer is
-     * bounded and channel-scoped — it is not a snapshot. Treating the first
-     * pushed message as the current state is how a reconnected client ends up
-     * confidently displaying a wrong balance. Defaults to `onPoll`.
-     */
-    onReconcile?: () => Promise<void>;
-    /** How often to send a heartbeat ping in ms (default: 30 000) */
-    heartbeatInterval?: number;
-    /** How long to wait for a pong before assuming the link is dead (default: 10 000) */
-    heartbeatTimeout?: number;
+  /** WebSocket server URL, e.g. wss://api.nester.fi/ws */
+  url: string;
+  /** Function to get JWT for authenticating the session. Called before each connection attempt. */
+  getToken: () => string | null;
+  /** Channels to subscribe to on connect, then again after reconnection */
+  channels: string[];
+  /** Called for every event message received */
+  onEvent: (event: WSEvent) => void;
+  /** How many reconnect attempts before giving up (default: 5) */
+  reconnectAttempts?: number;
+  /** Base interval for exponential back-off in ms (default: 1000) */
+  reconnectInterval?: number;
+  /** Interval in ms for REST polling fallback (default: 30 000) */
+  pollInterval?: number;
+  /** Optional: called to fetch latest snapshot via REST when polling */
+  onPoll?: () => Promise<void>;
+  /**
+   * Called after every successful (re)connect to reconcile state over HTTP.
+   * The hub replays buffered history on subscribe, but that buffer is
+   * bounded and channel-scoped — it is not a snapshot. Treating the first
+   * pushed message as the current state is how a reconnected client ends up
+   * confidently displaying a wrong balance. Defaults to `onPoll`.
+   */
+  onReconcile?: () => Promise<void>;
+  /** How often to send a heartbeat ping in ms (default: 30 000) */
+  heartbeatInterval?: number;
+  /** How long to wait for a pong before assuming the link is dead (default: 10 000) */
+  heartbeatTimeout?: number;
 }
 
 export interface UseWebSocketReturn {
-    isConnected: boolean;
-    status: WSConnectionStatus;
-    lastEvent: WSEvent | null;
-    /**
-     * Epoch ms of the last time displayed data was known-current — either an
-     * event arrived or an HTTP reconcile completed. null until first sync.
-     */
-    lastUpdatedAt: number | null;
-    subscribe: (channel: string) => void;
-    unsubscribe: (channel: string) => void;
-    disconnect: () => void;
-    manualReconnect: () => void;
+  isConnected: boolean;
+  status: WSConnectionStatus;
+  lastEvent: WSEvent | null;
+  /**
+   * Epoch ms of the last time displayed data was known-current — either an
+   * event arrived or an HTTP reconcile completed. null until first sync.
+   */
+  lastUpdatedAt: number | null;
+  subscribe: (channel: string) => void;
+  unsubscribe: (channel: string) => void;
+  disconnect: () => void;
+  manualReconnect: () => void;
 }
 
 const MAX_RECONNECT_ATTEMPTS = 5;
@@ -91,11 +86,11 @@ export const BACKOFF_JITTER_RATIO = 0.5;
  * subtracted — see getJitteredReconnectDelay.
  */
 export function getReconnectDelay(
-    attempt: number,
-    base: number = BASE_RECONNECT_INTERVAL_MS,
+  attempt: number,
+  base: number = BASE_RECONNECT_INTERVAL_MS,
 ): number {
-    const safeAttempt = Math.max(0, attempt);
-    return Math.min(base * 2 ** safeAttempt, MAX_BACKOFF_MS);
+  const safeAttempt = Math.max(0, attempt);
+  return Math.min(base * 2 ** safeAttempt, MAX_BACKOFF_MS);
 }
 
 /**
@@ -106,428 +101,481 @@ export function getReconnectDelay(
  * `random` is injectable so the jitter can be asserted deterministically.
  */
 export function getJitteredReconnectDelay(
-    attempt: number,
-    base: number = BASE_RECONNECT_INTERVAL_MS,
-    random: () => number = Math.random,
+  attempt: number,
+  base: number = BASE_RECONNECT_INTERVAL_MS,
+  random: () => number = Math.random,
 ): number {
-    const ceiling = getReconnectDelay(attempt, base);
-    const floor = ceiling * (1 - BACKOFF_JITTER_RATIO);
-    return Math.round(floor + random() * (ceiling - floor));
+  const ceiling = getReconnectDelay(attempt, base);
+  const floor = ceiling * (1 - BACKOFF_JITTER_RATIO);
+  return Math.round(floor + random() * (ceiling - floor));
 }
 
 function isDocumentHidden(): boolean {
-    return typeof document !== "undefined" && document.visibilityState === "hidden";
+  return (
+    typeof document !== "undefined" && document.visibilityState === "hidden"
+  );
 }
 
 export function useWebSocket({
-    url,
-    token,
-    channels,
-    onEvent,
-    reconnectAttempts = MAX_RECONNECT_ATTEMPTS,
-    reconnectInterval = BASE_RECONNECT_INTERVAL_MS,
-    pollInterval = POLL_INTERVAL_MS,
-    onPoll,
-    onReconcile,
-    heartbeatInterval = HEARTBEAT_INTERVAL_MS,
-    heartbeatTimeout = HEARTBEAT_TIMEOUT_MS,
+  url,
+  getToken,
+  channels,
+  onEvent,
+  reconnectAttempts = MAX_RECONNECT_ATTEMPTS,
+  reconnectInterval = BASE_RECONNECT_INTERVAL_MS,
+  pollInterval = POLL_INTERVAL_MS,
+  onPoll,
+  onReconcile,
+  heartbeatInterval = HEARTBEAT_INTERVAL_MS,
+  heartbeatTimeout = HEARTBEAT_TIMEOUT_MS,
 }: UseWebSocketOptions): UseWebSocketReturn {
-    const [status, setStatus] = useState<WSConnectionStatus>("offline");
-    const [lastEvent, setLastEvent] = useState<WSEvent | null>(null);
-    const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [status, setStatus] = useState<WSConnectionStatus>("offline");
+  const [lastEvent, setLastEvent] = useState<WSEvent | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
 
-    // Keep stable references so interval/event callbacks don't go stale.
-    const wsRef = useRef<WebSocket | null>(null);
-    const attemptsRef = useRef(0);
-    const isMountedRef = useRef(true);
-    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const pongTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const channelsRef = useRef<string[]>(channels);
-    const subscribedRef = useRef<Set<string>>(new Set());
-    const onEventRef = useRef(onEvent);
-    const onPollRef = useRef(onPoll);
-    const onReconcileRef = useRef(onReconcile);
-    const tokenRef = useRef(token);
-    /** Token the currently-open socket was authenticated with. */
-    const connectedTokenRef = useRef<string | null>(null);
-    const connectRef = useRef<() => void>(() => {});
-    /**
-     * Set when a reconnect was withheld because the tab is hidden. A hidden
-     * tab must not sit in a retry loop for hours; it waits for the user to
-     * come back and reconnects then.
-     */
-    const deferredWhileHiddenRef = useRef(false);
-    /** Set by disconnect() so nothing auto-revives the socket. */
-    const stoppedRef = useRef(false);
+  // Keep stable references so interval/event callbacks don't go stale.
+  const wsRef = useRef<WebSocket | null>(null);
+  const attemptsRef = useRef(0);
+  const isMountedRef = useRef(true);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pongTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const channelsRef = useRef<string[]>(channels);
+  const subscribedRef = useRef<Set<string>>(new Set());
+  const onEventRef = useRef(onEvent);
+  const onPollRef = useRef(onPoll);
+  const onReconcileRef = useRef(onReconcile);
+  const getTokenRef = useRef(getToken);
+  /** Token the currently-open socket was authenticated with. */
+  const connectedTokenRef = useRef<string | null>(null);
+  const connectRef = useRef<() => void>(() => {});
+  /**
+   * Set when a reconnect was withheld because the tab is hidden. A hidden
+   * tab must not sit in a retry loop for hours; it waits for the user to
+   * come back and reconnects then.
+   */
+  const deferredWhileHiddenRef = useRef(false);
+  /** Set by disconnect() so nothing auto-revives the socket. */
+  const stoppedRef = useRef(false);
 
-    // Keep refs in sync without triggering reconnects.
-    useEffect(() => { onEventRef.current = onEvent; }, [onEvent]);
-    useEffect(() => { onPollRef.current = onPoll; }, [onPoll]);
-    useEffect(() => { onReconcileRef.current = onReconcile; }, [onReconcile]);
-    useEffect(() => { tokenRef.current = token; }, [token]);
+  // Keep refs in sync without triggering reconnects.
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+  useEffect(() => {
+    onPollRef.current = onPoll;
+  }, [onPoll]);
+  useEffect(() => {
+    onReconcileRef.current = onReconcile;
+  }, [onReconcile]);
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
 
-    const markFresh = useCallback(() => {
-        if (isMountedRef.current) setLastUpdatedAt(Date.now());
-    }, []);
+  const markFresh = useCallback(() => {
+    if (isMountedRef.current) setLastUpdatedAt(Date.now());
+  }, []);
 
-    const stopPoll = useCallback(() => {
-        if (pollTimerRef.current !== null) {
-            clearInterval(pollTimerRef.current);
-            pollTimerRef.current = null;
-        }
-    }, []);
+  const stopPoll = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
 
-    const startPoll = useCallback(() => {
-        if (!onPollRef.current || pollTimerRef.current !== null) return;
-        pollTimerRef.current = setInterval(async () => {
-            // A hidden tab has nothing to show; don't spend the user's data
-            // on it. The visibility handler reconnects and reconciles the
-            // moment the tab comes back.
-            if (isDocumentHidden()) return;
-            try {
-                await onPollRef.current?.();
-                markFresh();
-            } catch {
-                // Polling errors are non-fatal; keep trying.
-            }
-        }, pollInterval);
-    }, [pollInterval, markFresh]);
+  const startPoll = useCallback(() => {
+    if (!onPollRef.current || pollTimerRef.current !== null) return;
+    pollTimerRef.current = setInterval(async () => {
+      // A hidden tab has nothing to show; don't spend the user's data
+      // on it. The visibility handler reconnects and reconciles the
+      // moment the tab comes back.
+      if (isDocumentHidden()) return;
+      try {
+        await onPollRef.current?.();
+        markFresh();
+      } catch {
+        // Polling errors are non-fatal; keep trying.
+      }
+    }, pollInterval);
+  }, [pollInterval, markFresh]);
 
-    const stopHeartbeat = useCallback(() => {
-        if (heartbeatTimerRef.current !== null) {
-            clearInterval(heartbeatTimerRef.current);
-            heartbeatTimerRef.current = null;
-        }
-        if (pongTimerRef.current !== null) {
-            clearTimeout(pongTimerRef.current);
-            pongTimerRef.current = null;
-        }
-    }, []);
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatTimerRef.current !== null) {
+      clearInterval(heartbeatTimerRef.current);
+      heartbeatTimerRef.current = null;
+    }
+    if (pongTimerRef.current !== null) {
+      clearTimeout(pongTimerRef.current);
+      pongTimerRef.current = null;
+    }
+  }, []);
 
-    // Send a ping every `heartbeatInterval`; if no pong arrives within
-    // `heartbeatTimeout`, assume the link is dead and force a reconnect by
-    // closing the socket (which triggers onclose → back-off).
-    //
-    // This is the only thing that detects a blackholed socket promptly. TCP
-    // will eventually notice, but "eventually" is minutes — minutes during
-    // which the UI is showing a balance it has no basis for.
-    const startHeartbeat = useCallback((ws: WebSocket) => {
-        stopHeartbeat();
-        heartbeatTimerRef.current = setInterval(() => {
-            if (ws.readyState !== WebSocket.OPEN) return;
+  // Send a ping every `heartbeatInterval`; if no pong arrives within
+  // `heartbeatTimeout`, assume the link is dead and force a reconnect by
+  // closing the socket (which triggers onclose → back-off).
+  //
+  // This is the only thing that detects a blackholed socket promptly. TCP
+  // will eventually notice, but "eventually" is minutes — minutes during
+  // which the UI is showing a balance it has no basis for.
+  const startHeartbeat = useCallback(
+    (ws: WebSocket) => {
+      stopHeartbeat();
+      heartbeatTimerRef.current = setInterval(() => {
+        if (ws.readyState !== WebSocket.OPEN) return;
 
-            // A deadline is already pending from an earlier ping that has not
-            // been answered. Rearming it here would push the deadline back
-            // once per interval and it could never fire, so a peer that stops
-            // answering would be detected only if the pong timeout were
-            // shorter than the ping interval. Let the pending one run out;
-            // onmessage clears it when a pong actually arrives.
-            if (pongTimerRef.current !== null) return;
+        // A deadline is already pending from an earlier ping that has not
+        // been answered. Rearming it here would push the deadline back
+        // once per interval and it could never fire, so a peer that stops
+        // answering would be detected only if the pong timeout were
+        // shorter than the ping interval. Let the pending one run out;
+        // onmessage clears it when a pong actually arrives.
+        if (pongTimerRef.current !== null) return;
 
-            const ping: ClientWireMessage = { action: "ping" };
-            ws.send(JSON.stringify(ping));
-            pongTimerRef.current = setTimeout(() => {
-                pongTimerRef.current = null;
-                // No pong in time — drop the connection so onclose reconnects.
-                ws.close();
-            }, heartbeatTimeout);
-        }, heartbeatInterval);
-    }, [heartbeatInterval, heartbeatTimeout, stopHeartbeat]);
+        const ping: ClientWireMessage = { action: "ping" };
+        ws.send(JSON.stringify(ping));
+        pongTimerRef.current = setTimeout(() => {
+          pongTimerRef.current = null;
+          // No pong in time — drop the connection so onclose reconnects.
+          ws.close();
+        }, heartbeatTimeout);
+      }, heartbeatInterval);
+    },
+    [heartbeatInterval, heartbeatTimeout, stopHeartbeat],
+  );
 
-    const sendFrame = useCallback((ws: WebSocket | null, frame: ClientWireMessage) => {
-        if (!ws || ws.readyState !== WebSocket.OPEN) return false;
-        ws.send(JSON.stringify(frame));
-        return true;
-    }, []);
+  const sendFrame = useCallback(
+    (ws: WebSocket | null, frame: ClientWireMessage) => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(JSON.stringify(frame));
+      return true;
+    },
+    [],
+  );
 
-    /**
-     * (Re)subscribe to every channel the caller currently wants. Called on
-     * each open, because the hub's subscription table lives on the
-     * connection — a reconnected socket starts with none.
-     */
-    const sendSubscriptions = useCallback((ws: WebSocket) => {
-        const wanted = channelsRef.current;
-        subscribedRef.current = new Set(wanted);
-        if (wanted.length === 0) return;
-        sendFrame(ws, { action: "subscribe", channels: [...wanted] });
-    }, [sendFrame]);
+  /**
+   * (Re)subscribe to every channel the caller currently wants. Called on
+   * each open, because the hub's subscription table lives on the
+   * connection — a reconnected socket starts with none.
+   */
+  const sendSubscriptions = useCallback(
+    (ws: WebSocket) => {
+      const wanted = channelsRef.current;
+      subscribedRef.current = new Set(wanted);
+      if (wanted.length === 0) return;
+      sendFrame(ws, { action: "subscribe", channels: [...wanted] });
+    },
+    [sendFrame],
+  );
 
-    /**
-     * Pull current state over HTTP after a reconnect rather than trusting
-     * whatever the socket pushes first.
-     */
-    const reconcile = useCallback(async () => {
-        const fn = onReconcileRef.current ?? onPollRef.current;
-        if (!fn) return;
-        try {
-            await fn();
-            markFresh();
-        } catch {
-            // A failed reconcile leaves lastUpdatedAt where it was, so the UI
-            // keeps reporting the older (honest) freshness timestamp.
-        }
-    }, [markFresh]);
+  /**
+   * Pull current state over HTTP after a reconnect rather than trusting
+   * whatever the socket pushes first.
+   */
+  const reconcile = useCallback(async () => {
+    const fn = onReconcileRef.current ?? onPollRef.current;
+    if (!fn) return;
+    try {
+      await fn();
+      markFresh();
+    } catch {
+      // A failed reconcile leaves lastUpdatedAt where it was, so the UI
+      // keeps reporting the older (honest) freshness timestamp.
+    }
+  }, [markFresh]);
 
-    const scheduleReconnect = useCallback(() => {
-        if (!isMountedRef.current || stoppedRef.current) return;
+  const scheduleReconnect = useCallback(() => {
+    if (!isMountedRef.current || stoppedRef.current) return;
 
-        if (isDocumentHidden()) {
-            // Hidden tab: stop here. No timer, no attempt counter churn.
-            deferredWhileHiddenRef.current = true;
-            setStatus("reconnecting");
-            return;
-        }
+    if (isDocumentHidden()) {
+      // Hidden tab: stop here. No timer, no attempt counter churn.
+      deferredWhileHiddenRef.current = true;
+      setStatus("reconnecting");
+      return;
+    }
 
-        if (attemptsRef.current >= reconnectAttempts) {
-            setStatus("offline");
-            startPoll();
-            return;
-        }
+    if (attemptsRef.current >= reconnectAttempts) {
+      setStatus("offline");
+      startPoll();
+      return;
+    }
 
-        // Back-off uses the current attempt index (0-based) before
-        // incrementing: ~1s, ~2s, ~4s, ~8s, ~16s, ~30s… each randomised
-        // downward by up to half so clients don't retry in lockstep.
-        const delay = getJitteredReconnectDelay(attemptsRef.current, reconnectInterval);
-        attemptsRef.current += 1;
-        setStatus("reconnecting");
-        if (reconnectTimerRef.current !== null) clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = setTimeout(() => connectRef.current(), delay);
-    }, [reconnectAttempts, reconnectInterval, startPoll]);
+    // Back-off uses the current attempt index (0-based) before
+    // incrementing: ~1s, ~2s, ~4s, ~8s, ~16s, ~30s… each randomised
+    // downward by up to half so clients don't retry in lockstep.
+    const delay = getJitteredReconnectDelay(
+      attemptsRef.current,
+      reconnectInterval,
+    );
+    attemptsRef.current += 1;
+    setStatus("reconnecting");
+    if (reconnectTimerRef.current !== null)
+      clearTimeout(reconnectTimerRef.current);
+    reconnectTimerRef.current = setTimeout(() => connectRef.current(), delay);
+  }, [reconnectAttempts, reconnectInterval, startPoll]);
 
-    const connect = useCallback(() => {
-        if (!isMountedRef.current || stoppedRef.current) return;
+  const connect = useCallback(() => {
+    if (!isMountedRef.current || stoppedRef.current) return;
 
-        deferredWhileHiddenRef.current = false;
-        if (reconnectTimerRef.current !== null) {
-            clearTimeout(reconnectTimerRef.current);
-            reconnectTimerRef.current = null;
-        }
+    deferredWhileHiddenRef.current = false;
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
 
-        // Close any existing socket cleanly.
-        stopHeartbeat();
-        if (wsRef.current) {
-            wsRef.current.onopen = null;
-            wsRef.current.onclose = null;
-            wsRef.current.onerror = null;
-            wsRef.current.onmessage = null;
-            wsRef.current.close();
-            wsRef.current = null;
-        }
+    // Close any existing socket cleanly.
+    stopHeartbeat();
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
 
-        if (!url) {
-            // No socket configured (local dev without NEXT_PUBLIC_WS_URL).
-            setStatus("offline");
-            startPoll();
-            return;
-        }
+    if (!url) {
+      // No socket configured (local dev without NEXT_PUBLIC_WS_URL).
+      setStatus("offline");
+      startPoll();
+      return;
+    }
 
-        const socketToken = tokenRef.current;
-        let ws: WebSocket;
-        try {
-            // The hub authenticates from the query string during the upgrade
-            // handshake — the browser WebSocket API cannot set headers.
-            ws = new WebSocket(buildSocketUrl(url, socketToken));
-        } catch {
-            // URL may be invalid in dev; fall back to polling.
-            setStatus("offline");
-            startPoll();
-            return;
-        }
+    // Get the current token before connecting (not a cached/stale one)
+    const socketToken = getTokenRef.current();
+    if (!socketToken) {
+      setStatus("offline");
+      startPoll();
+      return;
+    }
 
-        wsRef.current = ws;
-        connectedTokenRef.current = socketToken;
+    let ws: WebSocket;
+    try {
+      // The hub authenticates from the query string during the upgrade
+      // handshake — the browser WebSocket API cannot set headers.
+      ws = new WebSocket(buildSocketUrl(url, socketToken));
+    } catch {
+      // URL may be invalid in dev; fall back to polling.
+      setStatus("offline");
+      startPoll();
+      return;
+    }
 
-        ws.onopen = () => {
-            if (!isMountedRef.current) return;
-            attemptsRef.current = 0;
-            setStatus("connected");
-            stopPoll();
+    wsRef.current = ws;
+    connectedTokenRef.current = socketToken;
 
-            sendSubscriptions(ws);
+    ws.onopen = () => {
+      if (!isMountedRef.current) return;
+      attemptsRef.current = 0;
+      setStatus("connected");
+      stopPoll();
 
-            // Begin liveness pings now that the link is open.
-            startHeartbeat(ws);
+      sendSubscriptions(ws);
 
-            // Reconcile over HTTP instead of assuming the first pushed
-            // message carries the whole picture.
-            void reconcile();
-        };
+      // Begin liveness pings now that the link is open.
+      startHeartbeat(ws);
 
-        ws.onmessage = (evt: MessageEvent) => {
-            if (!isMountedRef.current) return;
-            let frame: unknown;
-            try {
-                frame = JSON.parse(evt.data as string);
-            } catch {
-                return; // Ignore malformed frames.
-            }
-
-            // Heartbeat frames are transport bookkeeping, not domain events.
-            if (isPongFrame(frame)) {
-                if (pongTimerRef.current !== null) {
-                    clearTimeout(pongTimerRef.current);
-                    pongTimerRef.current = null;
-                }
-                return;
-            }
-
-            const event = normalizeServerEvent(frame);
-            if (!event) return;
-
-            setLastEvent(event);
-            setLastUpdatedAt(Date.now());
-            onEventRef.current(event);
-        };
-
-        ws.onclose = () => {
-            stopHeartbeat();
-            if (!isMountedRef.current) return;
-            scheduleReconnect();
-        };
-
-        ws.onerror = () => {
-            // onerror is always followed by onclose; handle backoff there.
-            ws.close();
-        };
-    }, [url, sendSubscriptions, startPoll, stopPoll, startHeartbeat, stopHeartbeat, scheduleReconnect, reconcile]);
-
-    useEffect(() => { connectRef.current = connect; }, [connect]);
-
-    // Cleanup helper — tears down socket and timers without triggering reconnect.
-    const teardown = useCallback(() => {
-        if (reconnectTimerRef.current !== null) {
-            clearTimeout(reconnectTimerRef.current);
-            reconnectTimerRef.current = null;
-        }
-        deferredWhileHiddenRef.current = false;
-        stopPoll();
-        stopHeartbeat();
-        subscribedRef.current = new Set();
-        if (wsRef.current) {
-            wsRef.current.onopen = null;
-            wsRef.current.onclose = null;
-            wsRef.current.onerror = null;
-            wsRef.current.onmessage = null;
-            wsRef.current.close();
-            wsRef.current = null;
-        }
-    }, [stopPoll, stopHeartbeat]);
-
-    const disconnect = useCallback(() => {
-        stoppedRef.current = true;
-        attemptsRef.current = reconnectAttempts; // prevent auto-reconnect
-        teardown();
-        if (isMountedRef.current) setStatus("offline");
-    }, [reconnectAttempts, teardown]);
-
-    const manualReconnect = useCallback(() => {
-        stoppedRef.current = false;
-        attemptsRef.current = 0;
-        teardown();
-        connect();
-    }, [connect, teardown]);
-
-    const subscribe = useCallback((channel: string) => {
-        subscribedRef.current.add(channel);
-        sendFrame(wsRef.current, { action: "subscribe", channels: [channel] });
-    }, [sendFrame]);
-
-    const unsubscribe = useCallback((channel: string) => {
-        subscribedRef.current.delete(channel);
-        sendFrame(wsRef.current, { action: "unsubscribe", channels: [channel] });
-    }, [sendFrame]);
-
-    // Reconcile the live subscription set when the caller's channel list
-    // changes (e.g. the wallet resolves after mount and vault channels
-    // appear) without dropping the connection.
-    useEffect(() => {
-        channelsRef.current = channels;
-        const ws = wsRef.current;
-        if (!ws || ws.readyState !== WebSocket.OPEN) return;
-
-        const wanted = new Set(channels);
-        const added = channels.filter((c) => !subscribedRef.current.has(c));
-        const removed = [...subscribedRef.current].filter((c) => !wanted.has(c));
-
-        if (added.length > 0) sendFrame(ws, { action: "subscribe", channels: added });
-        if (removed.length > 0) sendFrame(ws, { action: "unsubscribe", channels: removed });
-        subscribedRef.current = wanted;
-    }, [channels, sendFrame]);
-
-    // The token is part of the upgrade URL, so a new token means the open
-    // socket is authenticated as somebody else (or as nobody). Reconnect.
-    useEffect(() => {
-        if (stoppedRef.current) return;
-        if (connectedTokenRef.current === null) return; // never connected yet
-        // Identity check on which credential the open socket used — not an
-        // authentication decision, so a constant-time compare is not called for.
-        // eslint-disable-next-line security/detect-possible-timing-attacks
-        if (connectedTokenRef.current === token) return;
-        attemptsRef.current = 0;
-        connectRef.current();
-    }, [token]);
-
-    // Suspend/resume. Two things bring a dropped connection back:
-    //
-    //  - the tab becoming visible again, which also covers the laptop-sleep
-    //    case where every timer fired late or not at all, and
-    //  - the browser reporting the network is back.
-    //
-    // Both reset the attempt counter: the previous failures described a
-    // network that no longer exists.
-    useEffect(() => {
-        const resume = () => {
-            if (!isMountedRef.current || stoppedRef.current) return;
-            if (isDocumentHidden()) return;
-            const ws = wsRef.current;
-            if (ws && ws.readyState === WebSocket.OPEN) return;
-            if (ws && ws.readyState === WebSocket.CONNECTING) return;
-            attemptsRef.current = 0;
-            connectRef.current();
-        };
-
-        const onVisibility = () => {
-            if (isDocumentHidden()) return;
-            // Always reconcile on return: even a socket that stayed open may
-            // have missed events while the tab was throttled.
-            if (deferredWhileHiddenRef.current || wsRef.current?.readyState !== WebSocket.OPEN) {
-                resume();
-            } else {
-                void reconcile();
-            }
-        };
-
-        document.addEventListener("visibilitychange", onVisibility);
-        window.addEventListener("online", resume);
-        return () => {
-            document.removeEventListener("visibilitychange", onVisibility);
-            window.removeEventListener("online", resume);
-        };
-    }, [reconcile]);
-
-    // Establish the connection on mount.
-    useEffect(() => {
-        isMountedRef.current = true;
-        stoppedRef.current = false;
-        connect();
-        return () => {
-            isMountedRef.current = false;
-            teardown();
-        };
-        // connect / teardown are stable — only run on mount/unmount.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    return {
-        isConnected: status === "connected",
-        status,
-        lastEvent,
-        lastUpdatedAt,
-        subscribe,
-        unsubscribe,
-        disconnect,
-        manualReconnect,
+      // Reconcile over HTTP instead of assuming the first pushed
+      // message carries the whole picture.
+      void reconcile();
     };
+
+    ws.onmessage = (evt: MessageEvent) => {
+      if (!isMountedRef.current) return;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(evt.data as string);
+      } catch {
+        return; // Ignore malformed frames.
+      }
+
+      // Heartbeat frames are transport bookkeeping, not domain events.
+      if (isPongFrame(frame)) {
+        if (pongTimerRef.current !== null) {
+          clearTimeout(pongTimerRef.current);
+          pongTimerRef.current = null;
+        }
+        return;
+      }
+
+      const event = normalizeServerEvent(frame);
+      if (!event) return;
+
+      setLastEvent(event);
+      setLastUpdatedAt(Date.now());
+      onEventRef.current(event);
+    };
+
+    ws.onclose = () => {
+      stopHeartbeat();
+      if (!isMountedRef.current) return;
+      scheduleReconnect();
+    };
+
+    ws.onerror = () => {
+      // onerror is always followed by onclose; handle backoff there.
+      ws.close();
+    };
+  }, [
+    url,
+    sendSubscriptions,
+    startPoll,
+    stopPoll,
+    startHeartbeat,
+    stopHeartbeat,
+    scheduleReconnect,
+    reconcile,
+  ]);
+
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
+
+  // Cleanup helper — tears down socket and timers without triggering reconnect.
+  const teardown = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    deferredWhileHiddenRef.current = false;
+    stopPoll();
+    stopHeartbeat();
+    subscribedRef.current = new Set();
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, [stopPoll, stopHeartbeat]);
+
+  const disconnect = useCallback(() => {
+    stoppedRef.current = true;
+    attemptsRef.current = reconnectAttempts; // prevent auto-reconnect
+    teardown();
+    if (isMountedRef.current) setStatus("offline");
+  }, [reconnectAttempts, teardown]);
+
+  const manualReconnect = useCallback(() => {
+    stoppedRef.current = false;
+    attemptsRef.current = 0;
+    teardown();
+    connect();
+  }, [connect, teardown]);
+
+  const subscribe = useCallback(
+    (channel: string) => {
+      subscribedRef.current.add(channel);
+      sendFrame(wsRef.current, { action: "subscribe", channels: [channel] });
+    },
+    [sendFrame],
+  );
+
+  const unsubscribe = useCallback(
+    (channel: string) => {
+      subscribedRef.current.delete(channel);
+      sendFrame(wsRef.current, { action: "unsubscribe", channels: [channel] });
+    },
+    [sendFrame],
+  );
+
+  // Reconcile the live subscription set when the caller's channel list
+  // changes (e.g. the wallet resolves after mount and vault channels
+  // appear) without dropping the connection.
+  useEffect(() => {
+    channelsRef.current = channels;
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    const wanted = new Set(channels);
+    const added = channels.filter((c) => !subscribedRef.current.has(c));
+    const removed = [...subscribedRef.current].filter((c) => !wanted.has(c));
+
+    if (added.length > 0)
+      sendFrame(ws, { action: "subscribe", channels: added });
+    if (removed.length > 0)
+      sendFrame(ws, { action: "unsubscribe", channels: removed });
+    subscribedRef.current = wanted;
+  }, [channels, sendFrame]);
+
+  // The token is part of the upgrade URL, so a new token means the open
+  // socket is authenticated as somebody else (or as nobody). Reconnect.
+  useEffect(() => {
+    if (stoppedRef.current) return;
+    if (connectedTokenRef.current === null) return; // never connected yet
+    // Identity check on which credential the open socket used — not an
+    // authentication decision, so a constant-time compare is not called for.
+    // eslint-disable-next-line security/detect-possible-timing-attacks
+    const currentToken = getTokenRef.current();
+    if (connectedTokenRef.current === currentToken) return;
+    attemptsRef.current = 0;
+    connectRef.current();
+  }, []);
+
+  // Suspend/resume. Two things bring a dropped connection back:
+  //
+  //  - the tab becoming visible again, which also covers the laptop-sleep
+  //    case where every timer fired late or not at all, and
+  //  - the browser reporting the network is back.
+  //
+  // Both reset the attempt counter: the previous failures described a
+  // network that no longer exists.
+  useEffect(() => {
+    const resume = () => {
+      if (!isMountedRef.current || stoppedRef.current) return;
+      if (isDocumentHidden()) return;
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) return;
+      if (ws && ws.readyState === WebSocket.CONNECTING) return;
+      attemptsRef.current = 0;
+      connectRef.current();
+    };
+
+    const onVisibility = () => {
+      if (isDocumentHidden()) return;
+      // Always reconcile on return: even a socket that stayed open may
+      // have missed events while the tab was throttled.
+      if (
+        deferredWhileHiddenRef.current ||
+        wsRef.current?.readyState !== WebSocket.OPEN
+      ) {
+        resume();
+      } else {
+        void reconcile();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("online", resume);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", resume);
+    };
+  }, [reconcile]);
+
+  // Establish the connection on mount.
+  useEffect(() => {
+    isMountedRef.current = true;
+    stoppedRef.current = false;
+    connect();
+    return () => {
+      isMountedRef.current = false;
+      teardown();
+    };
+    // connect / teardown are stable — only run on mount/unmount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    isConnected: status === "connected",
+    status,
+    lastEvent,
+    lastUpdatedAt,
+    subscribe,
+    unsubscribe,
+    disconnect,
+    manualReconnect,
+  };
 }

--- a/apps/dapp/frontend/hooks/useWebSocket.ts
+++ b/apps/dapp/frontend/hooks/useWebSocket.ts
@@ -512,7 +512,13 @@ export function useWebSocket({
     if (connectedTokenRef.current === currentToken) return;
     attemptsRef.current = 0;
     connectRef.current();
-  }, []);
+    // Deliberately no dependency array: the token is read from a ref, so
+    // there is no value React could watch. With `[]` this ran once on mount
+    // and never again, which meant a refreshed token kept the old socket
+    // open — authenticated as the previous credential — until something else
+    // happened to drop it. The guard above makes the re-run cheap: it
+    // returns immediately unless the token actually changed.
+  });
 
   // Suspend/resume. Two things bring a dropped connection back:
   //

--- a/apps/dapp/frontend/lib/e2e-harness.ts
+++ b/apps/dapp/frontend/lib/e2e-harness.ts
@@ -18,6 +18,21 @@ export const E2E_HARNESS_ENABLED = process.env.NEXT_PUBLIC_E2E_HARNESS === "1";
 export const E2E_HARNESS_CHANNELS = ["vaults:global"];
 
 /**
+ * Token the harness authenticates its socket with.
+ *
+ * useWebSocket refuses to open a socket without a credential, and the real
+ * one is minted by a wallet signature — which a browser-driven test cannot
+ * produce. Seeding the token store instead does not work either: AuthProvider
+ * clears the stored session whenever no wallet is connected, so the token is
+ * wiped moments after the page loads and the socket closes with it.
+ *
+ * This value never reaches a deployed environment: it is only read when
+ * NEXT_PUBLIC_E2E_HARNESS is set, and the Playwright suite routes the socket
+ * to an in-process fake hub that never checks it. A real hub would reject it.
+ */
+export const E2E_HARNESS_TOKEN = "e2e-harness-token";
+
+/**
  * Heartbeat timings for the harness.
  *
  * Production pings every 30s and allows 10s for the pong, so a blackholed

--- a/apps/dapp/frontend/tests/websocket-reconnect.spec.ts
+++ b/apps/dapp/frontend/tests/websocket-reconnect.spec.ts
@@ -31,6 +31,23 @@ interface FakeHub {
  * ordinary messages — see apps/api/internal/ws/client.go).
  */
 async function installFakeHub(page: Page): Promise<FakeHub> {
+    // Seed a session token before the app boots. useWebSocket refuses to open
+    // a socket without one — it sets status "offline" and falls back to
+    // polling — so with no token the badge never reaches "connected" and every
+    // assertion in this file times out.
+    //
+    // This became necessary when the provider stopped forging
+    // `mock_jwt_${address}` (nester#1230) and started reading the real token
+    // store. The forged value was always truthy, which is why the harness got
+    // away with never authenticating.
+    await page.addInitScript(() => {
+        try {
+            window.localStorage.setItem('nester_auth_token', 'e2e-harness-token');
+        } catch {
+            // Storage unavailable — the assertions below will surface it.
+        }
+    });
+
     const hub: FakeHub = {
         sockets: [],
         frames: [],

--- a/apps/dapp/frontend/tests/websocket-reconnect.spec.ts
+++ b/apps/dapp/frontend/tests/websocket-reconnect.spec.ts
@@ -10,7 +10,17 @@ import { test, expect, type Page, type WebSocketRoute } from '@playwright/test';
  * user can actually see.
  */
 
-const WS_URL = 'ws://localhost:3001/ws';
+/**
+ * Match the harness socket regardless of its query string.
+ *
+ * The client authenticates during the upgrade by appending `?token=…` (the
+ * browser WebSocket API cannot set headers), so the URL is not a fixed
+ * string. An exact-match pattern silently stops intercepting the moment a
+ * token is present: the route never fires, the page talks to a `/ws` that
+ * nothing is serving, and every assertion here reports "offline" instead of
+ * the reconnection behaviour under test.
+ */
+const WS_URL = /^ws:\/\/localhost:3001\/ws(\?.*)?$/;
 const HARNESS = '/e2e/connection';
 
 interface FakeHub {


### PR DESCRIPTION
Brings the security and compliance work from #1262 onto `dev`, together with fixes for the gaps review turned up.

That PR was merged into `integration/security-compliance-1228-1229-1230-1231` rather than straight into `dev`, so this PR carries its commits plus one commit of fixes. The contributor's authorship is preserved on the original commits.

## What the original PR got right

All four issues are genuinely addressed on the client side. `MOCK_BALANCE = 5000` is gone from the off-ramp and replaced with real balance state threaded through the Zod schema. The forged `mock_jwt_${address}` token is gone, replaced with the real session token from `lib/auth/token-store`. The settings KYC flow calls `/api/v1/users/me/kyc` instead of resolving a 1.2s `setTimeout`. And the property tests in `apps/api/internal/domain/vault/property_test.go` are real property tests over generated inputs, covering exactly the invariants #1228 named — conservation, round-trip safety, share-price monotonicity, and no-mint-from-nothing.

## The cross-user WebSocket hole

This one matters more than the rest combined, so it goes first.

#1262 fixed the *client* half of #1230 and added `TestHub_CrossUserSubscriptionRejection` to prove the server enforces channel ownership. The server check was never written. That test was failing, which is why `API (Go)` was red.

`client.go:58` subscribed to whatever channel name arrived in the frame:

```go
case ActionSubscribe:
    for _, ch := range msg.Channels {
        c.subs[ch] = true
        c.hub.subscribe(c, ch)
    }
```

So any authenticated client could name `notifications/<someone-else>` and receive that user's private events. Running the test says it plainly: *"Bob received Alice's private event (authorization failure)"*.

`maySubscribe` now rejects a user-scoped channel that does not belong to the requesting client. The id it compares against comes from the authenticated session rather than from the subscribe frame, so it cannot be spoofed by the message asking for the subscription. Channels outside the user-scoped namespaces are unchanged and stay open to any authenticated client.

Worth saying: a half-fix here was more dangerous than none. The client stopped forging tokens and a test existed with the right name, which together read as "this is closed" to anyone not running the suite.

## #1190 and #1191, reintroduced on a second route

The new `/api/v1/users/me/kyc` handler was written against the pre-fix shape of the old one. It discarded the identity fields:

```go
_ = fullName
_ = dateOfBirth
_ = country
```

and built its storage key by concatenating the client-supplied filename:

```go
frontKey := "s3://mock-bucket/" + idFrontHeader.Filename
```

Both were fixed on `/users/{id}/kyc` by #1265 and #1268. Rather than repair the copy, `submitKYC`'s body is now `submitKYCFor` and both routes call it, so the two cannot drift apart again. This is the failure mode that a clean textual merge cannot catch — nothing conflicted, the second route was simply written against an older truth.

## Build repair

- `pgregory.net/rapid` was in `go.mod` but missing from `go.sum`, so the whole `domain/vault` package failed to build
- `io.ReadAll` assigned to a single variable — compile error
- A `bytes.Buffer` declared and never used — compile error
- `%s` applied to an `int64` in a `Fatalf`, caught by vet
- The two new KYC routes tripped the authorization coverage guard; both are in the matrix now

## On the KYC handler test

`TestUserHandler_KYCSubmissionAndRetrieval` needed a document store and a cipher to reach the path it asserts on. Without a store the endpoint answers 503 `STORAGE_UNAVAILABLE`, and without a cipher it answers 500 — both of which are the handler behaving as #1191 requires, not faults in it. The test now wires the same `LocalDiskStore` and `AccountCipher` the existing KYC suite uses.

## Verification

- `go build ./...` and `go vet ./internal/... ./cmd/api/` clean
- `go test ./internal/...` exits 0 across all 46 packages, including `internal/ws`
- `TestHub_CrossUserSubscriptionRejection` verified failing before the fix and passing after, so it is a real regression guard rather than a test that always passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added self-service KYC submission and status tracking in Settings.
  - Offramp withdrawals now use live portfolio balances and submit real settlement requests.
  - WebSocket connections refresh authentication automatically and improve reconnection behavior.

- **Bug Fixes**
  - Prevented withdrawals exceeding available vault balances.
  - Blocked access to other users’ private notification channels.
  - Improved loading and error handling for balances and KYC requests.

- **Tests**
  - Expanded automated and nightly coverage for KYC, withdrawals, WebSockets, and vault accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->