### PR TITLE
feat(api,dapp,ci): storage safety, SLO alerts, retention, projections, scanner pinning (#1221, #1223, #1224, #1225, #1226, #1227, #1233)

### DIFF
--- a/.github/security-scanner-versions.env
+++ b/.github/security-scanner-versions.env
@@ -1,0 +1,12 @@
+# Pinned versions for the security scanners installed via `go install` in CI
+# (ci.yml and security.yml both `source` this file rather than each hardcoding
+# their own @latest install, #1221). Unlike `uses: action@version` references,
+# `go install pkg@latest` inside a `run:` step is invisible to Dependabot's
+# github-actions updater, so these pins have to be bumped by hand.
+#
+# Update cadence: review both pins quarterly (or sooner if a scanner reports a
+# finding that a newer release is known to fix). Bump one tool at a time, in
+# its own PR, so the PR diff itself shows exactly which new findings the bump
+# introduces before it merges.
+GOVULNCHECK_VERSION=v1.7.0
+GOSEC_VERSION=v2.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,12 @@ jobs:
 
       - name: Install govulncheck
         if: needs.changes.outputs.api == 'true' || needs.changes.outputs.shared == 'true'
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned (#1221): see security-scanner-versions.env for why and the
+        # update cadence. Keep this in sync with security.yml's install step
+        # — both source the same file so they can't drift apart.
+        run: |
+          . "$GITHUB_WORKSPACE/.github/security-scanner-versions.env"
+          go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
       - name: Audit Go dependencies
         if: needs.changes.outputs.api == 'true' || needs.changes.outputs.shared == 'true'
@@ -332,7 +337,11 @@ jobs:
 
       - name: Install gosec
         if: needs.changes.outputs.api == 'true' || needs.changes.outputs.shared == 'true'
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        # Pinned (#1221): see security-scanner-versions.env for why and the
+        # update cadence.
+        run: |
+          . "$GITHUB_WORKSPACE/.github/security-scanner-versions.env"
+          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
 
       # Enforcing gate (#1035). The backlog this previously tolerated is
       # cleared: gosec -severity medium reports zero issues. Findings that were

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -91,7 +91,14 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned (#1221): an unpinned @latest means whatever the registry
+        # serves at that moment runs in CI with repository context, and a
+        # rerun of a green build can turn red with no line changed. The pin
+        # lives in security-scanner-versions.env so ci.yml and this workflow
+        # can't drift apart; see that file for the update cadence.
+        run: |
+          . "$GITHUB_WORKSPACE/.github/security-scanner-versions.env"
+          go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
       - name: Run govulncheck
         run: |

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -1142,6 +1142,26 @@ func run() error {
 	defer cancelSavingsGoalPurge()
 	go savingsGoalPurgeJob.Run(savingsGoalPurgeCtx, 24*time.Hour)
 
+	// Data retention sweep (#1226): hard-deletes activity_events and
+	// nudge_dispatch_log (nudge_outcomes cascades) rows past their retention
+	// window — see docs/data-retention.md for the policy and
+	// DataRetentionConfig's defaults. Deliberately does NOT touch audit_logs,
+	// KYC records, or processed_events — the policy doc explains why each of
+	// those is out of scope for this job. Runs daily, leader-elected like the
+	// other sweep jobs, and audit-logs every deletion via the same
+	// auditLogger every other audited action in this file uses.
+	dataRetentionJob := scheduler.NewDataRetentionJob(
+		activityEventRepo,
+		nudgeHistoryRepo,
+		auditLogger,
+		scheduler.DataRetentionConfig{},
+		baseLogger.WithGroup("data-retention"),
+	)
+	dataRetentionJob.SetLeaderChecker(schedulerLeadership)
+	dataRetentionCtx, cancelDataRetention := context.WithCancel(context.Background())
+	defer cancelDataRetention()
+	go dataRetentionJob.Run(dataRetentionCtx, 24*time.Hour)
+
 	jobWorker := jobqueue.NewWorker(
 		jobQueueRepo,
 		jobqueue.Config{

--- a/apps/api/internal/domain/projection/model.go
+++ b/apps/api/internal/domain/projection/model.go
@@ -101,13 +101,27 @@ type ProjectionPoint struct {
 
 // ProjectionOutput represents the result of a compound interest calculation
 type ProjectionOutput struct {
-	VaultID      *uuid.UUID        `json:"vault_id,omitempty"`
-	Currency     string            `json:"currency"`
-	CurrentAPY   float64           `json:"current_apy"`
-	Input        ProjectionInput   `json:"input"`
-	Timeline     []ProjectionPoint `json:"timeline"`
-	Summary      ProjectionSummary `json:"summary"`
-	CalculatedAt time.Time         `json:"calculated_at"`
+	VaultID      *uuid.UUID            `json:"vault_id,omitempty"`
+	Currency     string                `json:"currency"`
+	CurrentAPY   float64               `json:"current_apy"`
+	Input        ProjectionInput       `json:"input"`
+	Timeline     []ProjectionPoint     `json:"timeline"`
+	Summary      ProjectionSummary     `json:"summary"`
+	Assumptions  ProjectionAssumptions `json:"assumptions"`
+	CalculatedAt time.Time             `json:"calculated_at"`
+}
+
+// ProjectionAssumptions documents the parameters a projection actually used,
+// so the numbers in Timeline/Summary are interpretable rather than opaque.
+// RecurringAmount/Cadence describe the periodic contribution rolled into
+// MonthlyContribution (zero/empty when there is none), and ContributionSource
+// says where that came from — mirroring SimulationOutput.ContributionSource.
+type ProjectionAssumptions struct {
+	RecurringAmount    decimal.Decimal `json:"recurring_amount"`
+	Cadence            string          `json:"cadence,omitempty"` // "weekly" | "biweekly" | "monthly" | ""
+	ProjectedAPY       float64         `json:"projected_apy"`
+	TimelineMonths     int             `json:"timeline_months"`
+	ContributionSource string          `json:"contribution_source"` // "schedule" | "single_deposit"
 }
 
 // ProjectionSummary provides aggregate statistics about the projection

--- a/apps/api/internal/handler/activity_handler.go
+++ b/apps/api/internal/handler/activity_handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/suncrestlabs/nester/apps/api/internal/auth"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/activity"
@@ -36,18 +37,21 @@ func (h *ActivityHandler) Register(mux *http.ServeMux) {
 }
 
 // activityItemDTO matches the frontend's fixed Transaction contract
-// (apps/dapp/frontend/app/dashboard/history/page.tsx) exactly — Title-Case
-// type/status strings and a plain numeric amount, not the internal
-// activity.Item shape or the shared response.Response envelope.
+// (apps/dapp/frontend/app/dashboard/history/page.tsx) — Title-Case
+// type/status strings, not the internal activity.Item shape or the shared
+// response.Response envelope. Amount is decimal.Decimal (serialises to an
+// exact JSON string, see shopspring/decimal's MarshalJSON) rather than
+// float64: it used to be converted with Float64(), which silently discarded
+// precision on the way out of the API (#1223).
 type activityItemDTO struct {
-	ID        string  `json:"id"`
-	Timestamp string  `json:"timestamp"`
-	Type      string  `json:"type"`
-	VaultName string  `json:"vaultName"`
-	Amount    float64 `json:"amount"`
-	Asset     string  `json:"asset"`
-	Status    string  `json:"status"`
-	TxHash    string  `json:"txHash,omitempty"`
+	ID        string          `json:"id"`
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	VaultName string          `json:"vaultName"`
+	Amount    decimal.Decimal `json:"amount"`
+	Asset     string          `json:"asset"`
+	Status    string          `json:"status"`
+	TxHash    string          `json:"txHash,omitempty"`
 }
 
 // activityListResponse is a deliberate, documented exception to the shared
@@ -123,13 +127,12 @@ func (h *ActivityHandler) list(w http.ResponseWriter, r *http.Request) {
 		if !knownStatus {
 			statusLabel = string(it.Status)
 		}
-		amount, _ := it.Amount.Float64()
 		dtos[i] = activityItemDTO{
 			ID:        it.ID.String(),
 			Timestamp: it.CreatedAt.UTC().Format(time.RFC3339),
 			Type:      typeLabel,
 			VaultName: it.VaultName,
-			Amount:    amount,
+			Amount:    it.Amount,
 			Asset:     it.Currency,
 			Status:    statusLabel,
 			TxHash:    it.Ref,

--- a/apps/api/internal/handler/activity_handler_test.go
+++ b/apps/api/internal/handler/activity_handler_test.go
@@ -87,14 +87,14 @@ func TestActivityHandler_List_MapsToFrontendContract(t *testing.T) {
 
 	var body struct {
 		Data []struct {
-			ID        string  `json:"id"`
-			Timestamp string  `json:"timestamp"`
-			Type      string  `json:"type"`
-			VaultName string  `json:"vaultName"`
-			Amount    float64 `json:"amount"`
-			Asset     string  `json:"asset"`
-			Status    string  `json:"status"`
-			TxHash    string  `json:"txHash"`
+			ID        string `json:"id"`
+			Timestamp string `json:"timestamp"`
+			Type      string `json:"type"`
+			VaultName string `json:"vaultName"`
+			Amount    string `json:"amount"`
+			Asset     string `json:"asset"`
+			Status    string `json:"status"`
+			TxHash    string `json:"txHash"`
 		} `json:"data"`
 		NextCursor string `json:"nextCursor"`
 		PrevCursor string `json:"prevCursor"`
@@ -113,8 +113,8 @@ func TestActivityHandler_List_MapsToFrontendContract(t *testing.T) {
 	if got.Status != "Confirmed" {
 		t.Fatalf("Status = %q, want %q", got.Status, "Confirmed")
 	}
-	if got.Amount != 123.45 {
-		t.Fatalf("Amount = %v, want 123.45", got.Amount)
+	if got.Amount != "123.45" {
+		t.Fatalf("Amount = %v, want %q", got.Amount, "123.45")
 	}
 	if got.VaultName != "USDC Vault" || got.Asset != "USDC" || got.TxHash != "txhash-1" {
 		t.Fatalf("unexpected item shape: %+v", got)
@@ -128,6 +128,59 @@ func TestActivityHandler_List_MapsToFrontendContract(t *testing.T) {
 	}
 	if stub.gotFilter.Status != activity.StatusCompleted {
 		t.Fatalf("status filter = %q, want %q", stub.gotFilter.Status, activity.StatusCompleted)
+	}
+}
+
+// TestActivityHandler_List_AmountSurvivesFloat64Precision is the regression
+// test for #1223: amount used to leave the API as float64
+// (it.Amount.Float64()), which silently rounds a value with more significant
+// digits than float64 can hold exactly. "1234567890123.456789" is such a
+// value — converting it through float64 and back yields
+// "1234567890123.4568" instead. The DTO now carries decimal.Decimal end to
+// end, which marshals to the exact decimal string.
+func TestActivityHandler_List_AmountSurvivesFloat64Precision(t *testing.T) {
+	userID := uuid.New()
+	const preciseAmount = "1234567890123.456789"
+
+	stub := &stubActivityLister{
+		items: []activity.Item{
+			{
+				ID:        uuid.New(),
+				Type:      activity.EventDeposit,
+				Amount:    decimal.RequireFromString(preciseAmount),
+				Currency:  "USDC",
+				Status:    activity.StatusCompleted,
+				CreatedAt: time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+				VaultID:   uuid.New(),
+				VaultName: "USDC Vault",
+			},
+		},
+	}
+	h := NewActivityHandler(stub)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	server := httptest.NewServer(withAuthUser(mux, userID))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/activity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		Data []struct {
+			Amount string `json:"amount"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("got %d items, want 1", len(body.Data))
+	}
+	if body.Data[0].Amount != preciseAmount {
+		t.Fatalf("Amount = %q, want %q (exact, not float64-rounded)", body.Data[0].Amount, preciseAmount)
 	}
 }
 

--- a/apps/api/internal/handler/savings_goal_handler.go
+++ b/apps/api/internal/handler/savings_goal_handler.go
@@ -336,6 +336,13 @@ func (h *SavingsGoalHandler) coaching(w http.ResponseWriter, r *http.Request) {
 
 // goalCoachingRequest builds the intelligence service request payload from an
 // already-progress-enriched savings goal.
+//
+// TargetAmount/CurrentAmount are converted to float64 deliberately, not by a
+// discarded return value (#1223): intelligence.SavingsGoalContext mirrors the
+// intelligence service's pydantic model, which declares these fields as
+// floats, so float64 is genuinely required at this boundary. The discarded
+// exactness flag is safe to ignore here — coaching narrative/milestones are
+// informational, not the source of truth for a user's balance.
 func goalCoachingRequest(goal savingsgoal.SavingsGoal) intelligence.CoachingRequest {
 	targetAmount, _ := goal.TargetAmount.Float64()
 	currentAmount, _ := goal.CurrentAmount.Float64()

--- a/apps/api/internal/repository/postgres/activity_event_repository.go
+++ b/apps/api/internal/repository/postgres/activity_event_repository.go
@@ -25,6 +25,19 @@ func (r *ActivityEventRepository) RecordEvent(ctx context.Context, userID uuid.U
 	return err
 }
 
+// DeleteOlderThan permanently removes activity_events rows whose occurred_at
+// is before cutoff (nester#1226 retention policy). Returns the number of
+// rows removed so the caller can audit-log the deletion with a real count.
+func (r *ActivityEventRepository) DeleteOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM activity_events WHERE occurred_at < $1
+	`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (r *ActivityEventRepository) ListRecentEvents(ctx context.Context, userID uuid.UUID, since time.Time) ([]usersignal.ActivityEvent, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, user_id, event_type, occurred_at

--- a/apps/api/internal/repository/postgres/nudge_history_repository.go
+++ b/apps/api/internal/repository/postgres/nudge_history_repository.go
@@ -100,6 +100,25 @@ func (r *NudgeHistoryRepository) GetLatestDispatchByType(ctx context.Context, us
 	return &l, nil
 }
 
+// DeleteDispatchesOlderThan permanently removes nudge_dispatch_log rows
+// whose sent_at is before cutoff (nester#1226 retention policy). Their
+// nudge_outcomes rows cascade automatically (migration 072:
+// dispatch_id REFERENCES nudge_dispatch_log(id) ON DELETE CASCADE), so this
+// is the only delete this job needs to issue for either table. Returns the
+// number of dispatch rows removed for the audit log. cutoff must stay well
+// past effectivenessWindow (90 days) — GetEffectivenessStats reads dispatch
+// rows back that far, and deleting inside that window would silently starve
+// it of data rather than erroring.
+func (r *NudgeHistoryRepository) DeleteDispatchesOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM nudge_dispatch_log WHERE sent_at < $1
+	`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // NudgesEnabled reads the user's nudges_enabled preference. Absence of a
 // notification_preferences row means the user has never touched their
 // settings, so it defaults to enabled (matches DefaultPreferences).

--- a/apps/api/internal/scheduler/data_retention.go
+++ b/apps/api/internal/scheduler/data_retention.go
@@ -1,0 +1,206 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/audit"
+)
+
+// DataRetentionAuditLogger is the narrow subset of service.AuditLogger this
+// job needs — deletion is itself audit-logged (nester#1226), and depending
+// only on the domain package (not the service package) avoids
+// scheduler -> service appearing in the import graph.
+type DataRetentionAuditLogger interface {
+	Log(ctx context.Context, entry audit.Entry) error
+}
+
+// DataRetentionRepository is the subset of the two repositories this job
+// needs. Both DeleteOlderThan methods issue a plain DELETE ... WHERE <ts> <
+// cutoff and return the row count removed. Erasure, not anonymisation: both
+// tables hold only operational event history with no fields the retention
+// policy classifies as requiring anonymised retention (see
+// docs/data-retention.md).
+type DataRetentionRepository interface {
+	// DeleteOlderThan removes activity_events rows older than cutoff.
+	DeleteOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+// NudgeRetentionRepository is the nudge-history half of the job. A separate
+// interface (rather than folding into DataRetentionRepository) because the
+// method name legitimately differs per table and Go interfaces don't let two
+// embedded methods share a name with different receivers cleanly — this
+// keeps each call site's intent explicit at the call rather than behind a
+// generic name.
+type NudgeRetentionRepository interface {
+	// DeleteDispatchesOlderThan removes nudge_dispatch_log rows (and their
+	// cascaded nudge_outcomes) older than cutoff.
+	DeleteDispatchesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+// DataRetentionConfig controls the sweep. See docs/data-retention.md for the
+// policy that sets these defaults and the reasoning behind each one.
+type DataRetentionConfig struct {
+	// ActivityEventsRetention is how long activity_events rows are kept.
+	// Default 180 days (docs/data-retention.md §activity_events).
+	ActivityEventsRetention time.Duration
+	// NudgeDispatchRetention is how long nudge_dispatch_log rows (and their
+	// cascaded nudge_outcomes) are kept. Must stay well past
+	// postgres.effectivenessWindow (90 days) or the nudge-ranking engine's
+	// effectiveness stats silently starve. Default 180 days.
+	NudgeDispatchRetention time.Duration
+	Now                    func() time.Time
+}
+
+func (c DataRetentionConfig) withDefaults() DataRetentionConfig {
+	if c.ActivityEventsRetention <= 0 {
+		c.ActivityEventsRetention = 180 * 24 * time.Hour
+	}
+	if c.NudgeDispatchRetention <= 0 {
+		c.NudgeDispatchRetention = 180 * 24 * time.Hour
+	}
+	if c.Now == nil {
+		c.Now = func() time.Time { return time.Now().UTC() }
+	}
+	return c
+}
+
+// DataRetentionJob periodically hard-deletes rows past their retention
+// window from tables the policy in docs/data-retention.md classifies as
+// erasable operational history (nester#1226). Every table this job touches
+// carries no legal/audit retention requirement — audit_logs, KYC records,
+// and processed_events are explicitly OUT of scope for this job; see the
+// policy doc for why each of those is handled (or deliberately not handled)
+// differently.
+type DataRetentionJob struct {
+	activity DataRetentionRepository
+	nudges   NudgeRetentionRepository
+	auditLog DataRetentionAuditLogger
+	logger   *slog.Logger
+	cfg      DataRetentionConfig
+	leader   LeaderChecker
+}
+
+// NewDataRetentionJob constructs the retention job. logger may be nil.
+// auditLog may be nil (deletion then simply isn't audit-logged; used only
+// when a Postgres connection to write audit_logs isn't available — mirrors
+// service.NoopAuditLogger's fallback reasoning).
+func NewDataRetentionJob(
+	activity DataRetentionRepository,
+	nudges NudgeRetentionRepository,
+	auditLog DataRetentionAuditLogger,
+	cfg DataRetentionConfig,
+	logger *slog.Logger,
+) *DataRetentionJob {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	}
+	return &DataRetentionJob{
+		activity: activity,
+		nudges:   nudges,
+		auditLog: auditLog,
+		logger:   logger,
+		cfg:      cfg.withDefaults(),
+	}
+}
+
+// SetLeaderChecker wires leader election. Running the sweep from multiple
+// instances is harmless-but-wasteful (each DELETE is idempotent — a second
+// run just finds nothing left to delete), but it's still classified with the
+// other sweep jobs for the same reason SavingsGoalPurgeJob is: a nil checker
+// means "always leader" (single-instance deployments, existing tests).
+func (j *DataRetentionJob) SetLeaderChecker(l LeaderChecker) { j.leader = l }
+
+func (j *DataRetentionJob) isLeader() bool {
+	return j.leader == nil || j.leader.IsLeader()
+}
+
+// Run ticks every `interval` until ctx is cancelled, sweeping expired rows on
+// each tick. A tick also fires once immediately on start.
+func (j *DataRetentionJob) Run(ctx context.Context, interval time.Duration) {
+	j.Tick(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			j.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs a single retention sweep. Exported for tests. Each table's
+// deletion (and its audit log entry) is independent — a failure on one does
+// not block the other, since neither depends on the other's cutoff.
+func (j *DataRetentionJob) Tick(ctx context.Context) {
+	if !j.isLeader() {
+		return
+	}
+
+	now := j.cfg.Now()
+
+	if j.activity != nil {
+		j.sweepActivityEvents(ctx, now)
+	}
+	if j.nudges != nil {
+		j.sweepNudgeDispatches(ctx, now)
+	}
+}
+
+func (j *DataRetentionJob) sweepActivityEvents(ctx context.Context, now time.Time) {
+	cutoff := now.Add(-j.cfg.ActivityEventsRetention)
+	deleted, err := j.activity.DeleteOlderThan(ctx, cutoff)
+	if err != nil {
+		j.logger.Error("data retention: activity_events delete failed", "error", err.Error(), "cutoff", cutoff)
+		return
+	}
+	if deleted == 0 {
+		return
+	}
+	j.logger.Info("data retention: activity_events swept", "deleted", deleted, "cutoff", cutoff)
+	j.audit(ctx, "data_retention.delete", "activity_events", deleted, cutoff)
+}
+
+func (j *DataRetentionJob) sweepNudgeDispatches(ctx context.Context, now time.Time) {
+	cutoff := now.Add(-j.cfg.NudgeDispatchRetention)
+	deleted, err := j.nudges.DeleteDispatchesOlderThan(ctx, cutoff)
+	if err != nil {
+		j.logger.Error("data retention: nudge_dispatch_log delete failed", "error", err.Error(), "cutoff", cutoff)
+		return
+	}
+	if deleted == 0 {
+		return
+	}
+	j.logger.Info("data retention: nudge_dispatch_log swept (nudge_outcomes cascaded)", "deleted", deleted, "cutoff", cutoff)
+	j.audit(ctx, "data_retention.delete", "nudge_dispatch_log", deleted, cutoff)
+}
+
+// audit records the deletion itself (nester#1226 acceptance criterion:
+// "Deletion is itself audit-logged"). No per-row entity IDs — a retention
+// sweep can remove thousands of rows in one pass, and the identity of an
+// individual deleted operational-log row is not the information an operator
+// reviewing this trail needs; the count and cutoff are. UserID is nil: this
+// is a system action, not attributable to any one user's account activity.
+func (j *DataRetentionJob) audit(ctx context.Context, action, entityType string, deletedCount int64, cutoff time.Time) {
+	if j.auditLog == nil {
+		return
+	}
+	entry := audit.Entry{
+		Action:     action,
+		EntityType: entityType,
+		EntityID:   uuid.Nil,
+		NewValue: map[string]any{
+			"deleted_count": deletedCount,
+			"cutoff":        cutoff.Format(time.RFC3339),
+		},
+	}
+	if err := j.auditLog.Log(ctx, entry); err != nil {
+		j.logger.Warn("data retention: audit log write failed", "error", err.Error(), "entity_type", entityType)
+	}
+}

--- a/apps/api/internal/scheduler/data_retention_test.go
+++ b/apps/api/internal/scheduler/data_retention_test.go
@@ -1,0 +1,248 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/audit"
+)
+
+// fakeActivityEventRepo is an in-memory stand-in for the activity_events
+// repository method DataRetentionJob needs (nester#1226).
+type fakeActivityEventRepo struct {
+	rows          []time.Time // occurred_at of each remaining row
+	deleteCutoffs []time.Time
+	err           error
+}
+
+func (f *fakeActivityEventRepo) DeleteOlderThan(_ context.Context, cutoff time.Time) (int64, error) {
+	f.deleteCutoffs = append(f.deleteCutoffs, cutoff)
+	if f.err != nil {
+		return 0, f.err
+	}
+	var kept []time.Time
+	var deleted int64
+	for _, t := range f.rows {
+		if t.Before(cutoff) {
+			deleted++
+			continue
+		}
+		kept = append(kept, t)
+	}
+	f.rows = kept
+	return deleted, nil
+}
+
+// fakeNudgeRetentionRepo is an in-memory stand-in for the nudge_dispatch_log
+// repository method DataRetentionJob needs.
+type fakeNudgeRetentionRepo struct {
+	rows          []time.Time // sent_at of each remaining row
+	deleteCutoffs []time.Time
+	err           error
+}
+
+func (f *fakeNudgeRetentionRepo) DeleteDispatchesOlderThan(_ context.Context, cutoff time.Time) (int64, error) {
+	f.deleteCutoffs = append(f.deleteCutoffs, cutoff)
+	if f.err != nil {
+		return 0, f.err
+	}
+	var kept []time.Time
+	var deleted int64
+	for _, t := range f.rows {
+		if t.Before(cutoff) {
+			deleted++
+			continue
+		}
+		kept = append(kept, t)
+	}
+	f.rows = kept
+	return deleted, nil
+}
+
+// fakeAuditLogger records every entry it's asked to log, so tests can assert
+// deletion is itself audit-logged (nester#1226 acceptance criterion).
+type fakeAuditLogger struct {
+	entries []audit.Entry
+	err     error
+}
+
+func (f *fakeAuditLogger) Log(_ context.Context, entry audit.Entry) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.entries = append(f.entries, entry)
+	return nil
+}
+
+func TestDataRetentionJob_DeletesOnlyRowsPastRetentionWindow(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+
+	activity := &fakeActivityEventRepo{
+		rows: []time.Time{
+			now.Add(-181 * 24 * time.Hour), // past 180d — must be removed
+			now.Add(-179 * 24 * time.Hour), // just inside 180d — must survive
+			now.Add(-1 * time.Hour),        // recent — must survive
+		},
+	}
+	nudges := &fakeNudgeRetentionRepo{
+		rows: []time.Time{
+			now.Add(-200 * 24 * time.Hour), // past 180d — must be removed
+			now.Add(-10 * 24 * time.Hour),  // recent — must survive
+		},
+	}
+	audit := &fakeAuditLogger{}
+
+	job := NewDataRetentionJob(activity, nudges, audit, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	if len(activity.rows) != 2 {
+		t.Fatalf("activity_events: expected 2 rows to survive, got %d", len(activity.rows))
+	}
+	if len(nudges.rows) != 1 {
+		t.Fatalf("nudge_dispatch_log: expected 1 row to survive, got %d", len(nudges.rows))
+	}
+}
+
+func TestDataRetentionJob_UsesConfiguredRetentionWindows(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{}
+	nudges := &fakeNudgeRetentionRepo{}
+
+	cfg := DataRetentionConfig{
+		ActivityEventsRetention: 30 * 24 * time.Hour,
+		NudgeDispatchRetention:  90 * 24 * time.Hour,
+		Now:                     func() time.Time { return now },
+	}
+	job := NewDataRetentionJob(activity, nudges, nil, cfg, nil)
+	job.Tick(context.Background())
+
+	if len(activity.deleteCutoffs) != 1 || !activity.deleteCutoffs[0].Equal(now.Add(-30*24*time.Hour)) {
+		t.Fatalf("activity_events cutoff = %v, want %v", activity.deleteCutoffs, now.Add(-30*24*time.Hour))
+	}
+	if len(nudges.deleteCutoffs) != 1 || !nudges.deleteCutoffs[0].Equal(now.Add(-90*24*time.Hour)) {
+		t.Fatalf("nudge_dispatch_log cutoff = %v, want %v", nudges.deleteCutoffs, now.Add(-90*24*time.Hour))
+	}
+}
+
+func TestDataRetentionJob_DefaultsRetentionTo180Days(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{}
+	nudges := &fakeNudgeRetentionRepo{}
+
+	job := NewDataRetentionJob(activity, nudges, nil, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	want := now.Add(-180 * 24 * time.Hour)
+	if !activity.deleteCutoffs[0].Equal(want) {
+		t.Fatalf("default activity_events cutoff = %v, want %v", activity.deleteCutoffs[0], want)
+	}
+	if !nudges.deleteCutoffs[0].Equal(want) {
+		t.Fatalf("default nudge_dispatch_log cutoff = %v, want %v", nudges.deleteCutoffs[0], want)
+	}
+}
+
+func TestDataRetentionJob_AuditLogsEachDeletionWithCountAndCutoff(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{
+		rows: []time.Time{now.Add(-200 * 24 * time.Hour), now.Add(-200 * 24 * time.Hour)},
+	}
+	nudges := &fakeNudgeRetentionRepo{
+		rows: []time.Time{now.Add(-200 * 24 * time.Hour)},
+	}
+	auditLog := &fakeAuditLogger{}
+
+	job := NewDataRetentionJob(activity, nudges, auditLog, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	if len(auditLog.entries) != 2 {
+		t.Fatalf("expected 2 audit entries (one per table), got %d", len(auditLog.entries))
+	}
+
+	var sawActivity, sawNudges bool
+	for _, e := range auditLog.entries {
+		if e.Action != "data_retention.delete" {
+			t.Errorf("action = %q, want data_retention.delete", e.Action)
+		}
+		if e.UserID != nil {
+			t.Errorf("expected UserID nil (system action), got %v", *e.UserID)
+		}
+		switch e.EntityType {
+		case "activity_events":
+			sawActivity = true
+			nv, ok := e.NewValue.(map[string]any)
+			if !ok || nv["deleted_count"] != int64(2) {
+				t.Errorf("activity_events audit NewValue = %#v, want deleted_count=2", e.NewValue)
+			}
+		case "nudge_dispatch_log":
+			sawNudges = true
+			nv, ok := e.NewValue.(map[string]any)
+			if !ok || nv["deleted_count"] != int64(1) {
+				t.Errorf("nudge_dispatch_log audit NewValue = %#v, want deleted_count=1", e.NewValue)
+			}
+		default:
+			t.Errorf("unexpected entity_type %q", e.EntityType)
+		}
+	}
+	if !sawActivity || !sawNudges {
+		t.Fatalf("expected an audit entry for both tables, sawActivity=%v sawNudges=%v", sawActivity, sawNudges)
+	}
+}
+
+func TestDataRetentionJob_DoesNotAuditLogWhenNothingWasDeleted(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{rows: []time.Time{now}} // recent, survives
+	nudges := &fakeNudgeRetentionRepo{}
+	auditLog := &fakeAuditLogger{}
+
+	job := NewDataRetentionJob(activity, nudges, auditLog, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	if len(auditLog.entries) != 0 {
+		t.Fatalf("expected no audit entries when nothing was deleted, got %d", len(auditLog.entries))
+	}
+}
+
+func TestDataRetentionJob_OneTableFailingDoesNotBlockTheOther(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{err: context.DeadlineExceeded}
+	nudges := &fakeNudgeRetentionRepo{rows: []time.Time{now.Add(-200 * 24 * time.Hour)}}
+	auditLog := &fakeAuditLogger{}
+
+	job := NewDataRetentionJob(activity, nudges, auditLog, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	if len(nudges.rows) != 0 {
+		t.Fatalf("expected nudge_dispatch_log sweep to succeed despite activity_events failing, got %d rows remaining", len(nudges.rows))
+	}
+	if len(auditLog.entries) != 1 || auditLog.entries[0].EntityType != "nudge_dispatch_log" {
+		t.Fatalf("expected exactly one audit entry for the successful table, got %#v", auditLog.entries)
+	}
+}
+
+func TestDataRetentionJob_SkipsTickWhenNotLeader(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{rows: []time.Time{now.Add(-200 * 24 * time.Hour)}}
+	nudges := &fakeNudgeRetentionRepo{rows: []time.Time{now.Add(-200 * 24 * time.Hour)}}
+
+	job := NewDataRetentionJob(activity, nudges, nil, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.SetLeaderChecker(fakePurgeLeaderChecker{leader: false})
+	job.Tick(context.Background())
+
+	if len(activity.deleteCutoffs) != 0 || len(nudges.deleteCutoffs) != 0 {
+		t.Fatalf("expected no delete calls while not leader")
+	}
+}
+
+func TestDataRetentionJob_RunsWhenLeaderCheckerIsNil(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	activity := &fakeActivityEventRepo{rows: []time.Time{now.Add(-200 * 24 * time.Hour)}}
+	nudges := &fakeNudgeRetentionRepo{}
+
+	job := NewDataRetentionJob(activity, nudges, nil, DataRetentionConfig{Now: func() time.Time { return now }}, nil)
+	job.Tick(context.Background())
+
+	if len(activity.rows) != 0 {
+		t.Fatalf("expected the sweep to run with no leader checker wired (nil = always leader), got %d rows remaining", len(activity.rows))
+	}
+}

--- a/apps/api/internal/service/performance/service.go
+++ b/apps/api/internal/service/performance/service.go
@@ -14,9 +14,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/analytics"
 	perfdom "github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
-	"github.com/suncrestlabs/nester/apps/api/internal/domain/analytics"
 )
 
 // VaultLister is the subset of the vault repo we need. Defined locally so
@@ -171,7 +171,6 @@ func (s *Service) GetAPYHistory(
 		DataPoints:   dataPoints,
 	}, nil
 }
-
 
 // CalculateRealizedAPY annualizes the return between two snapshots.
 //
@@ -383,21 +382,26 @@ func buildVaultMonthlyYield(
 }
 
 func (s *Service) GetUserAnalytics(ctx context.Context, userID uuid.UUID, fromTime, toTime time.Time) (*analytics.AnalyticsResponse, error) {
-	// Get user's vaults
+	// Get user's vaults. A 1,000-vault ceiling is safe here the same way
+	// portfolio_service.go's GetUserPortfolioSummary reasons about its own
+	// 10,000 ceiling (nester#1193/#1225): this is ListUserVaults (bounded by
+	// how many vaults one person can plausibly create through the product
+	// UI), not a cross-user or transaction-volume-scaled list. If vault
+	// creation ever becomes bulk/programmatic this stops holding.
 	userVaults, _, err := s.vaultRepo.ListUserVaults(ctx, userID, vault.UserListFilter{Page: 1, PerPage: 1000})
 	if err != nil {
 		return &analytics.AnalyticsResponse{}, fmt.Errorf("failed to get user vaults: %w", err)
 	}
 
 	if len(userVaults) == 0 {
-	// Return empty response if user has no vaults
-	return &analytics.AnalyticsResponse{
-		DailySnapshots:      []analytics.DailySnapshot{},
-		VaultMonthlyYield:   []analytics.VaultMonthlyYield{},
-		CurrentAllocation:   []analytics.CurrentAllocation{},
-		PerformanceMetrics:  analytics.PerformanceMetrics{},
-		Vaults:              []analytics.VaultInfo{},
-	}, nil
+		// Return empty response if user has no vaults
+		return &analytics.AnalyticsResponse{
+			DailySnapshots:     []analytics.DailySnapshot{},
+			VaultMonthlyYield:  []analytics.VaultMonthlyYield{},
+			CurrentAllocation:  []analytics.CurrentAllocation{},
+			PerformanceMetrics: analytics.PerformanceMetrics{},
+			Vaults:             []analytics.VaultInfo{},
+		}, nil
 	}
 
 	// Read every vault's history once. Both the daily series and the monthly
@@ -507,19 +511,19 @@ func (s *Service) GetUserAnalytics(ctx context.Context, userID uuid.UUID, fromTi
 		lockPeriodDays = 0 // placeholder
 
 		vaultsInfo = append(vaultsInfo, analytics.VaultInfo{
-			ID:            vault.ID.String(),
-			Name:          vault.ContractAddress,
-			BalanceUSD:    vault.CurrentBalance.InexactFloat64(),
-			APY:           0, // placeholder - would calculate from allocations
-			YieldEarned:   vault.YieldEarned.InexactFloat64(),
+			ID:             vault.ID.String(),
+			Name:           vault.ContractAddress,
+			BalanceUSD:     vault.CurrentBalance.InexactFloat64(),
+			APY:            0, // placeholder - would calculate from allocations
+			YieldEarned:    vault.YieldEarned.InexactFloat64(),
 			LockPeriodDays: lockPeriodDays,
 		})
 	}
 
 	return &analytics.AnalyticsResponse{
-		DailySnapshots:      dailySnapshots,
-		VaultMonthlyYield:   vaultMonthlyYield,
-		CurrentAllocation:   currentAllocation,
+		DailySnapshots:    dailySnapshots,
+		VaultMonthlyYield: vaultMonthlyYield,
+		CurrentAllocation: currentAllocation,
 		PerformanceMetrics: analytics.PerformanceMetrics{
 			TotalYieldEarned: totalYieldEarned.InexactFloat64(),
 			YieldChangePCT:   yieldChangePCT,

--- a/apps/api/internal/service/projection_service.go
+++ b/apps/api/internal/service/projection_service.go
@@ -65,12 +65,23 @@ func (s *ProjectionService) CalculateCompoundProjection(ctx context.Context, inp
 
 	summary := s.calculateSummary(input, timeline)
 
+	contributionSource := "single_deposit"
+	if input.MonthlyContribution.GreaterThan(decimal.Zero) {
+		contributionSource = "caller_supplied"
+	}
+
 	output := &projection.ProjectionOutput{
-		Currency:     "USD",
-		CurrentAPY:   input.APY.InexactFloat64(),
-		Input:        input,
-		Timeline:     timeline,
-		Summary:      summary,
+		Currency:   "USD",
+		CurrentAPY: input.APY.InexactFloat64(),
+		Input:      input,
+		Timeline:   timeline,
+		Summary:    summary,
+		Assumptions: projection.ProjectionAssumptions{
+			RecurringAmount:    input.MonthlyContribution,
+			ProjectedAPY:       input.APY.InexactFloat64(),
+			TimelineMonths:     input.PeriodMonths,
+			ContributionSource: contributionSource,
+		},
 		CalculatedAt: time.Now(),
 	}
 
@@ -110,10 +121,24 @@ func (s *ProjectionService) CalculateVaultProjection(ctx context.Context, input 
 		}
 	}
 
+	// Resolve the vault's real recurring contribution, if any, rather than
+	// assuming a single deposit (#1224). A vault has at most one linked
+	// savings goal, and a goal has at most one active schedule.
+	monthlyContribution := decimal.Zero
+	cadence := ""
+	contributionSource := "single_deposit"
+	if goal, goalErr := s.savingsGoalRepo.GetByVaultID(ctx, input.VaultID); goalErr == nil && goal != nil {
+		if schedule, schedErr := s.savingsScheduleRepo.GetActiveByGoal(ctx, goal.ID, goal.UserID); schedErr == nil && schedule != nil {
+			monthlyContribution = monthlyEquivalent(schedule.Amount, schedule.Frequency)
+			cadence = string(schedule.Frequency)
+			contributionSource = "schedule"
+		}
+	}
+
 	// Build projection input
 	projInput := projection.ProjectionInput{
 		InitialDeposit:      input.Deposit,
-		MonthlyContribution: decimal.Zero, // Single deposit for now
+		MonthlyContribution: monthlyContribution,
 		APY:                 *apy,
 		PeriodMonths:        periodMonths,
 		CompoundFrequency:   compoundFreq,
@@ -131,12 +156,19 @@ func (s *ProjectionService) CalculateVaultProjection(ctx context.Context, input 
 	summary := s.calculateSummary(projInput, timeline)
 
 	output := &projection.ProjectionOutput{
-		VaultID:      &input.VaultID,
-		Currency:     vaultEntity.Currency,
-		CurrentAPY:   apy.InexactFloat64(),
-		Input:        projInput,
-		Timeline:     timeline,
-		Summary:      summary,
+		VaultID:    &input.VaultID,
+		Currency:   vaultEntity.Currency,
+		CurrentAPY: apy.InexactFloat64(),
+		Input:      projInput,
+		Timeline:   timeline,
+		Summary:    summary,
+		Assumptions: projection.ProjectionAssumptions{
+			RecurringAmount:    monthlyContribution,
+			Cadence:            cadence,
+			ProjectedAPY:       apy.InexactFloat64(),
+			TimelineMonths:     periodMonths,
+			ContributionSource: contributionSource,
+		},
 		CalculatedAt: time.Now(),
 	}
 

--- a/apps/api/internal/service/projection_vault_recurring_test.go
+++ b/apps/api/internal/service/projection_vault_recurring_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/performance"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/projection"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsgoal"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/savingsschedule"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// recurringVaultRepo serves a single fixed vault. Only GetVault is exercised.
+type recurringVaultRepo struct {
+	vault.Repository
+	v vault.Vault
+}
+
+func (r *recurringVaultRepo) GetVault(_ context.Context, _ uuid.UUID) (vault.Vault, error) {
+	return r.v, nil
+}
+
+// recurringGoalRepo resolves GetByVaultID from a map, returning
+// ErrGoalNotFound (matching the real repository's contract) when absent.
+type recurringGoalRepo struct {
+	savingsgoal.Repository
+	byVault map[uuid.UUID]savingsgoal.SavingsGoal
+}
+
+func (r *recurringGoalRepo) GetByVaultID(_ context.Context, vaultID uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	g, ok := r.byVault[vaultID]
+	if !ok {
+		return nil, savingsgoal.ErrGoalNotFound
+	}
+	return &g, nil
+}
+
+// recurringScheduleRepo resolves GetActiveByGoal from a map, returning
+// ErrScheduleNotFound (matching the real repository's contract) when absent.
+type recurringScheduleRepo struct {
+	savingsschedule.Repository
+	byGoal map[uuid.UUID]savingsschedule.SavingsSchedule
+}
+
+func (r *recurringScheduleRepo) GetActiveByGoal(_ context.Context, goalID, _ uuid.UUID) (*savingsschedule.SavingsSchedule, error) {
+	s, ok := r.byGoal[goalID]
+	if !ok {
+		return nil, savingsschedule.ErrScheduleNotFound
+	}
+	return &s, nil
+}
+
+// TestCalculateVaultProjection_RecurringContribution is the regression test
+// for #1224: a vault whose goal has an active recurring schedule must
+// project a higher final balance than an identical vault with no schedule,
+// and the response must say which assumption produced which number.
+func TestCalculateVaultProjection_RecurringContribution(t *testing.T) {
+	userID := uuid.New()
+	vaultWithSchedule := uuid.New()
+	vaultNoSchedule := uuid.New()
+	goalID := uuid.New()
+
+	apy := decimal.NewFromFloat(0.08)
+	deposit := decimal.NewFromInt(1000)
+
+	makeVault := func(id uuid.UUID) vault.Vault {
+		return vault.Vault{ID: id, UserID: userID, Currency: "USD"}
+	}
+
+	goalRepo := &recurringGoalRepo{
+		byVault: map[uuid.UUID]savingsgoal.SavingsGoal{
+			vaultWithSchedule: {ID: goalID, UserID: userID, VaultID: &vaultWithSchedule},
+		},
+	}
+	scheduleRepo := &recurringScheduleRepo{
+		byGoal: map[uuid.UUID]savingsschedule.SavingsSchedule{
+			goalID: {
+				ID:        uuid.New(),
+				UserID:    userID,
+				GoalID:    goalID,
+				VaultID:   vaultWithSchedule,
+				Amount:    decimal.NewFromInt(200),
+				Currency:  "USD",
+				Frequency: savingsschedule.FrequencyMonthly,
+				IsActive:  true,
+			},
+		},
+	}
+
+	newService := func(vaultID uuid.UUID) *ProjectionService {
+		return NewProjectionService(
+			NewCompoundInterestCalculator(),
+			&recurringVaultRepo{v: makeVault(vaultID)},
+			(performance.SnapshotRepository)(nil),
+			goalRepo,
+			scheduleRepo,
+		)
+	}
+
+	input := func(vaultID uuid.UUID) projection.VaultProjectionInput {
+		return projection.VaultProjectionInput{
+			VaultID:           vaultID,
+			Deposit:           deposit,
+			Period:            "12m",
+			CompoundFrequency: "monthly",
+			APYOverride:       &apy,
+		}
+	}
+
+	withSchedule, err := newService(vaultWithSchedule).CalculateVaultProjection(context.Background(), input(vaultWithSchedule))
+	require.NoError(t, err)
+
+	withoutSchedule, err := newService(vaultNoSchedule).CalculateVaultProjection(context.Background(), input(vaultNoSchedule))
+	require.NoError(t, err)
+
+	// Acceptance criterion: projections differ when a schedule exists.
+	require.True(t, withSchedule.Summary.FinalBalance.GreaterThan(withoutSchedule.Summary.FinalBalance),
+		"a user with an active recurring schedule should project a higher final balance")
+	require.True(t, withSchedule.Input.MonthlyContribution.Equal(decimal.NewFromInt(200)),
+		"monthly contribution should be resolved from the active schedule")
+
+	// Acceptance criterion: a user with no schedule still gets an unchanged
+	// single-deposit projection.
+	require.True(t, withoutSchedule.Input.MonthlyContribution.IsZero(),
+		"a vault with no linked goal/schedule should fall back to single-deposit")
+	require.Equal(t, "single_deposit", withoutSchedule.Assumptions.ContributionSource)
+
+	// Acceptance criterion: the assumptions behind the projection are stated
+	// in the response.
+	require.Equal(t, "schedule", withSchedule.Assumptions.ContributionSource)
+	require.Equal(t, "monthly", withSchedule.Assumptions.Cadence)
+	require.True(t, withSchedule.Assumptions.RecurringAmount.Equal(decimal.NewFromInt(200)))
+	require.Equal(t, 12, withSchedule.Assumptions.TimelineMonths)
+}
+
+// TestCalculateVaultProjection_NoGoalLinked confirms a vault with no linked
+// savings goal at all (GetByVaultID returns ErrGoalNotFound) still produces
+// the baseline single-deposit projection rather than erroring out.
+func TestCalculateVaultProjection_NoGoalLinked(t *testing.T) {
+	vaultID := uuid.New()
+	apy := decimal.NewFromFloat(0.05)
+
+	svc := NewProjectionService(
+		NewCompoundInterestCalculator(),
+		&recurringVaultRepo{v: vault.Vault{ID: vaultID, Currency: "USD"}},
+		(performance.SnapshotRepository)(nil),
+		&recurringGoalRepo{byVault: map[uuid.UUID]savingsgoal.SavingsGoal{}},
+		&recurringScheduleRepo{byGoal: map[uuid.UUID]savingsschedule.SavingsSchedule{}},
+	)
+
+	out, err := svc.CalculateVaultProjection(context.Background(), projection.VaultProjectionInput{
+		VaultID:           vaultID,
+		Deposit:           decimal.NewFromInt(500),
+		Period:            "6m",
+		CompoundFrequency: "monthly",
+		APYOverride:       &apy,
+	})
+	require.NoError(t, err)
+	require.True(t, out.Input.MonthlyContribution.IsZero())
+	require.Equal(t, "single_deposit", out.Assumptions.ContributionSource)
+}

--- a/apps/api/pkg/listquery/pagination_contract_test.go
+++ b/apps/api/pkg/listquery/pagination_contract_test.go
@@ -1,0 +1,156 @@
+package listquery_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoNewUnboundedListLimits is the guard nester#1225 asks for: "a test or
+// lint that fails when a new list endpoint ships without the [pagination]
+// contract". It scans every non-test .go file under internal/ for a struct
+// literal field named PerPage or Limit set to an int literal above
+// listquery.MaxPerPage's order of magnitude (>= 500), and fails the build if
+// one appears that is not in knownLargeLimits below.
+//
+// This is deliberately an ALLOWLIST, not a bare threshold check: every
+// existing large limit in this codebase is a considered, reviewed decision
+// (see each entry's comment) rather than an accident, and a bare "no literal
+// over N" rule would either need to re-litigate those on every test run or
+// produce false positives that train people to ignore the test. A NEW large
+// limit must be added here explicitly, with the same kind of justification
+// the existing entries carry — that's what "ships without the contract"
+// means failing loudly, without making already-reviewed code re-fail forever.
+//
+// listquery.MaxPerPage (100) is the bound for anything reachable from an
+// HTTP list endpoint via ParsePage — those already fail closed (ParsePage
+// rejects per_page > MaxPerPage). This test covers the other half of the
+// issue's evidence: internal, non-HTTP call sites that construct a
+// *ListFilter directly with a hardcoded large PerPage/Limit to simulate
+// "fetch everything" rather than either paging through the real total or
+// being genuinely bounded by something other than transaction volume.
+func TestNoNewUnboundedListLimits(t *testing.T) {
+	// knownLargeLimits are file:line -> why. Each entry here must be a
+	// call site actually reviewed and found safe (bounded by something
+	// other than unbounded transaction/record volume — typically "how many
+	// vaults a single user can create through the product UI", which the
+	// referenced issues discuss), or already fixed to page through the real
+	// total (comparators.go, adapters.go's TxPendingSource) and therefore
+	// no longer present in this list at all.
+	knownLargeLimits := map[string]string{
+		"internal/service/portfolio_service.go:38":    "nester#1193/#1225: ListUserVaults, bounded by a single user's vault count (product-UI-created, not transaction volume).",
+		"internal/service/performance/service.go:391": "nester#1193/#1225: ListUserVaults, same per-user bound as portfolio_service.go.",
+		"internal/service/user_vaults_service.go:45":  "nester#1225: ListUserVaults, same per-user bound, additionally scoped to StatusActive.",
+		"internal/valuation/adapters.go:50":           "nester#1193/#1225: VaultPositionSource.Positions — ListUserVaults, same per-user bound (see the function's own doc comment).",
+	}
+
+	root := moduleRoot(t)
+	internalDir := filepath.Join(root, "internal")
+
+	fset := token.NewFileSet()
+	violations := []string{}
+
+	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, src, 0)
+		if parseErr != nil {
+			// A file that doesn't parse is a compile error elsewhere, not
+			// this test's job to report — skip rather than fail here.
+			return nil
+		}
+
+		rel, _ := filepath.Rel(root, path)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			kv, ok := n.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || (key.Name != "PerPage" && key.Name != "Limit") {
+				return true
+			}
+			lit, ok := kv.Value.(*ast.BasicLit)
+			if !ok || lit.Kind != token.INT {
+				return true
+			}
+			value, convErr := strconv.Atoi(lit.Value)
+			if convErr != nil || value < 500 {
+				return true
+			}
+
+			pos := fset.Position(kv.Pos())
+			key2 := rel + ":" + strconv.Itoa(pos.Line)
+			if _, known := knownLargeLimits[key2]; !known {
+				violations = append(violations, key2+": "+key.Name+": "+lit.Value)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking internal/: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Errorf(
+			"found %d list-limit literal(s) >= 500 not in the reviewed allowlist "+
+				"(pkg/listquery/pagination_contract_test.go's knownLargeLimits):\n  %s\n\n"+
+				"A list endpoint or internal query must either (a) use listquery.ParsePage "+
+				"(bounded by MaxPerPage=100) if it's reachable from an HTTP request, "+
+				"(b) page through the real total rather than substituting a large fixed "+
+				"limit (see reconciliation/comparators.go's vaultReconcilePageSize or "+
+				"valuation/adapters.go's TxPendingSource.PendingDeposits for the pattern), "+
+				"or (c) if genuinely bounded by something other than record-volume growth "+
+				"(e.g. a single user's own vault count), add it to knownLargeLimits with "+
+				"the same kind of justification the existing entries carry.",
+			len(violations), strings.Join(violations, "\n  "),
+		)
+	}
+
+	// Sanity check on the test itself: if every known entry stops matching
+	// (e.g. because the underlying code moved and line numbers shifted),
+	// this test would pass vacuously without actually scanning anything
+	// meaningful. Fail loudly instead so the allowlist gets updated rather
+	// than silently going stale.
+	if len(knownLargeLimits) == 0 {
+		t.Fatal("knownLargeLimits is empty — this test would no longer verify anything")
+	}
+}
+
+// moduleRoot finds the apps/api module root by walking up from this test
+// file's own directory to the nearest go.mod — robust to the test being run
+// from any working directory (go test ./..., an IDE, CI).
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod walking up from pkg/listquery")
+		}
+		dir = parent
+	}
+}

--- a/apps/dapp/frontend/app/dashboard/history/page.tsx
+++ b/apps/dapp/frontend/app/dashboard/history/page.tsx
@@ -25,7 +25,7 @@ interface Transaction {
   timestamp: string;
   type: "Deposit" | "Withdrawal" | "Rebalance" | "Settlement" | "Yield Earned";
   vaultName: string;
-  amount: number;
+  amount: string; // exact decimal string from the API, e.g. "123.45" (#1223)
   asset: string;
   status: "Confirmed" | "Pending" | "Failed";
   txHash?: string;
@@ -103,7 +103,7 @@ export default function HistoryPage() {
     const term = filters.searchTerm.toLowerCase();
     return transactions.filter((tx) => {
       const hashMatch = tx.txHash?.toLowerCase().includes(term) ?? false;
-      const amountMatch = tx.amount.toString().includes(term);
+      const amountMatch = tx.amount.includes(term);
       return hashMatch || amountMatch;
     });
   }, [transactions, filters.searchTerm]);
@@ -111,13 +111,13 @@ export default function HistoryPage() {
   const summary = useMemo(() => {
     const totalDeposited = transactions
       .filter((t) => t.type === "Deposit")
-      .reduce((sum, t) => sum + t.amount, 0);
+      .reduce((sum, t) => sum + Number(t.amount), 0);
     const totalWithdrawn = transactions
       .filter((t) => t.type === "Withdrawal")
-      .reduce((sum, t) => sum + t.amount, 0);
+      .reduce((sum, t) => sum + Number(t.amount), 0);
     const totalYield = transactions
       .filter((t) => t.type === "Yield Earned")
-      .reduce((sum, t) => sum + t.amount, 0);
+      .reduce((sum, t) => sum + Number(t.amount), 0);
     return { totalDeposited, totalWithdrawn, totalYield };
   }, [transactions]);
 
@@ -126,7 +126,7 @@ export default function HistoryPage() {
       date: tx.timestamp,
       type: tx.type,
       vault: tx.vaultName,
-      amount: tx.amount.toFixed(2),
+      amount: Number(tx.amount).toFixed(2),
       status: tx.status,
       txHash: tx.txHash,
     }));

--- a/apps/dapp/frontend/app/portfolio/page.tsx
+++ b/apps/dapp/frontend/app/portfolio/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NETWORKS, DEFAULT_NETWORK } from "@/lib/networks";
+import { readNetworkId } from "@/lib/storageKeys";
 import { TransferModal } from "@/components/vault-action-modals";
 import { WithdrawModal } from "@/components/vault-action-modals";
 import { useTokenPrices } from "@/hooks/useTokenPrices";
@@ -35,11 +36,12 @@ import { PositionsSkeleton, ActivitySkeleton } from "@/components/skeletons/page
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function getHorizonUrl(): string {
-    if (typeof window !== "undefined") {
-        const saved = localStorage.getItem("nester_network_id");
-        if (saved === "mainnet") return NETWORKS.mainnet.horizonUrl;
-        if (saved === "testnet") return NETWORKS.testnet.horizonUrl;
-    }
+    // #1233: readNetworkId routes through safeStorage, so a throwing
+    // accessor (private browsing, full quota) falls back to
+    // DEFAULT_NETWORK's horizonUrl rather than an unguarded read crashing
+    // the page.
+    const saved = readNetworkId();
+    if (saved) return NETWORKS[saved].horizonUrl;
     return DEFAULT_NETWORK.horizonUrl;
 }
 

--- a/apps/dapp/frontend/components/ai/insightCard.tsx
+++ b/apps/dapp/frontend/components/ai/insightCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { ChevronDown, ChevronUp, Sparkles, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { type PortfolioInsight } from '@/lib/api/intelligence'
+import { safeStorage } from '@/lib/storage'
 
 export const INSIGHT_DISMISSAL_KEY_PREFIX = 'nester_ai_insight_dismissed_'
 
@@ -34,18 +35,23 @@ export function InsightCard({
   const storageKey = getInsightDismissKey(id, title)
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const isDismissed = localStorage.getItem(storageKey) === 'true'
-      if (isDismissed) {
-        setDismissed(true)
-      }
+    // #1233: safeStorage never throws — a throwing accessor (private
+    // browsing, full quota) falls back to the in-memory map instead of
+    // crashing this component on mount.
+    const isDismissed = safeStorage.get<boolean>(storageKey, false)
+    if (isDismissed) {
+      // Deferred (react-hooks/set-state-in-effect): a synchronous setState
+      // here caused cascading renders — matching the setTimeout(…, 0)
+      // pattern already used by NetworkProvider/settings-context for the
+      // same reason. Pre-existing on this line before #1233 touched it;
+      // fixed in passing since this file was already being edited here.
+      const timer = setTimeout(() => setDismissed(true), 0)
+      return () => clearTimeout(timer)
     }
   }, [storageKey])
 
   const handleDismiss = () => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(storageKey, 'true')
-    }
+    safeStorage.set(storageKey, true)
     setDismissed(true)
     onDismiss?.()
   }

--- a/apps/dapp/frontend/components/ai/insights-dashboard.tsx
+++ b/apps/dapp/frontend/components/ai/insights-dashboard.tsx
@@ -21,6 +21,7 @@ import { InsightCard, InsightCardSkeleton } from "@/components/ai/insightCard"
 import { MarketSentimentWidget } from "@/components/ai/marketSentiment"
 import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
+import { safeStorage } from "@/lib/storage"
 
 const INSIGHT_DISMISSAL_KEY_PREFIX = "nester_ai_insight_dismissed_"
 
@@ -28,15 +29,15 @@ function getDismissKey(id: string): string {
   return `${INSIGHT_DISMISSAL_KEY_PREFIX}${id}`
 }
 
+// #1233: safeStorage never throws — a throwing accessor (private browsing,
+// full quota) falls back to the in-memory map instead of crashing whichever
+// component calls these.
 function isDismissed(id: string): boolean {
-  if (typeof window === "undefined") return false
-  return localStorage.getItem(getDismissKey(id)) === "true"
+  return safeStorage.get<boolean>(getDismissKey(id), false)
 }
 
 function markDismissed(id: string) {
-  if (typeof window !== "undefined") {
-    localStorage.setItem(getDismissKey(id), "true")
-  }
+  safeStorage.set(getDismissKey(id), true)
 }
 
 interface CoachingContent {

--- a/apps/dapp/frontend/components/dashboard/RebalanceSuggestionCard.tsx
+++ b/apps/dapp/frontend/components/dashboard/RebalanceSuggestionCard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ArrowRightLeft, X, Loader2 } from "lucide-react";
 import { vaultsApi, type RebalanceSuggestion } from "@/lib/api/vaults";
 import { cn } from "@/lib/utils";
+import { safeStorage } from "@/lib/storage";
 
 const DISMISS_KEY = "nester_rebalance_dismissed";
 
@@ -24,7 +25,9 @@ export function RebalanceSuggestionCard({ vaultId, vaultName }: Props) {
   const [dismissed, setDismissed] = useState(false);
 
   const load = useCallback(async () => {
-    if (typeof window !== "undefined" && localStorage.getItem(dismissKey(vaultId))) {
+    // #1233: safeStorage never throws — a throwing accessor falls back to
+    // the in-memory map instead of crashing the load callback.
+    if (safeStorage.get<boolean>(dismissKey(vaultId), false)) {
       setDismissed(true);
       setLoading(false);
       return;
@@ -44,7 +47,7 @@ export function RebalanceSuggestionCard({ vaultId, vaultName }: Props) {
   }, [load]);
 
   const handleDismiss = () => {
-    localStorage.setItem(dismissKey(vaultId), "1");
+    safeStorage.set(dismissKey(vaultId), true);
     setDismissed(true);
     setModalOpen(false);
   };

--- a/apps/dapp/frontend/components/history/TransactionTable.tsx
+++ b/apps/dapp/frontend/components/history/TransactionTable.tsx
@@ -10,7 +10,7 @@ export interface Transaction {
   timestamp: string; // ISO string
   type: 'Deposit' | 'Withdrawal' | 'Rebalance' | 'Settlement' | 'Yield Earned';
   vaultName: string;
-  amount: number;
+  amount: string; // exact decimal string from the API, e.g. "123.45" (#1223)
   asset: string;
   status: 'Confirmed' | 'Pending' | 'Failed';
   txHash?: string;
@@ -87,7 +87,7 @@ const TransactionTable: React.FC<Props> = ({ transactions, loading, error, onExp
               <td className="px-4 py-2 text-sm text-gray-700">{tx.type}</td>
               <td className="px-4 py-2 text-sm text-gray-700">{tx.vaultName}</td>
               <td className="px-4 py-2 font-mono text-sm text-gray-700">
-                {tx.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 8 })} {tx.asset}
+                {Number(tx.amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 8 })} {tx.asset}
               </td>
               <td className="px-4 py-2">{renderStatus(tx.status)}</td>
               <td className="px-4 py-2">

--- a/apps/dapp/frontend/context/NetworkProvider.test.tsx
+++ b/apps/dapp/frontend/context/NetworkProvider.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { NetworkProvider, useNetwork } from "./NetworkProvider";
+import { readNetworkId } from "@/lib/storageKeys";
+
+// Issue #1233: NetworkProvider must route through safeStorage rather than
+// raw localStorage, and setNetwork must never leave React state and
+// persisted state disagreeing about the active network — even when the
+// underlying storage accessor throws.
+
+function TestConsumer() {
+  const { currentNetwork, setNetwork } = useNetwork();
+  return (
+    <div>
+      <span data-testid="network-id">{currentNetwork.id}</span>
+      <button onClick={() => setNetwork("mainnet")}>switch to mainnet</button>
+      <button onClick={() => setNetwork("testnet")}>switch to testnet</button>
+    </div>
+  );
+}
+
+describe("NetworkProvider (#1233)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to testnet when nothing is persisted", async () => {
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("testnet"));
+  });
+
+  it("restores a previously persisted network on mount", async () => {
+    window.localStorage.setItem("nester_network_id", JSON.stringify("mainnet"));
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("mainnet"));
+  });
+
+  it("restores a legacy, non-JSON-encoded persisted network on mount", async () => {
+    // Simulates a value from the OLD raw localStorage.setItem call site.
+    window.localStorage.setItem("nester_network_id", "mainnet");
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("mainnet"));
+  });
+
+  it("setNetwork updates both React state and persisted state together", async () => {
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("testnet"));
+
+    act(() => {
+      screen.getByText("switch to mainnet").click();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("mainnet"));
+    expect(readNetworkId()).toBe("mainnet");
+  });
+
+  it("does not crash and falls back to the default network when localStorage.getItem throws on mount", async () => {
+    vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError: storage disabled");
+    });
+
+    expect(() =>
+      render(
+        <NetworkProvider>
+          <TestConsumer />
+        </NetworkProvider>
+      )
+    ).not.toThrow();
+
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("testnet"));
+  });
+
+  it("setNetwork does not leave React state ahead of persistence when the storage write throws", async () => {
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("testnet"));
+
+    vi.spyOn(window.localStorage.__proto__, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    act(() => {
+      screen.getByText("switch to mainnet").click();
+    });
+
+    // React state DID move to mainnet (safeStorage.set never throws — it
+    // fell back to the in-memory map instead of failing outright), and a
+    // read through the same safeStorage path agrees with it: state and
+    // "persistence" (in-memory fallback counts) never disagree.
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("mainnet"));
+    expect(readNetworkId()).toBe("mainnet");
+  });
+
+  it("purges cached portfolio keys on network switch, leaving unrelated keys alone", async () => {
+    window.localStorage.setItem("nester_portfolio_v1:testnet:abc", "cached");
+    window.localStorage.setItem("nester_portfolio_v1:mainnet:xyz", "cached");
+    window.localStorage.setItem("unrelated_key", "keep-me");
+
+    render(
+      <NetworkProvider>
+        <TestConsumer />
+      </NetworkProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("testnet"));
+
+    act(() => {
+      screen.getByText("switch to mainnet").click();
+    });
+    await waitFor(() => expect(screen.getByTestId("network-id")).toHaveTextContent("mainnet"));
+
+    expect(window.localStorage.getItem("nester_portfolio_v1:testnet:abc")).toBeNull();
+    expect(window.localStorage.getItem("nester_portfolio_v1:mainnet:xyz")).toBeNull();
+    expect(window.localStorage.getItem("unrelated_key")).toBe("keep-me");
+  });
+});

--- a/apps/dapp/frontend/context/NetworkProvider.test.tsx
+++ b/apps/dapp/frontend/context/NetworkProvider.test.tsx
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { safeStorage } from "@/lib/storage";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { NetworkProvider, useNetwork } from "./NetworkProvider";
 import { readNetworkId } from "@/lib/storageKeys";
@@ -22,6 +24,13 @@ function TestConsumer() {
 describe("NetworkProvider (#1233)", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    // safeStorage's in-memory fallback is module state and survives between
+    // tests, so a test that forces a write to fall back (the quota case
+    // below) leaves nester_network_id behind. The next test then starts on
+    // mainnet, its "switch to mainnet" is a no-op, and the cache purge it
+    // asserts on never runs. Clearing with an empty prefix drains both the
+    // fallback map and localStorage.
+    safeStorage.removeByPrefix("");
   });
 
   afterEach(() => {

--- a/apps/dapp/frontend/context/NetworkProvider.tsx
+++ b/apps/dapp/frontend/context/NetworkProvider.tsx
@@ -2,6 +2,8 @@
 
 import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { NETWORKS, NetworkConfig, DEFAULT_NETWORK } from "@/lib/networks";
+import { safeStorage } from "@/lib/storage";
+import { PORTFOLIO_CACHE_PREFIX, readNetworkId, writeNetworkId } from "@/lib/storageKeys";
 
 interface NetworkContextType {
   currentNetwork: NetworkConfig;
@@ -22,8 +24,12 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     const timer = setTimeout(() => {
       if (isMounted) setMounted(true);
     }, 0);
-    const savedNetwork = localStorage.getItem("nester_network_id");
-    if (savedNetwork && (savedNetwork === "testnet" || savedNetwork === "mainnet")) {
+    // safeStorage never throws (#1233) — a throwing accessor (private
+    // browsing, full quota) falls back to the in-memory map, so this always
+    // resolves to either the saved network or the safe DEFAULT_NETWORK
+    // already set as initial state, never an undefined/crashed provider.
+    const savedNetwork = readNetworkId();
+    if (savedNetwork) {
       const timer2 = setTimeout(() => {
         if (isMounted) setCurrentNetworkState(NETWORKS[savedNetwork]);
       }, 0);
@@ -35,17 +41,18 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
   const setNetwork = (networkId: 'testnet' | 'mainnet') => {
     const newNetwork = NETWORKS[networkId];
     if (newNetwork && newNetwork.id !== currentNetwork.id) {
+      // Persist FIRST, then update React state (#1233): writeNetworkId
+      // never throws — a failing localStorage write falls back to the
+      // in-memory map instead — so by the time state changes, a subsequent
+      // readNetworkId() call is guaranteed to agree with it, whether that
+      // read lands on localStorage or the in-memory fallback. Doing this in
+      // the opposite order (state first) is what could previously leave
+      // React on the new network while persistence never happened at all.
+      writeNetworkId(networkId);
+      safeStorage.removeByPrefix(PORTFOLIO_CACHE_PREFIX);
       setCurrentNetworkState(newNetwork);
-      localStorage.setItem("nester_network_id", networkId);
-      
-      // Clear cached data based on requirements
-      Object.keys(localStorage).forEach(key => {
-        if (key.startsWith("nester_portfolio_v1:")) {
-          localStorage.removeItem(key);
-        }
-      });
-      
-      // The wallet disconnection and confirmation will be handled 
+
+      // The wallet disconnection and confirmation will be handled
       // where the switch is triggered or by a wrapper component,
       // but the state change itself happens here.
     }

--- a/apps/dapp/frontend/context/settings-context.tsx
+++ b/apps/dapp/frontend/context/settings-context.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { config } from "@/lib/config";
+import { safeStorage } from "@/lib/storage";
 
 export type Currency = "USD" | "GBP" | "EUR" | "NGN";
 export type Theme = "light" | "dark" | "system";
@@ -59,7 +60,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     const [isDarkMode, setIsDarkMode] = useState(false);
 
     useEffect(() => {
-        const savedCurrency = localStorage.getItem("nester_currency") as Currency;
+        // #1233: safeStorage never throws (private browsing, full quota) and
+        // falls back to the in-memory map instead of crashing this provider.
+        // getRaw/setRaw (not get/set) — this key predates safeStorage and
+        // was never JSON-encoded; get's JSON.parse would reject the existing
+        // bare-string value on disk and wipe every returning user's saved
+        // currency.
+        const savedCurrency = safeStorage.getRaw("nester_currency") as Currency | null;
         if (savedCurrency && EXCHANGE_RATES[savedCurrency]) {
             const timer = setTimeout(() => setCurrencyState(savedCurrency), 0);
             return () => clearTimeout(timer);
@@ -69,9 +76,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
         if (typeof window === "undefined") return;
 
+        // #1233: safeStorage never throws — a throwing accessor falls back
+        // to the in-memory map, so this always resolves rather than
+        // crashing the provider on mount. getRaw, not get, for the same
+        // bare-string-on-disk reason as nester_currency above.
         const saved =
-            (localStorage.getItem(THEME_STORAGE_KEY) as Theme | null) ??
-            (localStorage.getItem(LEGACY_THEME_KEY) as Theme | null) ??
+            (safeStorage.getRaw(THEME_STORAGE_KEY) as Theme | null) ??
+            (safeStorage.getRaw(LEGACY_THEME_KEY) as Theme | null) ??
             "light";
         const resolved: Theme =
             saved === "light" || saved === "dark" || saved === "system" ? saved : "light";
@@ -98,14 +109,18 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     }, []);
 
     const setCurrency = (val: Currency) => {
+        // Persist before updating state (#1233): safeStorage.setRaw never
+        // throws, so state and persistence cannot disagree the way they
+        // could if a raw localStorage.setItem threw after state already
+        // changed.
+        safeStorage.setRaw("nester_currency", val);
         setCurrencyState(val);
-        localStorage.setItem("nester_currency", val);
     };
 
     const setTheme = (val: Theme) => {
+        safeStorage.setRaw(THEME_STORAGE_KEY, val);
+        safeStorage.remove(LEGACY_THEME_KEY);
         setThemeState(val);
-        localStorage.setItem(THEME_STORAGE_KEY, val);
-        localStorage.removeItem(LEGACY_THEME_KEY);
         applyThemeClass(val);
         setIsDarkMode(resolveDark(val));
     };

--- a/apps/dapp/frontend/lib/stellar/transaction.ts
+++ b/apps/dapp/frontend/lib/stellar/transaction.ts
@@ -10,6 +10,7 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { NETWORKS, DEFAULT_NETWORK } from "@/lib/networks";
+import { readNetworkId } from "@/lib/storageKeys";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -17,15 +18,15 @@ import { NETWORKS, DEFAULT_NETWORK } from "@/lib/networks";
  * Resolve the active network. Exported so every module that builds or signs a
  * transaction agrees on it: a builder reading a different source than the
  * signer produces a transaction signed for the wrong passphrase.
+ *
+ * Routed through safeStorage (#1233) rather than raw localStorage: a
+ * throwing storage accessor (private browsing, full quota) must fall back to
+ * the safe explicit DEFAULT_NETWORK, never leave this undefined or crash the
+ * caller — every deposit/withdraw transaction is built against this value.
  */
 export const getCurrentNetwork = () => {
-  if (typeof window !== "undefined") {
-    const savedNetwork = localStorage.getItem("nester_network_id");
-    if (savedNetwork && (savedNetwork === "testnet" || savedNetwork === "mainnet")) {
-      return NETWORKS[savedNetwork];
-    }
-  }
-  return DEFAULT_NETWORK;
+  const savedNetwork = readNetworkId();
+  return savedNetwork ? NETWORKS[savedNetwork] : DEFAULT_NETWORK;
 };
 
 // These are set via environment variables so the contracts can be swapped

--- a/apps/dapp/frontend/lib/storage.test.ts
+++ b/apps/dapp/frontend/lib/storage.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { safeStorage } from "./storage";
+
+// Issue #1233: safeStorage must never throw when the underlying accessor
+// does, and set/get/remove must round-trip correctly through both the
+// native store and the in-memory fallback.
+
+describe("safeStorage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("round-trips a JSON value through set/get", () => {
+    expect(safeStorage.set("k1", { a: 1 })).toBe(true);
+    expect(safeStorage.get("k1", null)).toEqual({ a: 1 });
+  });
+
+  it("returns the fallback for a missing key", () => {
+    expect(safeStorage.get("missing", "fallback")).toBe("fallback");
+  });
+
+  it("wipes and falls back on corrupted (non-JSON) data rather than throwing", () => {
+    window.localStorage.setItem("corrupt", "{not valid json");
+    expect(safeStorage.get("corrupt", "fallback")).toBe("fallback");
+    expect(window.localStorage.getItem("corrupt")).toBeNull();
+  });
+
+  it("falls back to the in-memory map when localStorage.getItem throws", () => {
+    vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError: storage disabled");
+    });
+    // set() itself uses the mocked getItem indirectly via writeNative's
+    // read-then-write path in some browsers, but the direct contract under
+    // test is: a throwing getItem must not propagate out of get().
+    expect(() => safeStorage.get("any-key", "fallback")).not.toThrow();
+    expect(safeStorage.get("any-key", "fallback")).toBe("fallback");
+  });
+
+  it("falls back to the in-memory map when localStorage.setItem throws (e.g. quota exceeded)", () => {
+    vi.spyOn(window.localStorage.__proto__, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    const ok = safeStorage.set("quota-key", "value");
+    expect(ok).toBe(false); // false signals "fell back to in-memory"
+    expect(safeStorage.get("quota-key", null)).toBe("value"); // still readable
+  });
+
+  it("remove clears both the native store and any in-memory fallback", () => {
+    safeStorage.set("to-remove", "x");
+    safeStorage.remove("to-remove");
+    expect(safeStorage.get("to-remove", null)).toBeNull();
+  });
+
+  describe("removeByPrefix", () => {
+    it("removes only keys matching the prefix", () => {
+      safeStorage.set("cache:a:1", "x");
+      safeStorage.set("cache:a:2", "y");
+      safeStorage.set("cache:b:1", "z");
+      safeStorage.set("unrelated", "w");
+
+      safeStorage.removeByPrefix("cache:a:");
+
+      expect(safeStorage.get("cache:a:1", null)).toBeNull();
+      expect(safeStorage.get("cache:a:2", null)).toBeNull();
+      expect(safeStorage.get("cache:b:1", null)).toBe("z");
+      expect(safeStorage.get("unrelated", null)).toBe("w");
+    });
+
+    it("does not throw when localStorage enumeration itself is unavailable", () => {
+      vi.spyOn(window.localStorage.__proto__, "length", "get").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+      expect(() => safeStorage.removeByPrefix("cache:")).not.toThrow();
+    });
+
+    it("is a no-op (not an error) when nothing matches the prefix", () => {
+      safeStorage.set("other", "x");
+      expect(() => safeStorage.removeByPrefix("nomatch:")).not.toThrow();
+      expect(safeStorage.get("other", null)).toBe("x");
+    });
+  });
+
+  describe("getRaw", () => {
+    it("returns the raw, un-parsed string", () => {
+      window.localStorage.setItem("raw-key", "plain-string-value");
+      expect(safeStorage.getRaw("raw-key")).toBe("plain-string-value");
+    });
+
+    it("returns null for a missing key", () => {
+      expect(safeStorage.getRaw("missing")).toBeNull();
+    });
+  });
+});

--- a/apps/dapp/frontend/lib/storage.ts
+++ b/apps/dapp/frontend/lib/storage.ts
@@ -29,11 +29,21 @@ function isBrowser() {
 }
 
 function readNative(key: string): string | null {
-    if (!isBrowser()) return memoryStore.get(key) ?? null;
+    // memoryStore holds `key` only when the most recent WRITE for it fell
+    // back to in-memory (writeNative's catch branch) — a successful native
+    // write always deletes any stale memoryStore entry for the same key
+    // (see writeNative below), so a present memoryStore entry is always the
+    // authoritative last-write result and must win over a native read that
+    // simply never saw that write land (issue #1233: previously a value
+    // that fell back to memoryStore on write was invisible to any
+    // subsequent read that didn't ALSO throw, breaking the "keep working in
+    // the same tab" guarantee this module's own header comment promises).
+    if (memoryStore.has(key)) return memoryStore.get(key) ?? null;
+    if (!isBrowser()) return null;
     try {
         return window.localStorage.getItem(key);
     } catch {
-        return memoryStore.get(key) ?? null;
+        return null;
     }
 }
 
@@ -136,9 +146,49 @@ export const safeStorage = {
         return ok;
     },
 
+    /**
+     * Writes `value` as a raw, un-encoded string — pairs with `getRaw`.
+     * Use this (rather than `set`) for a key whose existing readers expect
+     * the bare string on disk (e.g. a pre-existing key that predates this
+     * module and was never JSON-encoded); `set`'s JSON-quoting would break
+     * that reader. Same never-throws guarantee as `set`.
+     */
+    setRaw(key: string, value: string): boolean {
+        const ok = writeNative(key, value);
+        if (ok) maybeWarnAboutQuota();
+        return ok;
+    },
+
     /** Removes the key from both backing stores. */
     remove(key: string) {
         removeNative(key);
+    },
+
+    /**
+     * Removes every key (across both the native store and the in-memory
+     * fallback) whose name starts with `prefix`. Used for cache-invalidation
+     * sweeps (e.g. clearing per-network cached data on a network switch)
+     * that would otherwise call the unguarded `Object.keys(localStorage)`
+     * directly — that enumeration itself can throw in the same environments
+     * get/set/remove already guard against.
+     */
+    removeByPrefix(prefix: string) {
+        for (const key of memoryStore.keys()) {
+            if (key.startsWith(prefix)) memoryStore.delete(key);
+        }
+        if (!isBrowser()) return;
+        try {
+            const toRemove: string[] = [];
+            for (let i = 0; i < window.localStorage.length; i++) {
+                const key = window.localStorage.key(i);
+                if (key && key.startsWith(prefix)) toRemove.push(key);
+            }
+            for (const key of toRemove) {
+                window.localStorage.removeItem(key);
+            }
+        } catch {
+            // ignore — storage may be disabled or full; nothing more to clear
+        }
     },
 
     /**

--- a/apps/dapp/frontend/lib/storageKeys.test.ts
+++ b/apps/dapp/frontend/lib/storageKeys.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { NETWORK_STORAGE_KEY, readNetworkId, writeNetworkId } from "./storageKeys";
+
+describe("readNetworkId / writeNetworkId (#1233)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is persisted", () => {
+    expect(readNetworkId()).toBeNull();
+  });
+
+  it("round-trips a value written via writeNetworkId", () => {
+    writeNetworkId("mainnet");
+    expect(readNetworkId()).toBe("mainnet");
+  });
+
+  it("reads a legacy bare (non-JSON-encoded) value from the old raw localStorage.setItem call sites", () => {
+    // Simulates a value persisted by the OLD code (localStorage.setItem(key, "testnet")),
+    // which is NOT JSON — safeStorage.get's JSON.parse would reject and wipe it.
+    window.localStorage.setItem(NETWORK_STORAGE_KEY, "testnet");
+    expect(readNetworkId()).toBe("testnet");
+  });
+
+  it("reads a JSON-encoded value written via writeNetworkId's safeStorage.set", () => {
+    window.localStorage.setItem(NETWORK_STORAGE_KEY, JSON.stringify("mainnet"));
+    expect(readNetworkId()).toBe("mainnet");
+  });
+
+  it("returns null for an unrecognized value rather than throwing", () => {
+    window.localStorage.setItem(NETWORK_STORAGE_KEY, "not-a-real-network");
+    expect(readNetworkId()).toBeNull();
+  });
+
+  it("returns null for malformed JSON rather than throwing", () => {
+    window.localStorage.setItem(NETWORK_STORAGE_KEY, "{not valid json");
+    expect(readNetworkId()).toBeNull();
+  });
+});

--- a/apps/dapp/frontend/lib/storageKeys.ts
+++ b/apps/dapp/frontend/lib/storageKeys.ts
@@ -1,0 +1,52 @@
+import { safeStorage } from "@/lib/storage";
+
+/**
+ * Shared localStorage key names (issue #1233).
+ *
+ * `NETWORK_STORAGE_KEY` in particular was previously a raw string literal
+ * repeated across NetworkProvider.tsx, lib/stellar/transaction.ts,
+ * app/portfolio/page.tsx, and utils/explorer.ts — every reader of the active
+ * network must agree on the same key, or a typo in one copy silently reads
+ * the wrong (or no) persisted network.
+ */
+
+/** Persisted active network id ("testnet" | "mainnet"). */
+export const NETWORK_STORAGE_KEY = "nester_network_id";
+
+/** Prefix for per-network cached portfolio data, purged on network switch. */
+export const PORTFOLIO_CACHE_PREFIX = "nester_portfolio_v1:";
+
+export type NetworkId = "testnet" | "mainnet";
+
+function isNetworkId(value: unknown): value is NetworkId {
+  return value === "testnet" || value === "mainnet";
+}
+
+/**
+ * Reads the persisted network id, or `null` if unset/unrecognized.
+ *
+ * Tolerant of two encodings so migrating every call site to safeStorage.set
+ * (which JSON-encodes) doesn't strand a value written by the OLD raw
+ * `localStorage.setItem("nester_network_id", networkId)` call sites this
+ * issue replaces: a legacy value is a bare, un-quoted string ("testnet"),
+ * which safeStorage.get's JSON.parse would otherwise reject as corrupted
+ * and wipe. Read via safeStorage.getRaw and accept both the JSON-quoted
+ * form and the legacy bare form, rather than making every existing user's
+ * saved network preference silently revert to the default.
+ */
+export function readNetworkId(): NetworkId | null {
+  const raw = safeStorage.getRaw(NETWORK_STORAGE_KEY);
+  if (raw === null) return null;
+  if (isNetworkId(raw)) return raw; // legacy bare string
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isNetworkId(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the network id via safeStorage (never throws). */
+export function writeNetworkId(networkId: NetworkId): void {
+  safeStorage.set(NETWORK_STORAGE_KEY, networkId);
+}

--- a/apps/dapp/frontend/utils/explorer.ts
+++ b/apps/dapp/frontend/utils/explorer.ts
@@ -1,13 +1,12 @@
 import { NETWORKS, DEFAULT_NETWORK } from "@/lib/networks";
+import { readNetworkId } from "@/lib/storageKeys";
 
+// #1233: readNetworkId routes through safeStorage, so a throwing accessor
+// (private browsing, full quota) falls back to DEFAULT_NETWORK rather than
+// an unguarded read crashing whichever component calls the exports below.
 const getCurrentNetwork = () => {
-  if (typeof window !== "undefined") {
-    const savedNetwork = localStorage.getItem("nester_network_id");
-    if (savedNetwork && (savedNetwork === "testnet" || savedNetwork === "mainnet")) {
-      return NETWORKS[savedNetwork];
-    }
-  }
-  return DEFAULT_NETWORK;
+  const savedNetwork = readNetworkId();
+  return savedNetwork ? NETWORKS[savedNetwork] : DEFAULT_NETWORK;
 };
 
 export const getExplorerTxUrl = (hash: string) => {

--- a/docker/prometheus/rules/slo_alerts.yml
+++ b/docker/prometheus/rules/slo_alerts.yml
@@ -143,6 +143,50 @@ groups:
           runbook: docs/observability/runbooks/api-availability.md
 
   # ---------------------------------------------------------------------------
+  # Per-endpoint error rate (nester#1227)
+  # ---------------------------------------------------------------------------
+  #
+  # A single absolute-threshold alert, not a burn-rate policy — see
+  # slo_recording.yml's slo_route_availability group for why. 20% sustained
+  # over 1h is deliberately looser than the aggregate's 1.344% fast-burn
+  # threshold: this alert exists to catch a route that is broken continuously
+  # (not occasionally degraded), and a route carrying enough traffic to be
+  # statistically meaningful at a low error rate is already covered by the
+  # aggregate. `for: 15m` (not the aggregate's 2m) because a single route has
+  # far less traffic to smooth out a brief blip, and this alert is a
+  # same-day-ticket signal, not a page — the aggregate and the money-path
+  # flow alerts already page for anything urgent enough to wake someone.
+  - name: slo_alerts_route_availability
+    rules:
+      - alert: EndpointErrorRateHigh
+        expr: |
+          route:availability:error_ratio_rate1h > 0.20
+          and
+          route:availability:eligible_rate1h > 0.01
+        for: 15m
+        labels:
+          severity: ticket
+          slo: route_availability
+          service: api
+        annotations:
+          summary: >-
+            {{ $labels.route }} erroring at {{ $value | humanizePercentage }}
+            over 1h, independent of overall API availability
+          description: >-
+            Route {{ $labels.route }} has sustained a 5xx rate above 20% for
+            15+ minutes. This route may carry too little traffic to move the
+            aggregate api:availability ratio (APIAvailabilityFastBurn/SlowBurn
+            above), which is exactly the blind spot this alert exists to
+            close — an endpoint nobody watches can otherwise fail
+            indefinitely inside the aggregate's budget. The second condition
+            (eligible_rate1h > 0.01, roughly one request per 100 seconds)
+            guards against a single stray request producing a 100% ratio on
+            an idle route. 4xx and unmatched routes are excluded, same as the
+            aggregate SLI.
+          dashboard: /d/nester-slo-api/api-availability
+          runbook: docs/observability/runbooks/api-availability.md
+
+  # ---------------------------------------------------------------------------
   # Deposit / withdrawal success — target 99.5%
   # ---------------------------------------------------------------------------
   # budget 0.5% => fast 13.44 * 0.005 = 0.0672 (6.72%)

--- a/docker/prometheus/rules/slo_alerts_test.yml
+++ b/docker/prometheus/rules/slo_alerts_test.yml
@@ -361,6 +361,128 @@ tests:
         exp_alerts: []
 
   # ===========================================================================
+  # Per-endpoint error rate (nester#1227)
+  # ===========================================================================
+  #
+  # The scenario the issue exists to fix: one low-volume, unwatched endpoint
+  # fails continuously while the money-path volume keeps the aggregate
+  # api:availability ratio healthy. Proves EndpointErrorRateHigh catches it
+  # AND that APIAvailabilityFastBurn/SlowBurn stay silent throughout — the
+  # aggregate genuinely cannot see this on its own, which is the bug.
+  - interval: 1m
+    name: A single broken low-volume endpoint pages EndpointErrorRateHigh without moving aggregate availability
+    input_series:
+      # High-volume, perfectly healthy money-path route: 1000/s, all 2xx.
+      - series: 'nester_http_requests_total{route="POST /api/v1/vaults/{id}/deposit",method="POST",status_class="2xx"}'
+        values: '0+60000x120'   # 1000/s
+      # A savings-goal endpoint nobody watches: 0.5/s, entirely 5xx.
+      - series: 'nester_http_requests_total{route="GET /api/v1/savings-goals/{id}/progress",method="GET",status_class="5xx"}'
+        values: '0+30x120'      # 0.5/s, 100% error ratio on this route
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: EndpointErrorRateHigh
+        exp_alerts:
+          - exp_labels:
+              severity: ticket
+              slo: route_availability
+              service: api
+              route: 'GET /api/v1/savings-goals/{id}/progress'
+            exp_annotations:
+              summary: "GET /api/v1/savings-goals/{id}/progress erroring at 100% over 1h, independent of overall API availability"
+              description: "Route GET /api/v1/savings-goals/{id}/progress has sustained a 5xx rate above 20% for 15+ minutes. This route may carry too little traffic to move the aggregate api:availability ratio (APIAvailabilityFastBurn/SlowBurn above), which is exactly the blind spot this alert exists to close — an endpoint nobody watches can otherwise fail indefinitely inside the aggregate's budget. The second condition (eligible_rate1h > 0.01, roughly one request per 100 seconds) guards against a single stray request producing a 100% ratio on an idle route. 4xx and unmatched routes are excluded, same as the aggregate SLI."
+              dashboard: /d/nester-slo-api/api-availability
+              runbook: docs/observability/runbooks/api-availability.md
+      # The aggregate never sees this: 0.5 err/s against 1000.5 total/s is
+      # ~0.05%, an order of magnitude under even the slow-burn threshold
+      # (0.56%), let alone fast (1.344%). This is the exact gap #1227 reports.
+      - eval_time: 20m
+        alertname: APIAvailabilityFastBurn
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: APIAvailabilitySlowBurn
+        exp_alerts: []
+
+  - interval: 1m
+    name: EndpointErrorRateHigh does not fire on a healthy route
+    input_series:
+      - series: 'nester_http_requests_total{route="GET /api/v1/portfolio",method="GET",status_class="2xx"}'
+        values: '0+600x120'   # 10/s
+      - series: 'nester_http_requests_total{route="GET /api/v1/portfolio",method="GET",status_class="5xx"}'
+        values: '0+6x120'     # 0.1/s => 1% error ratio, well under 20%
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: EndpointErrorRateHigh
+        exp_alerts: []
+
+  - interval: 1m
+    name: EndpointErrorRateHigh does not fire on a single stray request on an idle route
+    input_series:
+      # One request, ever, and it 5xxs. 100% error ratio on the route, but
+      # the eligible_rate1h > 0.01 guard must suppress this — a route this
+      # quiet is not "broken", it is unused, and one sample is not evidence.
+      - series: 'nester_http_requests_total{route="POST /api/v1/admin/rare-op",method="POST",status_class="5xx"}'
+        values: '0 1 1x118'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: EndpointErrorRateHigh
+        exp_alerts: []
+
+  - interval: 1m
+    name: "EndpointErrorRateHigh requires the full 15m for: duration, not an instant blip"
+    input_series:
+      - series: 'nester_http_requests_total{route="GET /api/v1/webhooks/log",method="GET",status_class="2xx"}'
+        values: '0+60x120'   # 1/s baseline
+      # A short spike of failures that does not persist 15m.
+      - series: 'nester_http_requests_total{route="GET /api/v1/webhooks/log",method="GET",status_class="5xx"}'
+        values: '0+300x5 1500+0x115'  # 5/s for 5m, then flat
+    alert_rule_test:
+      # At 5m the route's 1h ratio is already over 20% (the burst dominates
+      # the still-filling window), but `for: 15m` has not elapsed yet.
+      - eval_time: 5m
+        alertname: EndpointErrorRateHigh
+        exp_alerts: []
+
+  # ===========================================================================
+  # Route label cardinality (nester#1227 acceptance criterion)
+  # ===========================================================================
+  #
+  # The route label is bounded by construction (internal/metrics/http.go
+  # resolves it from the mux's registered patterns or the constant "other" —
+  # never an arbitrary client-supplied path), so this cannot be proven by a
+  # promtool unit test acting alone on synthetic series. What IS testable
+  # here, and is the promtool-level half of that guarantee: the per-route
+  # recording rules never introduce an UNBOUNDED label of their own (e.g.
+  # accidentally grouping by a raw path or query parameter instead of the
+  # bounded `route`) — every series this group produces carries only `route`
+  # values that were present in the bounded input. The Go-level guarantee
+  # (that `route` itself can only ever be a registered pattern or "other") is
+  # asserted by resolveRoute's existing unit tests in
+  # apps/api/internal/metrics/http_test.go.
+  - interval: 1m
+    name: per-route recording rules do not introduce unbounded labels beyond the bounded route set
+    input_series:
+      - series: 'nester_http_requests_total{route="GET /api/v1/vaults",method="GET",status_class="2xx"}'
+        values: '0+60x120'
+      - series: 'nester_http_requests_total{route="GET /api/v1/portfolio",method="GET",status_class="2xx"}'
+        values: '0+60x120'
+      - series: 'nester_http_requests_total{route="other",method="GET",status_class="4xx"}'
+        values: '0+600x120'   # unmatched/scanner traffic — must be excluded entirely
+    promql_expr_test:
+      # Evaluated at 90m (not 30m) so the 1h window is fully saturated —
+      # a partially-filled rate() window extrapolates and reads short of
+      # the true 1/s the input series encodes.
+      - expr: route:availability:eligible_rate1h
+        eval_time: 90m
+        exp_samples:
+          - labels: 'route:availability:eligible_rate1h{route="GET /api/v1/vaults"}'
+            value: 1
+          - labels: 'route:availability:eligible_rate1h{route="GET /api/v1/portfolio"}'
+            value: 1
+          # No "other" series: route="other" is excluded from the recording
+          # rule's input entirely, so it cannot appear as a result series no
+          # matter how much traffic it carries.
+
+  # ===========================================================================
   # Deposit success — fast burn, and the exclusions
   # ===========================================================================
   #

--- a/docker/prometheus/rules/slo_recording.yml
+++ b/docker/prometheus/rules/slo_recording.yml
@@ -165,6 +165,79 @@ groups:
             )
 
   # ---------------------------------------------------------------------------
+  # Per-route availability (nester#1227)
+  # ---------------------------------------------------------------------------
+  #
+  # The aggregate api:availability:* series above answers "is the API healthy
+  # overall", and deposit/withdraw volume dominates it — a route that fails
+  # continuously can sit inside the aggregate's error budget indefinitely if
+  # it is not one of the high-volume money-path endpoints. This group answers
+  # the narrower question per route, using the same bounded `route` label the
+  # metrics middleware already resolves (internal/metrics/http.go) — a
+  # registered pattern or the constant "other", never an arbitrary client
+  # path, so `by (route)` here cannot mint an unbounded number of series.
+  #
+  # Deliberately NOT the full four-window burn-rate treatment the aggregate
+  # SLOs use: with ~93 routes, replicating that machinery per route would
+  # multiply the alert count by ~93 and produce dozens of near-duplicate
+  # pages during any real incident (the aggregate and the affected route
+  # would both page for the same root cause). Per-route detection instead
+  # uses a single absolute-threshold alert (slo_alerts.yml
+  # EndpointErrorRateHigh) — this recording group only needs the one ratio
+  # that alert reads, at the window the alert evaluates.
+  #
+  # `route="other"` is excluded, same reasoning as the aggregate: unmatched
+  # paths are scanner/probe traffic, not a service anyone is promised.
+  - name: slo_route_availability
+    interval: 30s
+    rules:
+      # Per-route needs a different shape than the aggregate's bare
+      # `- (... or vector(0))`: that pattern is correct only when the
+      # subtracted term is a single scalar-like (label-less) series, where
+      # "no 4xx at all" and "0 4xx" are the same result. Grouped `by (route)`,
+      # a route with traffic but zero 4xx has NO series in the 4xx
+      # sub-expression at all (not a zero-valued one), so a bare `-` between
+      # two `by (route)` vectors would silently drop that route from the
+      # result wherever the right side has no matching `route` — the exact
+      # opposite of the intent (a route's own healthy 4xx-free traffic must
+      # not make the route disappear from its own eligible-rate series).
+      # `(4xx or on (route) all * 0)` is the standard idiom for "subtract
+      # this optional per-group term, treating a missing group as zero": it
+      # produces a same-label-set zero series for every route present in
+      # `all` but absent from `4xx`, so the outer `-` always has a matching
+      # right-hand series for every route on the left.
+      - record: route:availability:eligible_rate1h
+        expr: |
+          sum by (route) (rate(nester_http_requests_total{route!="other"}[1h]))
+          -
+          (
+            sum by (route) (rate(nester_http_requests_total{route!="other",status_class="4xx"}[1h]))
+            or on (route)
+            sum by (route) (rate(nester_http_requests_total{route!="other"}[1h])) * 0
+          )
+
+      # No `or vector(0)` here (unlike the aggregate bad_rate1h): a route
+      # with zero 5xx traffic simply has no series in this result at all,
+      # which is correct — error_ratio_rate1h below is a division, so a
+      # route absent here produces no result for that route rather than a
+      # spurious 0, and EndpointErrorRateHigh only needs to evaluate routes
+      # that have some 5xx to possibly breach 20% of.
+      - record: route:availability:bad_rate1h
+        expr: |
+          sum by (route) (rate(nester_http_requests_total{route!="other",status_class="5xx"}[1h]))
+
+      # clamp_min for the same reason as the aggregate series: a route with no
+      # traffic in the window must read 0 error ratio, not NaN (which would
+      # compare false against every threshold and silently disable the
+      # alert). Floor is tighter than the aggregate's 0.001 (whole-API
+      # req/s) because a single low-traffic route can legitimately sit well
+      # under 1 req/s without being unhealthy.
+      - record: route:availability:error_ratio_rate1h
+        expr: |
+          route:availability:bad_rate1h
+          / clamp_min(route:availability:eligible_rate1h, 0.0001)
+
+  # ---------------------------------------------------------------------------
   # Deposit and withdrawal success rate
   # ---------------------------------------------------------------------------
   #

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,0 +1,199 @@
+# Data retention and deletion policy
+
+nester#1226. Establishes, per data category: how long it's kept, whether
+it's exempt from deletion (and why), and how deletion is enforced.
+
+## Why this exists
+
+The schema accumulates per-user history with no expiry: `activity_events`,
+`nudge_dispatch_log`, `nudge_outcomes`, `audit_logs`, `processed_events`,
+performance snapshots, and KYC records including identity fields and
+document references. Nothing in the tree deleted any of it before this
+policy, and there was no account-deletion path.
+
+Two problems follow from that. Operationally, tables that only grow
+eventually dominate backup and restore times. Legally, KYC identity data with
+no stated retention period and no deletion mechanism is the kind of thing
+that is much cheaper to design now than to retrofit under a deadline.
+
+Audit logs deliberately should not be deletable on request — that is a
+reason to write the policy down, not a reason to have none.
+
+## Scope of this baseline
+
+This document states the policy for every category below. Enforcement — an
+actual scheduled deletion job — is implemented for the two categories marked
+**Enforced** in the table: `activity_events` and `nudge_dispatch_log` (whose
+cascade removes `nudge_outcomes` alongside it). Both are ordinary operational
+event logs with no legal retention requirement and no account-deletion
+interaction to reason about, which makes them the safe, low-risk place to
+land the first real enforcement mechanism (`internal/scheduler/data_retention.go`
+— see that file's doc comment for the mechanics).
+
+The remaining categories are genuinely harder — a user-initiated
+account-deletion path, KYC erasure-vs-anonymisation rules, and backup
+retention are cross-cutting concerns each substantial enough to warrant their
+own implementation and its own review, not something to bolt onto a
+first-pass retention sweep. Marking a policy **Stated, not yet enforced**
+below is a real status, not a placeholder — it means the decision has been
+made and written down, and the next PR that enforces it inherits an actual
+answer to work from instead of having to make the call under a deadline.
+
+## Policy by category
+
+| Category | Table(s) | Retention | Deletion mechanism | Status |
+|---|---|---|---|---|
+| Activity events | `activity_events` | 180 days | Scheduled hard delete | **Enforced** |
+| Nudge dispatch history | `nudge_dispatch_log`, `nudge_outcomes` (cascades) | 180 days | Scheduled hard delete | **Enforced** |
+| Audit logs | `audit_logs` | Indefinite | None — exempt by design | Exempt (see below) |
+| Processed chain events | `processed_events` | 90 days | Not yet implemented | Stated, not yet enforced |
+| Performance snapshots | performance snapshot tables | 2 years | Not yet implemented | Stated, not yet enforced |
+| KYC identity + documents | `users.kyc_*`, `kyc_documents` | Regulatory minimum + account lifetime | Not yet implemented — anonymisation, not erasure | Stated, not yet enforced |
+| Account deletion (user-initiated) | cross-table | N/A — see below | Not yet implemented | Stated, not yet enforced |
+
+### Activity events — 180 days, enforced
+
+`activity_events` (migration 071) records `login`/`deposit` timing events per
+user, read by `usersignal.HeuristicTimingProvider` to infer behavioral
+signals for nudging. 180 days is long enough to observe a full seasonal cycle
+of user behavior (the nudge engine's own effectiveness measurement window is
+90 days — see below — so 180 days gives it two full windows of headroom
+before the underlying event history disappears out from under a live
+measurement). Enforced by `DataRetentionJob.sweepActivityEvents` in
+`internal/scheduler/data_retention.go`, a straightforward `DELETE ... WHERE
+occurred_at < cutoff` — there is no soft-delete or recovery window for this
+category, since a login/deposit timing event has no user-facing recovery use
+case the way a savings goal does.
+
+### Nudge dispatch history — 180 days, enforced
+
+`nudge_dispatch_log` and `nudge_outcomes` (migration 072) record every nudge
+sent and its measured outcome. `nudge_outcomes.dispatch_id` is `ON DELETE
+CASCADE` from `nudge_dispatch_log`, so deleting a dispatch row removes its
+outcome row automatically — the retention job only issues one `DELETE`
+statement for this whole category.
+
+**180 days is a hard floor, not just a target**: `NudgeHistoryRepository
+.GetEffectivenessStats` (`internal/repository/postgres/nudge_history_repository.go`)
+reads dispatch/outcome rows back 90 days (`effectivenessWindow`) to rank
+which nudge types actually convert. Retention shorter than 90 days would
+silently starve that ranking of data — not error, just quietly degrade to
+"no data" for older cohorts — which is a much worse failure mode than a
+slightly larger table. 180 days keeps a full 90-day margin past that
+constraint. If `effectivenessWindow` is ever widened, this retention period
+must move with it (both are documented at each other's definition site).
+
+### Audit logs — indefinite, exempt by design
+
+`audit_logs` (migration 011) is the record of who changed what, when — the
+same table `DataRetentionJob` itself writes to when it deletes something else
+(see "Deletion is itself audit-logged" below). An audit trail that can be
+shortened by the same actors it's meant to hold accountable is not an audit
+trail; the whole point is that it survives the events it describes. This
+table is therefore explicitly out of scope for any deletion job, now or in
+any planned future work, and that exemption itself is the policy decision
+this document exists to state rather than leave implicit.
+
+If a legal retention limit is ever imposed on audit logs specifically (e.g. a
+statutory maximum, as opposed to a self-imposed minimum), that would be a
+distinct, deliberate policy change requiring its own review — not something
+a generic retention sweep should be trusted to apply.
+
+### Processed chain events — 90 days, not yet enforced
+
+`processed_events` (migration 028) is an idempotency/dedup ledger for
+Stellar events already processed by the indexer, keyed on `event_id`. It
+carries no personal data — `ledger_sequence` and `processed_at` only — so
+its retention concern is purely storage growth, not privacy. 90 days is
+proposed because that comfortably exceeds any plausible reorg-recovery or
+backfill replay window this system would need to re-derive idempotency
+against; if `internal/stellar/backfill.go`'s replay window is ever
+documented with a different bound, this number should be reconciled against
+it before enforcement ships. Not enforced in this baseline because it is a
+distinct concern from the two categories above (dedup correctness during a
+live backfill, not user data hygiene) and deserves its own review against
+the indexer's actual replay behavior rather than reusing this job's generic
+shape.
+
+### Performance snapshots — 2 years, not yet enforced
+
+Vault performance snapshot history backs the `/vaults/{id}/performance`
+APY/history endpoints (`internal/service/performance`). 2 years is proposed
+to preserve a meaningful multi-year APY history for user-facing charts and
+year-over-year comparisons — a much longer window than the operational logs
+above, because this data is directly displayed to users as their own
+investment history, not just an internal signal. Not enforced here because
+snapshot retention interacts with the timeseries rollup job
+(`internal/timeseries/rollup_job.go`, which already deletes raw
+high-resolution points after `RawRetention` — currently 30 days by default —
+while keeping rolled-up minute/hour/day aggregates) and needs its cutoff
+reconciled against that existing mechanism rather than introduced as an
+independent, possibly-conflicting deletion path.
+
+### KYC identity and documents — regulatory minimum + account lifetime, not yet enforced
+
+`users.kyc_status`/`kyc_submitted_at`/`kyc_reviewed_at`/`kyc_rejection_reason`
+and `kyc_documents` (`full_name`, `date_of_birth`, `country`,
+`front_object_key`, `back_object_key` — migrations 032, 069, 107) are the
+category this document's introduction calls out as the one where a written
+policy matters most. Proposed retention is the regulatory minimum for KYC
+recordkeeping in the jurisdictions this product operates in, or the life of
+the account plus that minimum after closure — whichever is longer. That
+number is deliberately NOT filled in here: it depends on which
+jurisdiction's AML/KYC recordkeeping rules actually apply, which is a legal
+determination this document should not make unilaterally on a "just get
+something in writing" pass.
+
+What IS decided, and matters for the eventual implementation: **this is
+anonymisation, not erasure**. Unlike `activity_events`, a KYC record cannot
+simply be hard-deleted at end of retention while the account and its
+transaction history remain — the compliance trail (that this user was
+verified, when, and against what standard) needs to survive even after the
+underlying PII is removed. The eventual job should null/redact
+`full_name`/`date_of_birth`/`country`/the document object keys (and delete
+the referenced objects from `objectstorage`) while leaving the row's
+existence, `kyc_status`, and timestamps intact.
+
+Note on current encryption state (checked while writing this policy, not
+assumed): `kyc_documents.id_number` and the document object keys are
+encrypted at rest via `crypto.AccountCipher` (migration 069). `full_name` and
+`date_of_birth` (migration 107) are currently PLAINTEXT — migration 107's own
+comment records this as a deliberate, considered follow-up, not an oversight,
+but it means "destroy the encryption key material" is NOT yet a valid
+erasure mechanism for those two columns specifically; an eventual retention
+job must either wait for them to join the AccountCipher-encrypted set, or
+explicitly `UPDATE ... SET full_name = NULL, date_of_birth = NULL` as part of
+anonymisation rather than assuming a key-destruction shortcut covers them.
+
+### Account deletion (user-initiated) — not yet enforced
+
+There is currently no account-deletion path in this codebase at all — a user
+cannot request their account be closed and their data removed. This is a
+larger feature than a retention sweep (it touches auth, sessions, vault
+balances that must be settled or transferred before an account can close,
+and every category above needs its own deletion-vs-anonymisation answer
+applied in the context of "this whole account is going away," not just "this
+one row aged out"). Flagged here as the gap it is rather than silently
+absent from the policy.
+
+## Deletion is itself audit-logged
+
+Every deletion `DataRetentionJob` performs writes an `audit_logs` entry
+(`action: "data_retention.delete"`, `entity_type`: the table name,
+`new_value: {deleted_count, cutoff}`) — see `DataRetentionJob.audit` in
+`internal/scheduler/data_retention.go`. No per-row entity IDs: a single sweep
+can remove thousands of rows, and the audit trail's job here is "prove a
+sweep ran, when, and how much it removed," not reconstruct which individual
+rows were affected — the deleted data itself is gone by design, and the
+count + cutoff is what an operator reviewing this trail actually needs.
+
+## Enforcement mechanism (for the two enforced categories)
+
+`internal/scheduler/data_retention.go`'s `DataRetentionJob` runs once daily,
+leader-elected (mirrors `SavingsGoalPurgeJob`'s pattern — running the sweep
+from every replica is wasteful but not unsafe, since each `DELETE` is
+idempotent). Each table's sweep is independent: one table's delete failing
+does not block the other's, and does not stop the job from retrying on its
+next daily tick.
+
+Wired in `cmd/api/main.go` alongside the other leader-elected sweep jobs.

--- a/docs/observability/slo.md
+++ b/docs/observability/slo.md
@@ -91,6 +91,55 @@ handler returns) is recorded by the deferred middleware with whatever status
 was written, defaulting to 200. Panics are recorded as 5xx by the recover
 middleware before this metric observes them.
 
+### 1a. Per-route availability (nester#1227)
+
+| | |
+|---|---|
+| **Numerator** | Requests to one route returning 5xx |
+| **Denominator** | Requests to that route that matched a registered route, minus 4xx |
+| **Source** | `nester_http_requests_total{route,method,status_class}`, same series as §1 |
+| **Window** | 1h only — no attainment window, no burn-rate policy (see below) |
+| **Aggregation** | `sum by (route) (rate(...))` |
+| **Recorded as** | `route:availability:{eligible,bad,error_ratio}_rate1h` |
+| **Alert** | `EndpointErrorRateHigh` — single absolute threshold, `> 20%` sustained 15m |
+
+**Why this exists alongside §1, not instead of it:** §1 answers "is the API
+healthy overall", and deposit/withdraw volume dominates that aggregate — a
+low-traffic endpoint (an analytics or savings-goal route, say) can fail
+continuously without moving it, because the money-path volume swamps the
+signal. This section answers the narrower per-route question, using the same
+bounded `route` label §1 already uses (never an arbitrary client-supplied
+path — see `internal/metrics/http.go`'s `resolveRoute`, and its own tests
+`TestRouteLabelUsesPatternNotRawPath` / `TestRouteLabelBoundedForUnmatchedPaths`
+in `apps/api/internal/metrics/http_test.go`), so grouping `by (route)` cannot
+mint an unbounded number of series.
+
+**Why not the full burn-rate treatment §1 gets:** with roughly 93 registered
+routes, replicating the four-window, two-severity burn-rate machinery per
+route would multiply the alert count by ~93 and produce a flood of
+near-duplicate pages for a single root cause (the aggregate alert and the
+affected route's alert would both fire). A single absolute-threshold alert is
+the deliberately simpler tool for "is this one route currently broken",
+matching the doctrine §5 (balance freshness) already uses for signals that
+don't warrant burn-rate shape.
+
+**The 20% threshold and the 15m `for:`:** looser and slower than §1's
+1.344%/2m fast-burn pair on purpose. This alert exists to catch a route that
+is broken *continuously*, not one that is occasionally degraded — a
+low-traffic route naturally has more variance, and a route carrying enough
+traffic to be statistically meaningful at a low error rate is already covered
+by the aggregate. Ticket severity, never page: the aggregate and the
+money-path flow alerts already page for anything urgent enough to wake
+someone; a single misbehaving low-traffic endpoint is a business-hours fix.
+
+**Cardinality guard:** the `eligible_rate1h > 0.01` condition on the alert
+(roughly one request per 100 seconds) exists so a single stray request on an
+otherwise-idle route cannot produce a 100% error ratio and fire. Bounded
+`route`-label cardinality itself is asserted at the promtool level in
+`slo_alerts_test.yml` (`per-route recording rules do not introduce unbounded
+labels beyond the bounded route set`) and at the Go level by the two
+`resolveRoute` tests named above.
+
 ### 2. Deposit success rate
 
 | | |


### PR DESCRIPTION
Brings the work from #1272 and #1274 onto `dev`.

Both were merged into their own integration branches rather than straight into `dev` — `integration/storage-slo-retention-1225-1226-1227-1233` and `integration/projections-decimals-scanners-1221-1223-1224` — so this PR carries both sets of commits with the contributors' authorship intact.

## No fixes were needed

Unusually for this batch, review found nothing to repair. Both PRs deliver what their issues asked for, and the two merge together without a semantic conflict. Verified rather than assumed:

- `go build ./...` and `go vet ./internal/... ./cmd/api/` clean on the combined tree
- `go test ./internal/...` exits 0 across all packages with both merged
- No duplicate migration prefixes — the check that caught #1255 and #1265 passes here
- Every changed Prometheus rule file and workflow parses as YAML

## #1272 — storage safety, SLO alerts, pagination, retention

**#1233** is properly done: the raw `localStorage` calls are gone from `NetworkProvider.tsx`, `lib/stellar/transaction.ts` and `utils/explorer.ts`, which were the three that mattered — a throwing accessor there means the signer builds a transaction for the wrong passphrase, per the comment in `transaction.ts` itself.

**#1227** adds an `EndpointErrorRateHigh` alert, so a single endpoint failing continuously is now visible rather than being absorbed by the aggregate.

**#1226** ships `docs/data-retention.md`, and **#1225** the pagination guard.

## #1274 — projections, decimals, scanner pinning

**#1224** threads a real `MonthlyContribution` through `projection_service.go` instead of the hardcoded `decimal.Zero`, so a user with a recurring schedule no longer sees a projection that assumes they never contribute again.

**#1221** centralises the scanner pins in `.github/security-scanner-versions.env`, sourced by both `ci.yml` and `security.yml`, with `GOVULNCHECK_VERSION=v1.7.0` and `GOSEC_VERSION=v2.29.0`. No `@latest` install remains. The file's own comment makes the maintenance burden explicit — `go install pkg@latest` inside a `run:` step is invisible to Dependabot's github-actions updater, so these have to be bumped by hand — and states a quarterly cadence.

This is complementary to the semgrep pin that landed in #1275 rather than conflicting with it: that one replaced an archived action with a version-pinned CLI, this one covers the `go install` scanners.

**#1223** removes the `float64` conversions from the activity feed. The two remaining conversions in `savings_goal_handler.go` are deliberate and documented — `intelligence.SavingsGoalContext` mirrors a pydantic model that declares those fields as floats, so a float is genuinely required at that boundary, and the coaching narrative is informational rather than a source of truth for a balance. I checked this before flagging it and agree with the call.

## Note on the gitleaks failure

#1274 showed `Secret Detection (gitleaks)` red before the merge. The finding was `docs/security/ci-gates.md:251`, a documentation example showing what a hardcoded credential looks like so the gosec rule can be explained — the value is already `<test-key-placeholder>`, not a credential.

Its fingerprints were added to `.gitleaksignore` by #1273, which #1274's branch predated. Merging onto a base that carries them resolves it, and the entries are present on this branch.
