### PR TITLE
fix(dapp): decouple dashboard components from mock data module (#1232)

### DIFF
--- a/apps/dapp/frontend/components/dashboard/dashboard-stats.tsx
+++ b/apps/dapp/frontend/components/dashboard/dashboard-stats.tsx
@@ -8,7 +8,7 @@ import {
     ArrowDownToLine, 
     Sparkles 
 } from "lucide-react";
-import { PortfolioStats } from "@/lib/mock-data";
+import type { PortfolioStats } from "@/lib/types";
 import { useSettings } from "@/context/settings-context";
 
 interface DashboardStatsProps {
@@ -29,7 +29,7 @@ export function DashboardStats({ stats, loading }: DashboardStatsProps) {
         {
             label: "Total Yield Earned",
             value: formatValue(stats.totalYieldEarned),
-            change: "+12.5%", // Mock change
+            change: null,
             icon: TrendingUp,
         },
         {

--- a/apps/dapp/frontend/components/dashboard/portfolio-charts.tsx
+++ b/apps/dapp/frontend/components/dashboard/portfolio-charts.tsx
@@ -14,16 +14,23 @@ import {
     Tooltip,
     Legend
 } from "recharts";
-import { 
-    VaultPosition, 
-    mockPerformanceHistory 
-} from "@/lib/mock-data";
+import { VaultPosition } from "@/lib/types";
 import { subDays, parseISO, isAfter } from "date-fns";
 import { cn } from "@/lib/utils";
 import { useSettings } from "@/context/settings-context";
 
+/** A single point in the performance history series. */
+export interface PerformanceHistoryPoint {
+    date: string;
+    balance: number;
+    yield: number;
+    benchmark: number;
+}
+
 interface PortfolioChartsProps {
     positions: VaultPosition[];
+    /** Real performance history from the user's account. Omit or pass [] for empty state. */
+    performanceHistory?: PerformanceHistoryPoint[];
 }
 
 const CHART_COLORS = [
@@ -34,7 +41,7 @@ const CHART_COLORS = [
     "#f43f5e",
 ];
 
-export function PortfolioCharts({ positions }: PortfolioChartsProps) {
+export function PortfolioCharts({ positions, performanceHistory = [] }: PortfolioChartsProps) {
     const { formatValue, exchangeRate, currency } = useSettings();
     const [timeframe, setTimeframe] = useState<"7D" | "1M" | "3M" | "ALL">("1M");
 
@@ -49,7 +56,7 @@ export function PortfolioCharts({ positions }: PortfolioChartsProps) {
 
     // Filter Performance Data based on timeframe
     const filteredHistory = useMemo(() => {
-        const history = mockPerformanceHistory.map(d => ({
+        const history = performanceHistory.map(d => ({
             ...d,
             balance: d.balance * exchangeRate,
             yield: d.yield * exchangeRate,
@@ -62,7 +69,7 @@ export function PortfolioCharts({ positions }: PortfolioChartsProps) {
         const startDate = subDays(new Date(), days);
         
         return history.filter(d => isAfter(parseISO(d.date), startDate));
-    }, [timeframe, exchangeRate]);
+    }, [timeframe, exchangeRate, performanceHistory]);
 
     const totalBalanceValue = useMemo(() => {
         return positions.reduce((acc, p) => acc + p.balance, 0) * exchangeRate;
@@ -145,63 +152,72 @@ export function PortfolioCharts({ positions }: PortfolioChartsProps) {
                 </div>
 
                 <div className="flex-1 w-full min-h-[250px]">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <AreaChart data={filteredHistory} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
-                            <defs>
-                                <linearGradient id="colorYield" x1="0" y1="0" x2="0" y2="1">
-                                    <stop offset="5%" stopColor="#10b981" stopOpacity={0.1}/>
-                                    <stop offset="95%" stopColor="#10b981" stopOpacity={0}/>
-                                </linearGradient>
-                            </defs>
-                            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f1f1" />
-                            <XAxis 
-                                dataKey="date" 
-                                axisLine={false} 
-                                tickLine={false} 
-                                tick={{ fontSize: 9, fill: '#94a3b8' }}
-                                tickFormatter={(val) => new Date(val).toLocaleDateString([], { month: 'short', day: 'numeric' })}
-                                minTickGap={30}
-                            />
-                            <YAxis 
-                                hide={false}
-                                axisLine={false} 
-                                tickLine={false} 
-                                tick={{ fontSize: 9, fill: '#94a3b8' }}
-                                tickFormatter={(val) => currency === "USD" ? `$${(val / 1000).toFixed(0)}k` : `${(val / 1000).toFixed(0)}k`}
-                            />
-                            <Tooltip 
-                                labelStyle={{ fontSize: '11px', fontWeight: 'bold', marginBottom: '4px' }}
-                                itemStyle={{ fontSize: '11px' }}
-                                contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}
-                                formatter={(value) => formatValue(Number(value) / exchangeRate)}
-                            />
-                            <Legend 
-                                verticalAlign="top" 
-                                align="right" 
-                                iconType="circle" 
-                                iconSize={6}
-                                wrapperStyle={{ fontSize: '10px', paddingTop: '0', top: -35 }}
-                            />
-                            <Area 
-                                name="Portfolio"
-                                type="monotone" 
-                                dataKey="balance" 
-                                stroke="#10b981" 
-                                strokeWidth={2}
-                                fillOpacity={1} 
-                                fill="url(#colorYield)" 
-                            />
-                            <Area 
-                                name="Benchmark (Idle)"
-                                type="monotone" 
-                                dataKey="benchmark" 
-                                stroke="#94a3b8" 
-                                strokeWidth={1}
-                                strokeDasharray="5 5"
-                                fillOpacity={0} 
-                            />
-                        </AreaChart>
-                    </ResponsiveContainer>
+                    {filteredHistory.length > 0 ? (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <AreaChart data={filteredHistory} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+                                <defs>
+                                    <linearGradient id="colorYield" x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="5%" stopColor="#10b981" stopOpacity={0.1}/>
+                                        <stop offset="95%" stopColor="#10b981" stopOpacity={0}/>
+                                    </linearGradient>
+                                </defs>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f1f1" />
+                                <XAxis 
+                                    dataKey="date" 
+                                    axisLine={false} 
+                                    tickLine={false} 
+                                    tick={{ fontSize: 9, fill: '#94a3b8' }}
+                                    tickFormatter={(val) => new Date(val).toLocaleDateString([], { month: 'short', day: 'numeric' })}
+                                    minTickGap={30}
+                                />
+                                <YAxis 
+                                    hide={false}
+                                    axisLine={false} 
+                                    tickLine={false} 
+                                    tick={{ fontSize: 9, fill: '#94a3b8' }}
+                                    tickFormatter={(val) => currency === "USD" ? `$${(val / 1000).toFixed(0)}k` : `${(val / 1000).toFixed(0)}k`}
+                                />
+                                <Tooltip 
+                                    labelStyle={{ fontSize: '11px', fontWeight: 'bold', marginBottom: '4px' }}
+                                    itemStyle={{ fontSize: '11px' }}
+                                    contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}
+                                    formatter={(value) => formatValue(Number(value) / exchangeRate)}
+                                />
+                                <Legend 
+                                    verticalAlign="top" 
+                                    align="right" 
+                                    iconType="circle" 
+                                    iconSize={6}
+                                    wrapperStyle={{ fontSize: '10px', paddingTop: '0', top: -35 }}
+                                />
+                                <Area 
+                                    name="Portfolio"
+                                    type="monotone" 
+                                    dataKey="balance" 
+                                    stroke="#10b981" 
+                                    strokeWidth={2}
+                                    fillOpacity={1} 
+                                    fill="url(#colorYield)" 
+                                />
+                                <Area 
+                                    name="Benchmark (Idle)"
+                                    type="monotone" 
+                                    dataKey="benchmark" 
+                                    stroke="#94a3b8" 
+                                    strokeWidth={1}
+                                    strokeDasharray="5 5"
+                                    fillOpacity={0} 
+                                />
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    ) : (
+                        <div className="flex flex-col items-center justify-center h-full min-h-[250px] text-center">
+                            <p className="text-sm text-muted-foreground">No performance history yet</p>
+                            <p className="mt-1.5 text-xs text-muted-foreground/70">
+                                Your yield history will appear here once you have active positions.
+                            </p>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/apps/dapp/frontend/components/dashboard/recent-activity.tsx
+++ b/apps/dapp/frontend/components/dashboard/recent-activity.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Transaction } from "@/lib/mock-data";
+import type { Transaction } from "@/lib/types";
 import { cn, truncateAddress } from "@/lib/utils";
 import { 
     ArrowUpRight, 

--- a/apps/dapp/frontend/components/dashboard/vault-positions-table.tsx
+++ b/apps/dapp/frontend/components/dashboard/vault-positions-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { VaultPosition, RiskTier } from "@/lib/mock-data";
+import type { VaultPosition, RiskTier } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import Link from 'next/link';
 import { ExternalLink, Plus, Minus } from "lucide-react";

--- a/apps/dapp/frontend/lib/mock-data.ts
+++ b/apps/dapp/frontend/lib/mock-data.ts
@@ -1,39 +1,28 @@
+// Re-export domain types so existing imports continue to work.
+// New production code should import directly from "@/lib/types".
+export type {
+    TransactionType,
+    TransactionStatus,
+    Transaction,
+    RiskTier,
+    VaultPosition,
+    PortfolioStats,
+    LoadingState,
+} from "@/lib/types";
 
-export type TransactionType = "Deposit" | "Withdrawal" | "Yield Accrual" | "Rebalance";
-export type TransactionStatus = "Confirmed" | "Pending" | "Failed";
+// ── Mock data ────────────────────────────────────────────────────────────────
+// Only tests, storybooks, and local demos should consume these values.
+// Production components must derive all data from live hooks/APIs.
 
-export interface Transaction {
-    id: string;
-    type: TransactionType;
-    amount: string;
-    asset: string;
-    vaultName: string;
-    timestamp: string;
-    status: TransactionStatus;
-    txHash: string;
-    isOnChain?: boolean;
-}
-
-export type RiskTier = "Safe" | "Balanced" | "Aggressive";
-
-export interface VaultPosition {
-    id: string;
-    vaultName: string;
-    riskTier: RiskTier;
-    balance: number;
-    apy: string;
-    yieldEarned: number;
-    nVaultBalance: string;
-    asset: string;
-    trendData: number[];
-}
-
-export interface PortfolioStats {
-    totalBalance: number;
-    totalYieldEarned: number;
-    activeVaults: number;
-    prometheusInsights: number;
-}
+import type {
+    Transaction,
+    TransactionType,
+    TransactionStatus,
+    VaultPosition,
+    RiskTier,
+    PortfolioStats,
+    LoadingState,
+} from "@/lib/types";
 
 const VAULTS = ["Conservative Yield", "Balanced Growth", "DeFi500 Index", "Growth Strategy"];
 const ASSETS = ["USDC", "XLM"];
@@ -115,8 +104,6 @@ export const mockPerformanceHistory = Array.from({ length: 30 }, (_, i) => {
     };
 });
 
-
-export type LoadingState = "loading" | "error" | "success" | "empty";
 
 // Enhanced mock data with loading states
 export const mockDataWithStates = {

--- a/apps/dapp/frontend/lib/types.ts
+++ b/apps/dapp/frontend/lib/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Domain types for dashboard components.
+ *
+ * These live here (lib/types.ts) rather than in lib/mock-data.ts so that
+ * production components never import from the mock module — making it
+ * structurally impossible for mock values to drift back into shipped code.
+ */
+
+export type TransactionType = "Deposit" | "Withdrawal" | "Yield Accrual" | "Rebalance";
+export type TransactionStatus = "Confirmed" | "Pending" | "Failed";
+
+export interface Transaction {
+    id: string;
+    type: TransactionType;
+    amount: string;
+    asset: string;
+    vaultName: string;
+    timestamp: string;
+    status: TransactionStatus;
+    txHash: string;
+    isOnChain?: boolean;
+}
+
+export type RiskTier = "Safe" | "Balanced" | "Aggressive";
+
+export interface VaultPosition {
+    id: string;
+    vaultName: string;
+    riskTier: RiskTier;
+    balance: number;
+    apy: string;
+    yieldEarned: number;
+    nVaultBalance: string;
+    asset: string;
+    trendData: number[];
+}
+
+export interface PortfolioStats {
+    totalBalance: number;
+    totalYieldEarned: number;
+    activeVaults: number;
+    prometheusInsights: number;
+}
+
+export type LoadingState = "loading" | "error" | "success" | "empty";


### PR DESCRIPTION
## Summary

Closes #1232. Decouples the four shipped dashboard components from `lib/mock-data` so mock values cannot drift back into production code, and removes fabricated data the user would otherwise see.

## Changes

| File | What changed |
|------|-------------|
| `lib/types.ts` | **New.** Canonical home for domain types (`Transaction`, `VaultPosition`, `PortfolioStats`, `RiskTier`, `LoadingState`). |
| `lib/mock-data.ts` | Re-exports types from `@/lib/types` instead of defining them. Comments mark it test/demo-only. |
| `components/dashboard/portfolio-charts.tsx` | Imports types from `@/lib/types`. Accepts a `performanceHistory` prop; renders an explicit empty state when there is no real data. |
| `components/dashboard/dashboard-stats.tsx` | Imports types from `@/lib/types`. Hardcoded `change: "+12.5%"` replaced with `null` (mock yield indicator removed). |
| `components/dashboard/recent-activity.tsx` | Imports `Transaction` from `@/lib/types`. |
| `components/dashboard/vault-positions-table.tsx` | Imports `VaultPosition`, `RiskTier` from `@/lib/types`. |

## Acceptance criteria

- [x] Performance chart renders user's real history, or an explicit empty state when there is none.
- [x] Yield-change indicator is computed from real data or removed (removed — set to `null`).
- [x] Production components import domain types from `lib/types`, not `lib/mock-data`.
- [x] A user with no history sees an empty state rather than someone else's numbers.

## Verification

Typecheck passes cleanly for all changed files. Pre-existing test-file errors are unrelated.

Closes #1232 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio charts now support live performance history data.
  * Added a clear empty state when performance history is unavailable.
  * Dashboard data types are now shared consistently across portfolio, activity, and vault views.

* **Bug Fixes**
  * Removed the inaccurate hardcoded yield-change indicator when no change data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->