### PR TITLE
security(api): four money-path fixes from the follow-up audit (#1148, #1149, #1151, #1152)

### DIFF
--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -413,6 +413,34 @@ func run() error {
 		baseLogger.Info("no signing configured: chain write operations are unavailable")
 	}
 
+	// Operator-funded deposits (nester#1152).
+	//
+	// A deposit with no user-signed tx_hash is submitted with the operator as
+	// both caller and depositing user, so it spends platform funds on the
+	// caller's behalf. Disabled unless explicitly configured, and even then
+	// only for allowlisted vaults under a per-deposit cap, with every use
+	// logged. A nil policy would refuse everything, but it is always
+	// installed so the refusals are logged rather than silent.
+	operatorFundedVaults, err := service.ParseOperatorFundedVaultIDs(cfg.Stellar().OperatorFundedDepositVaults())
+	if err != nil {
+		return fmt.Errorf("parse operator-funded deposit allowlist: %w", err)
+	}
+	operatorFundedCap, err := decimal.NewFromString(cfg.Stellar().OperatorFundedDepositMaxAmount())
+	if err != nil {
+		return fmt.Errorf("parse operator-funded deposit cap: %w", err)
+	}
+	vaultService.SetOperatorFundedDepositPolicy(service.NewOperatorFundedDepositPolicy(
+		cfg.Stellar().OperatorFundedDepositsEnabled(),
+		operatorFundedVaults,
+		operatorFundedCap,
+		baseLogger.WithGroup("operator-funded-deposits"),
+	))
+	if cfg.Stellar().OperatorFundedDepositsEnabled() {
+		baseLogger.Warn("operator-funded deposits are ENABLED: the API can spend platform funds on a user's behalf",
+			"allowlisted_vaults", len(operatorFundedVaults),
+			"per_deposit_cap", operatorFundedCap.String())
+	}
+
 	if cfg.Stellar().RPCURL() != "" {
 		vaultService.SetChainEventVerifier(service.NewStellarChainEventVerifier(cfg.Stellar().RPCURL()))
 	}

--- a/apps/api/internal/auth/context.go
+++ b/apps/api/internal/auth/context.go
@@ -12,6 +12,15 @@ type User struct {
 	Scopes        []string
 	Roles         []string
 	SessionID     string
+	// ServiceName identifies the calling service on requests authenticated
+	// with the shared service API key. Empty for ordinary user sessions.
+	//
+	// The key carries no identity of its own, so without this an audit log
+	// can say a request was made by "some holder of the service key" and
+	// nothing more (nester#1149). It is self-asserted, not authenticated:
+	// good enough to tell well-behaved callers apart in logs, not an
+	// authorization signal.
+	ServiceName string
 }
 
 // HasScope reports whether the user holds the given scope.

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -994,6 +994,30 @@ func (c *Config) validate(loader *envLoader) {
 		loader.addError("AUTH_JWT_SECRET has insufficient entropy: use at least 8 distinct characters")
 	}
 
+	// NESTER_SERVICE_API_KEY authenticates service-to-service callers and is
+	// shared between them, so a weak value is a shared weak value. It stays
+	// optional, but a key that is set must be a real one (nester#1149).
+	//
+	// Absence is not treated as a failure: an empty key disables service auth
+	// outright (the middleware's `serviceAPIKey != ""` guard), which is the
+	// safest configuration rather than a weak one. Requiring the key to exist
+	// would force every deployment that does not use service-to-service auth
+	// to invent a secret it never uses. A key that IS set, however, must be a
+	// real one in every environment — a weak shared key is weak everywhere.
+	if serviceKey := strings.TrimSpace(c.auth.serviceAPIKey); serviceKey != "" {
+		if len(serviceKey) < 32 {
+			loader.addError("NESTER_SERVICE_API_KEY must be at least 32 characters")
+		}
+		if !jwtSecretHasAdequateEntropy(serviceKey) {
+			loader.addError("NESTER_SERVICE_API_KEY has insufficient entropy: use at least 8 distinct characters")
+		}
+		// Reusing the JWT secret would let any holder of the service key mint
+		// arbitrary user tokens outright, making every other control moot.
+		if serviceKey == strings.TrimSpace(c.auth.secret) {
+			loader.addError("NESTER_SERVICE_API_KEY must not reuse AUTH_JWT_SECRET")
+		}
+	}
+
 	if c.auth.accessTokenExpiry <= 0 {
 		loader.addError("AUTH_ACCESS_TOKEN_EXPIRY must be greater than 0")
 	}

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -242,6 +242,17 @@ type StellarConfig struct {
 	allocationStrategyAddress string
 	withdrawalSlippageBps     int
 	harvestDefaultCompound    bool
+	// operatorFundedDepositsEnabled allows the API to fund deposits from the
+	// shared operator account when the user did not sign one themselves.
+	// Off by default: the supported path is a wallet-signed deposit, and
+	// leaving this on makes the deposit endpoint a value transfer bounded
+	// only by the operator balance (nester#1152).
+	operatorFundedDepositsEnabled bool
+	// operatorFundedDepositVaults is the comma-separated allowlist of vault
+	// IDs permitted to use operator funds. Empty means none.
+	operatorFundedDepositVaults string
+	// operatorFundedDepositMaxAmount caps a single operator-funded deposit.
+	operatorFundedDepositMaxAmount string
 }
 
 type AllocationConfig struct {
@@ -335,17 +346,20 @@ func Load() (*Config, error) {
 			connectionTimeout: loader.durationDefault("DATABASE_CONNECTION_TIMEOUT", 5*time.Second),
 		},
 		stellar: StellarConfig{
-			networkPassphrase:         loader.requiredString("STELLAR_NETWORK_PASSPHRASE"),
-			rpcURL:                    loader.requiredURL("STELLAR_RPC_URL"),
-			horizonURL:                loader.requiredURL("STELLAR_HORIZON_URL"),
-			operatorSecret:            loader.stringDefault("STELLAR_OPERATOR_SECRET", ""),
-			operatorAddress:           loader.stringDefault("STELLAR_OPERATOR_ADDRESS", ""),
-			signerSocketPath:          loader.stringDefault("SIGNER_SOCKET_PATH", ""),
-			stellarUSDCIssuer:         loader.stringDefault("STELLAR_USDC_ISSUER", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
-			yieldRegistryContract:     loader.stringDefault("YIELD_REGISTRY_CONTRACT", ""),
-			allocationStrategyAddress: loader.stringDefault("STELLAR_ALLOCATION_STRATEGY_ADDRESS", ""),
-			withdrawalSlippageBps:     loader.intDefault("WITHDRAWAL_SLIPPAGE_BPS", 50),
-			harvestDefaultCompound:    loader.boolDefault("HARVEST_DEFAULT_COMPOUND", true),
+			networkPassphrase:              loader.requiredString("STELLAR_NETWORK_PASSPHRASE"),
+			rpcURL:                         loader.requiredURL("STELLAR_RPC_URL"),
+			horizonURL:                     loader.requiredURL("STELLAR_HORIZON_URL"),
+			operatorSecret:                 loader.stringDefault("STELLAR_OPERATOR_SECRET", ""),
+			operatorFundedDepositsEnabled:  loader.boolDefault("STELLAR_OPERATOR_FUNDED_DEPOSITS_ENABLED", false),
+			operatorFundedDepositVaults:    loader.stringDefault("STELLAR_OPERATOR_FUNDED_DEPOSIT_VAULTS", ""),
+			operatorFundedDepositMaxAmount: loader.stringDefault("STELLAR_OPERATOR_FUNDED_DEPOSIT_MAX_AMOUNT", "0"),
+			operatorAddress:                loader.stringDefault("STELLAR_OPERATOR_ADDRESS", ""),
+			signerSocketPath:               loader.stringDefault("SIGNER_SOCKET_PATH", ""),
+			stellarUSDCIssuer:              loader.stringDefault("STELLAR_USDC_ISSUER", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
+			yieldRegistryContract:          loader.stringDefault("YIELD_REGISTRY_CONTRACT", ""),
+			allocationStrategyAddress:      loader.stringDefault("STELLAR_ALLOCATION_STRATEGY_ADDRESS", ""),
+			withdrawalSlippageBps:          loader.intDefault("WITHDRAWAL_SLIPPAGE_BPS", 50),
+			harvestDefaultCompound:         loader.boolDefault("HARVEST_DEFAULT_COMPOUND", true),
 		},
 		intelligence: IntelligenceConfig{
 			baseURL:       loader.stringDefault("INTELLIGENCE_BASE_URL", loader.stringDefault("INTELLIGENCE_SERVICE_URL", "http://localhost:8000")),
@@ -1268,6 +1282,22 @@ func (s StellarConfig) HorizonURL() string {
 
 func (s StellarConfig) OperatorSecret() string {
 	return s.operatorSecret
+}
+
+// OperatorFundedDepositsEnabled reports whether the API may spend operator
+// funds on a user's behalf. Off unless explicitly enabled (nester#1152).
+func (s StellarConfig) OperatorFundedDepositsEnabled() bool {
+	return s.operatorFundedDepositsEnabled
+}
+
+// OperatorFundedDepositVaults is the raw comma-separated vault allowlist.
+func (s StellarConfig) OperatorFundedDepositVaults() string {
+	return s.operatorFundedDepositVaults
+}
+
+// OperatorFundedDepositMaxAmount caps a single operator-funded deposit.
+func (s StellarConfig) OperatorFundedDepositMaxAmount() string {
+	return s.operatorFundedDepositMaxAmount
 }
 
 // OperatorAddress returns the operator's public Stellar address. It is public

--- a/apps/api/internal/config/config_service_key_test.go
+++ b/apps/api/internal/config/config_service_key_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// NESTER_SERVICE_API_KEY authenticates service-to-service callers and is
+// shared between them, so a weak value is a weak value for every caller at
+// once. Startup must refuse it rather than serve with it (nester#1149).
+func TestLoadRejectsWeakServiceAPIKey(t *testing.T) {
+	// Written as readable words rather than random-looking hex, matching the
+	// convention in redact_test.go: a high-entropy literal in a _test.go file
+	// still looks like a leaked credential to a secret scanner, and the
+	// honest fix is a value that is not key-shaped. These only need to be
+	// long enough to clear the 32-character minimum and varied enough to
+	// clear the entropy check.
+	const strongJWTSecret = "SENTINEL-jwt-secret-not-a-real-secret"
+
+	tests := []struct {
+		name       string
+		serviceKey string
+		wantErr    string
+	}{
+		{
+			name:       "too short",
+			serviceKey: "short-service-key",
+			wantErr:    "at least 32 characters",
+		},
+		{
+			// Long enough to pass the length check, too few distinct bytes
+			// to be a real secret.
+			name:       "low entropy",
+			serviceKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			wantErr:    "entropy",
+		},
+		{
+			// Reuse would let any holder of the service key mint arbitrary
+			// user JWTs, making every other control on it pointless.
+			name:       "reuses the JWT secret",
+			serviceKey: strongJWTSecret,
+			wantErr:    "must not reuse AUTH_JWT_SECRET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			t.Setenv("AUTH_JWT_SECRET", strongJWTSecret)
+			t.Setenv("NESTER_SERVICE_API_KEY", tt.serviceKey)
+
+			chdir(t, t.TempDir())
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected Load() to fail for a %s service key", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to mention %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// A strong key must still boot, and an absent key must still boot: an empty
+// value disables service auth entirely, which is the safe configuration
+// rather than a weak one.
+func TestLoadAcceptsStrongOrAbsentServiceAPIKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceKey string
+	}{
+		{name: "strong key", serviceKey: "SENTINEL-service-key-not-a-real-secret"},
+		{name: "absent key disables service auth", serviceKey: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseEnv(t)
+			requiredEnv(t)
+			t.Setenv("APP_ENV", "development")
+			t.Setenv("AUTH_JWT_SECRET", "SENTINEL-jwt-secret-not-a-real-secret")
+			t.Setenv("NESTER_SERVICE_API_KEY", tt.serviceKey)
+
+			chdir(t, t.TempDir())
+
+			if _, err := Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+		})
+	}
+}

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -61,6 +61,17 @@ var (
 	// recurring-deposit job queue handler, #846) can treat this as "already
 	// recorded" and safely no-op rather than fail.
 	ErrDuplicateTransaction = errors.New("transaction already recorded")
+	// ErrContractAddressRegistered is returned when a vault is created for a
+	// contract address another live vault already claims. The database
+	// enforces this with the uq_vaults_contract_address_live partial unique
+	// index (migration 104); without a distinct error the collision would
+	// surface as an opaque 500.
+	//
+	// It matters beyond tidiness: the event indexer keys balance mutations on
+	// contract_address, so a second vault pointing at someone else's contract
+	// would have that victim's on-chain deposits credited to it as well
+	// (nester#1148).
+	ErrContractAddressRegistered = errors.New("a vault is already registered for this contract address")
 	ErrCapacityExceeded     = errors.New("deposit would exceed vault capacity limit")
 	// ErrUserCancelled is returned when a user declines the wallet signature
 	// or abandons an attempt before submission. It exists to keep that case

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -76,6 +76,11 @@ var (
 	// negative, which makes an asset/share conversion meaningless. It signals
 	// corrupted balances rather than bad user input.
 	ErrInvalidSharePrice = errors.New("vault share price is not positive")
+	// ErrOperatorFundedDepositRefused is returned when a deposit would have
+	// to be funded from the shared operator account and policy forbids it.
+	// The caller's remedy is to sign and submit the deposit from their own
+	// wallet and supply the resulting tx_hash (nester#1152).
+	ErrOperatorFundedDepositRefused = errors.New("deposits must be signed and funded by your own wallet: submit the transaction and supply its tx_hash")
 	ErrCapacityExceeded     = errors.New("deposit would exceed vault capacity limit")
 	// ErrUserCancelled is returned when a user declines the wallet signature
 	// or abandons an attempt before submission. It exists to keep that case

--- a/apps/api/internal/domain/vault/model.go
+++ b/apps/api/internal/domain/vault/model.go
@@ -72,6 +72,10 @@ var (
 	// would have that victim's on-chain deposits credited to it as well
 	// (nester#1148).
 	ErrContractAddressRegistered = errors.New("a vault is already registered for this contract address")
+	// ErrInvalidSharePrice is returned when a vault's share price is zero or
+	// negative, which makes an asset/share conversion meaningless. It signals
+	// corrupted balances rather than bad user input.
+	ErrInvalidSharePrice = errors.New("vault share price is not positive")
 	ErrCapacityExceeded     = errors.New("deposit would exceed vault capacity limit")
 	// ErrUserCancelled is returned when a user declines the wallet signature
 	// or abandons an attempt before submission. It exists to keep that case

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -792,6 +792,12 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 	case errors.Is(err, vault.ErrInvalidSharePrice):
 		response.WriteJSON(w, http.StatusInternalServerError,
 			response.Err(http.StatusInternalServerError, "INVALID_SHARE_PRICE", err.Error()))
+	// 403, not 400: the request is well-formed and the amount is valid; the
+	// server simply refuses to fund it. The message names the remedy, which
+	// is to sign the deposit from the user wallet (nester#1152).
+	case errors.Is(err, vault.ErrOperatorFundedDepositRefused):
+		response.WriteJSON(w, http.StatusForbidden,
+			response.Err(http.StatusForbidden, "OPERATOR_FUNDED_DEPOSIT_REFUSED", err.Error()))
 	case errors.Is(err, vault.ErrInsufficientBalance), errors.Is(err, vault.ErrVaultClosed), errors.Is(err, vault.ErrVaultNotActive):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -782,6 +782,10 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 	case errors.Is(err, vault.ErrDuplicateTransaction):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "DUPLICATE_TRANSACTION", err.Error()))
+	// 409, not 400: the request is well-formed, it just lost a race with an
+	// address another live vault already holds (nester#1148).
+	case errors.Is(err, vault.ErrContractAddressRegistered):
+		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "CONTRACT_ADDRESS_REGISTERED", err.Error()))
 	case errors.Is(err, vault.ErrInsufficientBalance), errors.Is(err, vault.ErrVaultClosed), errors.Is(err, vault.ErrVaultNotActive):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 

--- a/apps/api/internal/handler/vault_handler.go
+++ b/apps/api/internal/handler/vault_handler.go
@@ -786,6 +786,12 @@ func (h *VaultHandler) writeDomainError(w http.ResponseWriter, r *http.Request, 
 	// address another live vault already holds (nester#1148).
 	case errors.Is(err, vault.ErrContractAddressRegistered):
 		response.WriteJSON(w, http.StatusConflict, response.Err(http.StatusConflict, "CONTRACT_ADDRESS_REGISTERED", err.Error()))
+	// Corrupted balances, not bad input: the caller cannot fix this by
+	// changing the request, so it is a 500 via the default branch rather
+	// than a 400. Named here only to keep that deliberate.
+	case errors.Is(err, vault.ErrInvalidSharePrice):
+		response.WriteJSON(w, http.StatusInternalServerError,
+			response.Err(http.StatusInternalServerError, "INVALID_SHARE_PRICE", err.Error()))
 	case errors.Is(err, vault.ErrInsufficientBalance), errors.Is(err, vault.ErrVaultClosed), errors.Is(err, vault.ErrVaultNotActive):
 		response.WriteJSON(w, http.StatusBadRequest, response.ValidationErr(err.Error()))
 

--- a/apps/api/internal/handler/vault_handler_contract_address_test.go
+++ b/apps/api/internal/handler/vault_handler_contract_address_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/middleware"
+	"github.com/suncrestlabs/nester/apps/api/internal/service"
+)
+
+// Registering a vault against a contract address another live vault already
+// holds must be refused with a 409 the client can act on.
+//
+// The attack this closes: the event indexer keys balance mutations on
+// contract_address, so a second vault pointing at a victim's contract makes
+// every on-chain deposit the victim performs credit the attacker's vault too —
+// and that balance is withdrawable (nester#1148).
+func TestVaultHandlerRejectsDuplicateContractAddress(t *testing.T) {
+	const contractAddress = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	userID := uuid.New()
+	attackerID := uuid.New()
+	repository := newHandlerRepository(userID, attackerID)
+	vaultService := service.NewVaultService(repository)
+
+	handler := NewVaultHandler(vaultService)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	post := func(t *testing.T, as uuid.UUID) *http.Response {
+		t.Helper()
+		server := httptest.NewServer(
+			fakeAuthMiddleware(as)(middleware.Logging(slog.New(slog.NewTextHandler(io.Discard, nil)))(mux)),
+		)
+		t.Cleanup(server.Close)
+
+		body := bytes.NewBufferString(`{"contract_address":"` + contractAddress + `","currency":"USDC"}`)
+		response, err := http.Post(server.URL+"/api/v1/vaults", "application/json", body)
+		if err != nil {
+			t.Fatalf("POST /api/v1/vaults error = %v", err)
+		}
+		return response
+	}
+
+	first := post(t, userID)
+	defer first.Body.Close()
+	if first.StatusCode != http.StatusCreated {
+		t.Fatalf("first registration: expected 201, got %d", first.StatusCode)
+	}
+
+	// A different user claiming the same address is the hostile case.
+	second := post(t, attackerID)
+	defer second.Body.Close()
+
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate registration: expected 409, got %d", second.StatusCode)
+	}
+
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(second.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if envelope.Error.Code != "CONTRACT_ADDRESS_REGISTERED" {
+		t.Fatalf("error code = %q, want CONTRACT_ADDRESS_REGISTERED", envelope.Error.Code)
+	}
+}

--- a/apps/api/internal/handler/vault_handler_test.go
+++ b/apps/api/internal/handler/vault_handler_test.go
@@ -179,6 +179,14 @@ func (r *handlerRepository) CreateVault(_ context.Context, model vault.Vault) (v
 	if _, ok := r.users[model.UserID]; !ok {
 		return vault.Vault{}, vault.ErrUserNotFound
 	}
+	// Mirrors uq_vaults_contract_address_live (migration 104), scoped to live
+	// rows exactly as the partial index is, so the handler's conflict branch
+	// is exercised against the same rule the database enforces (#1148).
+	for _, existing := range r.vaults {
+		if existing.DeletedAt == nil && existing.ContractAddress == model.ContractAddress {
+			return vault.Vault{}, vault.ErrContractAddressRegistered
+		}
+	}
 	now := time.Now().UTC()
 	model.CreatedAt = now
 	model.UpdatedAt = now

--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -54,13 +55,42 @@ func Authenticate(secret, serviceAPIKey string, rules []RouteRule, revocation Re
 			}
 
 			// Service-to-service auth for intelligence and internal callers.
-			if serviceAPIKey != "" && token == serviceAPIKey {
+			//
+			// subtle.ConstantTimeCompare rather than ==, matching the JWT path
+			// below: a byte-wise short-circuit on a shared secret leaks its
+			// prefix to anyone who can time responses (nester#1149).
+			if serviceAPIKey != "" && constantTimeEqual(token, serviceAPIKey) {
 				userID := strings.TrimSpace(r.Header.Get("X-User-Id"))
 				if userID == "" {
 					writeMiddlewareError(w, http.StatusUnauthorized, "X-User-Id header required for service auth")
 					return
 				}
-				user := auth.User{ID: userID, WalletAddress: "", Scopes: nil, Roles: []string{"service"}}
+
+				// The key is shared with the intelligence service and has no
+				// per-caller identity of its own, so anyone holding it could
+				// otherwise act as any user on any route. Money-path routes
+				// refuse it outright: a service asserting a user identity has
+				// no business moving that user's funds (nester#1149).
+				if isMoneyPathRoute(r) {
+					writeMiddlewareError(w, http.StatusForbidden,
+						"service credentials cannot act on behalf of a user on money-path routes")
+					return
+				}
+
+				// Identify the calling service separately from the key, so
+				// audit logs distinguish callers that share one secret.
+				serviceName := strings.TrimSpace(r.Header.Get("X-Service-Name"))
+				if serviceName == "" {
+					serviceName = "unknown"
+				}
+
+				user := auth.User{
+					ID:            userID,
+					WalletAddress: "",
+					Scopes:        nil,
+					Roles:         []string{"service"},
+					ServiceName:   serviceName,
+				}
 				next.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), user)))
 				return
 			}
@@ -109,6 +139,55 @@ func Authenticate(secret, serviceAPIKey string, rules []RouteRule, revocation Re
 			next.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), user)))
 		})
 	}
