### PR TITLE
security(api): money-path integrity and auth handshake hardening

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -132,6 +132,18 @@ RATELIMIT_WALLET_WINDOW=1m
 RATELIMIT_AUTH_LIMIT=10
 RATELIMIT_AUTH_WINDOW=1m
 
+# Auth-failure lockout (nester#1104). Distinct from RATELIMIT_AUTH_* above,
+# which bounds how FAST the auth endpoints may be called; these bound how many
+# times a caller may FAIL, tracked per wallet address and per client IP
+# independently. The backoff doubles per failure past the threshold, starting
+# at AUTH_LOCKOUT_BASE and capped at AUTH_LOCKOUT_MAX. The cap is deliberate:
+# without it anyone could deny service to a wallet they do not control by
+# failing verify against it forever. A successful login clears the history.
+AUTH_FAILURE_THRESHOLD=5
+AUTH_FAILURE_WINDOW=15m
+AUTH_LOCKOUT_BASE=30s
+AUTH_LOCKOUT_MAX=15m
+
 # Strict per-user rate limit for settlement creation (POST /api/v1/settlements).
 # Keyed by user ID so a single account cannot spam settlements across IPs.
 RATELIMIT_SETTLEMENT_LIMIT=5

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -1379,6 +1379,28 @@ func run() error {
 		},
 		"authentication rate limit exceeded",
 	)
