### PR TITLE
fix: swallowed projection lookup errors, localStorage shadowing, and two gaps in the pagination guard

### DIFF
--- a/apps/api/internal/domain/projection/model.go
+++ b/apps/api/internal/domain/projection/model.go
@@ -117,11 +117,15 @@ type ProjectionOutput struct {
 // MonthlyContribution (zero/empty when there is none), and ContributionSource
 // says where that came from — mirroring SimulationOutput.ContributionSource.
 type ProjectionAssumptions struct {
-	RecurringAmount    decimal.Decimal `json:"recurring_amount"`
-	Cadence            string          `json:"cadence,omitempty"` // "weekly" | "biweekly" | "monthly" | ""
-	ProjectedAPY       float64         `json:"projected_apy"`
-	TimelineMonths     int             `json:"timeline_months"`
-	ContributionSource string          `json:"contribution_source"` // "schedule" | "single_deposit"
+	RecurringAmount decimal.Decimal `json:"recurring_amount"`
+	Cadence         string          `json:"cadence,omitempty"` // "weekly" | "biweekly" | "monthly" | ""
+	ProjectedAPY    float64         `json:"projected_apy"`
+	TimelineMonths  int             `json:"timeline_months"`
+	// ContributionSource is "schedule" when the amount came from the vault's
+	// linked savings goal's active schedule, "caller_supplied" when the caller
+	// passed a MonthlyContribution straight to the generic compound endpoint,
+	// and "single_deposit" when there is no recurring contribution at all.
+	ContributionSource string `json:"contribution_source"`
 }
 
 // ProjectionSummary provides aggregate statistics about the projection

--- a/apps/api/internal/service/projection_service.go
+++ b/apps/api/internal/service/projection_service.go
@@ -20,10 +20,11 @@ import (
 
 // ProjectionService handles compound interest projections, including the
 // Monte Carlo savings forecast added for issue #843 (see
-// projection_simulation.go). savingsGoalRepo/savingsScheduleRepo are only
-// used by the Monte Carlo path (to resolve a goal's target/deadline and a
-// user's real contribution cadence); the deterministic methods below don't
-// touch them.
+// projection_simulation.go). savingsGoalRepo/savingsScheduleRepo resolve a
+// goal's target/deadline and a user's real contribution cadence for the Monte
+// Carlo path, and CalculateVaultProjection also reads them to find the vault's
+// active recurring schedule (#1224) rather than assuming a single deposit.
+// Both must be non-nil.
 type ProjectionService struct {
 	calculator      projection.Calculator
 	vaultRepo       vault.Repository
@@ -127,8 +128,24 @@ func (s *ProjectionService) CalculateVaultProjection(ctx context.Context, input 
 	monthlyContribution := decimal.Zero
 	cadence := ""
 	contributionSource := "single_deposit"
-	if goal, goalErr := s.savingsGoalRepo.GetByVaultID(ctx, input.VaultID); goalErr == nil && goal != nil {
-		if schedule, schedErr := s.savingsScheduleRepo.GetActiveByGoal(ctx, goal.ID, goal.UserID); schedErr == nil && schedule != nil {
+	// Only genuine absence falls back to a single-deposit projection:
+	// ErrGoalNotFound (no linked goal) and a nil schedule (a linked goal with
+	// no active schedule) are both normal. Every other error is operational --
+	// a database failure, a cancelled context -- and has to surface rather
+	// than be reported as a successful projection that happens to assume the
+	// user never contributes again. Swallowing those produced exactly the
+	// wrong number for the question #1224 is about, on a screen people use to
+	// decide whether a savings goal is reachable.
+	goal, goalErr := s.savingsGoalRepo.GetByVaultID(ctx, input.VaultID)
+	if goalErr != nil && !errors.Is(goalErr, savingsgoal.ErrGoalNotFound) {
+		return nil, fmt.Errorf("failed to resolve the vault's savings goal: %w", goalErr)
+	}
+	if goal != nil {
+		schedule, schedErr := s.savingsScheduleRepo.GetActiveByGoal(ctx, goal.ID, goal.UserID)
+		if schedErr != nil && !errors.Is(schedErr, savingsschedule.ErrScheduleNotFound) {
+			return nil, fmt.Errorf("failed to resolve the goal's active savings schedule: %w", schedErr)
+		}
+		if schedule != nil {
 			monthlyContribution = monthlyEquivalent(schedule.Amount, schedule.Frequency)
 			cadence = string(schedule.Frequency)
 			contributionSource = "schedule"

--- a/apps/api/internal/service/projection_vault_recurring_test.go
+++ b/apps/api/internal/service/projection_vault_recurring_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -27,12 +28,18 @@ func (r *recurringVaultRepo) GetVault(_ context.Context, _ uuid.UUID) (vault.Vau
 
 // recurringGoalRepo resolves GetByVaultID from a map, returning
 // ErrGoalNotFound (matching the real repository's contract) when absent.
+// err, when set, is returned instead of a lookup result: the operational
+// failure case (a dead database, a cancelled context).
 type recurringGoalRepo struct {
 	savingsgoal.Repository
 	byVault map[uuid.UUID]savingsgoal.SavingsGoal
+	err     error
 }
 
 func (r *recurringGoalRepo) GetByVaultID(_ context.Context, vaultID uuid.UUID) (*savingsgoal.SavingsGoal, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
 	g, ok := r.byVault[vaultID]
 	if !ok {
 		return nil, savingsgoal.ErrGoalNotFound
@@ -40,17 +47,25 @@ func (r *recurringGoalRepo) GetByVaultID(_ context.Context, vaultID uuid.UUID) (
 	return &g, nil
 }
 
-// recurringScheduleRepo resolves GetActiveByGoal from a map, returning
-// ErrScheduleNotFound (matching the real repository's contract) when absent.
+// recurringScheduleRepo resolves GetActiveByGoal from a map. Absence returns
+// (nil, nil), which is what postgres.SavingsScheduleRepository.GetActiveByGoal
+// actually does for a linked goal with no active schedule — it maps
+// sql.ErrNoRows to a nil schedule and a nil error, never ErrScheduleNotFound.
+// This mock previously returned the sentinel, so the "goal exists but has no
+// active schedule" path was never exercised against the real contract.
 type recurringScheduleRepo struct {
 	savingsschedule.Repository
 	byGoal map[uuid.UUID]savingsschedule.SavingsSchedule
+	err    error
 }
 
 func (r *recurringScheduleRepo) GetActiveByGoal(_ context.Context, goalID, _ uuid.UUID) (*savingsschedule.SavingsSchedule, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
 	s, ok := r.byGoal[goalID]
 	if !ok {
-		return nil, savingsschedule.ErrScheduleNotFound
+		return nil, nil
 	}
 	return &s, nil
 }
@@ -138,29 +153,118 @@ func TestCalculateVaultProjection_RecurringContribution(t *testing.T) {
 	require.Equal(t, 12, withSchedule.Assumptions.TimelineMonths)
 }
 
-// TestCalculateVaultProjection_NoGoalLinked confirms a vault with no linked
-// savings goal at all (GetByVaultID returns ErrGoalNotFound) still produces
-// the baseline single-deposit projection rather than erroring out.
-func TestCalculateVaultProjection_NoGoalLinked(t *testing.T) {
-	vaultID := uuid.New()
-	apy := decimal.NewFromFloat(0.05)
+// TestCalculateVaultProjection_ScheduleLookup covers how the projection
+// resolves (or fails to resolve) a recurring schedule. The distinction that
+// matters: genuine absence falls back to a single-deposit projection, but an
+// operational failure must surface as an error rather than as a successful
+// projection that silently assumes the user never contributes again.
+func TestCalculateVaultProjection_ScheduleLookup(t *testing.T) {
+	dbDown := errors.New("connection refused")
 
-	svc := NewProjectionService(
-		NewCompoundInterestCalculator(),
-		&recurringVaultRepo{v: vault.Vault{ID: vaultID, Currency: "USD"}},
-		(performance.SnapshotRepository)(nil),
-		&recurringGoalRepo{byVault: map[uuid.UUID]savingsgoal.SavingsGoal{}},
-		&recurringScheduleRepo{byGoal: map[uuid.UUID]savingsschedule.SavingsSchedule{}},
-	)
+	tests := []struct {
+		name string
+		// linkGoal seeds a goal for the vault; linkSchedule seeds an active
+		// schedule for that goal.
+		linkGoal     bool
+		linkSchedule bool
+		goalErr      error
+		scheduleErr  error
 
-	out, err := svc.CalculateVaultProjection(context.Background(), projection.VaultProjectionInput{
-		VaultID:           vaultID,
-		Deposit:           decimal.NewFromInt(500),
-		Period:            "6m",
-		CompoundFrequency: "monthly",
-		APYOverride:       &apy,
-	})
-	require.NoError(t, err)
-	require.True(t, out.Input.MonthlyContribution.IsZero())
-	require.Equal(t, "single_deposit", out.Assumptions.ContributionSource)
+		wantErr          error
+		wantContribution decimal.Decimal
+		wantSource       string
+		wantCadence      string
+	}{
+		{
+			name:             "active schedule is rolled into the projection",
+			linkGoal:         true,
+			linkSchedule:     true,
+			wantContribution: decimal.NewFromInt(200),
+			wantSource:       "schedule",
+			wantCadence:      "monthly",
+		},
+		{
+			// The case the old mock could not reach: postgres returns
+			// (nil, nil) here, not a sentinel error.
+			name:             "linked goal with no active schedule falls back",
+			linkGoal:         true,
+			linkSchedule:     false,
+			wantContribution: decimal.Zero,
+			wantSource:       "single_deposit",
+		},
+		{
+			name:             "no linked goal at all falls back",
+			linkGoal:         false,
+			wantContribution: decimal.Zero,
+			wantSource:       "single_deposit",
+		},
+		{
+			name:    "a failing goal lookup is returned, not swallowed",
+			goalErr: dbDown,
+			wantErr: dbDown,
+		},
+		{
+			name:        "a failing schedule lookup is returned, not swallowed",
+			linkGoal:    true,
+			scheduleErr: dbDown,
+			wantErr:     dbDown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID := uuid.New()
+			vaultID := uuid.New()
+			goalID := uuid.New()
+			apy := decimal.NewFromFloat(0.05)
+
+			goals := map[uuid.UUID]savingsgoal.SavingsGoal{}
+			if tt.linkGoal {
+				goals[vaultID] = savingsgoal.SavingsGoal{ID: goalID, UserID: userID, VaultID: &vaultID}
+			}
+			schedules := map[uuid.UUID]savingsschedule.SavingsSchedule{}
+			if tt.linkSchedule {
+				schedules[goalID] = savingsschedule.SavingsSchedule{
+					ID:        uuid.New(),
+					UserID:    userID,
+					GoalID:    goalID,
+					VaultID:   vaultID,
+					Amount:    decimal.NewFromInt(200),
+					Currency:  "USD",
+					Frequency: savingsschedule.FrequencyMonthly,
+					IsActive:  true,
+				}
+			}
+
+			svc := NewProjectionService(
+				NewCompoundInterestCalculator(),
+				&recurringVaultRepo{v: vault.Vault{ID: vaultID, UserID: userID, Currency: "USD"}},
+				(performance.SnapshotRepository)(nil),
+				&recurringGoalRepo{byVault: goals, err: tt.goalErr},
+				&recurringScheduleRepo{byGoal: schedules, err: tt.scheduleErr},
+			)
+
+			out, err := svc.CalculateVaultProjection(context.Background(), projection.VaultProjectionInput{
+				VaultID:           vaultID,
+				Deposit:           decimal.NewFromInt(500),
+				Period:            "6m",
+				CompoundFrequency: "monthly",
+				APYOverride:       &apy,
+			})
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr,
+					"an operational lookup failure must surface, not degrade to a zero-contribution projection")
+				require.Nil(t, out)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, out.Input.MonthlyContribution.Equal(tt.wantContribution),
+				"monthly contribution: want %s, got %s", tt.wantContribution, out.Input.MonthlyContribution)
+			require.Equal(t, tt.wantSource, out.Assumptions.ContributionSource)
+			require.Equal(t, tt.wantCadence, out.Assumptions.Cadence)
+		})
+	}
 }

--- a/apps/api/pkg/listquery/pagination_contract_test.go
+++ b/apps/api/pkg/listquery/pagination_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -54,6 +55,7 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 
 	fset := token.NewFileSet()
 	violations := []string{}
+	matchedKnown := map[string]bool{}
 
 	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -94,7 +96,11 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 			if !ok || lit.Kind != token.INT {
 				return true
 			}
-			value, convErr := strconv.Atoi(lit.Value)
+			// ParseInt with base 0, not Atoi: a token.INT literal may be
+			// written 1_000, 0x2710 or 0o1750, and Atoi rejects all three.
+			// Because the error branch skips rather than reports, those
+			// forms would slip past the guard entirely.
+			value, convErr := strconv.ParseInt(lit.Value, 0, 64)
 			if convErr != nil || value < 500 {
 				return true
 			}
@@ -103,6 +109,8 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 			key2 := rel + ":" + strconv.Itoa(pos.Line)
 			if _, known := knownLargeLimits[key2]; !known {
 				violations = append(violations, key2+": "+key.Name+": "+lit.Value)
+			} else {
+				matchedKnown[key2] = true
 			}
 			return true
 		})
@@ -113,6 +121,7 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 	}
 
 	if len(violations) > 0 {
+		sort.Strings(violations)
 		t.Errorf(
 			"found %d list-limit literal(s) >= 500 not in the reviewed allowlist "+
 				"(pkg/listquery/pagination_contract_test.go's knownLargeLimits):\n  %s\n\n"+
@@ -128,13 +137,37 @@ func TestNoNewUnboundedListLimits(t *testing.T) {
 		)
 	}
 
-	// Sanity check on the test itself: if every known entry stops matching
-	// (e.g. because the underlying code moved and line numbers shifted),
-	// this test would pass vacuously without actually scanning anything
-	// meaningful. Fail loudly instead so the allowlist gets updated rather
-	// than silently going stale.
+	// Sanity check on the test itself. Checking only that the map is non-empty
+	// does not catch staleness: it is a map literal, so it is non-empty by
+	// construction even when every entry has drifted off its call site.
+	// Assert each entry still matches a real one instead.
+	//
+	// This is also what makes the file:line keying self-correcting. Inserting
+	// lines above an allowlisted literal moves it, and the guard then reports
+	// the moved literal as a violation AND its old key as stale — naming both
+	// halves, so the fix is to update the key rather than to guess at it. A
+	// content-keyed scheme would avoid that churn, but every candidate key
+	// (enclosing function, literal value) is ambiguous here: several entries
+	// are the same ListUserVaults call with the same value, so the key would
+	// stop identifying a unique site.
 	if len(knownLargeLimits) == 0 {
 		t.Fatal("knownLargeLimits is empty — this test would no longer verify anything")
+	}
+	stale := []string{}
+	for key := range knownLargeLimits {
+		if !matchedKnown[key] {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf(
+			"%d knownLargeLimits entr(ies) no longer match a large list-limit literal:\n  %s\n\n"+
+				"The referenced code moved, changed, or was fixed. Update the allowlist to the "+
+				"current file:line (or drop the entry if the limit is gone) so this guard keeps "+
+				"covering what it claims to.",
+			len(stale), strings.Join(stale, "\n  "),
+		)
 	}
 }
 

--- a/apps/dapp/frontend/context/NetworkProvider.test.tsx
+++ b/apps/dapp/frontend/context/NetworkProvider.test.tsx
@@ -23,14 +23,20 @@ function TestConsumer() {
 
 describe("NetworkProvider (#1233)", () => {
   beforeEach(() => {
-    window.localStorage.clear();
     // safeStorage's in-memory fallback is module state and survives between
     // tests, so a test that forces a write to fall back (the quota case
-    // below) leaves nester_network_id behind. The next test then starts on
-    // mainnet, its "switch to mainnet" is a no-op, and the cache purge it
-    // asserts on never runs. Clearing with an empty prefix drains both the
-    // fallback map and localStorage.
-    safeStorage.removeByPrefix("");
+    // below) leaves nester_network_id behind, shadowing localStorage for
+    // every later test: a present memoryStore entry wins over a native read.
+    // The next test then starts on mainnet, its "switch to mainnet" is a
+    // no-op, and the cache purge it asserts on never runs.
+    //
+    // safeStorage.clear() drains both stores. It supersedes the earlier
+    // removeByPrefix("") used here: an empty prefix does match every key, but
+    // it reads as a prefix sweep rather than as "reset storage", and it only
+    // worked around the shadowing in tests while leaving it live in
+    // production — a user who hit a quota error kept reading the stale value
+    // back for the rest of the session.
+    safeStorage.clear();
   });
 
   afterEach(() => {

--- a/apps/dapp/frontend/lib/storage.test.ts
+++ b/apps/dapp/frontend/lib/storage.test.ts
@@ -7,7 +7,11 @@ import { safeStorage } from "./storage";
 
 describe("safeStorage", () => {
   beforeEach(() => {
-    window.localStorage.clear();
+    // safeStorage.clear(), not window.localStorage.clear(): the in-memory
+    // fallback is module state that survives between tests, and a present
+    // entry wins over a native read, so a test whose write fell back to
+    // memory would otherwise shadow localStorage for every test after it.
+    safeStorage.clear();
   });
 
   afterEach(() => {
@@ -92,6 +96,41 @@ describe("safeStorage", () => {
 
     it("returns null for a missing key", () => {
       expect(safeStorage.getRaw("missing")).toBeNull();
+    });
+  });
+
+  describe("clear", () => {
+    it("clears the in-memory fallback, not just localStorage", () => {
+      // A write that hits quota falls back to the in-memory map, and that
+      // entry is authoritative over a native read. Clearing only the native
+      // store would leave it shadowing localStorage for the rest of the
+      // session, so a caller that cleared storage would still read the stale
+      // value back.
+      const setItem = vi
+        .spyOn(window.localStorage.__proto__, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("QuotaExceededError");
+        });
+      safeStorage.set("shadowed", "from-memory");
+      setItem.mockRestore();
+
+      expect(safeStorage.get("shadowed", null)).toBe("from-memory");
+
+      safeStorage.clear();
+      expect(safeStorage.get("shadowed", null)).toBeNull();
+    });
+
+    it("clears values that were written durably to localStorage", () => {
+      safeStorage.set("durable", "v");
+      safeStorage.clear();
+      expect(safeStorage.get("durable", null)).toBeNull();
+    });
+
+    it("does not throw when localStorage.clear itself throws", () => {
+      vi.spyOn(window.localStorage.__proto__, "clear").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+      expect(() => safeStorage.clear()).not.toThrow();
     });
   });
 });

--- a/apps/dapp/frontend/lib/storage.ts
+++ b/apps/dapp/frontend/lib/storage.ts
@@ -192,6 +192,28 @@ export const safeStorage = {
     },
 
     /**
+     * Clears BOTH backing stores.
+     *
+     * `window.localStorage.clear()` alone is not enough, and the difference is
+     * a production bug rather than a test-only concern: since a present
+     * memoryStore entry is authoritative over a native read (see readNative),
+     * any key whose write once fell back to memory — private browsing, quota
+     * exceeded — keeps shadowing localStorage for the rest of the session. A
+     * caller that "cleared storage" and then read the key back would still get
+     * the stale fallback value. Concretely: a user who hit a quota error while
+     * switching networks kept reading the old network id even after a clear.
+     */
+    clear() {
+        memoryStore.clear();
+        if (!isBrowser()) return;
+        try {
+            window.localStorage.clear();
+        } catch {
+            // ignore — storage may be disabled; the memory fallback is cleared
+        }
+    },
+
+    /**
      * Subscribe to cross-tab updates for a single key. The callback receives
      * the parsed value when another tab writes, or `null` on remove. Returns
      * an unsubscribe function.


### PR DESCRIPTION
## Summary

Three follow-up fixes on top of #1278 and #1277. No issue-closing lines: #1233, #1227, #1226, #1225, #1224, #1223 and #1221 were already closed by those PRs. This is the remainder — two defects found while verifying that work, and four findings from CodeRabbit's review of #1276 that were worth acting on.

## The money-path one

`CalculateVaultProjection` resolved the vault's linked goal and active schedule with `goalErr == nil && goal != nil`, which treats **every** repository error as "no schedule". Only two outcomes are genuine absence — `ErrGoalNotFound` for a vault with no linked goal, and a nil schedule for a linked goal with no active one. A database failure or a cancelled context took the same branch and returned a *successful* projection that silently assumes the user never contributes again.

That is the exact number #1224 exists to stop being wrong, on a screen people use to decide whether a savings goal is reachable. Now the two absence cases fall back and everything else propagates.

The test mock was hiding it. `postgres.SavingsScheduleRepository.GetActiveByGoal` maps `sql.ErrNoRows` to `(nil, nil)` and never returns `ErrScheduleNotFound`, but `recurringScheduleRepo` returned the sentinel while its comment claimed it matched the real contract — so "linked goal, no active schedule" was never exercised the way production behaves. Corrected, and the single no-goal case is replaced with a table-driven suite covering active schedule, linked goal without schedule, no goal, and a failing lookup on either repository.

## The storage one

`readNative` treats a present `memoryStore` entry as authoritative over a native read — that is what makes a memory-fallback write visible to a later read. But nothing ever cleared that map, and `window.localStorage.clear()` does not touch it. Once a key lands there (private browsing, quota error) it shadows `localStorage` for the rest of the session: a user who hit a quota error while switching networks kept reading the stale network id back even after clearing storage.

`safeStorage.clear()` drains both stores and never throws, consistent with the rest of the module.

#1278 fixed the resulting test-order failure with `removeByPrefix("")`. That does match every key, but it only worked around the shadowing inside the tests and left it live in production. Both suites now reset through `clear()`, which says what it means.

## Pagination guard

Two ways a new large list limit could ship unnoticed:

- `strconv.Atoi` rejects valid `token.INT` forms (`1_000`, `0x2710`, `0o1750`), and the error branch *skips* rather than reports — so any literal written that way slipped past silently. Now `ParseInt` with base 0.
- The staleness check asserted only that `knownLargeLimits` was non-empty, which a map literal is by construction. An entry whose line number drifted would stop matching any call site and nothing would fail — precisely the vacuous pass it was written to prevent. It now tracks which entries actually matched and reports the ones that did not.

That second change also makes the `file:line` keying self-correcting: inserting lines above an allowlisted literal reports the moved literal as a violation *and* its old key as stale, naming both halves. Keying by content was considered and rejected — several entries are the same `ListUserVaults` call with the same value, so no content-derived key identifies a unique site.

## Verification

```
cd apps/api && go build ./...   # clean
go vet ./...                    # clean
go test ./...                   # all packages pass

cd apps/dapp/frontend
npx vitest run                  # 35 files, 309 tests pass
npx next build                  # succeeds
npx eslint <touched files>      # 0 errors
```

Both fixes were checked against their own bug rather than just run green:

- Reverting the projection fix makes exactly the two error-propagation cases fail; restoring it makes them pass.
- Weakening `clear()` to native-only makes exactly the shadowing test fail, and no other.

## Not addressed here

CodeRabbit also flagged that `DataRetentionJob`'s hard delete and its audit entry are not atomic — if `auditLog.Log` fails, the rows are already gone and no later sweep can reconstruct the record. That is a fair observation, but fixing it means threading a transaction through the job's repository interfaces, which is a larger change to #1278's design than belongs in a fix-up PR. Worth its own issue.

Separately, its workflow-injection finding (`.github/security-scanner-versions.env` sourced as shell code in three steps, in a workflow granting `security-events: write`) is about code already merged to `dev`, so it needs handling there regardless of this PR.