+}
+
+// constantTimeEqual compares two secrets without leaking their contents
+// through timing. subtle.ConstantTimeCompare is itself only constant-time for
+// equal-length inputs, so length is folded into the result rather than being
+// allowed to short-circuit the comparison.
+func constantTimeEqual(got, want string) bool {
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// moneyPathSuffixes are the request-path suffixes that move value.
+//
+// Matched as suffixes because vault routes are registered with a path
+// parameter ("/api/v1/vaults/{id}/deposit"), so the concrete request path
+// carries an id this table cannot enumerate.
+var moneyPathSuffixes = []string{
+	"/deposit",
+	"/withdraw",
+	"/emergency-withdraw",
+	"/harvest",
+	"/rebalance",
+	"/rebalance/execute",
+	"/transfer",
+	"/payout",
+}
+
+// isMoneyPathRoute reports whether the request targets a route that moves
+// user funds.
+//
+// Deliberately a denylist of value-moving suffixes rather than an allowlist of
+// safe routes: the read surface is large and grows constantly, and a new
+// analytics endpoint appearing without a matching entry here should not be
+// what stops the intelligence service from working. The set that moves money
+// is small, stable, and worth naming explicitly.
+//
+// Trailing slashes are trimmed so "/deposit/" cannot slip past, and the match
+// is case-insensitive because Go's ServeMux routes are case-sensitive while
+// some proxies are not.
+func isMoneyPathRoute(r *http.Request) bool {
+	path := strings.ToLower(strings.TrimRight(r.URL.Path, "/"))
+	if path == "" {
+		return false
+	}
+	for _, suffix := range moneyPathSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // bearerToken extracts the raw token string from an

--- a/apps/api/internal/middleware/auth_service_key_test.go
+++ b/apps/api/internal/middleware/auth_service_key_test.go
@@ -1,0 +1,196 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/auth"
+)
+
+// Readable rather than key-shaped, per the convention in redact_test.go: a
+// high-entropy literal in a test file still looks like a leaked credential to
+// a secret scanner.
+const testServiceKey = "SENTINEL-service-api-key-not-a-real-secret"
+
+// A holder of the shared service key must not be able to move a user's money
+// by asserting their identity in a header.
+//
+// The key is shared with the intelligence service, carries no per-caller
+// identity, and has no rotation story, so treating it as "any user" on the
+// money path makes every deposit and withdrawal reachable by anyone who has
+// ever seen it (nester#1149).
+func TestServiceKeyCannotImpersonateOnMoneyPathRoutes(t *testing.T) {
+	moneyPaths := []string{
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/deposit",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/withdraw",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/emergency-withdraw",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/harvest",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/rebalance",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/rebalance/execute",
+		"/api/v1/users/savings-goals/deposit",
+		// Trailing slash and mixed case must not be an escape hatch.
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/deposit/",
+		"/api/v1/vaults/11111111-1111-1111-1111-111111111111/DEPOSIT",
+	}
+
+	handler := Authenticate(testSecret, testServiceKey, defaultRules, alwaysActiveRevocation)(ok200)
+
+	for _, path := range moneyPaths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set("Authorization", "Bearer "+testServiceKey)
+			req.Header.Set("X-User-Id", "victim-user-id")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s: got %d, want 403 — service key must not act as a user on the money path", path, rec.Code)
+			}
+		})
+	}
+}
+
+// Service auth is still allowed to do its actual job: reading on behalf of a
+// user on non-money routes. Denying everything would break the intelligence
+// service rather than secure it.
+func TestServiceKeyStillWorksOnNonMoneyRoutes(t *testing.T) {
+	handler := Authenticate(testSecret, testServiceKey, defaultRules, alwaysActiveRevocation)(ok200)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+testServiceKey)
+	req.Header.Set("X-User-Id", "user-42")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 for service auth on a non-money route", rec.Code)
+	}
+}
+
+// The calling service must be identifiable separately from the key it holds,
+// so an audit trail can name the caller rather than "someone with the key".
+func TestServiceKeyRecordsCallingServiceName(t *testing.T) {
+	var captured auth.User
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured, _ = auth.GetUserFromContext(r.Context())
+	})
+
+	handler := Authenticate(testSecret, testServiceKey, defaultRules, alwaysActiveRevocation)(capture)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+testServiceKey)
+	req.Header.Set("X-User-Id", "user-42")
+	req.Header.Set("X-Service-Name", "intelligence")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if captured.ServiceName != "intelligence" {
+		t.Fatalf("ServiceName = %q, want %q", captured.ServiceName, "intelligence")
+	}
+	if captured.ID != "user-42" {
+		t.Fatalf("ID = %q, want %q", captured.ID, "user-42")
+	}
+}
+
+// An unnamed caller is still identified as such rather than silently blending
+// in with named ones.
+func TestServiceKeyDefaultsServiceNameWhenAbsent(t *testing.T) {
+	var captured auth.User
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured, _ = auth.GetUserFromContext(r.Context())
+	})
+
+	handler := Authenticate(testSecret, testServiceKey, defaultRules, alwaysActiveRevocation)(capture)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+testServiceKey)
+	req.Header.Set("X-User-Id", "user-42")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if captured.ServiceName != "unknown" {
+		t.Fatalf("ServiceName = %q, want %q", captured.ServiceName, "unknown")
+	}
+}
+
+// A near-miss key must not authenticate. This also pins the comparison to a
+// whole-value check rather than a prefix one.
+func TestServiceKeyRejectsNearMissAndEmptyKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		presented  string
+	}{
+		{name: "prefix of the real key", configured: testServiceKey, presented: testServiceKey[:len(testServiceKey)-1]},
+		{name: "real key plus a suffix", configured: testServiceKey, presented: testServiceKey + "x"},
+		// An unset key must never turn an empty bearer token into service auth.
+		{name: "service auth disabled", configured: "", presented: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := Authenticate(testSecret, tt.configured, defaultRules, alwaysActiveRevocation)(ok200)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.presented)
+			req.Header.Set("X-User-Id", "user-42")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusOK {
+				t.Fatal("a non-matching key authenticated as a service caller")
+			}
+		})
+	}
+}
+
+func TestConstantTimeEqual(t *testing.T) {
+	if !constantTimeEqual("abc", "abc") {
+		t.Fatal("identical values compared unequal")
+	}
+	if constantTimeEqual("abc", "abd") {
+		t.Fatal("different values compared equal")
+	}
+	if constantTimeEqual("abc", "abcd") {
+		t.Fatal("different-length values compared equal")
+	}
+	if constantTimeEqual("", "abc") {
+		t.Fatal("empty compared equal to non-empty")
+	}
+}
+
+func TestIsMoneyPathRoute(t *testing.T) {
+	money := []string{
+		"/api/v1/vaults/abc/deposit",
+		"/api/v1/vaults/abc/withdraw",
+		"/api/v1/vaults/abc/emergency-withdraw",
+		"/api/v1/vaults/abc/deposit/",
+	}
+	safe := []string{
+		"/api/v1/vaults",
+		"/api/v1/vaults/abc",
+		"/api/v1/vaults/abc/performance",
+		"/api/v1/analytics/summary",
+		"/health",
+		"/",
+	}
+
+	for _, path := range money {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		if !isMoneyPathRoute(req) {
+			t.Errorf("isMoneyPathRoute(%q) = false, want true", path)
+		}
+	}
+	for _, path := range safe {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if isMoneyPathRoute(req) {
+			t.Errorf("isMoneyPathRoute(%q) = true, want false", path)
+		}
+	}
+}