+	// authGuard hardens the same handshake beyond request rate (nester#1104):
+	// a per-wallet limit (the limiter above keys only on IP, so a distributed
+	// client could flood the challenge store for one wallet without tripping
+	// it), and a progressive lockout on repeated FAILURES tracked per wallet
+	// and per IP. Slowing down does not evade the lockout, because the backoff
+	// escalates with the failure count rather than resetting with time.
+	authLockoutCfg := middleware.AuthLockoutConfig{
+		Threshold: cfg.RateLimit().AuthFailureThreshold(),
+		Window:    cfg.RateLimit().AuthFailureWindow(),
+		Base:      cfg.RateLimit().AuthLockoutBase(),
+		Max:       cfg.RateLimit().AuthLockoutMax(),
+	}
+	authGuard := middleware.NewAuthGuard(
+		middleware.NewLimiter(redisClient, "authwallet", cfg.RateLimit().AuthLimit(), cfg.RateLimit().AuthWindow()),
+		middleware.NewAuthLockout(redisClient, "wallet", authLockoutCfg),
+		middleware.NewAuthLockout(redisClient, "ip", authLockoutCfg),
+		appMetrics,
+		[]middleware.AuthGuardStage{
+			{Stage: metrics.AuthStageChallenge, Route: middleware.RouteMatch{Method: http.MethodPost, Path: "/api/v1/auth/challenge"}},
+			{Stage: metrics.AuthStageVerify, Route: middleware.RouteMatch{Method: http.MethodPost, Path: "/api/v1/auth/verify"}},
+		},
+	).Middleware()
 	// settlementLimiter applies a strict per-user limit to settlement creation to
 	// prevent settlement spam. Placed after authentication so it keys by user ID.
 	settlementLimiter := middleware.SensitiveUserRouteLimiter(
@@ -1487,19 +1509,24 @@ func run() error {
 						middleware.IndexerFreshness(indexerFreshness)(
 							globalLimiter(
 								authRouteLimiter(
-									writeLimiter(
-										authenticator(
-											walletBinding(
-												idempotencyMiddleware(
-													costQuota(
-														settlementLimiter(
-															walletLimiter(
-																middleware.LimitRequestBody(1 * 1024 * 1024)(
-																	middleware.Logging(baseLogger)(
-																		middleware.Tracing(
-																			cfg.Tracing().ServiceName(),
-																			cfg.Tracing().LatencyThreshold(),
-																		)(mux),
+									// Inside the per-IP limiter so an already
+									// rate-limited request never reaches the
+									// lockout bookkeeping (nester#1104).
+									authGuard(
+										writeLimiter(
+											authenticator(
+												walletBinding(
+													idempotencyMiddleware(
+														costQuota(
+															settlementLimiter(
+																walletLimiter(
+																	middleware.LimitRequestBody(1 * 1024 * 1024)(
+																		middleware.Logging(baseLogger)(
+																			middleware.Tracing(
+																				cfg.Tracing().ServiceName(),
+																				cfg.Tracing().LatencyThreshold(),
+																			)(mux),
+																		),
 																	),
 																),
 															),

--- a/apps/api/cmd/api/main.go
+++ b/apps/api/cmd/api/main.go
@@ -277,6 +277,12 @@ func run() error {
 	// Balance is moved only after a deposit/withdrawal is confirmed on-chain
 	// (issue #496); the vault repository applies it idempotently by tx hash.
 	transactionService.SetBalanceApplier(vaultRepository)
+	// A successful hash is not proof it paid this vault. The lookup supplies
+	// the vault's real contract address and currency so a confirmation is
+	// checked against the transaction's actual operations, and the credited
+	// amount is taken from the chain rather than the request body
+	// (nester#1145).
+	transactionService.SetVaultLookup(vaultRepository)
 	transactionHandler := handler.NewTransactionHandler(transactionService)
 	transactionHandler.SetVaultRepository(vaultRepository)
 

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -264,19 +264,26 @@ type AuthConfig struct {
 }
 
 type RateLimitConfig struct {
-	globalLimit       int
-	globalWindow      time.Duration
-	writeLimit        int
-	writeWindow       time.Duration
-	walletLimit       int
-	walletWindow      time.Duration
-	rebalanceLimit    int
-	rebalanceWindow   time.Duration
-	authLimit         int
-	authWindow        time.Duration
-	settlementLimit   int
-	settlementWindow  time.Duration
-	trustedProxyCount int
+	globalLimit     int
+	globalWindow    time.Duration
+	writeLimit      int
+	writeWindow     time.Duration
+	walletLimit     int
+	walletWindow    time.Duration
+	rebalanceLimit  int
+	rebalanceWindow time.Duration
+	authLimit       int
+	authWindow      time.Duration
+	// Auth-failure lockout (nester#1104). Distinct from authLimit/authWindow,
+	// which bound request *rate*; these bound repeated *failures* and escalate
+	// a backoff the attacker cannot outrun by slowing down.
+	authFailureThreshold int
+	authFailureWindow    time.Duration
+	authLockoutBase      time.Duration
+	authLockoutMax       time.Duration
+	settlementLimit      int
+	settlementWindow     time.Duration
+	trustedProxyCount    int
 
 	// Cost-weighted quota (see middleware.CostQuota). This meters downstream
 	// work per user rather than request count, so an expensive route can be
@@ -377,16 +384,26 @@ func Load() (*Config, error) {
 			challengeExpiry:         loader.durationDefault("AUTH_CHALLENGE_EXPIRY", 5*time.Minute),
 		},
 		rateLimit: RateLimitConfig{
-			globalLimit:       loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
-			globalWindow:      loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
-			writeLimit:        loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
-			writeWindow:       loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
-			walletLimit:       loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
-			walletWindow:      loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
-			rebalanceLimit:    loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
-			rebalanceWindow:   loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
-			authLimit:         loader.intDefault("RATELIMIT_AUTH_LIMIT", 10),
-			authWindow:        loader.durationDefault("RATELIMIT_AUTH_WINDOW", 1*time.Minute),
+			globalLimit:     loader.intDefault("RATELIMIT_GLOBAL_LIMIT", 100),
+			globalWindow:    loader.durationDefault("RATELIMIT_GLOBAL_WINDOW", 1*time.Minute),
+			writeLimit:      loader.intDefault("RATELIMIT_WRITE_LIMIT", 20),
+			writeWindow:     loader.durationDefault("RATELIMIT_WRITE_WINDOW", 1*time.Minute),
+			walletLimit:     loader.intDefault("RATELIMIT_WALLET_LIMIT", 60),
+			walletWindow:    loader.durationDefault("RATELIMIT_WALLET_WINDOW", 1*time.Minute),
+			rebalanceLimit:  loader.intDefault("RATELIMIT_REBALANCE_LIMIT", 3),
+			rebalanceWindow: loader.durationDefault("RATELIMIT_REBALANCE_WINDOW", 1*time.Hour),
+			authLimit:       loader.intDefault("RATELIMIT_AUTH_LIMIT", 10),
+			authWindow:      loader.durationDefault("RATELIMIT_AUTH_WINDOW", 1*time.Minute),
+			// 5 failures in 15 minutes starts the backoff. A legitimate user
+			// retrying a flaky wallet signature stays well under it; a
+			// signature brute-force does not.
+			authFailureThreshold: loader.intDefault("AUTH_FAILURE_THRESHOLD", 5),
+			authFailureWindow:    loader.durationDefault("AUTH_FAILURE_WINDOW", 15*time.Minute),
+			// Doubling from 30s, capped at 15m: the 6th failure locks for 30s,
+			// the 7th for 1m, and so on. The cap keeps a wallet from being
+			// locked out indefinitely by someone else spamming its address.
+			authLockoutBase:   loader.durationDefault("AUTH_LOCKOUT_BASE", 30*time.Second),
+			authLockoutMax:    loader.durationDefault("AUTH_LOCKOUT_MAX", 15*time.Minute),
 			settlementLimit:   loader.intDefault("RATELIMIT_SETTLEMENT_LIMIT", 5),
 			settlementWindow:  loader.durationDefault("RATELIMIT_SETTLEMENT_WINDOW", 1*time.Minute),
 			trustedProxyCount: loader.intDefault("RATELIMIT_TRUSTED_PROXY_COUNT", 0),
@@ -1056,6 +1073,18 @@ func (c *Config) validate(loader *envLoader) {
 	} else if c.rateLimit.authWindow < time.Millisecond {
 		loader.addError("RATELIMIT_AUTH_WINDOW must be at least 1ms")
 	}
+	if c.rateLimit.authFailureThreshold <= 0 {
+		loader.addError("AUTH_FAILURE_THRESHOLD must be greater than 0")
+	}
+	if c.rateLimit.authFailureWindow <= 0 {
+		loader.addError("AUTH_FAILURE_WINDOW must be greater than 0")
+	}
+	if c.rateLimit.authLockoutBase <= 0 {
+		loader.addError("AUTH_LOCKOUT_BASE must be greater than 0")
+	}
+	if c.rateLimit.authLockoutMax < c.rateLimit.authLockoutBase {
+		loader.addError("AUTH_LOCKOUT_MAX must be at least AUTH_LOCKOUT_BASE")
+	}
 	if c.rateLimit.settlementLimit <= 0 {
 		loader.addError("RATELIMIT_SETTLEMENT_LIMIT must be greater than 0")
 	}
@@ -1354,6 +1383,28 @@ func (r RateLimitConfig) AuthLimit() int {
 
 func (r RateLimitConfig) AuthWindow() time.Duration {
 	return r.authWindow
+}
+
+// AuthFailureThreshold is how many failures inside AuthFailureWindow are
+// tolerated before lockouts begin (nester#1104).
+func (r RateLimitConfig) AuthFailureThreshold() int {
+	return r.authFailureThreshold
+}
+
+// AuthFailureWindow is the sliding period over which auth failures accumulate.
+func (r RateLimitConfig) AuthFailureWindow() time.Duration {
+	return r.authFailureWindow
+}
+
+// AuthLockoutBase is the first lockout duration; it doubles per failure beyond
+// the threshold.
+func (r RateLimitConfig) AuthLockoutBase() time.Duration {
+	return r.authLockoutBase
+}
+
+// AuthLockoutMax caps the progressive backoff.
+func (r RateLimitConfig) AuthLockoutMax() time.Duration {
+	return r.authLockoutMax
 }
 
 func (r RateLimitConfig) SettlementLimit() int {

--- a/apps/api/internal/domain/transaction/model.go
+++ b/apps/api/internal/domain/transaction/model.go
@@ -27,9 +27,39 @@ const (
 
 var (
 	ErrTransactionNotFound = errors.New("transaction not found")
-	ErrInvalidTransaction   = errors.New("invalid transaction input")
-	ErrInvalidStatus        = errors.New("invalid transaction status")
-	ErrInvalidType          = errors.New("invalid transaction type")
+	ErrInvalidTransaction  = errors.New("invalid transaction input")
+	ErrInvalidStatus       = errors.New("invalid transaction status")
+	ErrInvalidType         = errors.New("invalid transaction type")
+
+	// ErrChainClaimMismatch is returned when a transaction hash is confirmed
+	// successful on-chain but its operations do not match what the client
+	// claimed: wrong asset, wrong destination, or an amount other than the one
+	// actually transferred. A successful transaction is not evidence that it
+	// moved the claimed value to the claimed vault (nester#1145).
+	ErrChainClaimMismatch = errors.New("on-chain operations do not match the claimed transaction")
+)
+
+// Typed failure reasons persisted in Transaction.ErrorReason when a
+// confirmation is rejected. They are stable strings: dashboards and support
+// tooling match on them, so change them only with a migration of consumers.
+const (
+	// ReasonNoMatchingOperation: the transaction succeeded but carries no
+	// payment operation to (or from) the vault's contract address at all. This
+	// is the unrelated-but-successful hash case.
+	ReasonNoMatchingOperation = "chain_no_matching_operation"
+	// ReasonAmountMismatch: a matching operation exists but moved a different
+	// amount than the request claimed.
+	ReasonAmountMismatch = "chain_amount_mismatch"
+	// ReasonAssetMismatch: a matching operation exists but moved a different
+	// asset than the vault's currency.
+	ReasonAssetMismatch = "chain_asset_mismatch"
+	// ReasonDestinationMismatch: a payment exists for the claimed asset and
+	// amount, but not to the vault's contract address.
+	ReasonDestinationMismatch = "chain_destination_mismatch"
+	// ReasonVaultUnresolvable: the vault (and therefore the expected
+	// destination) could not be loaded, so the claim cannot be checked. The
+	// transaction is left pending rather than credited.
+	ReasonVaultUnresolvable = "chain_vault_unresolvable"
 )
 
 type Transaction struct {

--- a/apps/api/internal/metrics/authlockout.go
+++ b/apps/api/internal/metrics/authlockout.go
@@ -1,0 +1,96 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Scope labels for the auth-failure collectors. The label set is deliberately
+// closed: the *values* being counted (wallet addresses, client IPs) are
+// unbounded and attacker-controlled, so they must never become label values —
+// that would let a single attacker create a series per address and exhaust
+// Prometheus' memory. Only the scope is labelled.
+const (
+	// AuthScopeWallet counts activity keyed by the claimed wallet address.
+	AuthScopeWallet = "wallet"
+	// AuthScopeIP counts activity keyed by the client IP.
+	AuthScopeIP = "ip"
+)
+
+// Auth stages, so a lockout on the signature check is distinguishable from one
+// on challenge issuance.
+const (
+	AuthStageChallenge = "challenge"
+	AuthStageVerify    = "verify"
+)
+
+// authCollectors instrument the auth challenge/verify hardening (nester#1104).
+//
+// The pair is the useful signal. failures_total rising alone means users are
+// fumbling signatures; lockouts_total rising means the backoff has actually
+// engaged and something is hammering the endpoint. An alert watches the
+// second, a capacity review reads the first.
+type authCollectors struct {
+	failures *prometheus.CounterVec
+	lockouts *prometheus.CounterVec
+	rejected *prometheus.CounterVec
+}
+
+func newAuthCollectors() *authCollectors {
+	labels := []string{"scope", "stage"}
+
+	return &authCollectors{
+		// Every recorded auth failure, before any lockout decision.
+		failures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "auth",
+			Name:      "failures_total",
+			Help:      "Authentication failures recorded, by key scope and auth stage.",
+		}, labels),
+
+		// Counts the transitions into a locked state — the moment a key
+		// crosses the failure threshold and a backoff is applied. This is the
+		// observable the issue asks for: it moves only under sustained abuse.
+		lockouts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "auth",
+			Name:      "lockouts_total",
+			Help:      "Authentication lockouts triggered by repeated failures, by key scope and auth stage.",
+		}, labels),
+
+		// Requests refused because a lockout was already in force. Rated
+		// against lockouts_total this shows how hard a locked-out client keeps
+		// trying, which distinguishes a confused user from a running attack.
+		rejected: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "auth",
+			Name:      "locked_requests_total",
+			Help:      "Requests rejected because an authentication lockout was in force, by key scope and auth stage.",
+		}, labels),
+	}
+}
+
+func (c *authCollectors) collectors() []prometheus.Collector {
+	return []prometheus.Collector{c.failures, c.lockouts, c.rejected}
+}
+
+// RecordAuthFailure counts one authentication failure for a key scope.
+func (m *Metrics) RecordAuthFailure(scope, stage string) {
+	if m == nil {
+		return
+	}
+	m.auth.failures.WithLabelValues(scope, stage).Inc()
+}
+
+// RecordAuthLockout counts one key entering a locked state.
+func (m *Metrics) RecordAuthLockout(scope, stage string) {
+	if m == nil {
+		return
+	}
+	m.auth.lockouts.WithLabelValues(scope, stage).Inc()
+}
+
+// RecordAuthLockedRequest counts one request refused by an active lockout.
+func (m *Metrics) RecordAuthLockedRequest(scope, stage string) {
+	if m == nil {
+		return
+	}
+	m.auth.rejected.WithLabelValues(scope, stage).Inc()
+}

--- a/apps/api/internal/metrics/metrics.go
+++ b/apps/api/internal/metrics/metrics.go
@@ -70,6 +70,10 @@ type Metrics struct {
 	// in rpc.go. These count logical calls, where the outbound collectors
 	// above count HTTP attempts.
 	rpc *rpcCollectors
+
+	// Auth challenge/verify hardening (nester#1104). Defined in
+	// authlockout.go.
+	auth *authCollectors
 }
 
 // New builds the registry and registers every collector on it.
@@ -159,8 +163,9 @@ func New() *Metrics {
 			Help:      "Total outbound HTTP requests that failed before a response, by upstream and error kind.",
 		}, []string{"upstream", "kind"}),
 
-		slo: newSLOCollectors(),
-		rpc: newRPCCollectors(),
+		slo:  newSLOCollectors(),
+		rpc:  newRPCCollectors(),
+		auth: newAuthCollectors(),
 	}
 
 	registry.MustRegister(
@@ -177,6 +182,7 @@ func New() *Metrics {
 
 	registry.MustRegister(m.slo.collectors()...)
 	registry.MustRegister(m.rpc.collectors()...)
+	registry.MustRegister(m.auth.collectors()...)
 
 	// Process and Go runtime collectors: goroutine count, heap, GC pauses,
 	// open file descriptors, CPU. Free to collect and the first thing anyone

--- a/apps/api/internal/middleware/authguard.go
+++ b/apps/api/internal/middleware/authguard.go
@@ -1,0 +1,226 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
+)
+
+// maxAuthBodyPeek bounds how much of a challenge/verify body is buffered to
+// read the wallet address out of it. Both bodies are a handful of short JSON
+// fields; anything larger is not a legitimate request, and reading it in full
+// to find a rate-limit key would itself be the memory-exhaustion vector this
+// middleware exists to close.
+const maxAuthBodyPeek = 8 << 10 // 8 KiB
+
+// AuthGuardStage identifies which auth endpoint a guard protects, for metrics
+// and for keying.
+type AuthGuardStage struct {
+	// Stage is metrics.AuthStageChallenge or metrics.AuthStageVerify.
+	Stage string
+	Route RouteMatch
+}
+
+// AuthGuardRecorder receives the lockout observations. *metrics.Metrics
+// satisfies it; tests pass a fake.
+type AuthGuardRecorder interface {
+	RecordAuthFailure(scope, stage string)
+	RecordAuthLockout(scope, stage string)
+	RecordAuthLockedRequest(scope, stage string)
+}
+
+// AuthGuard hardens the auth challenge/verify handshake (nester#1104).
+//
+// It layers three controls on top of the per-IP request limiter from #782,
+// which stays in place and is unchanged:
+//
+//  1. A per-wallet request limit. The existing limiter keys only on IP, so a
+//     distributed client could flood the challenge store for one wallet from
+//     many addresses without ever tripping it.
+//  2. A progressive lockout on repeated failures, tracked per wallet and per
+//     IP independently. See authlockout.go for why the backoff is capped.
+//  3. Lockout observability, so the control is visible rather than silent.
+//
+// The guard sits in front of the handler and inspects the response status to
+// decide what counts as a failure, so it needs no cooperation from the handler
+// itself: any 4xx on verify is a failed authentication attempt. A 5xx is the
+// server's fault and is deliberately not counted against the user.
+type AuthGuard struct {
+	// walletLimiter bounds request rate per claimed wallet address.
+	walletLimiter Limiter
+	// walletLockout and ipLockout track failures on their respective keys.
+	walletLockout AuthLockout
+	ipLockout     AuthLockout
+	recorder      AuthGuardRecorder
+	stages        []AuthGuardStage
+}
+
+// NewAuthGuard builds the middleware. stages lists the routes it applies to;
+// requests matching none of them pass through untouched.
+func NewAuthGuard(
+	walletLimiter Limiter,
+	walletLockout, ipLockout AuthLockout,
+	recorder AuthGuardRecorder,
+	stages []AuthGuardStage,
+) *AuthGuard {
+	return &AuthGuard{
+		walletLimiter: walletLimiter,
+		walletLockout: walletLockout,
+		ipLockout:     ipLockout,
+		recorder:      recorder,
+		stages:        stages,
+	}
+}
+
+// Middleware returns the http middleware func.
+func (g *AuthGuard) Middleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			stage, ok := g.stageFor(r)
+			if !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			wallet, restore, err := peekWalletAddress(r)
+			if err != nil {
+				// A body we cannot read is the handler's problem to report;
+				// pass it on rather than masking a 400 behind a 429.
+				next.ServeHTTP(w, r)
+				return
+			}
+			r = restore
+
+			ip := clientIP(r)
+
+			// An active lockout short-circuits before any work is done — this
+			// is what stops the challenge store being flooded, because a
+			// locked-out caller never reaches the handler that would write to
+			// it.
+			if wallet != "" {
+				if locked, wait := g.walletLockout.Locked(r.Context(), wallet); locked {
+					g.record(func(rec AuthGuardRecorder) {
+						rec.RecordAuthLockedRequest(metrics.AuthScopeWallet, stage.Stage)
+					})
+					writeRateLimited(w, wait, "too many failed authentication attempts for this wallet")
+					return
+				}
+			}
+			if locked, wait := g.ipLockout.Locked(r.Context(), ip); locked {
+				g.record(func(rec AuthGuardRecorder) {
+					rec.RecordAuthLockedRequest(metrics.AuthScopeIP, stage.Stage)
+				})
+				writeRateLimited(w, wait, "too many failed authentication attempts from this client")
+				return
+			}
+
+			// Per-wallet rate limit. Complements, rather than replaces, the
+			// per-IP limiter already wired on these routes.
+			if wallet != "" && g.walletLimiter != nil {
+				if allowed, wait := g.walletLimiter.Allow(r.Context(), wallet); !allowed {
+					writeRateLimited(w, wait, "authentication rate limit exceeded for this wallet")
+					return
+				}
+			}
+
+			// statusRecorder is the shared recorder defined in logging.go; a
+			// handler that never calls WriteHeader leaves the seeded 200.
+			recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(recorder, r)
+
+			g.observe(r, stage, wallet, ip, recorder.status)
+		})
+	}
+}
+
+// observe turns the handler's status into failure/success bookkeeping.
+//
+// Only 4xx counts as a failure: it is the class that covers a bad signature, an
+// expired or replayed challenge, and a malformed request, all of which are
+// things a brute-force produces in volume. 5xx is excluded so an outage cannot
+// lock every user out, and 429 is excluded so an already-throttled client does
+// not have its own throttling counted as fresh failures.
+func (g *AuthGuard) observe(r *http.Request, stage AuthGuardStage, wallet, ip string, status int) {
+	if status < 400 {
+		// A successful authentication clears the slate for both keys, so a
+		// user who mistyped or retried a flaky wallet signature is not left
+		// carrying a backoff.
+		if wallet != "" {
+			g.walletLockout.Reset(r.Context(), wallet)
+		}
+		g.ipLockout.Reset(r.Context(), ip)
+		return
+	}
+	if status >= 500 || status == http.StatusTooManyRequests {
+		return
+	}
+
+	if wallet != "" {
+		g.recordFailure(r, g.walletLockout, wallet, metrics.AuthScopeWallet, stage.Stage)
+	}
+	g.recordFailure(r, g.ipLockout, ip, metrics.AuthScopeIP, stage.Stage)
+}
+
+func (g *AuthGuard) recordFailure(r *http.Request, lockout AuthLockout, key, scope, stage string) {
+	g.record(func(rec AuthGuardRecorder) { rec.RecordAuthFailure(scope, stage) })
+
+	if _, justLocked := lockout.RecordFailure(r.Context(), key); justLocked {
+		g.record(func(rec AuthGuardRecorder) { rec.RecordAuthLockout(scope, stage) })
+	}
+}
+
+func (g *AuthGuard) record(fn func(AuthGuardRecorder)) {
+	if g.recorder == nil {
+		return
+	}
+	fn(g.recorder)
+}
+
+func (g *AuthGuard) stageFor(r *http.Request) (AuthGuardStage, bool) {
+	for _, s := range g.stages {
+		if r.Method == s.Route.Method && matchPathPattern(s.Route.Path, r.URL.Path) {
+			return s, true
+		}
+	}
+	return AuthGuardStage{}, false
+}
+
+// peekWalletAddress reads wallet_address out of a JSON body and returns a
+// request whose body can still be read in full by the handler.
+//
+// The body is bounded by maxAuthBodyPeek and restored from the buffer, so the
+// handler behaves exactly as it would without this middleware — including
+// seeing an oversized body and rejecting it itself.
+func peekWalletAddress(r *http.Request) (string, *http.Request, error) {
+	if r.Body == nil {
+		return "", r, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxAuthBodyPeek+1))
+	if err != nil {
+		return "", r, err
+	}
+	_ = r.Body.Close()
+
+	// Hand the bytes back to the handler either way.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	if len(body) > maxAuthBodyPeek {
+		// Too large to be a real auth request. Fall through with no wallet
+		// key; the IP-scoped controls still apply and the handler will reject
+		// the body on its own terms.
+		return "", r, nil
+	}
+
+	var payload struct {
+		WalletAddress string `json:"wallet_address"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", r, nil
+	}
+	return strings.TrimSpace(payload.WalletAddress), r, nil
+}

--- a/apps/api/internal/middleware/authguard_test.go
+++ b/apps/api/internal/middleware/authguard_test.go
@@ -1,0 +1,314 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/metrics"
+)
+
+// recordingAuthMetrics captures what the guard reported.
+type recordingAuthMetrics struct {
+	mu       sync.Mutex
+	failures map[string]int
+	lockouts map[string]int
+	rejected map[string]int
+}
+
+func newRecordingAuthMetrics() *recordingAuthMetrics {
+	return &recordingAuthMetrics{
+		failures: map[string]int{},
+		lockouts: map[string]int{},
+		rejected: map[string]int{},
+	}
+}
+
+func (m *recordingAuthMetrics) RecordAuthFailure(scope, stage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failures[scope+"/"+stage]++
+}
+
+func (m *recordingAuthMetrics) RecordAuthLockout(scope, stage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lockouts[scope+"/"+stage]++
+}
+
+func (m *recordingAuthMetrics) RecordAuthLockedRequest(scope, stage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rejected[scope+"/"+stage]++
+}
+
+func (m *recordingAuthMetrics) count(kind map[string]int, key string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return kind[key]
+}
+
+func testAuthStages() []AuthGuardStage {
+	return []AuthGuardStage{
+		{Stage: metrics.AuthStageChallenge, Route: RouteMatch{Method: http.MethodPost, Path: "/api/v1/auth/challenge"}},
+		{Stage: metrics.AuthStageVerify, Route: RouteMatch{Method: http.MethodPost, Path: "/api/v1/auth/verify"}},
+	}
+}
+
+func testLockoutConfig() AuthLockoutConfig {
+	return AuthLockoutConfig{
+		Threshold: 3,
+		Window:    time.Minute,
+		Base:      30 * time.Second,
+		Max:       10 * time.Minute,
+	}
+}
+
+// newTestGuard wires an in-memory guard (nil Redis) around a handler that
+// returns the supplied status, and reports how many times the handler ran.
+func newTestGuard(t *testing.T, status int, walletLimit int) (http.Handler, *recordingAuthMetrics, *int32) {
+	t.Helper()
+
+	var handlerCalls int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&handlerCalls, 1)
+		w.WriteHeader(status)
+	})
+
+	rec := newRecordingAuthMetrics()
+	guard := NewAuthGuard(
+		NewLimiter(nil, "authwallet", walletLimit, time.Minute),
+		NewAuthLockout(nil, "wallet", testLockoutConfig()),
+		NewAuthLockout(nil, "ip", testLockoutConfig()),
+		rec,
+		testAuthStages(),
+	)
+	return guard.Middleware()(handler), rec, &handlerCalls
+}
+
+func authRequest(t *testing.T, path, wallet, ip string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path,
+		strings.NewReader(fmt.Sprintf(`{"wallet_address":%q,"signature":"sig"}`, wallet)))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = ip + ":12345"
+	return req
+}
+
+// Repeated failures must eventually lock the caller out, and the lockout must
+// be reported as a metric (nester#1104).
+func TestAuthGuard_RepeatedFailures_LockOutAndAreObservable(t *testing.T) {
+	h, rec, calls := newTestGuard(t, http.StatusUnauthorized, 1000)
+
+	const wallet = "GWALLETLOCKOUT"
+	// Threshold is 3, so the 4th failure locks.
+	var lastCode int
+	for i := 0; i < 5; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, authRequest(t, "/api/v1/auth/verify", wallet, "10.0.0.1"))
+		lastCode = w.Code
+	}
+
+	if lastCode != http.StatusTooManyRequests {
+		t.Fatalf("last status = %d, want %d once locked out", lastCode, http.StatusTooManyRequests)
+	}
+	if got := rec.count(rec.lockouts, metrics.AuthScopeWallet+"/"+metrics.AuthStageVerify); got != 1 {
+		t.Errorf("wallet lockouts = %d, want exactly 1 (the transition)", got)
+	}
+	if got := rec.count(rec.rejected, metrics.AuthScopeWallet+"/"+metrics.AuthStageVerify); got == 0 {
+		t.Error("expected rejected-request metric to be recorded while locked")
+	}
+	// Once locked, the handler must stop being reached at all — that is what
+	// protects the challenge store.
+	if int(atomic.LoadInt32(calls)) >= 5 {
+		t.Errorf("handler ran %d times; the lockout should have short-circuited it", *calls)
+	}
+}
+
+// A 429 response carries Retry-After so a legitimate client can back off.
+func TestAuthGuard_LockedResponse_CarriesRetryAfter(t *testing.T) {
+	h, _, _ := newTestGuard(t, http.StatusUnauthorized, 1000)
+
+	const wallet = "GWALLETRETRYAFTER"
+	var w *httptest.ResponseRecorder
+	for i := 0; i < 5; i++ {
+		w = httptest.NewRecorder()
+		h.ServeHTTP(w, authRequest(t, "/api/v1/auth/verify", wallet, "10.0.0.2"))
+	}
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("Retry-After header missing on a lockout response")
+	}
+}
+
+// A successful authentication clears the failure history, so a user who
+// fumbles a signature and then succeeds is not left carrying a backoff.
+func TestAuthGuard_SuccessResetsFailureHistory(t *testing.T) {
+	var status atomic.Int32
+	status.Store(http.StatusUnauthorized)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(status.Load()))
+	})
+	rec := newRecordingAuthMetrics()
+	h := NewAuthGuard(
+		NewLimiter(nil, "authwallet", 1000, time.Minute),
+		NewAuthLockout(nil, "wallet", testLockoutConfig()),
+		NewAuthLockout(nil, "ip", testLockoutConfig()),
+		rec,
+		testAuthStages(),
+	).Middleware()(handler)
+
+	const wallet = "GWALLETRESET"
+	// Three failures: at the threshold, not yet locked.
+	for i := 0; i < 3; i++ {
+		h.ServeHTTP(httptest.NewRecorder(), authRequest(t, "/api/v1/auth/verify", wallet, "10.0.0.3"))
+	}
+
+	// Now succeed, which should clear the history.
+	status.Store(http.StatusOK)
+	h.ServeHTTP(httptest.NewRecorder(), authRequest(t, "/api/v1/auth/verify", wallet, "10.0.0.3"))
+
+	// Three more failures must again be tolerated without a lockout.
+	status.Store(http.StatusUnauthorized)
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, authRequest(t, "/api/v1/auth/verify", wallet, "10.0.0.3"))
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("locked out on attempt %d after a successful auth reset the counter", i+1)
+		}
+	}
+}
+
+// A server error is the server's fault and must not count against the user.
+func TestAuthGuard_ServerErrorsDoNotCountAsFailures(t *testing.T) {
+	h, rec, _ := newTestGuard(t, http.StatusInternalServerError, 1000)
+
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, authRequest(t, "/api/v1/auth/verify", "GWALLET500", "10.0.0.4"))
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("locked out by 5xx responses on attempt %d", i+1)
+		}
+	}
+	if got := rec.count(rec.failures, metrics.AuthScopeWallet+"/"+metrics.AuthStageVerify); got != 0 {
+		t.Errorf("recorded %d failures for 5xx responses, want 0", got)
+	}
+}
+
+// The per-wallet limit must hold even when every request comes from a
+// different IP — the case the pre-existing per-IP limiter cannot see.
+func TestAuthGuard_PerWalletLimit_HoldsAcrossDistinctIPs(t *testing.T) {
+	h, _, calls := newTestGuard(t, http.StatusOK, 5)
+
+	const wallet = "GWALLETDISTRIBUTED"
+	limited := 0
+	for i := 0; i < 30; i++ {
+		w := httptest.NewRecorder()
+		// A different source IP every time.
+		h.ServeHTTP(w, authRequest(t, "/api/v1/auth/challenge", wallet, fmt.Sprintf("10.1.%d.%d", i/256, i%256)))
+		if w.Code == http.StatusTooManyRequests {
+			limited++
+		}
+	}
+
+	if limited == 0 {
+		t.Fatal("per-wallet limit never engaged despite 30 requests from distinct IPs")
+	}
+	if got := int(atomic.LoadInt32(calls)); got > 5 {
+		t.Errorf("handler ran %d times, want at most the 5-request wallet limit", got)
+	}
+}
+
+// The load test the issue asks for: the challenge store cannot be flooded.
+//
+// It drives concurrent challenge requests for one wallet from many IPs and
+// asserts that the number of requests reaching the handler — each of which
+// would write one entry into the challenge store — is bounded by the limit,
+// not by how many requests the attacker sends.
+func TestAuthGuard_ChallengeStoreCannotBeFlooded(t *testing.T) {
+	const (
+		walletLimit = 10
+		attempts    = 500
+		workers     = 25
+	)
+
+	h, _, calls := newTestGuard(t, http.StatusOK, walletLimit)
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < attempts/workers; i++ {
+				h.ServeHTTP(httptest.NewRecorder(), authRequest(t,
+					"/api/v1/auth/challenge",
+					"GWALLETFLOOD",
+					fmt.Sprintf("10.2.%d.%d", worker, i%256),
+				))
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	reached := int(atomic.LoadInt32(calls))
+	if reached > walletLimit {
+		t.Errorf("%d of %d flood requests reached the challenge store, want at most %d",
+			reached, attempts, walletLimit)
+	}
+	if reached == 0 {
+		t.Error("no requests got through at all; the limit is not merely bounding, it is blocking everything")
+	}
+}
+
+// Routes the guard does not cover must be untouched.
+func TestAuthGuard_UnrelatedRoutePassesThrough(t *testing.T) {
+	h, rec, calls := newTestGuard(t, http.StatusUnauthorized, 1)
+
+	for i := 0; i < 20; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, authRequest(t, "/api/v1/vaults", "GWALLETOTHER", "10.0.0.5"))
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("unrelated route rate-limited on attempt %d", i+1)
+		}
+	}
+	if got := int(atomic.LoadInt32(calls)); got != 20 {
+		t.Errorf("handler ran %d times, want all 20 to pass through", got)
+	}
+	if got := rec.count(rec.failures, metrics.AuthScopeIP+"/"+metrics.AuthStageVerify); got != 0 {
+		t.Errorf("recorded %d failures on an unguarded route, want 0", got)
+	}
+}
+
+// The handler must still be able to read the body the guard peeked at.
+func TestAuthGuard_BodyRemainsReadableByHandler(t *testing.T) {
+	var seen string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, 512)
+		n, _ := r.Body.Read(body)
+		seen = string(body[:n])
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := NewAuthGuard(
+		NewLimiter(nil, "authwallet", 100, time.Minute),
+		NewAuthLockout(nil, "wallet", testLockoutConfig()),
+		NewAuthLockout(nil, "ip", testLockoutConfig()),
+		newRecordingAuthMetrics(),
+		testAuthStages(),
+	).Middleware()(handler)
+
+	h.ServeHTTP(httptest.NewRecorder(), authRequest(t, "/api/v1/auth/verify", "GWALLETBODY", "10.0.0.6"))
+
+	if !strings.Contains(seen, "GWALLETBODY") {
+		t.Errorf("handler read %q, want the original body preserved", seen)
+	}
+}

--- a/apps/api/internal/middleware/authlockout.go
+++ b/apps/api/internal/middleware/authlockout.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Auth-failure lockout (nester#1104).
+//
+// This sits on top of the per-IP request limiter from #782, and is a different
+// control: the limiter bounds how FAST anyone may call challenge/verify, this
+// bounds how many times they may FAIL. A signature brute-force that stays under
+// the rate limit is still a brute-force, and slowing down does not help the
+// attacker here because the backoff escalates with the failure count rather
+// than resetting with time.
+//
+// Two keys are tracked independently for each attempt: the claimed wallet
+// address and the client IP. A distributed attack from many IPs against one
+// wallet is caught by the wallet key; a single host spraying many wallets is
+// caught by the IP key.
+//
+// The backoff doubles per failure past the threshold, from Base, capped at Max.
+// The cap matters: without it, anyone could permanently deny service to a
+// wallet address they do not control simply by failing verify against it
+// repeatedly. With it, the worst an attacker can impose on a third party is a
+// Max-long delay, while their own IP key locks out just as hard.
+
+// AuthLockout tracks authentication failures and decides whether a key is
+// currently locked out.
+//
+// Implementations must be safe for concurrent use.
+type AuthLockout interface {
+	// Locked reports whether key is currently locked out, and for how long.
+	Locked(ctx context.Context, key string) (locked bool, retryAfter time.Duration)
+	// RecordFailure registers one failure for key and returns the lockout it
+	// now carries. justLocked is true only on the transition into a locked
+	// state, so a caller can count lockouts without double-counting every
+	// subsequent rejected request.
+	RecordFailure(ctx context.Context, key string) (lockout time.Duration, justLocked bool)
+	// Reset clears the failure history for key. Called after a successful
+	// authentication so a user who eventually signs in correctly is not
+	// penalised for earlier fumbles.
+	Reset(ctx context.Context, key string)
+}
+
+// AuthLockoutConfig parameterises the progressive backoff.
+type AuthLockoutConfig struct {
+	// Threshold is the number of failures tolerated before lockouts begin.
+	Threshold int
+	// Window is how long a failure counts toward the threshold.
+	Window time.Duration
+	// Base is the first lockout duration, applied at Threshold+1 failures.
+	Base time.Duration
+	// Max caps the doubling.
+	Max time.Duration
+}
+
+// lockoutFor computes the backoff for a given cumulative failure count:
+// zero until the threshold is passed, then Base doubled once per extra
+// failure, capped at Max.
+func (c AuthLockoutConfig) lockoutFor(failures int) time.Duration {
+	if failures <= c.Threshold {
+		return 0
+	}
+
+	lockout := c.Base
+	// Doubling is done by repeated multiplication with an early exit at Max
+	// rather than a shift, so a large failure count cannot overflow the
+	// duration into a negative value.
+	for i := 0; i < failures-c.Threshold-1; i++ {
+		if lockout >= c.Max {
+			return c.Max
+		}
+		lockout *= 2
+	}
+	if lockout > c.Max {
+		return c.Max
+	}
+	return lockout
+}
+
+// NewAuthLockout returns a Redis-backed tracker when rc is non-nil (so the
+// lockout holds across every API instance, which is the only way it bounds a
+// distributed attack) and a process-local one otherwise.
+//
+// prefix namespaces the keys so the wallet-scoped and IP-scoped trackers do not
+// collide.
+func NewAuthLockout(rc *redis.Client, prefix string, cfg AuthLockoutConfig) AuthLockout {
+	if rc != nil {
+		return &redisAuthLockout{rc: rc, prefix: prefix, cfg: cfg}
+	}
+	return newMemoryAuthLockout(cfg)
+}
+
+// ── Redis implementation ─────────────────────────────────────────────────────
+
+type redisAuthLockout struct {
+	rc     *redis.Client
+	prefix string
+	cfg    AuthLockoutConfig
+}
+
+func (l *redisAuthLockout) failKey(key string) string { return "authfail:" + l.prefix + ":" + key }
+func (l *redisAuthLockout) lockKey(key string) string { return "authlock:" + l.prefix + ":" + key }
+
+func (l *redisAuthLockout) Locked(ctx context.Context, key string) (bool, time.Duration) {
+	ctx, cancel := context.WithTimeout(ctx, redisCallTimeout)
+	defer cancel()
+
+	ttl, err := l.rc.PTTL(ctx, l.lockKey(key)).Result()
+	if err != nil {
+		// Fail open, consistent with the rate limiter: a Redis outage must not
+		// lock every user out of the product. The per-IP request limiter still
+		// applies, so the endpoint is not left unprotected.
+		slog.Default().WarnContext(ctx, "auth lockout: redis error, failing open",
+			"prefix", l.prefix, "error", err)
+		return false, 0
+	}
+	if ttl <= 0 {
+		return false, 0
+	}
+	return true, ttl
+}
+
+// authFailureScript increments the failure counter, (re)sets its window TTL,
+// and returns the resulting count. Keeping increment and expiry in one script
+// means a counter can never be left without a TTL and so leak forever.
+var authFailureScript = redis.NewScript(`
+local failures = redis.call("INCR", KEYS[1])
+redis.call("PEXPIRE", KEYS[1], ARGV[1])
+return failures
+`)
+
+func (l *redisAuthLockout) RecordFailure(ctx context.Context, key string) (time.Duration, bool) {
+	ctx, cancel := context.WithTimeout(ctx, redisCallTimeout)
+	defer cancel()
+
+	res, err := authFailureScript.Run(ctx, l.rc,
+		[]string{l.failKey(key)}, l.cfg.Window.Milliseconds()).Result()
+	if err != nil {
+		slog.Default().WarnContext(ctx, "auth lockout: redis error recording failure, failing open",
+			"prefix", l.prefix, "error", err)
+		return 0, false
+	}
+
+	failures, _ := res.(int64)
+	lockout := l.cfg.lockoutFor(int(failures))
+	if lockout <= 0 {
+		return 0, false
+	}
+
+	// SET NX reports whether this call created the lock, which is exactly the
+	// transition the lockout metric should count. A later failure extends the
+	// lock via a plain SET without re-counting it.
+	created, err := l.rc.SetNX(ctx, l.lockKey(key), "1", lockout).Result()
+	if err != nil {
+		slog.Default().WarnContext(ctx, "auth lockout: redis error setting lock",
+			"prefix", l.prefix, "error", err)
+		return lockout, false
+	}
+	if !created {
+		// Already locked; extend to the newly computed (longer) backoff.
+		if err := l.rc.Set(ctx, l.lockKey(key), "1", lockout).Err(); err != nil {
+			slog.Default().WarnContext(ctx, "auth lockout: redis error extending lock",
+				"prefix", l.prefix, "error", err)
+		}
+	}
+	return lockout, created
+}
+
+func (l *redisAuthLockout) Reset(ctx context.Context, key string) {
+	ctx, cancel := context.WithTimeout(ctx, redisCallTimeout)
+	defer cancel()
+
+	if err := l.rc.Del(ctx, l.failKey(key), l.lockKey(key)).Err(); err != nil {
+		slog.Default().WarnContext(ctx, "auth lockout: redis error clearing failures",
+			"prefix", l.prefix, "error", err)
+	}
+}
+
+// ── In-memory implementation (dev / single-instance fallback) ────────────────
+
+type memoryAuthEntry struct {
+	failures    int
+	failuresEnd time.Time
+	lockedUntil time.Time
+}
+
+type memoryAuthLockout struct {
+	mu  sync.Mutex
+	m   map[string]*memoryAuthEntry
+	cfg AuthLockoutConfig
+}
+
+func newMemoryAuthLockout(cfg AuthLockoutConfig) *memoryAuthLockout {
+	return &memoryAuthLockout{m: make(map[string]*memoryAuthEntry), cfg: cfg}
+}
+
+func (l *memoryAuthLockout) Locked(_ context.Context, key string) (bool, time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry, ok := l.m[key]
+	if !ok {
+		return false, 0
+	}
+	now := time.Now()
+	if entry.lockedUntil.After(now) {
+		return true, time.Until(entry.lockedUntil)
+	}
+	return false, 0
+}
+
+func (l *memoryAuthLockout) RecordFailure(_ context.Context, key string) (time.Duration, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	l.evictExpiredLocked(now)
+
+	entry, ok := l.m[key]
+	if !ok || now.After(entry.failuresEnd) {
+		entry = &memoryAuthEntry{}
+		l.m[key] = entry
+	}
+	entry.failures++
+	entry.failuresEnd = now.Add(l.cfg.Window)
+
+	lockout := l.cfg.lockoutFor(entry.failures)
+	if lockout <= 0 {
+		return 0, false
+	}
+
+	justLocked := !entry.lockedUntil.After(now)
+	entry.lockedUntil = now.Add(lockout)
+	return lockout, justLocked
+}
+
+func (l *memoryAuthLockout) Reset(_ context.Context, key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.m, key)
+}
+
+// evictExpiredLocked drops entries whose failure window and lockout have both
+// passed. Without it the map grows once per distinct wallet address or IP an
+// attacker chooses to use, which is itself a memory-exhaustion vector.
+//
+// The caller must hold l.mu.
+func (l *memoryAuthLockout) evictExpiredLocked(now time.Time) {
+	for key, entry := range l.m {
+		if now.After(entry.failuresEnd) && now.After(entry.lockedUntil) {
+			delete(l.m, key)
+		}
+	}
+}

--- a/apps/api/internal/middleware/authlockout_test.go
+++ b/apps/api/internal/middleware/authlockout_test.go
@@ -1,0 +1,142 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func backoffConfig() AuthLockoutConfig {
+	return AuthLockoutConfig{
+		Threshold: 3,
+		Window:    time.Minute,
+		Base:      30 * time.Second,
+		Max:       10 * time.Minute,
+	}
+}
+
+// The backoff is zero up to the threshold, then doubles per extra failure,
+// capped at Max (nester#1104).
+func TestAuthLockoutConfig_ProgressiveBackoff(t *testing.T) {
+	cfg := backoffConfig()
+
+	cases := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{0, 0},
+		{1, 0},
+		{3, 0}, // at the threshold, still tolerated
+		{4, 30 * time.Second},
+		{5, 1 * time.Minute},
+		{6, 2 * time.Minute},
+		{7, 4 * time.Minute},
+		{8, 8 * time.Minute},
+		{9, 10 * time.Minute},  // capped
+		{50, 10 * time.Minute}, // still capped
+	}
+
+	for _, tc := range cases {
+		if got := cfg.lockoutFor(tc.failures); got != tc.want {
+			t.Errorf("lockoutFor(%d) = %s, want %s", tc.failures, got, tc.want)
+		}
+	}
+}
+
+// A very large failure count must stay capped rather than overflowing the
+// duration into a negative (which would read as "not locked").
+func TestAuthLockoutConfig_LargeFailureCountDoesNotOverflow(t *testing.T) {
+	cfg := backoffConfig()
+	for _, failures := range []int{100, 1_000, 100_000} {
+		got := cfg.lockoutFor(failures)
+		if got != cfg.Max {
+			t.Errorf("lockoutFor(%d) = %s, want the %s cap", failures, got, cfg.Max)
+		}
+		if got <= 0 {
+			t.Fatalf("lockoutFor(%d) overflowed to %s", failures, got)
+		}
+	}
+}
+
+func TestMemoryAuthLockout_LocksAfterThresholdAndResets(t *testing.T) {
+	ctx := context.Background()
+	l := NewAuthLockout(nil, "test", backoffConfig())
+
+	const key = "GWALLET"
+
+	if locked, _ := l.Locked(ctx, key); locked {
+		t.Fatal("a fresh key must not be locked")
+	}
+
+	// Up to the threshold, no lockout.
+	for i := 0; i < 3; i++ {
+		if lockout, justLocked := l.RecordFailure(ctx, key); lockout != 0 || justLocked {
+			t.Fatalf("failure %d produced lockout=%s justLocked=%v, want none", i+1, lockout, justLocked)
+		}
+	}
+
+	// The next one locks, and reports the transition exactly once.
+	lockout, justLocked := l.RecordFailure(ctx, key)
+	if lockout != 30*time.Second || !justLocked {
+		t.Fatalf("threshold+1 gave lockout=%s justLocked=%v, want 30s/true", lockout, justLocked)
+	}
+	if locked, wait := l.Locked(ctx, key); !locked || wait <= 0 {
+		t.Fatalf("key should be locked with a positive wait, got locked=%v wait=%s", locked, wait)
+	}
+
+	// A further failure extends the lock but is not a fresh transition, so a
+	// lockout metric is not double-counted.
+	if _, justLocked := l.RecordFailure(ctx, key); justLocked {
+		t.Error("an already-locked key reported a second lock transition")
+	}
+
+	l.Reset(ctx, key)
+	if locked, _ := l.Locked(ctx, key); locked {
+		t.Error("Reset should clear an active lockout")
+	}
+}
+
+// Distinct keys must not interfere: locking one wallet must not lock another.
+func TestMemoryAuthLockout_KeysAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	l := NewAuthLockout(nil, "test", backoffConfig())
+
+	for i := 0; i < 6; i++ {
+		l.RecordFailure(ctx, "GVICTIM")
+	}
+	if locked, _ := l.Locked(ctx, "GVICTIM"); !locked {
+		t.Fatal("the hammered key should be locked")
+	}
+	if locked, _ := l.Locked(ctx, "GBYSTANDER"); locked {
+		t.Error("an unrelated key was locked out")
+	}
+}
+
+// Entries must be evicted once their window and lockout have both passed, so a
+// flood of distinct keys cannot grow the map without bound.
+func TestMemoryAuthLockout_EvictsExpiredEntries(t *testing.T) {
+	l := newMemoryAuthLockout(AuthLockoutConfig{
+		Threshold: 3,
+		Window:    time.Millisecond,
+		Base:      time.Millisecond,
+		Max:       time.Millisecond,
+	})
+	ctx := context.Background()
+
+	for i := 0; i < 100; i++ {
+		l.RecordFailure(ctx, string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+
+	// Let every window and lockout lapse, then record once more to trigger the
+	// eviction sweep.
+	time.Sleep(20 * time.Millisecond)
+	l.RecordFailure(ctx, "trigger")
+
+	l.mu.Lock()
+	size := len(l.m)
+	l.mu.Unlock()
+
+	if size > 1 {
+		t.Errorf("map holds %d entries after expiry, want the single fresh one", size)
+	}
+}

--- a/apps/api/internal/repository/postgres/vault_repository.go
+++ b/apps/api/internal/repository/postgres/vault_repository.go
@@ -287,6 +287,22 @@ func (r *VaultRepository) UpdateVaultBalances(ctx context.Context, id uuid.UUID,
 	return nil
 }
 
+// RecordDeposit credits a vault for a deposit recorded through the API and
+// writes the matching ledger row.
+//
+// The ledger insert is ON CONFLICT (transaction_hash) DO NOTHING and, when the
+// hash is already claimed, the whole call becomes a no-op: the event indexer
+// claims the same key before crediting the same on-chain movement, so a deposit
+// observed by both writers is credited exactly once (nester#1147). See
+// internal/stellar/balance_ownership.go for the ownership model.
+//
+// A record with no transaction hash keeps the previous behaviour — it cannot
+// collide, because NULLs stay distinct under the unique index, and nothing else
+// will credit it.
+//
+// Lock ordering is unchanged (see RecordWithdrawal): the vaults row is updated
+// first, the ledger row inserted second. The claim is therefore detected after
+// the UPDATE, and a lost claim rolls the UPDATE back with the transaction.
 func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, record vault.TransactionRecord) error {
 	if record.Amount.Cmp(decimal.Zero) <= 0 {
 		return vault.ErrInvalidAmount
@@ -320,12 +336,13 @@ func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, recor
 		return vault.ErrVaultNotFound
 	}
 
-	if _, err := tx.ExecContext(
+	ledger, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO vault_transactions (
 			vault_id, user_id, type, amount, transaction_hash,
 			shares_minted_or_burned, share_price_at_time, fee_charged
-		) VALUES ($1, $2, 'deposit', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric, $7::numeric)`,
+		) VALUES ($1, $2, 'deposit', $3::numeric, NULLIF($4, ''), $5::numeric, $6::numeric, $7::numeric)
+		ON CONFLICT (transaction_hash) DO NOTHING`,
 		id.String(),
 		record.UserID.String(),
 		record.Amount.String(),
@@ -333,8 +350,20 @@ func (r *VaultRepository) RecordDeposit(ctx context.Context, id uuid.UUID, recor
 		record.SharesMintedOrBurned.String(),
 		record.SharePriceAtTime.String(),
 		record.FeeCharged.String(),
-	); err != nil {
+	)
+	if err != nil {
 		return mapRepositoryError(err)
+	}
+
+	inserted, err := ledger.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 0 {
+		// The hash was already claimed, so this deposit has already been
+		// credited (by the indexer, or by an earlier retry of this call).
+		// Roll the UPDATE back rather than committing a second credit.
+		return vault.ErrDuplicateTransaction
 	}
 
 	return tx.Commit()

--- a/apps/api/internal/service/transaction_chain_claim.go
+++ b/apps/api/internal/service/transaction_chain_claim.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+// TransactionVaultLookup resolves the vault a transaction belongs to, so a
+// confirmation can be checked against the vault's real contract address and
+// currency rather than against values the client supplied.
+//
+// It is the same narrow seam the transaction handler already uses; production
+// passes the Postgres vault repository.
+type TransactionVaultLookup interface {
+	GetVault(ctx context.Context, id uuid.UUID) (vault.Vault, error)
+}
+
+// SetVaultLookup wires the vault lookup used to verify that a confirmed
+// transaction actually moved the claimed asset, in the claimed amount, to the
+// vault's contract address (nester#1145).
+//
+// When unset, claim verification is skipped and a successful transaction is
+// confirmed on its success flag alone — the pre-#1145 behaviour, retained only
+// so existing tests that exercise status transitions need no vault fixture.
+// Production always wires it.
+func (s *TransactionService) SetVaultLookup(lookup TransactionVaultLookup) {
+	s.vaults = lookup
+}
+
+// horizonOperation is one operation of a Horizon transaction. Only the fields
+// needed to prove a value transfer are decoded.
+//
+// Horizon renders the native asset as {"asset_type":"native"} with no code or
+// issuer, and every other asset as
+// {"asset_type":"credit_alphanum4|12","asset_code":"USDC","asset_issuer":"G..."}.
+type horizonOperation struct {
+	Type        string `json:"type"`
+	AssetType   string `json:"asset_type"`
+	AssetCode   string `json:"asset_code"`
+	AssetIssuer string `json:"asset_issuer"`
+	Amount      string `json:"amount"`
+	From        string `json:"from"`
+	To          string `json:"to"`
+	// Account/Into carry the destination for account-merge and
+	// create-account style operations, which do not populate To.
+	Account   string `json:"account"`
+	Into      string `json:"into"`
+	AssetName string `json:"asset_name"`
+}
+
+// destination is the account the operation credited, normalising across the
+// operation shapes Horizon uses.
+func (o horizonOperation) destination() string {
+	for _, candidate := range []string{o.To, o.Into, o.Account} {
+		if c := strings.TrimSpace(candidate); c != "" {
+			return c
+		}
+	}
+	return ""
+}
+
+// assetCode is the asset the operation moved, in the same vocabulary as
+// vault.Currency. Horizon's native asset is XLM.
+func (o horizonOperation) assetCode() string {
+	if strings.EqualFold(strings.TrimSpace(o.AssetType), "native") {
+		return "XLM"
+	}
+	return strings.ToUpper(strings.TrimSpace(o.AssetCode))
+}
+
+// isValueTransfer reports whether the operation type can move asset value.
+// Horizon exposes many operation types (set_options, manage_data, ...) that
+// never credit a balance; treating those as a transfer would let a hash with
+// an incidental matching amount pass.
+func (o horizonOperation) isValueTransfer() bool {
+	switch strings.ToLower(strings.TrimSpace(o.Type)) {
+	case "payment", "create_account", "account_merge",
+		"path_payment_strict_receive", "path_payment_strict_send",
+		"invoke_host_function":
+		return true
+	default:
+		return false
+	}
+}
+
+type horizonOperationsResponse struct {
+	Embedded struct {
+		Records []horizonOperation `json:"records"`
+	} `json:"_embedded"`
+}
+
+// chainClaim is the assertion a pending transaction makes about the chain:
+// "this hash moved Amount of Asset to Destination".
+type chainClaim struct {
+	Destination string
+	Asset       string
+	Amount      decimal.Decimal
+}
+
+// verifiedChainAmount is the amount actually moved on-chain, as read from the
+// matching operation. It is what gets credited — never the request body.
+type verifiedChainAmount struct {
+	Amount decimal.Decimal
+}
+
+// verifyChainClaim confirms that hash actually moved the claimed asset, in the
+// claimed amount, to the claimed destination, and returns the on-chain amount.
+//
+// A successful transaction proves only that *something* succeeded. Without this
+// check any real successful hash could be posted with an arbitrary amount and
+// the poller would credit it in full (nester#1145).
+func (s *TransactionService) verifyChainClaim(ctx context.Context, hash string, claim chainClaim) (verifiedChainAmount, string, error) {
+	ops, err := s.lookupHorizonOperations(ctx, hash)
+	if err != nil {
+		return verifiedChainAmount{}, "", err
+	}
+
+	// Walk the operations narrowing by destination, then asset, then amount,
+	// so the recorded reason names the first thing that actually diverged
+	// rather than a generic "no match".
+	destinationMatched := false
+	assetMatched := false
+
+	for _, op := range ops {
+		if !op.isValueTransfer() {
+			continue
+		}
+		if !strings.EqualFold(op.destination(), claim.Destination) {
+			continue
+		}
+		destinationMatched = true
+
+		if claim.Asset != "" && !strings.EqualFold(op.assetCode(), claim.Asset) {
+			continue
+		}
+		assetMatched = true
+
+		onChain, err := decimal.NewFromString(strings.TrimSpace(op.Amount))
+		if err != nil || onChain.Cmp(decimal.Zero) <= 0 {
+			continue
+		}
+		if !onChain.Equal(claim.Amount) {
+			continue
+		}
+		return verifiedChainAmount{Amount: onChain}, "", nil
+	}
+
+	switch {
+	case !destinationMatched:
+		// Nothing in the transaction paid the vault at all. This is the
+		// unrelated-but-successful hash.
+		if len(ops) == 0 {
+			return verifiedChainAmount{}, transaction.ReasonNoMatchingOperation, transaction.ErrChainClaimMismatch
+		}
+		return verifiedChainAmount{}, transaction.ReasonDestinationMismatch, transaction.ErrChainClaimMismatch
+	case !assetMatched:
+		return verifiedChainAmount{}, transaction.ReasonAssetMismatch, transaction.ErrChainClaimMismatch
+	default:
+		return verifiedChainAmount{}, transaction.ReasonAmountMismatch, transaction.ErrChainClaimMismatch
+	}
+}
+
+// lookupHorizonOperations fetches the operations of a transaction. Horizon
+// paginates; the limit is well above the protocol maximum of 100 operations
+// per transaction, so a single page always holds them all.
+func (s *TransactionService) lookupHorizonOperations(ctx context.Context, hash string) ([]horizonOperation, error) {
+	url := fmt.Sprintf("%s/transactions/%s/operations?limit=200", s.horizonURL, hash)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errTransactionPending
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("horizon operations lookup failed: %s", resp.Status)
+	}
+
+	var payload horizonOperationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	return payload.Embedded.Records, nil
+}
+
+// verifyConfirmedClaim checks a Horizon-confirmed transaction against what the
+// client claimed, and returns the amount actually moved on-chain.
+//
+// Only deposits are value claims against the vault's contract address: a
+// withdrawal moves value *out* of the vault to the user's own account, and a
+// settlement moves no vault balance at all, so neither is checked here and
+// both keep their recorded amount.
+func (s *TransactionService) verifyConfirmedClaim(ctx context.Context, model transaction.Transaction) (verifiedChainAmount, string, error) {
+	if s.vaults == nil || s.balance == nil {
+		// Claim verification is not wired (see SetVaultLookup) or no balance
+		// moves at all; keep the recorded amount.
+		return verifiedChainAmount{Amount: model.Amount}, "", nil
+	}
+	if model.Type != transaction.TypeDeposit {
+		return verifiedChainAmount{Amount: model.Amount}, "", nil
+	}
+
+	v, err := s.vaults.GetVault(ctx, model.VaultID)
+	if err != nil {
+		// Cannot establish the expected destination. Treat as transient: the
+		// caller leaves the transaction pending rather than crediting it.
+		return verifiedChainAmount{}, transaction.ReasonVaultUnresolvable, fmt.Errorf("resolve vault for chain claim: %w", err)
+	}
+
+	destination := strings.TrimSpace(v.ContractAddress)
+	if destination == "" {
+		return verifiedChainAmount{}, transaction.ReasonVaultUnresolvable, fmt.Errorf("%w: vault %s has no contract address", vault.ErrUnverifiedChainTx, model.VaultID)
+	}
+
+	return s.verifyChainClaim(ctx, model.TxHash, chainClaim{
+		Destination: destination,
+		Asset:       strings.ToUpper(strings.TrimSpace(v.Currency)),
+		Amount:      model.Amount,
+	})
+}

--- a/apps/api/internal/service/transaction_chain_claim_test.go
+++ b/apps/api/internal/service/transaction_chain_claim_test.go
@@ -1,0 +1,284 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/transaction"
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+)
+
+const claimVaultContract = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+
+// fakeVaultLookup resolves a single vault, or fails, so the claim path can be
+// exercised without a database.
+type fakeVaultLookup struct {
+	v   vault.Vault
+	err error
+}
+
+func (f fakeVaultLookup) GetVault(_ context.Context, _ uuid.UUID) (vault.Vault, error) {
+	if f.err != nil {
+		return vault.Vault{}, f.err
+	}
+	return f.v, nil
+}
+
+// claimHorizonStub serves both the transaction lookup (always successful) and
+// its operations, so a test can post a genuinely successful hash whose
+// operations do or do not back the claim.
+func claimHorizonStub(t *testing.T, hash string, ops []horizonOperation) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/transactions/")
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.HasSuffix(path, "/operations") {
+			if strings.TrimSuffix(path, "/operations") != hash {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			var payload horizonOperationsResponse
+			payload.Embedded.Records = ops
+			_ = json.NewEncoder(w).Encode(payload)
+			return
+		}
+
+		if path != hash {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"successful":true,"created_at":"` +
+			time.Now().UTC().Format(time.RFC3339) + `","result_xdr":""}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// newClaimService builds a deposit transaction for `claimed` units of USDC and
+// a service whose Horizon reports the transaction successful with ops.
+func newClaimService(t *testing.T, hash string, claimed decimal.Decimal, ops []horizonOperation) (*TransactionService, *fakeTransactionRepo, *fakeBalanceApplier, transaction.Transaction) {
+	t.Helper()
+
+	tx := newPendingTx(transaction.TypeDeposit, hash, time.Minute)
+	tx.Amount = claimed
+	repo := newFakeTransactionRepo(tx)
+
+	svc := NewTransactionService(repo, claimHorizonStub(t, hash, ops))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+	svc.SetVaultLookup(fakeVaultLookup{v: vault.Vault{
+		ID:              tx.VaultID,
+		ContractAddress: claimVaultContract,
+		Currency:        "USDC",
+	}})
+	return svc, repo, applier, tx
+}
+
+func paymentOp(to, code, amount string) horizonOperation {
+	return horizonOperation{
+		Type:        "payment",
+		AssetType:   "credit_alphanum4",
+		AssetCode:   code,
+		AssetIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+		Amount:      amount,
+		To:          to,
+	}
+}
+
+// assertRejected asserts the transaction was marked failed with the given
+// typed reason and that no balance moved.
+func assertRejected(t *testing.T, repo *fakeTransactionRepo, applier *fakeBalanceApplier, hash, wantReason string) {
+	t.Helper()
+
+	stored, err := repo.GetByHash(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("GetByHash: %v", err)
+	}
+	if stored.Status != transaction.StatusFailed {
+		t.Fatalf("status = %q, want failed", stored.Status)
+	}
+	if stored.ErrorReason != wantReason {
+		t.Errorf("error reason = %q, want %q", stored.ErrorReason, wantReason)
+	}
+	if applier.depositCount() != 0 {
+		t.Fatalf("balance was credited %d time(s) for a rejected claim", applier.depositCount())
+	}
+}
+
+// A real, successful, but entirely unrelated transaction hash must not credit
+// anything. This is the core nester#1145 exploit: no forged amount needed.
+func TestReconcile_UnrelatedSuccessfulHash_IsRejected(t *testing.T) {
+	const hash = "unrelated-success"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(500), []horizonOperation{
+		paymentOp("GBSOMEONEELSEACCOUNTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "USDC", "500.0000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonDestinationMismatch)
+}
+
+// A transaction that really did pay the vault, but for less than claimed, must
+// not credit the inflated figure.
+func TestReconcile_InflatedAmount_IsRejected(t *testing.T) {
+	const hash = "inflated-amount"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(1_000_000), []horizonOperation{
+		paymentOp(claimVaultContract, "USDC", "1.0000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonAmountMismatch)
+}
+
+func TestReconcile_WrongAsset_IsRejected(t *testing.T) {
+	const hash = "wrong-asset"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(100), []horizonOperation{
+		paymentOp(claimVaultContract, "EURC", "100.0000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonAssetMismatch)
+}
+
+func TestReconcile_WrongDestination_IsRejected(t *testing.T) {
+	const hash = "wrong-destination"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(100), []horizonOperation{
+		paymentOp("CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K", "USDC", "100.0000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonDestinationMismatch)
+}
+
+// A transaction carrying no operations at all is rejected with the
+// no-operation reason rather than being credited.
+func TestReconcile_NoOperations_IsRejected(t *testing.T) {
+	const hash = "no-operations"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(100), nil)
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonNoMatchingOperation)
+}
+
+// Non-transfer operation types must not satisfy a claim even when they carry a
+// matching-looking amount.
+func TestReconcile_NonTransferOperation_IsRejected(t *testing.T) {
+	const hash = "manage-data-only"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(100), []horizonOperation{
+		{Type: "manage_data", AssetType: "credit_alphanum4", AssetCode: "USDC", Amount: "100.0000000", To: claimVaultContract},
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonDestinationMismatch)
+}
+
+// The matching case: the credited amount is the on-chain operation amount.
+func TestReconcile_MatchingTransaction_CreditsOnChainAmount(t *testing.T) {
+	const hash = "matching-deposit"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.RequireFromString("250.5"), []horizonOperation{
+		paymentOp("GBSOMEOTHERACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "USDC", "9999.0000000"),
+		paymentOp(claimVaultContract, "USDC", "250.5000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+
+	stored, err := repo.GetByHash(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("GetByHash: %v", err)
+	}
+	if stored.Status != transaction.StatusCompleted {
+		t.Fatalf("status = %q, want completed", stored.Status)
+	}
+	if applier.depositCount() != 1 {
+		t.Fatalf("expected exactly 1 credit, got %d", applier.depositCount())
+	}
+	if got := applier.deposits[0].amount; !got.Equal(decimal.RequireFromString("250.5")) {
+		t.Errorf("credited %s, want the on-chain 250.5", got)
+	}
+}
+
+// An operation must match the claim exactly, so a mismatch in either direction
+// is rejected rather than silently crediting the smaller figure.
+func TestReconcile_UnderstatedAmount_IsRejected(t *testing.T) {
+	const hash = "understated-amount"
+	svc, repo, applier, tx := newClaimService(t, hash, decimal.NewFromInt(1), []horizonOperation{
+		paymentOp(claimVaultContract, "USDC", "100.0000000"),
+	})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	assertRejected(t, repo, applier, hash, transaction.ReasonAmountMismatch)
+}
+
+// When the vault cannot be resolved the transaction stays pending and nothing
+// is credited: an unverifiable claim must never fall through to a credit.
+func TestReconcile_VaultUnresolvable_StaysPendingAndCreditsNothing(t *testing.T) {
+	const hash = "vault-missing"
+	tx := newPendingTx(transaction.TypeDeposit, hash, time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	svc := NewTransactionService(repo, claimHorizonStub(t, hash, []horizonOperation{
+		paymentOp(claimVaultContract, "USDC", "100.0000000"),
+	}))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+	svc.SetVaultLookup(fakeVaultLookup{err: errors.New("vault gone")})
+
+	if _, changed, err := svc.ReconcileTransaction(context.Background(), tx); err == nil || changed {
+		t.Fatalf("expected a transient error and no status change, got err=%v changed=%v", err, changed)
+	}
+
+	stored, _ := repo.GetByHash(context.Background(), hash)
+	if stored.Status != transaction.StatusPending {
+		t.Errorf("status = %q, want pending", stored.Status)
+	}
+	if applier.depositCount() != 0 {
+		t.Errorf("credited %d time(s) despite an unresolvable vault", applier.depositCount())
+	}
+}
+
+// Withdrawals move value out of the vault, not into its contract address, so
+// they are not subject to the deposit claim check.
+func TestReconcile_Withdrawal_IsNotClaimChecked(t *testing.T) {
+	const hash = "withdrawal-tx"
+	tx := newPendingTx(transaction.TypeWithdrawal, hash, time.Minute)
+	repo := newFakeTransactionRepo(tx)
+
+	svc := NewTransactionService(repo, claimHorizonStub(t, hash, nil))
+	applier := &fakeBalanceApplier{}
+	svc.SetBalanceApplier(applier)
+	svc.SetVaultLookup(fakeVaultLookup{v: vault.Vault{
+		ID: tx.VaultID, ContractAddress: claimVaultContract, Currency: "USDC",
+	}})
+
+	if _, _, err := svc.ReconcileTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("ReconcileTransaction: %v", err)
+	}
+	if applier.withdrawalCount() != 1 {
+		t.Fatalf("expected the withdrawal to still apply, got %d", applier.withdrawalCount())
+	}
+}

--- a/apps/api/internal/service/transaction_service.go
+++ b/apps/api/internal/service/transaction_service.go
@@ -31,9 +31,13 @@ type VaultBalanceApplier interface {
 
 type TransactionService struct {
 	repository transaction.Repository
-	horizonURL  string
-	client      *http.Client
-	balance     VaultBalanceApplier
+	horizonURL string
+	client     *http.Client
+	balance    VaultBalanceApplier
+	// vaults resolves the vault a transaction belongs to, so a confirmation
+	// can be checked against the vault's real contract address and currency
+	// (nester#1145). See SetVaultLookup.
+	vaults TransactionVaultLookup
 }
 
 type RegisterTransactionInput struct {
@@ -144,6 +148,29 @@ func (s *TransactionService) ReconcileTransaction(ctx context.Context, model tra
 
 	switch horizonStatus {
 	case transaction.StatusCompleted:
+		// A successful transaction proves only that something succeeded. Before
+		// crediting anything, confirm the transaction actually moved the
+		// claimed asset, in the claimed amount, to this vault's contract
+		// address, and replace the client-supplied amount with the on-chain one
+		// (nester#1145).
+		verified, reason, verifyErr := s.verifyConfirmedClaim(ctx, model)
+		if verifyErr != nil {
+			if errors.Is(verifyErr, transaction.ErrChainClaimMismatch) {
+				// The claim is false: mark the transaction failed with the
+				// typed reason and never touch the balance.
+				updated, updateErr := s.repository.UpdateStatus(ctx, model.TxHash, transaction.StatusFailed, confirmedAt, reason)
+				if updateErr != nil {
+					return model, false, updateErr
+				}
+				return updated, true, nil
+			}
+			// Transient (Horizon unavailable, vault not loadable): leave the
+			// transaction pending so the next poll retries rather than
+			// crediting on an unverified claim.
+			return model, false, verifyErr
+		}
+		model.Amount = verified.Amount
+
 		// Credit/debit the vault BEFORE marking the transaction completed.
 		// If the balance change fails, we return the error and leave the
 		// transaction pending so the next poll retries; the applier is

--- a/apps/api/internal/stellar/backfill.go
+++ b/apps/api/internal/stellar/backfill.go
@@ -428,6 +428,7 @@ func fetchSorobanEventsRange(
 				ID         string         `json:"id"`
 				ContractID string         `json:"contractId"`
 				Ledger     uint64         `json:"ledger"`
+				TxHash     string         `json:"txHash"`
 				Topic      []interface{}  `json:"topic"`
 				Value      map[string]any `json:"value"`
 			} `json:"events"`
@@ -466,6 +467,7 @@ func fetchSorobanEventsRange(
 			EventType:  eventType,
 			Ledger:     raw.Ledger,
 			Data:       raw.Value,
+			TxHash:     raw.TxHash,
 		})
 		if raw.Ledger > maxLedgerSeen {
 			maxLedgerSeen = raw.Ledger

--- a/apps/api/internal/stellar/balance_ownership.go
+++ b/apps/api/internal/stellar/balance_ownership.go
@@ -1,0 +1,97 @@
+package stellar
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// Balance ownership model (nester#1147).
+//
+// Two independent writers can credit the same vault balance columns:
+//
+//  1. The API write path. A user records a deposit through the API; the vault
+//     repository increments vaults.total_deposited / vaults.current_balance
+//     keyed on the vault id, and inserts a vault_transactions row.
+//
+//  2. This indexer. The corresponding on-chain event arrives and
+//     applyEventMutation increments the same two columns keyed on the vault's
+//     contract_address.
+//
+// Both describe the SAME movement of money. Before this file the two had no
+// shared dedupe key — the indexer deduped only on processed_events.event_id,
+// which is unique per *event*, not per deposit, and says nothing about whether
+// the API already credited it. Every deposit made through the API was
+// therefore counted twice: once at record time and again when its event was
+// indexed.
+//
+// The model chosen is SHARED IDEMPOTENCY KEY, not single-writer.
+//
+// The key is vault_transactions.transaction_hash, which already carries a
+// unique index (migration 023, column renamed in 033) and which the API
+// confirmation path already claims in exactly this way
+// (VaultRepository.applyConfirmedBalanceChange). Both writers now insert that
+// row with ON CONFLICT (transaction_hash) DO NOTHING *before* touching a
+// balance, and whichever writer loses the race applies nothing. Whoever
+// observes the transaction first credits it; the other becomes a no-op.
+//
+// Single-writer was rejected: making the indexer the only writer would leave a
+// deposit invisible until its event is indexed (seconds to minutes behind, and
+// unbounded when the RPC is degraded), and making the API the only writer would
+// drop every deposit made directly on-chain, which the indexer exists to catch.
+// The shared key keeps both entry points live and still credits exactly once.
+//
+// Events that carry no transaction hash cannot participate in the shared key.
+// See claimBalanceTxHash for how they are handled.
+
+// claimBalanceTxHash claims an event's transaction hash in vault_transactions
+// so that only one writer credits a given on-chain movement.
+//
+// It reports whether the caller should proceed with the balance mutation:
+// true when this call won the claim, false when the hash was already recorded
+// (by the API write path or by an earlier delivery of the event), in which
+// case the balance has already moved and the caller must do nothing.
+//
+// An event with no transaction hash is allowed through. Such an event cannot
+// have come from the API path — that path always records a hash — so it can
+// only be a direct on-chain movement that nothing else will credit. Blocking
+// it would silently drop real deposits, which is the worse failure; it remains
+// deduped by processed_events.event_id against repeat delivery of the same
+// event.
+//
+// The insert runs inside the caller's transaction, so a later failure rolls the
+// claim back with the mutation and the event can be retried.
+func claimBalanceTxHash(ctx context.Context, tx *sql.Tx, event indexedEvent, txType string, amount decimal.Decimal) (bool, error) {
+	txHash := strings.TrimSpace(event.TxHash)
+	if txHash == "" {
+		return true, nil
+	}
+
+	result, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO vault_transactions (vault_id, type, amount, transaction_hash)
+		 SELECT id, $2, $3::numeric, $4 FROM vaults
+		 WHERE contract_address = $1 AND deleted_at IS NULL
+		 ON CONFLICT (transaction_hash) DO NOTHING`,
+		event.ContractID,
+		txType,
+		amount.String(),
+		txHash,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+
+	// Zero rows means either the hash was already claimed (the API path
+	// credited it, or this event was delivered before) or no live vault
+	// matches the contract address. Neither is a case where this indexer
+	// should move a balance.
+	return inserted > 0, nil
+}

--- a/apps/api/internal/stellar/balance_ownership_test.go
+++ b/apps/api/internal/stellar/balance_ownership_test.go
@@ -23,7 +23,8 @@ func TestApplyIndexedEvent_Deposit_AlreadyClaimedHash_DoesNotCredit(t *testing.T
 		EventType:  "deposit",
 		Ledger:     900,
 		TxHash:     "hash-already-credited",
-		Data:       map[string]any{"amount": "10"},
+		// Stroops, as the contract emits them: 10 asset units (nester#1146).
+		Data: map[string]any{"amount": "100000000"},
 	}
 
 	mock.ExpectBegin()
@@ -55,7 +56,8 @@ func TestApplyIndexedEvent_Deposit_UnclaimedHash_Credits(t *testing.T) {
 		EventType:  "deposit",
 		Ledger:     901,
 		TxHash:     "hash-not-yet-seen",
-		Data:       map[string]any{"amount": "10"},
+		// Stroops, as the contract emits them: 10 asset units (nester#1146).
+		Data: map[string]any{"amount": "100000000"},
 	}
 
 	mock.ExpectBegin()
@@ -89,7 +91,8 @@ func TestApplyIndexedEvent_Deposit_NoTxHash_CreditsWithoutClaiming(t *testing.T)
 		ContractID: "C1",
 		EventType:  "deposit",
 		Ledger:     902,
-		Data:       map[string]any{"amount": "7"},
+		// 7 asset units in stroops.
+		Data: map[string]any{"amount": "70000000"},
 	}
 
 	mock.ExpectBegin()
@@ -121,7 +124,8 @@ func TestApplyIndexedEvent_Withdraw_AlreadyClaimedHash_DoesNotDebit(t *testing.T
 		EventType:  "withdraw",
 		Ledger:     903,
 		TxHash:     "wd-hash-already-applied",
-		Data:       map[string]any{"amount": "3"},
+		// 3 asset units in stroops.
+		Data: map[string]any{"amount": "30000000"},
 	}
 
 	mock.ExpectBegin()

--- a/apps/api/internal/stellar/balance_ownership_test.go
+++ b/apps/api/internal/stellar/balance_ownership_test.go
@@ -1,0 +1,140 @@
+package stellar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+// A deposit event whose transaction hash has already been claimed (by the API
+// write path, or by an earlier delivery) must not move the balance a second
+// time: the claim insert affects zero rows and no UPDATE follows
+// (nester#1147).
+func TestApplyIndexedEvent_Deposit_AlreadyClaimedHash_DoesNotCredit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	event := indexedEvent{
+		ID:         "evt-dup",
+		ContractID: "C1",
+		EventType:  "deposit",
+		Ledger:     900,
+		TxHash:     "hash-already-credited",
+		Data:       map[string]any{"amount": "10"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// The API path already claimed this hash: zero rows inserted.
+	mock.ExpectExec("INSERT INTO vault_transactions").
+		WithArgs(event.ContractID, "deposit", "10", event.TxHash).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// Crucially: no "UPDATE vaults" is expected.
+	mock.ExpectCommit()
+
+	processed, err := applyIndexedEvent(context.Background(), db, event)
+	assert.NoError(t, err)
+	assert.True(t, processed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// When the indexer wins the claim it credits normally.
+func TestApplyIndexedEvent_Deposit_UnclaimedHash_Credits(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	event := indexedEvent{
+		ID:         "evt-fresh",
+		ContractID: "C1",
+		EventType:  "deposit",
+		Ledger:     901,
+		TxHash:     "hash-not-yet-seen",
+		Data:       map[string]any{"amount": "10"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO vault_transactions").
+		WithArgs(event.ContractID, "deposit", "10", event.TxHash).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE vaults").
+		WithArgs("10", event.ContractID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	processed, err := applyIndexedEvent(context.Background(), db, event)
+	assert.NoError(t, err)
+	assert.True(t, processed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// An event with no transaction hash cannot participate in the shared key. It
+// must still be applied — it can only be a direct on-chain movement nothing
+// else will credit — and must not attempt a claim.
+func TestApplyIndexedEvent_Deposit_NoTxHash_CreditsWithoutClaiming(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	event := indexedEvent{
+		ID:         "evt-nohash",
+		ContractID: "C1",
+		EventType:  "deposit",
+		Ledger:     902,
+		Data:       map[string]any{"amount": "7"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// No claim insert is expected; straight to the balance update.
+	mock.ExpectExec("UPDATE vaults").
+		WithArgs("7", event.ContractID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	processed, err := applyIndexedEvent(context.Background(), db, event)
+	assert.NoError(t, err)
+	assert.True(t, processed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Withdrawals share the same key, so an already-claimed withdrawal hash must
+// not debit twice.
+func TestApplyIndexedEvent_Withdraw_AlreadyClaimedHash_DoesNotDebit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	event := indexedEvent{
+		ID:         "evt-wd-dup",
+		ContractID: "C1",
+		EventType:  "withdraw",
+		Ledger:     903,
+		TxHash:     "wd-hash-already-applied",
+		Data:       map[string]any{"amount": "3"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO vault_transactions").
+		WithArgs(event.ContractID, "withdrawal", "3", event.TxHash).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	processed, err := applyIndexedEvent(context.Background(), db, event)
+	assert.NoError(t, err)
+	assert.True(t, processed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/apps/api/internal/stellar/chain_event_verifier.go
+++ b/apps/api/internal/stellar/chain_event_verifier.go
@@ -18,8 +18,6 @@ import (
 	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
 )
 
-const stroopsPerUnit int64 = 10_000_000
-
 // VerifiedVaultEvent is a vault contract event taken from a confirmed
 // on-chain transaction. Amount is in display units (stroops / 1e7), matching
 // the vault ledger — never the client-supplied request body (nester#1076).
@@ -295,8 +293,11 @@ func i128PartsToDecimal(parts xdr.Int128Parts) (decimal.Decimal, bool) {
 	return hi.Mul(shift).Add(lo), true
 }
 
+// stroopsToDisplay converts a raw stroop event amount into the asset units the
+// vault ledger stores. It delegates to StroopsToAssetUnits so this path and the
+// event indexer share one conversion (nester#1146).
 func stroopsToDisplay(stroops decimal.Decimal) decimal.Decimal {
-	return stroops.Div(decimal.NewFromInt(stroopsPerUnit))
+	return StroopsToAssetUnits(stroops)
 }
 
 func normalizeEventType(eventType string) string {

--- a/apps/api/internal/stellar/double_credit_integration_test.go
+++ b/apps/api/internal/stellar/double_credit_integration_test.go
@@ -83,7 +83,10 @@ func TestAPIDepositThenIndexedEvent_CreditsExactlyOnce(t *testing.T) {
 	seedDoubleCreditVault(t, db)
 
 	const txHash = "0d1e2f3a4b5c6d7e8f90112233445566778899aabbccddeeff00112233445566"
+	// The API path stores asset units; a contract event carries stroops for
+	// the same movement (nester#1146). Both must resolve to one credit.
 	const amount = "100"
+	const amountStroops = "1000000000"
 
 	// 1. The user records the deposit through the API.
 	repo := postgres.NewVaultRepository(db)
@@ -110,7 +113,7 @@ func TestAPIDepositThenIndexedEvent_CreditsExactlyOnce(t *testing.T) {
 		EventType:  "deposit",
 		Ledger:     4242,
 		TxHash:     txHash,
-		Data:       map[string]any{"amount": amount},
+		Data:       map[string]any{"amount": amountStroops},
 	})
 	if err != nil {
 		t.Fatalf("applyIndexedEvent: %v", err)
@@ -141,6 +144,7 @@ func TestIndexedEventThenAPIDeposit_CreditsExactlyOnce(t *testing.T) {
 
 	const txHash = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788990"
 	const amount = "250"
+	const amountStroops = "2500000000"
 
 	processed, err := applyIndexedEvent(context.Background(), db, indexedEvent{
 		ID:         "evt-indexer-first",
@@ -148,7 +152,7 @@ func TestIndexedEventThenAPIDeposit_CreditsExactlyOnce(t *testing.T) {
 		EventType:  "deposit",
 		Ledger:     4343,
 		TxHash:     txHash,
-		Data:       map[string]any{"amount": amount},
+		Data:       map[string]any{"amount": amountStroops},
 	})
 	if err != nil {
 		t.Fatalf("applyIndexedEvent: %v", err)
@@ -198,6 +202,7 @@ func TestRedeliveredEventForSameTxHash_CreditsExactlyOnce(t *testing.T) {
 
 	const txHash = "ffeeddccbbaa99887766554433221100ffeeddccbbaa998877665544332211000"
 	const amount = "40"
+	const amountStroops = "400000000"
 
 	for _, eventID := range []string{"evt-first-delivery", "evt-second-delivery"} {
 		if _, err := applyIndexedEvent(context.Background(), db, indexedEvent{
@@ -206,7 +211,7 @@ func TestRedeliveredEventForSameTxHash_CreditsExactlyOnce(t *testing.T) {
 			EventType:  "deposit",
 			Ledger:     4444,
 			TxHash:     txHash,
-			Data:       map[string]any{"amount": amount},
+			Data:       map[string]any{"amount": amountStroops},
 		}); err != nil {
 			t.Fatalf("applyIndexedEvent(%s): %v", eventID, err)
 		}

--- a/apps/api/internal/stellar/double_credit_integration_test.go
+++ b/apps/api/internal/stellar/double_credit_integration_test.go
@@ -1,0 +1,226 @@
+package stellar
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/shopspring/decimal"
+
+	"github.com/suncrestlabs/nester/apps/api/internal/domain/vault"
+	"github.com/suncrestlabs/nester/apps/api/internal/repository/postgres"
+	"github.com/suncrestlabs/nester/apps/api/internal/testutil"
+)
+
+// The double-credit integration test for nester#1147.
+//
+// It drives the two real writers against a real database — the API write path
+// (VaultRepository.RecordDeposit) and the event indexer (applyIndexedEvent) —
+// for the SAME on-chain transaction, and asserts the balance moves exactly
+// once. Mocks would only prove the mocks agree with each other; the shared key
+// is a database uniqueness guarantee, so it has to be exercised against the
+// real constraint.
+
+const (
+	doubleCreditContract = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+	doubleCreditUserID   = "44444444-4444-4444-8444-444444444444"
+	doubleCreditVaultID  = "55555555-5555-4555-8555-555555555555"
+)
+
+// seedDoubleCreditVault applies the full migration chain and seeds one user and
+// one zero-balance vault whose contract address the indexer keys on.
+func seedDoubleCreditVault(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	testutil.ApplyAllMigrations(t, db, filepath.Join("..", "..", "migrations"))
+
+	if _, err := db.Exec(
+		`INSERT INTO users (id, wallet_address, display_name) VALUES ($1, $2, $3)`,
+		doubleCreditUserID, "GAKX7VYAJTQOZ4ZKQ7GCTAWOAKCXY6BFCHOEQ4RRWJBTAY3EKQXHTKZL", "double-credit-user",
+	); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	if _, err := db.Exec(`
+INSERT INTO vaults (id, user_id, contract_address, currency, status, total_deposited, current_balance, yield_earned)
+VALUES ($1, $2, $3, 'USDC', 'active', 0, 0, 0)`,
+		doubleCreditVaultID, doubleCreditUserID, doubleCreditContract,
+	); err != nil {
+		t.Fatalf("seed vault: %v", err)
+	}
+}
+
+func readVaultBalances(t *testing.T, db *sql.DB) (totalDeposited, currentBalance decimal.Decimal) {
+	t.Helper()
+	var total, current string
+	if err := db.QueryRow(
+		`SELECT total_deposited::text, current_balance::text FROM vaults WHERE id = $1`,
+		doubleCreditVaultID,
+	).Scan(&total, &current); err != nil {
+		t.Fatalf("read balances: %v", err)
+	}
+	return decimal.RequireFromString(total), decimal.RequireFromString(current)
+}
+
+func countLedgerRowsForHash(t *testing.T, db *sql.DB, hash string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM vault_transactions WHERE transaction_hash = $1`, hash,
+	).Scan(&n); err != nil {
+		t.Fatalf("count ledger rows: %v", err)
+	}
+	return n
+}
+
+// An API deposit followed by the corresponding indexed event credits once.
+// This is the exact sequence that previously double-counted every deposit.
+func TestAPIDepositThenIndexedEvent_CreditsExactlyOnce(t *testing.T) {
+	db := openBackfillIntegrationDB(t)
+	seedDoubleCreditVault(t, db)
+
+	const txHash = "0d1e2f3a4b5c6d7e8f90112233445566778899aabbccddeeff00112233445566"
+	const amount = "100"
+
+	// 1. The user records the deposit through the API.
+	repo := postgres.NewVaultRepository(db)
+	if err := repo.RecordDeposit(context.Background(), uuid.MustParse(doubleCreditVaultID), vault.TransactionRecord{
+		UserID:               uuid.MustParse(doubleCreditUserID),
+		Amount:               decimal.RequireFromString(amount),
+		TransactionHash:      txHash,
+		SharesMintedOrBurned: decimal.NewFromInt(100),
+		SharePriceAtTime:     decimal.NewFromInt(1),
+		FeeCharged:           decimal.Zero,
+	}); err != nil {
+		t.Fatalf("RecordDeposit: %v", err)
+	}
+
+	total, current := readVaultBalances(t, db)
+	if !total.Equal(decimal.RequireFromString(amount)) || !current.Equal(decimal.RequireFromString(amount)) {
+		t.Fatalf("after API deposit: total=%s current=%s, want %s/%s", total, current, amount, amount)
+	}
+
+	// 2. The indexer observes the resulting on-chain event for the same hash.
+	processed, err := applyIndexedEvent(context.Background(), db, indexedEvent{
+		ID:         "evt-double-credit",
+		ContractID: doubleCreditContract,
+		EventType:  "deposit",
+		Ledger:     4242,
+		TxHash:     txHash,
+		Data:       map[string]any{"amount": amount},
+	})
+	if err != nil {
+		t.Fatalf("applyIndexedEvent: %v", err)
+	}
+	if !processed {
+		t.Fatal("event should be marked processed so the cursor advances")
+	}
+
+	// 3. The balance must not have moved again.
+	total, current = readVaultBalances(t, db)
+	want := decimal.RequireFromString(amount)
+	if !total.Equal(want) {
+		t.Errorf("total_deposited = %s, want %s (deposit was counted twice)", total, want)
+	}
+	if !current.Equal(want) {
+		t.Errorf("current_balance = %s, want %s (deposit was counted twice)", current, want)
+	}
+	if got := countLedgerRowsForHash(t, db, txHash); got != 1 {
+		t.Errorf("ledger rows for hash = %d, want exactly 1", got)
+	}
+}
+
+// The reverse order must hold too: when the indexer observes the deposit
+// first, a later API record for the same hash must not add a second credit.
+func TestIndexedEventThenAPIDeposit_CreditsExactlyOnce(t *testing.T) {
+	db := openBackfillIntegrationDB(t)
+	seedDoubleCreditVault(t, db)
+
+	const txHash = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788990"
+	const amount = "250"
+
+	processed, err := applyIndexedEvent(context.Background(), db, indexedEvent{
+		ID:         "evt-indexer-first",
+		ContractID: doubleCreditContract,
+		EventType:  "deposit",
+		Ledger:     4343,
+		TxHash:     txHash,
+		Data:       map[string]any{"amount": amount},
+	})
+	if err != nil {
+		t.Fatalf("applyIndexedEvent: %v", err)
+	}
+	if !processed {
+		t.Fatal("event should be marked processed")
+	}
+
+	total, current := readVaultBalances(t, db)
+	want := decimal.RequireFromString(amount)
+	if !total.Equal(want) || !current.Equal(want) {
+		t.Fatalf("after indexed event: total=%s current=%s, want %s", total, current, want)
+	}
+
+	// The API path now tries to record the same transaction. It must report
+	// the duplicate rather than crediting again.
+	repo := postgres.NewVaultRepository(db)
+	err = repo.RecordDeposit(context.Background(), uuid.MustParse(doubleCreditVaultID), vault.TransactionRecord{
+		UserID:               uuid.MustParse(doubleCreditUserID),
+		Amount:               decimal.RequireFromString(amount),
+		TransactionHash:      txHash,
+		SharesMintedOrBurned: decimal.NewFromInt(250),
+		SharePriceAtTime:     decimal.NewFromInt(1),
+		FeeCharged:           decimal.Zero,
+	})
+	if err == nil {
+		t.Fatal("RecordDeposit should report the already-claimed hash")
+	}
+
+	total, current = readVaultBalances(t, db)
+	if !total.Equal(want) {
+		t.Errorf("total_deposited = %s, want %s (credited twice)", total, want)
+	}
+	if !current.Equal(want) {
+		t.Errorf("current_balance = %s, want %s (credited twice)", current, want)
+	}
+	if got := countLedgerRowsForHash(t, db, txHash); got != 1 {
+		t.Errorf("ledger rows for hash = %d, want exactly 1", got)
+	}
+}
+
+// Repeat delivery of the same event (a different event id for the same
+// transaction, e.g. after a backfill overlap) must still credit only once.
+func TestRedeliveredEventForSameTxHash_CreditsExactlyOnce(t *testing.T) {
+	db := openBackfillIntegrationDB(t)
+	seedDoubleCreditVault(t, db)
+
+	const txHash = "ffeeddccbbaa99887766554433221100ffeeddccbbaa998877665544332211000"
+	const amount = "40"
+
+	for _, eventID := range []string{"evt-first-delivery", "evt-second-delivery"} {
+		if _, err := applyIndexedEvent(context.Background(), db, indexedEvent{
+			ID:         eventID,
+			ContractID: doubleCreditContract,
+			EventType:  "deposit",
+			Ledger:     4444,
+			TxHash:     txHash,
+			Data:       map[string]any{"amount": amount},
+		}); err != nil {
+			t.Fatalf("applyIndexedEvent(%s): %v", eventID, err)
+		}
+	}
+
+	total, current := readVaultBalances(t, db)
+	want := decimal.RequireFromString(amount)
+	if !total.Equal(want) {
+		t.Errorf("total_deposited = %s, want %s", total, want)
+	}
+	if !current.Equal(want) {
+		t.Errorf("current_balance = %s, want %s", current, want)
+	}
+	if got := countLedgerRowsForHash(t, db, txHash); got != 1 {
+		t.Errorf("ledger rows for hash = %d, want exactly 1", got)
+	}
+}

--- a/apps/api/internal/stellar/indexer.go
+++ b/apps/api/internal/stellar/indexer.go
@@ -262,7 +262,7 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 			return err
 		}
 	case "deposit":
-		amount, ok := extractEventAmount(event)
+		amount, ok := extractEventAmountUnits(event)
 		if !ok {
 			return fmt.Errorf("deposit event missing parseable amount")
 		}
@@ -280,7 +280,7 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 			return err
 		}
 	case "withdraw", "withdrawal":
-		amount, ok := extractEventAmount(event)
+		amount, ok := extractEventAmountUnits(event)
 		if !ok {
 			return fmt.Errorf("withdraw event missing parseable amount")
 		}
@@ -301,7 +301,7 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 	// without changing total_deposited: the principal the user paid in is
 	// unchanged, only the earned yield and the spendable balance grow.
 	case "harvest", "harvested", "yield_harvest":
-		amount, ok := extractEventAmount(event)
+		amount, ok := extractEventAmountUnits(event)
 		if !ok {
 			return fmt.Errorf("harvest event missing parseable amount")
 		}
@@ -361,7 +361,13 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 	return nil
 }
 
-func extractEventAmount(event indexedEvent) (decimal.Decimal, bool) {
+// extractEventAmountStroops reads the raw amount out of an event's data map.
+//
+// The value is in STROOPS, exactly as the Soroban contract emitted it. Callers
+// that write a vault balance column must not use this directly — use
+// extractEventAmountUnits, which applies the stroop -> asset-unit conversion
+// (nester#1146).
+func extractEventAmountStroops(event indexedEvent) (decimal.Decimal, bool) {
 	if event.Data == nil {
 		return decimal.Zero, false
 	}
@@ -407,9 +413,24 @@ func extractEventAmount(event indexedEvent) (decimal.Decimal, bool) {
 	return decimal.Zero, false
 }
 
+// extractEventAmountUnits reads an event amount and converts it from the
+// stroops the contract emitted into the asset units the vault ledger stores.
+//
+// Every balance-writing branch of applyEventMutation goes through this, so an
+// indexed 1 USDC deposit credits 1 and not 10_000_000 (nester#1146). The
+// conversion itself lives in StroopsToAssetUnits, shared with the transaction
+// chain-event verifier.
+func extractEventAmountUnits(event indexedEvent) (decimal.Decimal, bool) {
+	stroops, ok := extractEventAmountStroops(event)
+	if !ok {
+		return decimal.Zero, false
+	}
+	return StroopsToAssetUnits(stroops), true
+}
+
 // extractEventField reads an arbitrary numeric field (not just "amount"/
 // "value") from an event's data map, using the same tolerant type handling
-// as extractEventAmount.
+// as extractEventAmountStroops.
 func extractEventField(event indexedEvent, key string) (decimal.Decimal, bool) {
 	if event.Data == nil {
 		return decimal.Zero, false

--- a/apps/api/internal/stellar/indexer.go
+++ b/apps/api/internal/stellar/indexer.go
@@ -199,6 +199,12 @@ type indexedEvent struct {
 	EventType  string
 	Ledger     uint64
 	Data       map[string]any
+	// TxHash is the Stellar transaction that emitted the event. It is the
+	// shared idempotency key between the indexer and the API write path: both
+	// claim it in vault_transactions before moving a balance, so a deposit
+	// made through the API and later observed on-chain is credited exactly
+	// once (nester#1147). Empty for events from an RPC that did not report it.
+	TxHash string
 }
 
 // applyIndexedEvent applies one event in its own transaction, without
@@ -266,7 +272,18 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 		if !ok {
 			return fmt.Errorf("deposit event missing parseable amount")
 		}
-		_, err := tx.ExecContext(
+		// The API write path may already have credited this exact transaction
+		// (see the ownership model documented at the top of this file). Claim
+		// the hash first; if it is already claimed, the credit has happened and
+		// this event must not apply a second one (nester#1147).
+		claimed, err := claimBalanceTxHash(ctx, tx, event, "deposit", amount)
+		if err != nil {
+			return err
+		}
+		if !claimed {
+			return nil
+		}
+		_, err = tx.ExecContext(
 			ctx,
 			`UPDATE vaults
 			 SET total_deposited = total_deposited + $1::numeric,
@@ -284,7 +301,14 @@ func applyEventMutation(ctx context.Context, tx *sql.Tx, event indexedEvent) err
 		if !ok {
 			return fmt.Errorf("withdraw event missing parseable amount")
 		}
-		_, err := tx.ExecContext(
+		claimed, err := claimBalanceTxHash(ctx, tx, event, "withdrawal", amount)
+		if err != nil {
+			return err
+		}
+		if !claimed {
+			return nil
+		}
+		_, err = tx.ExecContext(
 			ctx,
 			`UPDATE vaults
 			 SET current_balance = current_balance - $1::numeric,
@@ -698,6 +722,7 @@ func fetchSorobanEvents(
 				ID         string         `json:"id"`
 				ContractID string         `json:"contractId"`
 				Ledger     uint64         `json:"ledger"`
+				TxHash     string         `json:"txHash"`
 				Topic      []interface{}  `json:"topic"`
 				Value      map[string]any `json:"value"`
 			} `json:"events"`
@@ -731,6 +756,7 @@ func fetchSorobanEvents(
 			EventType:  eventType,
 			Ledger:     raw.Ledger,
 			Data:       raw.Value,
+			TxHash:     raw.TxHash,
 		})
 	}
 

--- a/apps/api/internal/stellar/indexer_test.go
+++ b/apps/api/internal/stellar/indexer_test.go
@@ -21,7 +21,8 @@ func TestApplyIndexedEvent_Deposit_ProcessesOnce(t *testing.T) {
 		EventType:  "deposit",
 		Ledger:     123,
 		Data: map[string]any{
-			"amount": "10.25",
+			// Stroops, as the contract emits them: 10.25 asset units.
+			"amount": "102500000",
 		},
 	}
 
@@ -68,7 +69,7 @@ func TestApplyIndexedEvent_DuplicateEvent_IsSkipped(t *testing.T) {
 }
 
 func TestExtractEventAmount_JSONNumber(t *testing.T) {
-	amount, ok := extractEventAmount(indexedEvent{
+	amount, ok := extractEventAmountStroops(indexedEvent{
 		Data: map[string]any{
 			"amount": json.Number("123456789012345678901234567890"),
 		},
@@ -83,27 +84,27 @@ func TestExtractEventAmount_LargeAmountPrecision(t *testing.T) {
 
 	t.Run("json.Number preserves precision", func(t *testing.T) {
 		ev := indexedEvent{Data: map[string]any{"amount": json.Number(bigStroops)}}
-		got, ok := extractEventAmount(ev)
+		got, ok := extractEventAmountStroops(ev)
 		assert.True(t, ok)
 		assert.Equal(t, bigStroops, got.String())
 	})
 
 	t.Run("string preserves precision", func(t *testing.T) {
 		ev := indexedEvent{Data: map[string]any{"value": bigStroops}}
-		got, ok := extractEventAmount(ev)
+		got, ok := extractEventAmountStroops(ev)
 		assert.True(t, ok)
 		assert.Equal(t, bigStroops, got.String())
 	})
 
 	t.Run("float64 above 2^53 is rejected instead of silently truncated", func(t *testing.T) {
 		ev := indexedEvent{Data: map[string]any{"amount": float64(1e18)}}
-		_, ok := extractEventAmount(ev)
+		_, ok := extractEventAmountStroops(ev)
 		assert.False(t, ok)
 	})
 
 	t.Run("safe float64 integer is still accepted", func(t *testing.T) {
 		ev := indexedEvent{Data: map[string]any{"amount": float64(1500)}}
-		got, ok := extractEventAmount(ev)
+		got, ok := extractEventAmountStroops(ev)
 		assert.True(t, ok)
 		assert.Equal(t, "1500", got.String())
 	})

--- a/apps/api/internal/stellar/poller_test.go
+++ b/apps/api/internal/stellar/poller_test.go
@@ -274,8 +274,9 @@ func TestIntegrationCursorAndBalanceCommitAtomically(t *testing.T) {
 		t.Fatal("retry did not apply the event; it was wrongly recorded as processed")
 	}
 
+	// 999000000000 stroops is 99900 asset units (nester#1146).
 	assertVault(t, db, vaultA, vaultExpectation{
-		totalDeposited: "999000000000.00000000",
+		totalDeposited: "99900.00000000",
 		currentBalance: "0.00000000",
 		yieldEarned:    "0.00000000",
 		status:         "active",
@@ -369,21 +370,29 @@ func TestSortEventsForApply_EnforcesLedgerOrder(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestIntegrationLargeAmountRoundTripsExactly proves a large i128 stroop
-// amount survives parsing, arithmetic, persistence, and read-back with no
-// precision loss.
+// amount survives parsing, the stroop -> asset-unit conversion, persistence,
+// and read-back with no precision loss.
 //
 // 1e18 and the odd 17-digit values below are all above float64's 2^53
 // exact-integer limit, so any float64 anywhere in this path corrupts them.
+//
+// The expectation is the amount divided by 1e7, not the raw stroop figure:
+// balances are stored in asset units (nester#1146). The division is exact on
+// decimal.Decimal, so an odd stroop count keeps its low digits after the
+// decimal point rather than being rounded away — which is precisely what this
+// test guards.
 func TestIntegrationLargeAmountRoundTripsExactly(t *testing.T) {
 	db := replayDB(t)
 
 	cases := []struct {
 		name   string
 		amount string
+		// want is amount/1e7 rendered at the column's 8dp scale.
+		want string
 	}{
-		{"one quintillion stroops", "1000000000000000000"},
-		{"odd value above 2^53", "90071992547409931"},
-		{"max-ish i64 stroops", "9223372036854775807"},
+		{"one quintillion stroops", "1000000000000000000", "100000000000.00000000"},
+		{"odd value above 2^53", "90071992547409931", "9007199254.74099310"},
+		{"max-ish i64 stroops", "9223372036854775807", "922337203685.47758070"},
 	}
 
 	for _, tc := range cases {
@@ -409,9 +418,8 @@ func TestIntegrationLargeAmountRoundTripsExactly(t *testing.T) {
 				t.Fatalf("read balance: %v", err)
 			}
 
-			want := tc.amount + ".00000000"
-			if stored != want {
-				t.Fatalf("amount lost precision: stored %s, want %s", stored, want)
+			if stored != tc.want {
+				t.Fatalf("amount lost precision: stored %s, want %s", stored, tc.want)
 			}
 		})
 	}

--- a/apps/api/internal/stellar/poller_test.go
+++ b/apps/api/internal/stellar/poller_test.go
@@ -454,13 +454,13 @@ func TestAmountPathHasNoFloat64(t *testing.T) {
 // has already lost precision before the indexer saw it, so writing it would
 // store a wrong balance. Rejecting surfaces the problem instead.
 func TestExtractEventAmount_RejectsUnsafeFloat64(t *testing.T) {
-	if _, ok := extractEventAmount(indexedEvent{
+	if _, ok := extractEventAmountStroops(indexedEvent{
 		Data: map[string]any{"amount": float64(1e18)},
 	}); ok {
 		t.Fatal("a float64 amount above 2^53 was accepted; it has already lost precision (B-11)")
 	}
 
-	got, ok := extractEventAmount(indexedEvent{
+	got, ok := extractEventAmountStroops(indexedEvent{
 		Data: map[string]any{"amount": json.Number("1000000000000000000")},
 	})
 	if !ok {

--- a/apps/api/internal/stellar/replay_harness_test.go
+++ b/apps/api/internal/stellar/replay_harness_test.go
@@ -344,25 +344,29 @@ func TestIntegrationReplay_CleanSinglePass(t *testing.T) {
 	// not against whatever the code produced. A test that only compared runs to
 	// each other would pass happily on a uniformly wrong implementation.
 	//
-	// Amounts are stored as emitted: the indexer persists raw contract amounts
-	// and does not rescale stroops into display units anywhere in this path.
+	// The fixture emits STROOPS, as a contract does; balances are stored in
+	// asset units, so every figure below is the hand-computed stroop total
+	// divided by 1e7 (nester#1146). The division is exact on decimal.Decimal,
+	// so this remains the B-11 precision evidence: a float64 anywhere in the
+	// path still corrupts vault B's values, which sit far above 2^53.
 	//
-	// Vault A: deposits 25000000000 + 12500000000 + 750000000 = 38250000000,
-	//          harvest 375000000, withdraw 5000000000.
-	//          current_balance = 38250000000 + 375000000 - 5000000000.
-	// Vault B: deposit 1e18, harvest 2.5e17, withdraw 5e17 — every one of
-	//          these is far above float64's 2^53 exact-integer limit, so the
-	//          exact totals below are the B-11 precision evidence.
+	// Vault A: deposits 25000000000 + 12500000000 + 750000000 = 38250000000
+	//          stroops = 3825 units; harvest 375000000 = 37.5;
+	//          withdraw 5000000000 = 500.
+	//          current_balance = 3825 + 37.5 - 500 = 3362.5.
+	// Vault B: deposit 1e18 = 1e11 units, harvest 2.5e17 = 2.5e10,
+	//          withdraw 5e17 = 5e10.
+	//          current_balance = 1e11 + 2.5e10 - 5e10 = 7.5e10.
 	assertVault(t, db, vaultA, vaultExpectation{
-		totalDeposited: "38250000000.00000000",
-		currentBalance: "33625000000.00000000",
-		yieldEarned:    "375000000.00000000",
+		totalDeposited: "3825.00000000",
+		currentBalance: "3362.50000000",
+		yieldEarned:    "37.50000000",
 		status:         "active",
 	})
 	assertVault(t, db, vaultB, vaultExpectation{
-		totalDeposited: "1000000000000000000.00000000",
-		currentBalance: "750000000000000000.00000000",
-		yieldEarned:    "250000000000000000.00000000",
+		totalDeposited: "100000000000.00000000",
+		currentBalance: "75000000000.00000000",
+		yieldEarned:    "25000000000.00000000",
 		status:         "active",
 	})
 

--- a/apps/api/internal/stellar/stroops.go
+++ b/apps/api/internal/stellar/stroops.go
@@ -1,0 +1,34 @@
+package stellar
+
+import "github.com/shopspring/decimal"
+
+// StroopsPerUnit is the fixed-point scale Stellar and Soroban use for asset
+// amounts: one asset unit is 10^7 stroops. Soroban contract events carry
+// stroops, while the vault ledger (vaults.total_deposited,
+// vaults.current_balance, vault_transactions.amount) stores plain asset units.
+//
+// Every value crossing that boundary must be converted exactly once. Writing a
+// raw stroop amount into a balance column inflates it by 1e7 (nester#1146).
+const StroopsPerUnit int64 = 10_000_000
+
+// StroopsToAssetUnits converts an on-chain stroop amount into the asset units
+// the vault ledger stores.
+//
+// This is the single conversion helper for the chain -> ledger direction: the
+// event indexer and the transaction chain-event verifier both route through it
+// so the two write paths cannot drift apart in scale. Do not inline the
+// division at a call site.
+//
+// The division is exact — decimal.Decimal is arbitrary precision, so no
+// rounding is applied and sub-unit stroop remainders are preserved rather than
+// silently truncated.
+func StroopsToAssetUnits(stroops decimal.Decimal) decimal.Decimal {
+	return stroops.Div(decimal.NewFromInt(StroopsPerUnit))
+}
+
+// AssetUnitsToStroops converts an asset-unit amount into the stroops a Soroban
+// contract call expects. It is the exact inverse of StroopsToAssetUnits and is
+// rounded to a whole stroop, the smallest representable on-chain quantity.
+func AssetUnitsToStroops(units decimal.Decimal) decimal.Decimal {
+	return units.Mul(decimal.NewFromInt(StroopsPerUnit)).Round(0)
+}

--- a/apps/api/internal/stellar/stroops_test.go
+++ b/apps/api/internal/stellar/stroops_test.go
@@ -1,0 +1,135 @@
+package stellar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// oneUSDCInStroops is 1 USDC as a Soroban contract emits it: 1 * 10^7.
+const oneUSDCInStroops = "10000000"
+
+func TestStroopsToAssetUnits(t *testing.T) {
+	cases := []struct {
+		name    string
+		stroops string
+		want    string
+	}{
+		{"one unit", oneUSDCInStroops, "1"},
+		{"zero", "0", "0"},
+		{"one stroop is the smallest unit", "1", "0.0000001"},
+		{"fractional units", "102500000", "10.25"},
+		{"large amount beyond float64 exact range", "1000000000000000000", "100000000000"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StroopsToAssetUnits(decimal.RequireFromString(tc.stroops))
+			assert.Equal(t, tc.want, got.String())
+		})
+	}
+}
+
+// TestStroopsRoundTrip pins the two helpers as exact inverses so a future edit
+// to one cannot silently desynchronise the chain-call path from the ledger.
+func TestStroopsRoundTrip(t *testing.T) {
+	for _, units := range []string{"1", "0.5", "10.25", "12345.6789012"} {
+		got := StroopsToAssetUnits(AssetUnitsToStroops(decimal.RequireFromString(units)))
+		assert.True(t, got.Equal(decimal.RequireFromString(units)), "round trip lost value for %s: got %s", units, got)
+	}
+}
+
+// TestApplyIndexedEvent_Deposit_ConvertsStroopsToAssetUnits is the regression
+// test for nester#1146: a 1 USDC on-chain deposit must credit 1, not
+// 10_000_000.
+func TestApplyIndexedEvent_Deposit_ConvertsStroopsToAssetUnits(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	event := indexedEvent{
+		ID:         "evt-1usdc",
+		ContractID: "C1",
+		EventType:  "deposit",
+		Ledger:     500,
+		Data:       map[string]any{"amount": oneUSDCInStroops},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO processed_events").
+		WithArgs(event.ID, event.Ledger).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE vaults").
+		WithArgs("1", event.ContractID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	processed, err := applyIndexedEvent(context.Background(), db, event)
+	assert.NoError(t, err)
+	assert.True(t, processed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyIndexedEvent_WithdrawAndHarvest_ConvertStroops(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		eventType string
+	}{
+		{"withdraw", "withdraw"},
+		{"harvest", "harvest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			assert.NoError(t, err)
+			defer db.Close()
+
+			event := indexedEvent{
+				ID:         "evt-" + tc.eventType,
+				ContractID: "C1",
+				EventType:  tc.eventType,
+				Ledger:     501,
+				Data:       map[string]any{"amount": oneUSDCInStroops},
+			}
+
+			mock.ExpectBegin()
+			mock.ExpectExec("INSERT INTO processed_events").
+				WithArgs(event.ID, event.Ledger).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectExec("UPDATE vaults").
+				WithArgs("1", event.ContractID).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			processed, err := applyIndexedEvent(context.Background(), db, event)
+			assert.NoError(t, err)
+			assert.True(t, processed)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// TestIndexerAndVerifierAgreeOnScale is the round-trip requirement of
+// nester#1146: for the same on-chain deposit, the amount the indexer writes to
+// the balance and the amount the API path credits (via the chain event
+// verifier) must be identical.
+//
+// Both paths are driven from the same stroop figure. The verifier's conversion
+// is exercised through stroopsToDisplay, which is what
+// verifiedEventFromXDR assigns to VerifiedVaultEvent.Amount and what
+// VaultService.RecordDeposit then credits.
+func TestIndexerAndVerifierAgreeOnScale(t *testing.T) {
+	for _, stroops := range []string{oneUSDCInStroops, "1", "102500000", "999000000000"} {
+		raw := decimal.RequireFromString(stroops)
+
+		indexed, ok := extractEventAmountUnits(indexedEvent{Data: map[string]any{"amount": stroops}})
+		assert.True(t, ok)
+
+		viaVerifier := stroopsToDisplay(raw)
+
+		assert.True(t, indexed.Equal(viaVerifier),
+			"indexer credited %s but API path credited %s for %s stroops", indexed, viaVerifier, stroops)
+	}
+}


### PR DESCRIPTION
Testnet launch backlog: the three money-path integrity findings plus the auth-specific hardening. Four branches, one PR — #1145 and #1147 touch the same confirmation path and #1146 and #1147 the same indexer branches, so they are easier to review and land together than separately.

Closes #1104
Closes #1145
Closes #1146
Closes #1147

## What each commit does

**#1145 — verify amount and destination, not just success.** The Horizon lookup decoded only the success flag and credited `model.Amount` from the request body, so any real successful hash posted as a deposit credited an arbitrary amount. Confirmation now decodes the transaction's operations and requires a value-transferring operation that paid the vault's own contract address, in the vault's currency, for the claimed amount. The credited figure comes from the on-chain operation. Mismatches are marked failed with a typed reason; transient failures stay pending rather than falling through to a credit.

**#1146 — stroop conversion.** The indexer wrote raw stroop event amounts into balance columns that store asset units, inflating every indexed deposit by 1e7. Conversion now happens at the extraction boundary through one shared helper, which the existing chain-event verifier also routes through.

**#1147 — double counting.** The indexer and the API write path incremented the same columns with no shared dedupe key, so an API deposit was credited again when its event arrived. Both writers now claim `vault_transactions.transaction_hash` before moving a balance. The ownership model and why single-writer was rejected are documented in `internal/stellar/balance_ownership.go`.

**#1104 — auth lockout.** Adds per-wallet limiting and a progressive, capped failure lockout (per wallet and per IP) on top of the per-IP limiter from #782, with lockout metrics. Challenges were already single-use and short-lived, so that criterion needed no change.

## Verification

`go build ./...` and `go vet ./...` clean. Unit suites green for middleware, metrics, config, handler, service, stellar. The #1147 integration tests run against real PostgreSQL with the full migration chain.

Each fix was mutation-tested — reverted, and the new tests confirmed to fail. #1147's headline test fails with `total_deposited = 200, want 100`; 8 of 10 #1145 tests fail against the pre-fix behaviour.

## Notes for review

- `#1145` scopes the claim check to deposits: withdrawals move value out of the vault rather than into its contract address, and settlements move no vault balance.
- `#1147` deliberately still applies events carrying no transaction hash — those can only be direct on-chain movements nothing else will credit, and blocking them would silently drop real deposits.
- `#1104` keeps wallet addresses and IPs out of metric label values on purpose; they are attacker-controlled and unbounded.
- `apps/api/internal/stellar/submission_pipeline.go` is unformatted on `dev` already and was left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added progressive authentication lockouts after repeated failures, with separate wallet and IP protection.
  - Added authentication lockout monitoring and retry guidance.

- **Bug Fixes**
  - Deposits and withdrawals are now protected against duplicate balance credits or debits.
  - Deposit confirmations verify the on-chain destination, asset, and amount before crediting funds.
  - Improved handling of precise Stellar asset amounts to prevent conversion errors.
  - Invalid or mismatched confirmations no longer incorrectly update balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->