--- a/apps/api/internal/repository/postgres/money_path_constraints_integration_test.go
+++ b/apps/api/internal/repository/postgres/money_path_constraints_integration_test.go
@@ -1,11 +1,13 @@
 package postgres
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
 
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
 )
 
@@ -43,8 +45,14 @@ func TestIntegrationMoneyPathConstraintsRejectViolations(t *testing.T) {
 		// Two vaults on one contract makes the indexer's
 		// `WHERE contract_address = $1` update both, so one user's on-chain
 		// deposit credits another user's vault.
-		if err := insertVault(uuid.New(), contract); err == nil {
+		err := insertVault(uuid.New(), contract)
+		if err == nil {
 			t.Fatal("a second vault on the same contract address was accepted")
+		}
+		// The rejection must reach callers as a distinct domain error, not an
+		// opaque driver error the handler can only turn into a 500 (#1148).
+		if mapped := mapRepositoryError(err); !errors.Is(mapped, vault.ErrContractAddressRegistered) {
+			t.Fatalf("mapRepositoryError = %v, want ErrContractAddressRegistered", mapped)
 		}
 	})
 

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -1140,6 +1140,12 @@ func mapRepositoryError(err error) error {
 		if pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "transaction_hash") {
 			return vault.ErrDuplicateTransaction
 		}
+		// uq_vaults_contract_address_live (migration 104). Checked before the
+		// generic 23505 fallthrough so a duplicate registration is a clear
+		// client error rather than an opaque 500 (nester#1148).
+		if pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "vaults_contract_address") {
+			return vault.ErrContractAddressRegistered
+		}
 	}
 
 	return err

--- a/apps/api/internal/repository/postgres/vault_repository_error_test.go
+++ b/apps/api/internal/repository/postgres/vault_repository_error_test.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// A duplicate contract address must surface as a domain error rather than a
+// raw driver error. Without the mapping the handler falls through to its
+// default branch and answers 500, which tells the client to retry a request
+// that can never succeed (nester#1148).
+func TestMapRepositoryErrorContractAddressConflict(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		want       error
+		wantMapped bool
+	}{
+		{
+			name: "live contract address unique index",
+			err: &pgconn.PgError{
+				Code:           "23505",
+				ConstraintName: "uq_vaults_contract_address_live",
+			},
+			want:       vault.ErrContractAddressRegistered,
+			wantMapped: true,
+		},
+		{
+			name: "wrapped by the driver",
+			err: fmt.Errorf("insert vault: %w", &pgconn.PgError{
+				Code:           "23505",
+				ConstraintName: "uq_vaults_contract_address_live",
+			}),
+			want:       vault.ErrContractAddressRegistered,
+			wantMapped: true,
+		},
+		{
+			name: "transaction hash conflict stays distinct",
+			err: &pgconn.PgError{
+				Code:           "23505",
+				ConstraintName: "idx_vault_transactions_transaction_hash_unique",
+			},
+			want:       vault.ErrDuplicateTransaction,
+			wantMapped: true,
+		},
+		{
+			name: "unrelated unique violation is passed through",
+			err: &pgconn.PgError{
+				Code:           "23505",
+				ConstraintName: "uq_something_else",
+			},
+			wantMapped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapRepositoryError(tt.err)
+			if !tt.wantMapped {
+				if !errors.Is(got, tt.err) {
+					t.Fatalf("mapRepositoryError(%v) = %v, want the original error", tt.err, got)
+				}
+				return
+			}
+			if !errors.Is(got, tt.want) {
+				t.Fatalf("mapRepositoryError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapRepositoryErrorNil(t *testing.T) {
+	if err := mapRepositoryError(nil); err != nil {
+		t.Fatalf("mapRepositoryError(nil) = %v, want nil", err)
+	}
+}

--- a/apps/api/internal/service/operator_funded_deposits.go
+++ b/apps/api/internal/service/operator_funded_deposits.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// Distinct reasons an operator-funded deposit was refused. All wrap
+// vault.ErrOperatorFundedDepositRefused so callers and the HTTP layer can
+// treat them uniformly while logs keep the specific cause.
+var (
+	ErrOperatorFundedDepositDisabled = fmt.Errorf(
+		"%w (operator-funded deposits are disabled)", vault.ErrOperatorFundedDepositRefused)
+	ErrOperatorFundedDepositNotAllowed = fmt.Errorf(
+		"%w (vault is not allowlisted for operator-funded deposits)", vault.ErrOperatorFundedDepositRefused)
+	ErrOperatorFundedDepositCapExceeded = fmt.Errorf(
+		"%w (amount exceeds the operator-funded deposit cap)", vault.ErrOperatorFundedDepositRefused)
+)
+
+// OperatorFundedDepositPolicy decides whether the API may spend the shared
+// operator account's funds to make a deposit on a user's behalf.
+//
+// The vault contract's deposit takes the operator as both caller and
+// depositing user, so a server-submitted deposit moves platform money, not the
+// user's. POST /vaults/{id}/deposit was therefore a value transfer bounded
+// only by the operator balance (nester#1152).
+//
+// The real fix is the wallet-signed path that already exists: the client signs
+// its own deposit and submits a tx_hash the chain verifier checks. This policy
+// governs what remains — an operator-funded fallback that is off unless
+// explicitly configured, capped per deposit, restricted to named vaults, and
+// audit-logged on every use.
+type OperatorFundedDepositPolicy struct {
+	// enabled gates the whole path. Zero value is disabled, so a
+	// OperatorFundedDepositPolicy{} refuses everything.
+	enabled bool
+	// allowedVaults is the set of vault IDs permitted to use operator funds.
+	// Empty means none: an enabled policy with no allowlist still refuses,
+	// so enabling the feature is never on its own enough to move money.
+	allowedVaults map[uuid.UUID]struct{}
+	// maxAmount caps a single operator-funded deposit. Non-positive means
+	// no deposit is permitted, for the same reason.
+	maxAmount decimal.Decimal
+
+	logger *slog.Logger
+
+	mu    sync.Mutex
+	spent map[uuid.UUID]decimal.Decimal
+}
+
+// NewOperatorFundedDepositPolicy builds a policy from configuration.
+//
+// Every argument must be deliberately set for the path to work at all:
+// disabled, an empty allowlist, or a non-positive cap each independently
+// refuse. Defaults fail closed because the failure mode here is spending
+// platform funds on a stranger's behalf.
+func NewOperatorFundedDepositPolicy(
+	enabled bool,
+	allowedVaults []uuid.UUID,
+	maxAmount decimal.Decimal,
+	logger *slog.Logger,
+) *OperatorFundedDepositPolicy {
+	allowed := make(map[uuid.UUID]struct{}, len(allowedVaults))
+	for _, id := range allowedVaults {
+		if id != uuid.Nil {
+			allowed[id] = struct{}{}
+		}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OperatorFundedDepositPolicy{
+		enabled:       enabled,
+		allowedVaults: allowed,
+		maxAmount:     maxAmount,
+		logger:        logger,
+		spent:         make(map[uuid.UUID]decimal.Decimal),
+	}
+}
+
+// ParseOperatorFundedVaultIDs turns a comma-separated allowlist into vault
+// IDs. A malformed entry is an error rather than a silent skip: quietly
+// dropping an unparseable id would widen or narrow the allowlist without
+// anyone noticing.
+func ParseOperatorFundedVaultIDs(raw string) ([]uuid.UUID, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parts := strings.Split(trimmed, ",")
+	ids := make([]uuid.UUID, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		id, err := uuid.Parse(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vault id %q in operator-funded deposit allowlist: %w", part, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// Authorize reports whether an operator-funded deposit may proceed, and logs
+// the decision either way.
+//
+// Both outcomes are logged at a level that survives production filtering: a
+// permitted one because it is a movement of platform funds and the audit trail
+// is the whole point, and a refused one because a rejected attempt is exactly
+// what an operator wants to see.
+func (p *OperatorFundedDepositPolicy) Authorize(
+	_ context.Context,
+	vaultID, userID uuid.UUID,
+	amount decimal.Decimal,
+) error {
+	if p == nil || !p.enabled {
+		return ErrOperatorFundedDepositDisabled
+	}
+
+	if _, ok := p.allowedVaults[vaultID]; !ok {
+		p.logRefusal(vaultID, userID, amount, "vault is not in the operator-funded allowlist")
+		return ErrOperatorFundedDepositNotAllowed
+	}
+
+	if p.maxAmount.Sign() <= 0 || amount.GreaterThan(p.maxAmount) {
+		p.logRefusal(vaultID, userID, amount, "amount exceeds the operator-funded deposit cap")
+		return ErrOperatorFundedDepositCapExceeded
+	}
+
+	p.mu.Lock()
+	p.spent[vaultID] = p.spent[vaultID].Add(amount)
+	total := p.spent[vaultID]
+	p.mu.Unlock()
+
+	// Logged after the decision so the entry records a deposit that was
+	// actually authorized, and carries the running total so a slow drain
+	// across many small deposits is visible in one field.
+	p.logger.Warn("operator-funded deposit authorized: platform funds are being spent on a user's behalf",
+		"vault_id", vaultID.String(),
+		"user_id", userID.String(),
+		"amount", amount.String(),
+		"cap", p.maxAmount.String(),
+		"vault_total_since_start", total.String(),
+		"issue", "nester#1152",
+	)
+	return nil
+}
+
+func (p *OperatorFundedDepositPolicy) logRefusal(vaultID, userID uuid.UUID, amount decimal.Decimal, reason string) {
+	p.logger.Warn("operator-funded deposit refused",
+		"vault_id", vaultID.String(),
+		"user_id", userID.String(),
+		"amount", amount.String(),
+		"reason", reason,
+		"issue", "nester#1152",
+	)
+}
+
+// allowOperatorFundedForTest builds a policy permitting operator-funded
+// deposits for the given vaults with an effectively unbounded cap.
+//
+// It lives here rather than in a _test.go file because several test files in
+// this package need it, and it is deliberately explicit: a test that wants a
+// server-submitted deposit has to say so, which is what keeps the production
+// default a refusal.
+func allowOperatorFundedForTest(vaultIDs ...uuid.UUID) *OperatorFundedDepositPolicy {
+	return NewOperatorFundedDepositPolicy(
+		true,
+		vaultIDs,
+		decimal.NewFromInt(1_000_000_000),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+}

--- a/apps/api/internal/service/operator_funded_deposits_test.go
+++ b/apps/api/internal/service/operator_funded_deposits_test.go
@@ -1,0 +1,288 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// operatorBalanceInvoker models the shared operator account: a server-submitted
+// deposit debits it, exactly as the contract's deposit(operator, operator, ...)
+// does on chain.
+type operatorBalanceInvoker struct {
+	operatorBalance decimal.Decimal
+	depositCalls    int
+}
+
+func newOperatorBalanceInvoker(start string) *operatorBalanceInvoker {
+	return &operatorBalanceInvoker{operatorBalance: decimal.RequireFromString(start)}
+}
+
+func (o *operatorBalanceInvoker) DepositToVault(_ context.Context, _ string, amountStroops int64) error {
+	o.depositCalls++
+	o.operatorBalance = o.operatorBalance.Sub(
+		decimal.NewFromInt(amountStroops).Div(decimal.NewFromInt(10_000_000)),
+	)
+	return nil
+}
+
+func (o *operatorBalanceInvoker) WithdrawFromVault(context.Context, string, int64, int) (string, error) {
+	return "hash", nil
+}
+
+func (o *operatorBalanceInvoker) PreviewDeposit(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+func (o *operatorBalanceInvoker) PreviewWithdraw(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+func (o *operatorBalanceInvoker) HarvestVault(context.Context, string, string, bool) (string, error) {
+	return "", nil
+}
+
+func (o *operatorBalanceInvoker) EmergencyWithdrawAll(context.Context, string) error { return nil }
+
+func newVaultForOperatorTest(t *testing.T, svc *VaultService, userID uuid.UUID) vault.Vault {
+	t.Helper()
+	created, err := svc.CreateVault(context.Background(), CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	return created
+}
+
+// The acceptance criterion of nester#1152: a deposit must not reduce the
+// operator balance.
+//
+// Before this change DepositToVault was called with the operator as both
+// caller and depositing user, so POST /vaults/{id}/deposit spent platform
+// funds for anyone who asked.
+func TestRecordDeposit_DoesNotDebitOperatorAccount(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+
+	invoker := newOperatorBalanceInvoker("1000")
+	svc.SetDepositInvoker(invoker)
+	created := newVaultForOperatorTest(t, svc, userID)
+
+	before := invoker.operatorBalance
+
+	_, err := svc.RecordDeposit(ctx, RecordDepositInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("100"),
+	})
+	if !errors.Is(err, vault.ErrOperatorFundedDepositRefused) {
+		t.Fatalf("err = %v, want ErrOperatorFundedDepositRefused", err)
+	}
+
+	if invoker.depositCalls != 0 {
+		t.Errorf("DepositToVault called %d times, want 0", invoker.depositCalls)
+	}
+	if !invoker.operatorBalance.Equal(before) {
+		t.Fatalf("operator balance = %s, want %s (a deposit must not spend platform funds)",
+			invoker.operatorBalance, before)
+	}
+}
+
+// The wallet-signed path is what deposits are supposed to use, and it must
+// keep working: the user signs, the chain verifier confirms the event, and the
+// operator account is never touched.
+func TestRecordDeposit_WalletSignedPathDoesNotTouchOperator(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+
+	invoker := newOperatorBalanceInvoker("1000")
+	svc.SetDepositInvoker(invoker)
+	created := newVaultForOperatorTest(t, svc, userID)
+
+	svc.SetChainEventVerifier(&fakeChainVerifier{events: map[string]VerifiedVaultEvent{
+		"user-signed-hash": {
+			Amount:     decimal.RequireFromString("100"),
+			EventType:  "deposit",
+			ContractID: created.ContractAddress,
+		},
+	}})
+
+	before := invoker.operatorBalance
+
+	updated, err := svc.RecordDeposit(ctx, RecordDepositInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("100"),
+		TxHash:  "user-signed-hash",
+	})
+	if err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	if invoker.depositCalls != 0 {
+		t.Errorf("DepositToVault called %d times, want 0 for a wallet-signed deposit", invoker.depositCalls)
+	}
+	if !invoker.operatorBalance.Equal(before) {
+		t.Fatalf("operator balance = %s, want %s", invoker.operatorBalance, before)
+	}
+	if !updated.CurrentBalance.Equal(decimal.RequireFromString("100")) {
+		t.Fatalf("vault balance = %s, want 100", updated.CurrentBalance)
+	}
+}
+
+// An explicitly allowlisted, capped, operator-funded deposit is still
+// permitted: the escape hatch the issue allows for.
+func TestRecordDeposit_AllowlistedOperatorFundedDepositIsPermitted(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+
+	invoker := newOperatorBalanceInvoker("1000")
+	svc.SetDepositInvoker(invoker)
+	created := newVaultForOperatorTest(t, svc, userID)
+
+	svc.SetOperatorFundedDepositPolicy(NewOperatorFundedDepositPolicy(
+		true,
+		[]uuid.UUID{created.ID},
+		decimal.RequireFromString("500"),
+		discardLogger(),
+	))
+
+	if _, err := svc.RecordDeposit(ctx, RecordDepositInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	if invoker.depositCalls != 1 {
+		t.Fatalf("DepositToVault called %d times, want 1", invoker.depositCalls)
+	}
+	// This path DOES spend operator funds; that is what the allowlist opts
+	// into, and why it is capped and logged.
+	if !invoker.operatorBalance.Equal(decimal.RequireFromString("900")) {
+		t.Fatalf("operator balance = %s, want 900", invoker.operatorBalance)
+	}
+}
+
+func TestOperatorFundedDepositPolicy_Authorize(t *testing.T) {
+	allowed := uuid.New()
+	other := uuid.New()
+	user := uuid.New()
+
+	tests := []struct {
+		name    string
+		policy  *OperatorFundedDepositPolicy
+		vaultID uuid.UUID
+		amount  string
+		wantErr error
+	}{
+		{
+			name:    "nil policy refuses",
+			policy:  nil,
+			vaultID: allowed,
+			amount:  "1",
+			wantErr: ErrOperatorFundedDepositDisabled,
+		},
+		{
+			name:    "disabled refuses",
+			policy:  NewOperatorFundedDepositPolicy(false, []uuid.UUID{allowed}, decimal.NewFromInt(100), discardLogger()),
+			vaultID: allowed,
+			amount:  "1",
+			wantErr: ErrOperatorFundedDepositDisabled,
+		},
+		{
+			name:    "enabled with empty allowlist refuses",
+			policy:  NewOperatorFundedDepositPolicy(true, nil, decimal.NewFromInt(100), discardLogger()),
+			vaultID: allowed,
+			amount:  "1",
+			wantErr: ErrOperatorFundedDepositNotAllowed,
+		},
+		{
+			name:    "vault outside the allowlist refuses",
+			policy:  NewOperatorFundedDepositPolicy(true, []uuid.UUID{allowed}, decimal.NewFromInt(100), discardLogger()),
+			vaultID: other,
+			amount:  "1",
+			wantErr: ErrOperatorFundedDepositNotAllowed,
+		},
+		{
+			name:    "amount over the cap refuses",
+			policy:  NewOperatorFundedDepositPolicy(true, []uuid.UUID{allowed}, decimal.NewFromInt(100), discardLogger()),
+			vaultID: allowed,
+			amount:  "100.01",
+			wantErr: ErrOperatorFundedDepositCapExceeded,
+		},
+		{
+			name:    "zero cap refuses even an allowlisted vault",
+			policy:  NewOperatorFundedDepositPolicy(true, []uuid.UUID{allowed}, decimal.Zero, discardLogger()),
+			vaultID: allowed,
+			amount:  "1",
+			wantErr: ErrOperatorFundedDepositCapExceeded,
+		},
+		{
+			name:    "allowlisted and at the cap is permitted",
+			policy:  NewOperatorFundedDepositPolicy(true, []uuid.UUID{allowed}, decimal.NewFromInt(100), discardLogger()),
+			vaultID: allowed,
+			amount:  "100",
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.Authorize(context.Background(), tt.vaultID, user, decimal.RequireFromString(tt.amount))
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("Authorize() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Authorize() = %v, want %v", err, tt.wantErr)
+			}
+			// Every refusal must also be recognisable to the HTTP layer.
+			if !errors.Is(err, vault.ErrOperatorFundedDepositRefused) {
+				t.Fatalf("Authorize() = %v, want it to wrap ErrOperatorFundedDepositRefused", err)
+			}
+		})
+	}
+}
+
+func TestParseOperatorFundedVaultIDs(t *testing.T) {
+	id1, id2 := uuid.New(), uuid.New()
+
+	got, err := ParseOperatorFundedVaultIDs("  " + id1.String() + " , " + id2.String() + " ")
+	if err != nil {
+		t.Fatalf("ParseOperatorFundedVaultIDs: %v", err)
+	}
+	if len(got) != 2 || got[0] != id1 || got[1] != id2 {
+		t.Fatalf("got %v, want [%s %s]", got, id1, id2)
+	}
+
+	if got, err := ParseOperatorFundedVaultIDs(""); err != nil || got != nil {
+		t.Fatalf("empty input: got %v, %v; want nil, nil", got, err)
+	}
+
+	// A malformed entry must fail loudly rather than silently shrink the
+	// allowlist into something nobody configured.
+	if _, err := ParseOperatorFundedVaultIDs(id1.String() + ",not-a-uuid"); err == nil {
+		t.Fatal("expected an error for a malformed vault id")
+	}
+}

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -82,9 +82,16 @@ type ConvertResponse struct {
 // Implementations invoke the Soroban vault contract; the noop is used when
 // no operator secret is configured.
 type VaultDepositInvoker interface {
+	// DepositToVault takes an ASSET amount in stroops (1 unit = 10^7).
 	DepositToVault(ctx context.Context, contractAddress string, amountStroops int64) error
+	// WithdrawFromVault takes a SHARE amount in stroops, NOT assets: the
+	// value is forwarded to preview_withdraw_net and to the contract's
+	// share-denominated withdraw. Callers holding an asset amount must
+	// convert it first — see resolveWithdrawalShares (nester#1151).
 	WithdrawFromVault(ctx context.Context, contractAddress string, sharesStroops int64, slippageBps int) (txHash string, err error)
+	// PreviewDeposit maps ASSET stroops in to SHARE stroops out.
 	PreviewDeposit(ctx context.Context, contractAddress string, amountStroops int64) (int64, error)
+	// PreviewWithdraw maps SHARE stroops in to ASSET stroops out.
 	PreviewWithdraw(ctx context.Context, contractAddress string, sharesStroops int64) (int64, error)
 	HarvestVault(ctx context.Context, contractAddress, userAddress string, compound bool) (string, error)
 	// EmergencyWithdrawAll triggers the vault contract's emergency_withdraw_all
@@ -714,15 +721,35 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 	}
 
 	txHash := strings.TrimSpace(input.TxHash)
+	// Shares actually burned on chain, when this call submitted the
+	// transaction itself. Zero means "not known from a submission" and the
+	// share figure falls back to the share-price computation below.
+	submittedShares := decimal.Zero
 	// A client-supplied hash means the withdraw already landed on-chain
 	// (wallet-signed). Do not submit again.
 	if txHash == "" && s.depositInvoker != nil {
-		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
-		submitted, err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, stroops, input.SlippageBps)
+		// WithdrawFromVault's second parameter is SHARES in stroops, not
+		// assets: it is forwarded to preview_withdraw_net and to the
+		// contract's share-denominated withdraw. Passing asset stroops here
+		// burned the wrong number of shares whenever the share price was not
+		// exactly 1.0 — taking materially more or less than the user asked
+		// for, while the database recorded the requested amount either way
+		// (nester#1151).
+		sharesStroops, err := s.resolveWithdrawalShares(ctx, existing, input.Amount)
+		if err != nil {
+			return vault.Vault{}, err
+		}
+
+		submitted, err := s.depositInvoker.WithdrawFromVault(ctx, existing.ContractAddress, sharesStroops, input.SlippageBps)
 		if err != nil {
 			return vault.Vault{}, fmt.Errorf("on-chain withdrawal failed: %w", err)
 		}
 		txHash = strings.TrimSpace(submitted)
+		// The contract burned sharesStroops and returned the corresponding
+		// assets. Record what the chain actually did rather than what was
+		// requested; when a verifier is configured the block below replaces
+		// this with the emitted event, which is better still.
+		submittedShares = decimal.NewFromInt(sharesStroops).Div(stroopsPerUnit)
 	}
 
 	amount := input.Amount
@@ -751,6 +778,12 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 
 	sharePrice := vault.ComputeSharePrice(existing)
 	shares := amount.Div(sharePrice).Round(6)
+	// Prefer the share count the chain actually burned over one re-derived
+	// from the price: the recorded withdrawal must reflect what happened on
+	// chain, not what was requested (nester#1151).
+	if submittedShares.IsPositive() {
+		shares = submittedShares.Round(6)
+	}
 
 	record := vault.TransactionRecord{
 		UserID:               userID,
@@ -765,6 +798,69 @@ func (s *VaultService) RecordWithdrawal(ctx context.Context, input RecordWithdra
 	}
 
 	return s.repository.GetVault(ctx, input.VaultID)
+}
+
+// stroopsPerUnit is the fixed-point scale Soroban uses for asset and share
+// amounts: 1 unit = 10^7 stroops.
+var stroopsPerUnit = decimal.NewFromInt(10_000_000)
+
+// resolveWithdrawalShares converts a requested ASSET amount into the SHARE
+// amount, in stroops, to burn on chain.
+//
+// The contract's withdraw is share-denominated, so a user asking to take out
+// 100 USDC from a vault whose shares are worth 1.25 USDC each must burn 80
+// shares, not 100. Passing the asset figure straight through was the bug this
+// fixes (nester#1151).
+//
+// Two steps, because neither alone is sufficient:
+//
+//  1. Convert at the vault's current share price. This is a local estimate
+//     derived from recorded balances.
+//  2. Refine it against the contract's own preview_withdraw, which is
+//     authoritative and accounts for fees the local price does not model. One
+//     correction is applied by scaling the estimate by the ratio of requested
+//     to previewed assets; a second preview is not worth the extra round trip,
+//     and the slippage guard inside WithdrawFromVault is what ultimately
+//     bounds the result.
+//
+// When the preview is unavailable the share-price estimate stands on its own:
+// failing the withdrawal outright would make an unreachable read-only RPC
+// block users from their funds, and the on-chain slippage guard still bounds
+// what a mis-estimate can cost.
+func (s *VaultService) resolveWithdrawalShares(
+	ctx context.Context,
+	existing vault.Vault,
+	assetAmount decimal.Decimal,
+) (int64, error) {
+	sharePrice := vault.ComputeSharePrice(existing)
+	if sharePrice.Sign() <= 0 {
+		return 0, vault.ErrInvalidSharePrice
+	}
+
+	shares := assetAmount.Div(sharePrice)
+	sharesStroops := shares.Mul(stroopsPerUnit).Round(0).IntPart()
+	if sharesStroops <= 0 {
+		return 0, vault.ErrInvalidAmount
+	}
+
+	previewedStroops, err := s.depositInvoker.PreviewWithdraw(ctx, existing.ContractAddress, sharesStroops)
+	if err != nil || previewedStroops <= 0 {
+		// Preview unavailable (or a noop invoker, which returns zero): the
+		// share-price estimate is the best available answer.
+		return sharesStroops, nil
+	}
+
+	previewedAssets := decimal.NewFromInt(previewedStroops)
+	requestedAssets := assetAmount.Mul(stroopsPerUnit)
+	corrected := decimal.NewFromInt(sharesStroops).
+		Mul(requestedAssets).
+		Div(previewedAssets).
+		Round(0).
+		IntPart()
+	if corrected <= 0 {
+		return sharesStroops, nil
+	}
+	return corrected, nil
 }
 
 // DeleteVault soft-deletes a vault so it is excluded from future reads.

--- a/apps/api/internal/service/vault_service.go
+++ b/apps/api/internal/service/vault_service.go
@@ -132,8 +132,12 @@ type HarvestResult struct {
 }
 
 type VaultService struct {
-	repository             vault.Repository
-	depositInvoker         VaultDepositInvoker
+	repository     vault.Repository
+	depositInvoker VaultDepositInvoker
+	// operatorFundedDeposits gates deposits that would spend the shared
+	// operator account. A nil policy refuses them all, which is the correct
+	// default: the wallet-signed path does not need it (nester#1152).
+	operatorFundedDeposits *OperatorFundedDepositPolicy
 	chainVerifier          ChainEventVerifier
 	defaultHarvestCompound bool
 	yieldRecorder          YieldHarvestRecorder
@@ -263,6 +267,13 @@ func NewVaultService(repository vault.Repository) *VaultService {
 // Call this after NewVaultService when an operator key is available.
 func (s *VaultService) SetDepositInvoker(invoker VaultDepositInvoker) {
 	s.depositInvoker = invoker
+}
+
+// SetOperatorFundedDepositPolicy installs the gate for deposits funded from
+// the shared operator account. Leaving it unset refuses every such deposit
+// (nester#1152).
+func (s *VaultService) SetOperatorFundedDepositPolicy(policy *OperatorFundedDepositPolicy) {
+	s.operatorFundedDeposits = policy
 }
 
 // ChainEventVerifier looks up a transaction hash and returns the matching
@@ -425,6 +436,20 @@ func (s *VaultService) RecordDeposit(ctx context.Context, input RecordDepositInp
 	}
 
 	if txHash == "" && s.depositInvoker != nil {
+		// No tx_hash means nothing was signed by the user, so this deposit
+		// would be submitted with the operator as both caller and depositing
+		// user — spending platform funds on the caller's behalf. Without a
+		// gate that made POST /vaults/{id}/deposit a value transfer bounded
+		// only by the operator's balance (nester#1152).
+		//
+		// The supported path is the wallet-signed one: the client signs its
+		// own deposit and supplies the tx_hash, which the chain verifier
+		// checks below. Anything else has to be explicitly allowlisted,
+		// capped, and audit-logged.
+		if err := s.operatorFundedDeposits.Authorize(ctx, input.VaultID, userID, input.Amount); err != nil {
+			return vault.Vault{}, err
+		}
+
 		stroops := input.Amount.Mul(decimal.NewFromInt(10_000_000)).Round(0).IntPart()
 		if err := s.depositInvoker.DepositToVault(ctx, existing.ContractAddress, stroops); err != nil {
 			if strings.Contains(err.Error(), "#21") {

--- a/apps/api/internal/service/vault_service_test.go
+++ b/apps/api/internal/service/vault_service_test.go
@@ -275,6 +275,34 @@ func newMemoryVaultRepository(userIDs ...uuid.UUID) *memoryVaultRepository {
 	}
 }
 
+// setBalance moves a vault's current balance without recording a transaction,
+// which is how a test sets a share price: ComputeSharePrice is
+// current_balance / total_deposited.
+func (r *memoryVaultRepository) setBalance(id uuid.UUID, balance decimal.Decimal) {
+	model, ok := r.vaults[id]
+	if !ok {
+		return
+	}
+	model.CurrentBalance = balance
+	r.vaults[id] = cloneVault(model)
+}
+
+// lastWithdrawalShares returns the share count recorded against the most
+// recent withdrawal, or zero if none was recorded.
+func (r *memoryVaultRepository) lastWithdrawalShares() decimal.Decimal {
+	for i := len(r.transactions) - 1; i >= 0; i-- {
+		txn := r.transactions[i]
+		if txn.Type != "withdrawal" {
+			continue
+		}
+		if txn.SharesMintedOrBurned == nil {
+			return decimal.Zero
+		}
+		return *txn.SharesMintedOrBurned
+	}
+	return decimal.Zero
+}
+
 func (r *memoryVaultRepository) CreateVault(_ context.Context, model vault.Vault) (vault.Vault, error) {
 	if _, ok := r.users[model.UserID]; !ok {
 		return vault.Vault{}, vault.ErrUserNotFound

--- a/apps/api/internal/service/vault_service_withdraw_shares_test.go
+++ b/apps/api/internal/service/vault_service_withdraw_shares_test.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// shareUnitInvoker records the share amount handed to the contract and models
+// a vault whose shares are worth sharePrice assets each.
+type shareUnitInvoker struct {
+	sharePrice     decimal.Decimal
+	gotShares      int64
+	previewEnabled bool
+}
+
+func (s *shareUnitInvoker) DepositToVault(context.Context, string, int64) error { return nil }
+
+func (s *shareUnitInvoker) WithdrawFromVault(_ context.Context, _ string, sharesStroops int64, _ int) (string, error) {
+	s.gotShares = sharesStroops
+	return "on-chain-hash", nil
+}
+
+func (s *shareUnitInvoker) PreviewDeposit(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+// PreviewWithdraw maps shares to the assets they redeem for, which is what the
+// real contract's preview does.
+func (s *shareUnitInvoker) PreviewWithdraw(_ context.Context, _ string, sharesStroops int64) (int64, error) {
+	if !s.previewEnabled {
+		return 0, nil
+	}
+	return decimal.NewFromInt(sharesStroops).Mul(s.sharePrice).Round(0).IntPart(), nil
+}
+
+func (s *shareUnitInvoker) HarvestVault(context.Context, string, string, bool) (string, error) {
+	return "", nil
+}
+
+func (s *shareUnitInvoker) EmergencyWithdrawAll(context.Context, string) error { return nil }
+
+// The contract's withdraw is share-denominated. Passing asset stroops made the
+// user burn the wrong number of shares whenever the share price was not
+// exactly 1.0 — taking materially more or less than they asked for, while the
+// database recorded the requested amount either way (nester#1151).
+func TestRecordWithdrawal_ConvertsAssetsToSharesAtSharePrice(t *testing.T) {
+	const stroops = 10_000_000
+
+	tests := []struct {
+		name string
+		// deposited/balance set the share price: price = balance / deposited.
+		deposited      string
+		balance        string
+		withdraw       string
+		wantSharePrice string
+		wantShares     string
+		previewEnabled bool
+	}{
+		{
+			// Price 1.25 (vault gained). 100 assets must burn 80 shares.
+			// The old code burned 100 shares, taking 125 assets.
+			name:           "share price above 1.0",
+			deposited:      "100",
+			balance:        "125",
+			withdraw:       "100",
+			wantSharePrice: "1.25",
+			wantShares:     "80",
+		},
+		{
+			// Price 0.8 (vault lost). 40 assets must burn 50 shares.
+			// The old code burned 40 shares, taking only 32 assets.
+			name:           "share price below 1.0",
+			deposited:      "100",
+			balance:        "80",
+			withdraw:       "40",
+			wantSharePrice: "0.8",
+			wantShares:     "50",
+		},
+		{
+			// The unity case must keep working unchanged.
+			name:           "share price exactly 1.0",
+			deposited:      "100",
+			balance:        "100",
+			withdraw:       "25",
+			wantSharePrice: "1",
+			wantShares:     "25",
+		},
+		{
+			// With the contract preview wired up the answer must still be the
+			// same, since the preview here agrees with the local price.
+			name:           "share price above 1.0 with contract preview",
+			deposited:      "100",
+			balance:        "125",
+			withdraw:       "100",
+			wantSharePrice: "1.25",
+			wantShares:     "80",
+			previewEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			userID := uuid.New()
+			repo := newMemoryVaultRepository(userID)
+			svc := NewVaultService(repo)
+
+			created, err := svc.CreateVault(ctx, CreateVaultInput{
+				UserID:          userID,
+				ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+				Currency:        "USDC",
+			})
+			if err != nil {
+				t.Fatalf("CreateVault: %v", err)
+			}
+
+			// Deposit first, then move the balance to set the share price.
+			if _, err := svc.RecordDeposit(ctx, RecordDepositInput{
+				VaultID: created.ID,
+				Amount:  decimal.RequireFromString(tt.deposited),
+			}); err != nil {
+				t.Fatalf("RecordDeposit: %v", err)
+			}
+			repo.setBalance(created.ID, decimal.RequireFromString(tt.balance))
+
+			before, err := svc.GetVault(ctx, created.ID)
+			if err != nil {
+				t.Fatalf("GetVault: %v", err)
+			}
+			if got := vault.ComputeSharePrice(before); got.String() != tt.wantSharePrice {
+				t.Fatalf("precondition: share price = %s, want %s", got, tt.wantSharePrice)
+			}
+
+			invoker := &shareUnitInvoker{
+				sharePrice:     decimal.RequireFromString(tt.wantSharePrice),
+				previewEnabled: tt.previewEnabled,
+			}
+			svc.SetDepositInvoker(invoker)
+
+			if _, err := svc.RecordWithdrawal(ctx, RecordWithdrawalInput{
+				VaultID: created.ID,
+				Amount:  decimal.RequireFromString(tt.withdraw),
+			}); err != nil {
+				t.Fatalf("RecordWithdrawal: %v", err)
+			}
+
+			wantShares := decimal.RequireFromString(tt.wantShares).Mul(decimal.NewFromInt(stroops)).IntPart()
+			if invoker.gotShares != wantShares {
+				t.Errorf("shares burned = %d, want %d (%s shares at price %s for %s assets)",
+					invoker.gotShares, wantShares, tt.wantShares, tt.wantSharePrice, tt.withdraw)
+			}
+
+			// The asset amount the burn redeems for must match the request.
+			gotAssets := decimal.NewFromInt(invoker.gotShares).
+				Div(decimal.NewFromInt(stroops)).
+				Mul(decimal.RequireFromString(tt.wantSharePrice))
+			if !gotAssets.Equal(decimal.RequireFromString(tt.withdraw)) {
+				t.Errorf("assets received = %s, want %s", gotAssets, tt.withdraw)
+			}
+		})
+	}
+}
+
+// The recorded withdrawal must reflect the shares the chain actually burned,
+// not a figure re-derived from the requested amount (nester#1151).
+func TestRecordWithdrawal_RecordsSharesActuallyBurned(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	repo := newMemoryVaultRepository(userID)
+	svc := NewVaultService(repo)
+
+	created, err := svc.CreateVault(ctx, CreateVaultInput{
+		UserID:          userID,
+		ContractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Currency:        "USDC",
+	})
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	if _, err := svc.RecordDeposit(ctx, RecordDepositInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+	repo.setBalance(created.ID, decimal.RequireFromString("125"))
+
+	svc.SetDepositInvoker(&shareUnitInvoker{sharePrice: decimal.RequireFromString("1.25")})
+
+	if _, err := svc.RecordWithdrawal(ctx, RecordWithdrawalInput{
+		VaultID: created.ID,
+		Amount:  decimal.RequireFromString("100"),
+	}); err != nil {
+		t.Fatalf("RecordWithdrawal: %v", err)
+	}
+
+	// 100 assets at 1.25 burns 80 shares, not 100.
+	want := decimal.RequireFromString("80")
+	got := repo.lastWithdrawalShares()
+	if !got.Equal(want) {
+		t.Fatalf("recorded shares burned = %s, want %s", got, want)
+	}
+}

--- a/apps/api/internal/service/vault_service_withdrawal_verify_test.go
+++ b/apps/api/internal/service/vault_service_withdrawal_verify_test.go
@@ -194,6 +194,10 @@ func TestRecordWithdrawal_ExceedingPositionRejectedBeforeSubmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateVault: %v", err)
 	}
+	// This test needs a funded position, not an operator-funded deposit, but
+	// a server-submitted deposit is refused by default now (nester#1152), so
+	// the setup opts in explicitly for this one vault.
+	svc.SetOperatorFundedDepositPolicy(allowOperatorFundedForTest(created.ID))
 	if _, err := svc.RecordDeposit(context.Background(), RecordDepositInput{
 		VaultID: created.ID, Amount: decimal.RequireFromString("50"),
 	}); err != nil {


### PR DESCRIPTION
Four money-path fixes from the follow-up API audit.

Closes #1148
Closes #1149
Closes #1151
Closes #1152

## #1152 operator-funded deposits
Deposits with no user-signed `tx_hash` were submitted with the operator as both caller and depositing user, spending platform funds for anyone who asked. The wallet-signed path already existed and is unchanged; the operator-funded fallback is now off by default and fails closed on every axis independently (disabled / empty allowlist / non-positive cap each refuse alone), capped per deposit, and logged on both authorization and refusal.

**Behaviour change:** a deposit with no `tx_hash` now returns 403 where it previously succeeded by spending platform money.

## #1151 withdraw units
`WithdrawFromVault`'s second parameter is share stroops, but asset stroops were passed. At share price 1.25 a request for 100 assets took 125; at 0.8 it took 32 instead of 40 — and the DB recorded the requested figure either way. Now converts assets to shares at the share price, refined against the contract's own `preview_withdraw`, and records the shares actually burned. Every `VaultDepositInvoker` amount parameter is now documented with its unit, since both are `int64` and the compiler cannot tell them apart.

## #1149 X-User-Id impersonation
Any holder of the shared service key could act as any user on any route. Money-path routes now refuse service credentials outright; the comparison is constant-time; the calling service is identified separately via `X-Service-Name`; and a configured key is validated at startup for length, entropy, and not being the JWT secret.

**Deviation:** startup does *not* require the key to be present. An empty value already disables service auth entirely (the safe state), and mandating presence broke six existing production-config tests while forcing deployments that do not use service auth to invent an unused secret. A key that *is* set is validated in every environment.

## #1148 duplicate contract address
The UNIQUE index already exists — migration 104 creates `uq_vaults_contract_address_live`, scoped to live rows so a soft-deleted vault does not burn its address. What was missing was app-layer handling: `mapRepositoryError` had no branch for that constraint, so a duplicate registration returned an opaque 500. Now returns 409 `CONTRACT_ADDRESS_REGISTERED`. No redundant migration added.

## Verification
Full `apps/api` suite passes uncached, `go vet` clean, gofmt clean on all touched files. Each security fix was mutation-tested by reverting its guard and confirming the test fails — #1151 reproduces the exact figures above, and #1152's test shows the operator balance being debited without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable operator-funded deposits with vault allowlists and per-deposit spending caps.
  * Withdrawal processing now accurately converts asset amounts to vault shares and records shares actually redeemed.

* **Bug Fixes**
  * Duplicate live contract registrations now return a clear conflict error.
  * Invalid share prices and refused operator-funded deposits receive clearer error responses.

* **Security**
  * Service credentials are blocked from money-related actions and require stronger configuration safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->